### PR TITLE
feat(reader): add ability for clients to override behavior when user taps verse

### DIFF
--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -21,9 +21,10 @@ public struct BibleReaderView: View {
 
     public init(reference: BibleReference? = nil,
                 appName: String,
-                signInMessage: String
+                signInMessage: String,
+                onVerseTap: ((BibleReference) -> Void)? = nil
     ) {
-        viewModel = BibleReaderViewModel(reference: reference)
+        viewModel = BibleReaderViewModel(reference: reference, onVerseTap: onVerseTap)
         detents = [fontSettingsDetent, fontListDetent]
         selectedDetent = fontSettingsDetent
         self.appName = appName

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -19,6 +19,21 @@ public struct BibleReaderView: View {
     @State private var selectedDetent: PresentationDetent
     @State private var detents: Set<PresentationDetent>
 
+    /// Creates a Bible reader view.
+    ///
+    /// - Parameters:
+    ///   - reference: The Bible reference to display initially. When `nil`, the reader
+    ///     restores the last-viewed reference or defaults to John 1.
+    ///   - appName: The name of the host app, shown in sign-in dialogs.
+    ///   - signInMessage: A message explaining why the user should sign in,
+    ///     displayed on the sign-in sheet.
+    ///   - onVerseTap: An optional closure called when the user taps a verse.
+    ///     When provided, the closure receives the tapped ``BibleReference`` and
+    ///     the reader takes no further action — the host app is responsible for
+    ///     handling the interaction. When `nil` (the default), tapping a verse
+    ///     triggers the built-in sign-in prompt for unauthenticated users or
+    ///     opens the verse actions drawer for authenticated users. Footnote taps
+    ///     are always handled by the reader regardless of this closure.
     public init(reference: BibleReference? = nil,
                 appName: String,
                 signInMessage: String,

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -88,6 +88,11 @@ extension BibleReaderViewModel {
             return
         }
         
+        if let onVerseTap {
+            onVerseTap(reference)
+            return
+        }
+
         guard YouVersionAPI.isSignedIn else {
             showingSignInSheet = true
             return

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -26,7 +26,7 @@ final class BibleReaderViewModel {
     let highlightsViewModel: BibleHighlightsViewModel
     var version: BibleVersion?
     let versionRepository = BibleVersionRepository()
-    var onVerseTap: ((BibleReference) -> Void)?
+    let onVerseTap: ((BibleReference) -> Void)?
 
     init(reference: BibleReference? = nil, highlightsViewModel: BibleHighlightsViewModel? = nil, onVerseTap: ((BibleReference) -> Void)? = nil) {
         // grab the saved data first, because initializing myVersions will clear the saved data.

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -26,8 +26,9 @@ final class BibleReaderViewModel {
     let highlightsViewModel: BibleHighlightsViewModel
     var version: BibleVersion?
     let versionRepository = BibleVersionRepository()
+    var onVerseTap: ((BibleReference) -> Void)?
 
-    init(reference: BibleReference? = nil, highlightsViewModel: BibleHighlightsViewModel? = nil) {
+    init(reference: BibleReference? = nil, highlightsViewModel: BibleHighlightsViewModel? = nil, onVerseTap: ((BibleReference) -> Void)? = nil) {
         // grab the saved data first, because initializing myVersions will clear the saved data.
         let savedIds = UserDefaults.standard.array(forKey: userDefaultsKeyForMyVersions) as? [Int] ?? []
 
@@ -48,6 +49,7 @@ final class BibleReaderViewModel {
             }
         }
 
+        self.onVerseTap = onVerseTap
         self.highlightsViewModel = highlightsViewModel ?? BibleHighlightsViewModel()
         self.colorTheme = ReaderTheme.theme()
         self.myVersions = []


### PR DESCRIPTION
## Description

Add an optional `onVerseTap` callback to `BibleReaderView` so client apps can override the default verse tap behavior. When provided, tapping a verse calls the closure with the tapped `BibleReference` instead of triggering the SDK's built-in sign-in prompt and verse selection drawer. Footnote taps are unaffected.

This allows client apps to handle verse taps with their own actions that don't require authentication.

## Type of Change

- [x] `feat:` New feature (non-breaking change which adds functionality)

## Breaking Changes

- [ ] This PR contains **BREAKING CHANGES**

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] All commit messages follow [conventional commits](https://www.conventionalcommits.org/) format

## Changes

- **`BibleReaderView.swift`** — Added optional `onVerseTap: ((BibleReference) -> Void)?` parameter to the public initializer, passed through to the view model.
- **`BibleReaderViewModel.swift`** — Added `onVerseTap` stored property, assigned during `init`.
- **`BibleReaderViewModel+Navigation.swift`** — In `handleVerseTap`, if `onVerseTap` is set, calls the closure with the tapped reference and returns early — bypassing the sign-in check and internal verse selection. Footnote taps are handled first and remain unaffected.

## Usage

```swift
BibleReaderView(
    reference: activeReference,
    appName: "My App",
    signInMessage: "Sign In",
    onVerseTap: { reference in
        // Handle verse tap without requiring sign-in
    }
)
```

When `onVerseTap` is `nil` (the default), existing behavior is preserved.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional `onVerseTap` callback to `BibleReaderView` that, when provided, intercepts verse taps and delivers the tapped `BibleReference` to the host app instead of triggering the built-in sign-in prompt or verse selection drawer. The implementation is clean: `onVerseTap` is stored as a `let` constant (correctly excluding it from `@Observable` tracking), placed before the sign-in guard in `handleVerseTap`, and documented with a thorough doc comment that clearly communicates the set-once semantic and footnote behaviour.

<h3>Confidence Score: 5/5</h3>

Safe to merge — implementation is correct, prior review concerns are fully resolved, and no new issues were found.

All three files make narrow, well-scoped changes. The `let` declaration correctly excludes the closure from `@Observable` tracking, the early-return placement in `handleVerseTap` is logically correct (footnote handling is preserved, sign-in bypass is intentional and documented), and the public API addition is backward-compatible with a `nil` default. No P0 or P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Adds `onVerseTap` to the public initializer with a clear doc comment; parameter ordering preserves backward compatibility. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Stores `onVerseTap` as `let`, correctly excluding it from `@Observable` tracking; wired into `init` with a safe default of `nil`. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift | Early-return guard for `onVerseTap` is correctly placed after footnote handling and before sign-in check; no side-effects on `selectedVerses` or the drawer. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant BibleTextView
    participant ViewModel as BibleReaderViewModel
    participant HostApp as Host App Closure

    User->>BibleTextView: Tap verse
    BibleTextView->>ViewModel: handleVerseTap(reference, actionType, footnotes)

    alt actionType == footnote
        ViewModel-->>BibleTextView: showingFootnotes = true (return)
    else onVerseTap != nil
        ViewModel->>HostApp: onVerseTap(reference)
        HostApp-->>ViewModel: (host handles interaction)
        ViewModel-->>BibleTextView: return (no selection, no drawer)
    else onVerseTap == nil && not signed in
        ViewModel-->>BibleTextView: showingSignInSheet = true (return)
    else onVerseTap == nil && signed in
        ViewModel-->>BibleTextView: toggle selectedVerses, show/hide drawer
    end
```

<sub>Reviews (3): Last reviewed commit: ["docs(reader): add DocC comments to Bible..."](https://github.com/youversion/platform-sdk-swift/commit/367082abb3f38c8d4f1cedfbb40586ecc7276eef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28223830)</sub>

<!-- /greptile_comment -->