### PR TITLE
feat(logging): introduce YouVersionPlatformLogger to silence SDK console spam

### DIFF
--- a/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
@@ -20,7 +20,10 @@ public extension YouVersionAPI.Bible {
 
         let elapsed1 = time2.timeIntervalSince(time1)
         let elapsed2 = time3.timeIntervalSince(time2)
-        print("Version \(versionId) fetched in \(String(format: "%.1f", elapsed1)) and \(String(format: "%.1f", elapsed2)) seconds.")
+        YouVersionPlatformLogger.debug(
+            "Version \(versionId) fetched in \(String(format: "%.1f", elapsed1)) and \(String(format: "%.1f", elapsed2)) seconds.",
+            category: "BibleVersion"
+        )
 
         return BibleVersion(
             id: basic.id,
@@ -120,17 +123,17 @@ public extension YouVersionAPI.Bible {
         let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            print("unexpected response type")
+            YouVersionPlatformLogger.error("unexpected response type", category: "BibleVersion")
             throw YouVersionAPIError.invalidResponse
         }
 
         if httpResponse.statusCode == 403 {
-            print("Not permitted; check your appKey and its entitlements.")
+            YouVersionPlatformLogger.error("Not permitted; check your appKey and its entitlements.", category: "BibleVersion")
             throw YouVersionAPIError.notPermitted
         }
 
         guard httpResponse.statusCode == 200 else {
-            print("error \(httpResponse.statusCode) while fetching an html chapter")
+            YouVersionPlatformLogger.error("error \(httpResponse.statusCode) while fetching an html chapter", category: "BibleVersion")
             throw YouVersionAPIError.cannotDownload
         }
 

--- a/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift
@@ -36,17 +36,17 @@ public extension YouVersionAPI.Bible {
             let (data, response) = try await session.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
-                print("unexpected response type")
+                YouVersionPlatformLogger.error("unexpected response type", category: "BibleVersions")
                 throw YouVersionAPIError.invalidResponse
             }
 
             if httpResponse.statusCode == 401 {
-                print("error 401: unauthorized. Check your appKey")
+                YouVersionPlatformLogger.error("error 401: unauthorized. Check your appKey", category: "BibleVersions")
                 throw YouVersionAPIError.notPermitted
             }
 
             guard httpResponse.statusCode == 200 || httpResponse.statusCode == 204 else {
-                print("error in findVersions: \(httpResponse.statusCode)")
+                YouVersionPlatformLogger.error("error in findVersions: \(httpResponse.statusCode)", category: "BibleVersions")
                 throw YouVersionAPIError.cannotDownload
             }
 

--- a/Sources/YouVersionPlatformCore/APIs/Bible/Highlights.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/Highlights.swift
@@ -96,7 +96,7 @@ public extension YouVersionAPI {
             }
 
             if httpResponse.statusCode == 401 {
-                print("getHighlights: error 401: unauthorized. Check your access token")
+                YouVersionPlatformLogger.error("getHighlights: error 401: unauthorized. Check your access token", category: "Highlights")
                 return []
             }
 
@@ -105,7 +105,7 @@ public extension YouVersionAPI {
             }
 
             guard httpResponse.statusCode >= 200 && httpResponse.statusCode < 300 else {
-                print("getHighlights: unexpected status code \(httpResponse.statusCode)")
+                YouVersionPlatformLogger.error("getHighlights: unexpected status code \(httpResponse.statusCode)", category: "Highlights")
                 return []
             }
 

--- a/Sources/YouVersionPlatformCore/APIs/Languages/Languages.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Languages/Languages.swift
@@ -83,17 +83,17 @@ public extension YouVersionAPI {
                 let (data, response) = try await session.data(for: request)
 
                 guard let httpResponse = response as? HTTPURLResponse else {
-                    print("unexpected response type")
+                    YouVersionPlatformLogger.error("unexpected response type", category: "Languages")
                     throw YouVersionAPIError.invalidResponse
                 }
 
                 if httpResponse.statusCode == 401 {
-                    print("error 401: unauthorized. Check your appKey")
+                    YouVersionPlatformLogger.error("error 401: unauthorized. Check your appKey", category: "Languages")
                     throw YouVersionAPIError.notPermitted
                 }
 
                 guard httpResponse.statusCode == 200 else {
-                    print("error in languages: \(httpResponse.statusCode)")
+                    YouVersionPlatformLogger.error("error in languages: \(httpResponse.statusCode)", category: "Languages")
                     throw YouVersionAPIError.cannotDownload
                 }
 

--- a/Sources/YouVersionPlatformCore/APIs/Users/Users.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Users/Users.swift
@@ -93,7 +93,7 @@ public extension YouVersionAPI {
                 throw URLError(.badServerResponse)
             }
             if httpResponse.statusCode != 200 {
-                print("obtainToken got status: \(httpResponse.statusCode)")
+                YouVersionPlatformLogger.error("obtainToken got status: \(httpResponse.statusCode)", category: "Auth")
                 throw URLError(.badServerResponse)
             }
 
@@ -103,7 +103,7 @@ public extension YouVersionAPI {
         static func extractSignInWithYouVersionResult(from tokens: TokenResponse, nonce: String) throws -> SignInWithYouVersionResult {
             let idClaims = try decodeJWT(tokens.idToken)
             guard idClaims["nonce"] as? String == nonce else {
-                print("Nonce mismatch")
+                YouVersionPlatformLogger.error("Nonce mismatch", category: "Auth")
                 throw URLError(.badServerResponse)
             }
             let permissions = tokens.scope

--- a/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
@@ -22,7 +22,7 @@ public enum YouVersionAPI {
         }
         guard let refreshToken = data.refreshToken,
               let result = try? await Users.performRefresh(with: refreshToken, idToken: data.idToken, session: session) else {
-            print("token refresh failed")
+            YouVersionPlatformLogger.error("token refresh failed", category: "Auth")
             return false
         }
         await MainActor.run {
@@ -45,17 +45,17 @@ public enum YouVersionAPI {
         let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            print("YouVersionAPI: unexpected response type")
+            YouVersionPlatformLogger.error("unexpected response type", category: "API")
             throw YouVersionAPIError.invalidResponse
         }
 
         if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
-            print("from server: \(httpResponse.statusCode)")
+            YouVersionPlatformLogger.error("from server: \(httpResponse.statusCode)", category: "API")
             throw YouVersionAPIError.notPermitted
         }
 
         guard httpResponse.statusCode == 200 else {
-            print("from server: \(httpResponse.statusCode)")
+            YouVersionPlatformLogger.error("from server: \(httpResponse.statusCode)", category: "API")
             throw YouVersionAPIError.cannotDownload
         }
         return data

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -44,10 +44,10 @@ public actor ChapterDiskCache {
             if let data = content.data(using: .utf8) {
                 try data.write(to: url, options: .atomic)
             } else {
-                print("WARNING: Failed to convert content to UTF-8 data for \(url)")
+                YouVersionPlatformLogger.notice("Failed to convert content to UTF-8 data for \(url)", category: "ChapterCache")
             }
         } catch {
-            print("WARNING: ChapterDiskCache failed to write data to \(url): \(error)")
+            YouVersionPlatformLogger.notice("ChapterDiskCache failed to write data to \(url): \(error)", category: "ChapterCache")
         }
     }
 
@@ -56,7 +56,10 @@ public actor ChapterDiskCache {
         do {
             try FileManager.default.removeItem(at: cacheURL)
         } catch {
-            print("ChapterDiskCache got error while removing: \(error.localizedDescription)")
+            YouVersionPlatformLogger.notice(
+                "ChapterDiskCache got error while removing: \(error.localizedDescription)",
+                category: "ChapterCache"
+            )
         }
     }
 }
@@ -158,7 +161,10 @@ public actor ChapterDownloadCache {
         do {
             try FileManager.default.removeItem(at: cacheURL)
         } catch {
-            print("ChapterDownloadCache got error while removing: \(error.localizedDescription)")
+            YouVersionPlatformLogger.notice(
+                "ChapterDownloadCache got error while removing: \(error.localizedDescription)",
+                category: "ChapterCache"
+            )
         }
     }
 

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift
@@ -86,7 +86,10 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
                 }
                 result[chapterKey] = bibleHighlights
             } catch {
-                print("Failed to fetch highlights for chapter \(chapterKey): \(error)")
+                YouVersionPlatformLogger.error(
+                    "Failed to fetch highlights for chapter \(chapterKey): \(error)",
+                    category: "Highlights"
+                )
                 result[chapterKey] = []
             }
         }
@@ -102,7 +105,10 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
                 let success = try await processOperation(operation)
                 results[operation.id] = success
             } catch {
-                print("Failed to process operation \(operation.id): \(error)")
+                YouVersionPlatformLogger.error(
+                    "Failed to process operation \(operation.id): \(error)",
+                    category: "Highlights"
+                )
                 results[operation.id] = false
             }
         }
@@ -119,7 +125,10 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
         guard components.count >= 3,
               let chapter = Int(components[1]),
               let verse = Int(components[2]) else {
-            print("Invalid passage ID format: \(apiHighlight.passageId)")
+            YouVersionPlatformLogger.error(
+                "Invalid passage ID format: \(apiHighlight.passageId)",
+                category: "Highlights"
+            )
             return nil
         }
 
@@ -170,7 +179,10 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
                     success = false
                 }
             } catch {
-                print("Failed to create highlight for \(passageId): \(error)")
+                YouVersionPlatformLogger.error(
+                    "Failed to create highlight for \(passageId): \(error)",
+                    category: "Highlights"
+                )
                 success = false
             }
         }
@@ -192,7 +204,10 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
                     success = false
                 }
             } catch {
-                print("Failed to delete highlight for \(passageId): \(error)")
+                YouVersionPlatformLogger.error(
+                    "Failed to delete highlight for \(passageId): \(error)",
+                    category: "Highlights"
+                )
                 success = false
             }
         }
@@ -222,7 +237,10 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
                     success = false
                 }
             } catch {
-                print("Failed to update highlight for \(passageId): \(error)")
+                YouVersionPlatformLogger.error(
+                    "Failed to update highlight for \(passageId): \(error)",
+                    category: "Highlights"
+                )
                 success = false
             }
         }

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
@@ -112,7 +112,10 @@ public class BibleHighlightsViewModel: ObservableObject {
             cache.applyServerHighlights(for: chapter, highlights: highlights)
             cache.recordChapterFetch(chapter)
         } catch {
-            print("Failed to load highlights for chapter \(chapter): \(error)")
+            YouVersionPlatformLogger.error(
+                "Failed to load highlights for chapter \(chapter): \(error)",
+                category: "Highlights"
+            )
         }
 
         cache.unmarkChapterAsLoading(chapter)

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -117,7 +117,10 @@ public actor VersionDiskCache: BibleVersionCaching {
         do {
             try FileManager.default.removeItem(at: url)
         } catch {
-            print("VersionDiskCache got error while removing: \(error.localizedDescription)")
+            YouVersionPlatformLogger.notice(
+                "VersionDiskCache got error while removing: \(error.localizedDescription)",
+                category: "VersionCache"
+            )
         }
     }
 
@@ -131,7 +134,10 @@ public actor VersionDiskCache: BibleVersionCaching {
     public func removeUnpermittedVersions(permittedIds: Set<Int>) async {
         let cached: [Int] = Array(await Self.cachedVersions().compactMap(\.self) )
         for id in cached where !permittedIds.contains(id) {
-            print("Removing cached Bible version \(id) because it is no longer permitted")
+            YouVersionPlatformLogger.notice(
+                "Removing cached Bible version \(id) because it is no longer permitted",
+                category: "VersionCache"
+            )
             await removeVersion(withId: id)
         }
     }
@@ -189,14 +195,20 @@ public actor VersionDownloadCache: BibleVersionCaching {
         do {
             try FileManager.default.removeItem(at: url)
         } catch {
-            print("VersionDownloadCache got error while removing: \(error.localizedDescription)")
+            YouVersionPlatformLogger.notice(
+                "VersionDownloadCache got error while removing: \(error.localizedDescription)",
+                category: "VersionCache"
+            )
         }
     }
 
     public func removeUnpermittedVersions(permittedIds: Set<Int>) {
         let downloads = Self.downloadedVersions
         for downloadedId in downloads where !permittedIds.contains(downloadedId) {
-            print("Removing downloaded Bible version \(downloadedId) because it is no longer permitted")
+            YouVersionPlatformLogger.notice(
+                "Removing downloaded Bible version \(downloadedId) because it is no longer permitted",
+                category: "VersionCache"
+            )
             removeVersion(withId: downloadedId)
         }
     }
@@ -257,7 +269,7 @@ public actor BibleVersionRepository: Observable {
                 return version
             }
         } catch {
-            print("BibleVersionRepository.version: \(error)")
+            YouVersionPlatformLogger.error("BibleVersionRepository.version: \(error)", category: "VersionCache")
         }
 
         // If a fetch is already in-flight, await its result

--- a/Sources/YouVersionPlatformCore/Logging/YouVersionPlatformLogger.swift
+++ b/Sources/YouVersionPlatformCore/Logging/YouVersionPlatformLogger.swift
@@ -1,0 +1,106 @@
+import Foundation
+#if canImport(os)
+import os
+#endif
+
+/// A lightweight logger used by the YouVersion Platform SDK.
+///
+/// By default, only messages at ``Level/error`` or higher are emitted, keeping
+/// client consoles quiet. Lower the level (for example to ``Level/debug``) to
+/// surface more detail while debugging, or set it to ``Level/off`` to silence
+/// the SDK entirely.
+///
+/// ```swift
+/// YouVersionPlatformLogger.level = .debug
+/// ```
+///
+/// On Apple platforms messages flow through `os.Logger`, so they appear in
+/// Xcode's debug console and in Console.app under the
+/// `com.youversion.platform-sdk` subsystem. On other platforms (notably
+/// Linux, used for SDK test runs) messages are written to standard output.
+public enum YouVersionPlatformLogger {
+
+    /// Severity levels, mirroring the levels exposed by `os.Logger`.
+    ///
+    /// Levels are ordered from most verbose to most severe:
+    /// ``debug`` < ``info`` < ``notice`` < ``error`` < ``fault`` < ``off``.
+    public enum Level: Int, Sendable, Comparable {
+        case debug
+        case info
+        case notice
+        case error
+        case fault
+        case off
+
+        public static func < (lhs: Level, rhs: Level) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
+    }
+
+    /// The minimum severity emitted by the SDK. Defaults to ``Level/error`` so
+    /// client apps see only real problems unless they opt in to more detail.
+    nonisolated(unsafe) public static var level: Level = .error
+
+    private static let subsystem = "com.youversion.platform-sdk"
+
+    public static func debug(
+        _ message: @autoclosure () -> String,
+        category: String = "default"
+    ) {
+        log(level: .debug, category: category, message: message)
+    }
+
+    public static func info(
+        _ message: @autoclosure () -> String,
+        category: String = "default"
+    ) {
+        log(level: .info, category: category, message: message)
+    }
+
+    public static func notice(
+        _ message: @autoclosure () -> String,
+        category: String = "default"
+    ) {
+        log(level: .notice, category: category, message: message)
+    }
+
+    public static func error(
+        _ message: @autoclosure () -> String,
+        category: String = "default"
+    ) {
+        log(level: .error, category: category, message: message)
+    }
+
+    public static func fault(
+        _ message: @autoclosure () -> String,
+        category: String = "default"
+    ) {
+        log(level: .fault, category: category, message: message)
+    }
+
+    private static func log(level: Level, category: String, message: () -> String) {
+        guard level >= Self.level else {
+            return
+        }
+        let text = message()
+        #if canImport(os)
+        let logger = Logger(subsystem: subsystem, category: category)
+        switch level {
+        case .debug:
+            logger.debug("\(text, privacy: .public)")
+        case .info:
+            logger.info("\(text, privacy: .public)")
+        case .notice:
+            logger.notice("\(text, privacy: .public)")
+        case .error:
+            logger.error("\(text, privacy: .public)")
+        case .fault:
+            logger.fault("\(text, privacy: .public)")
+        case .off:
+            break
+        }
+        #else
+        print("[YouVersionPlatform][\(category)] \(text)")
+        #endif
+    }
+}

--- a/Sources/YouVersionPlatformCore/Logging/YouVersionPlatformLogger.swift
+++ b/Sources/YouVersionPlatformCore/Logging/YouVersionPlatformLogger.swift
@@ -100,7 +100,7 @@ public enum YouVersionPlatformLogger {
             break
         }
         #else
-        print("[YouVersionPlatform][\(category)] \(text)")
+        print("[YouVersionPlatform][\(level)][\(category)] \(text)")
         #endif
     }
 }

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -329,7 +329,7 @@ public struct BibleReaderView: View {
                 
                 viewModel.updateSignInState()
             } catch {
-                print(error)
+                YouVersionPlatformLogger.error("\(error)", category: "Reader")
             }
         }
     }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -134,7 +134,7 @@ extension BibleReaderViewModel {
 
     func addVerseColor(_ color: Color) {
         guard let hex = color.hexString else {
-            print("Unable to convert color to hex: \(color)")
+            YouVersionPlatformLogger.error("Unable to convert color to hex: \(color)", category: "Reader")
             return
         }
         highlightsViewModel.addHighlights(references: Array(selectedVerses), color: hex)
@@ -143,7 +143,7 @@ extension BibleReaderViewModel {
 
     func removeVerseColor(_ color: Color) {
         guard let hex = color.hexString else {
-            print("Unable to convert color to hex: \(color)")
+            YouVersionPlatformLogger.error("Unable to convert color to hex: \(color)", category: "Reader")
             return
         }
         for reference in selectedVerses {
@@ -223,7 +223,7 @@ extension BibleReaderViewModel {
             lastScrollOffset = 0
             scrollToTop = true
         } catch {
-            print("Error loading version/chapter: \(error)")
+            YouVersionPlatformLogger.error("Error loading version/chapter: \(error)", category: "Reader")
         }
     }
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
@@ -52,7 +52,7 @@ extension BibleReaderViewModel {
                 selectedVersion = version
                 versionsStackPush(to: .versionInfo)
             } catch {
-                print("Error loading version: \(error)")
+                YouVersionPlatformLogger.error("Error loading version: \(error)", category: "Reader")
                 showGenericAlert = true
                 textForGenericAlertTitle = .localized("generic.error")
                 textForGenericAlertBody = .localized("reader.versionAccessErrorBody")
@@ -68,7 +68,10 @@ extension BibleReaderViewModel {
             let time1 = Date()
             let languages = try await YouVersionAPI.Languages.languages(fields: ["language", "display_names"])
             let elapsed = Date().timeIntervalSince(time1)
-            print("loadLanguageNames got \(languages.count) in \(String(format: "%.2f", elapsed)) seconds.")
+            YouVersionPlatformLogger.debug(
+                "loadLanguageNames got \(languages.count) in \(String(format: "%.2f", elapsed)) seconds.",
+                category: "Reader"
+            )
             var map: [String: String] = [:]
             for language in languages where language.displayNames != nil {
                 if let displayNames = language.displayNames,
@@ -77,10 +80,10 @@ extension BibleReaderViewModel {
                     map[languageCode] = name
                 }
             }
-            print("loadLanguageNames filtered to \(map.count) with displayNames.")
+            YouVersionPlatformLogger.debug("loadLanguageNames filtered to \(map.count) with displayNames.", category: "Reader")
             languageNames = map
         } catch {
-            print("Error fetching languageNames: \(error.localizedDescription)")
+            YouVersionPlatformLogger.error("Error fetching languageNames: \(error.localizedDescription)", category: "Reader")
         }
     }
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -147,7 +147,7 @@ final class BibleReaderViewModel {
             } catch YouVersionAPIError.notPermitted {
                 await selectFallbackVersion(savedIds: savedIds)
             } catch {
-                print("Error loading default version: \(error)")
+                YouVersionPlatformLogger.error("Error loading default version: \(error)", category: "Reader")
             }
         }
     }
@@ -188,7 +188,7 @@ final class BibleReaderViewModel {
                 return version.id
             }
         } else {
-            print("Could not fetch the permitted versions")
+            YouVersionPlatformLogger.error("Could not fetch the permitted versions", category: "Reader")
         }
         return nil  // at this point we must be offline or the app has been shut down. Give up.
     }
@@ -331,7 +331,10 @@ final class BibleReaderViewModel {
         let time1 = Date()
         let versions = try? await YouVersionAPI.Bible.permittedVersions(forLanguageTag: nil)
         let elapsed = Date().timeIntervalSince(time1)
-        print("fetchBibleVersionMinimalInfo got \(versions?.count ?? -999) in \(String(format: "%.2f", elapsed)) seconds.")
+        YouVersionPlatformLogger.debug(
+            "fetchBibleVersionMinimalInfo got \(versions?.count ?? -999) in \(String(format: "%.2f", elapsed)) seconds.",
+            category: "Reader"
+        )
 
         if let versions {
             await MainActor.run {
@@ -359,7 +362,10 @@ final class BibleReaderViewModel {
             let time1 = Date()
             if let unsortedVersions = try? await YouVersionAPI.Bible.versions(forLanguageTag: code) {
                 let elapsed = Date().timeIntervalSince(time1)
-                print("fetchVersionsInLanguage('\(code)') got \(unsortedVersions.count) in \(String(format: "%.2f", elapsed)) seconds.")
+                YouVersionPlatformLogger.debug(
+                    "fetchVersionsInLanguage('\(code)') got \(unsortedVersions.count) in \(String(format: "%.2f", elapsed)) seconds.",
+                    category: "Reader"
+                )
                 let sortedVersions = unsortedVersions.sorted {
                     let a = $0.localizedTitle ?? $0.title ?? $0.localizedAbbreviation ?? $0.abbreviation ?? String($0.id)
                     let b = $1.localizedTitle ?? $1.title ?? $1.localizedAbbreviation ?? $1.abbreviation ?? String($1.id)
@@ -403,9 +409,12 @@ final class BibleReaderViewModel {
             let time1 = Date()
             suggestedLanguagesList = try await YouVersionAPI.Languages.languages(country: region, fields: ["language", "display_names"])
             let elapsed = Date().timeIntervalSince(time1)
-            print("loadSuggestedLanguages got \(suggestedLanguagesList.count) in \(String(format: "%.2f", elapsed)) seconds.")
+            YouVersionPlatformLogger.debug(
+                "loadSuggestedLanguages got \(suggestedLanguagesList.count) in \(String(format: "%.2f", elapsed)) seconds.",
+                category: "Reader"
+            )
         } catch {
-            print("Error fetching languages: \(error.localizedDescription)")
+            YouVersionPlatformLogger.error("Error fetching languages: \(error.localizedDescription)", category: "Reader")
         }
     }
 

--- a/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
@@ -1,6 +1,7 @@
 import CoreText
 import Foundation
 import SwiftUI
+import YouVersionPlatformCore
 
 public enum ReaderFonts {
 
@@ -27,7 +28,7 @@ public enum ReaderFonts {
             if let cfURL = bundle.url(forResource: name, withExtension: "ttf") as CFURL? {
                 CTFontManagerRegisterFontsForURL(cfURL, CTFontManagerScope.process, nil)
             } else {
-                print("missing font: \(name)")
+                YouVersionPlatformLogger.notice("missing font: \(name)", category: "Fonts")
             }
         }
     }

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
@@ -173,7 +173,7 @@ public struct BibleTextView: View {
         } catch is CancellationError {
             loadingPhase = .inactive
         } catch let err {
-            print("loadBlocks unexpected error: \(err)")
+            YouVersionPlatformLogger.error("loadBlocks unexpected error: \(err)", category: "BibleText")
             loadingPhase = .failed
         }
     }

--- a/Sources/YouVersionPlatformUI/Views/VotdView.swift
+++ b/Sources/YouVersionPlatformUI/Views/VotdView.swift
@@ -45,10 +45,13 @@ public struct VotdView: View {
                     self.reference = reference
                     self.title = version.displayTitle(for: reference, includesVersionAbbreviation: true)
                 } else {
-                    print("VotdView: could not load version, or reference is invalid for this version")
+                    YouVersionPlatformLogger.error(
+                        "VotdView: could not load version, or reference is invalid for this version",
+                        category: "VOTD"
+                    )
                 }
             } catch {
-                print("VotdView: error loading votd: \(error)")
+                YouVersionPlatformLogger.error("VotdView: error loading votd: \(error)", category: "VOTD")
             }
         }
     }


### PR DESCRIPTION
## Summary

Client apps currently see unconditional `print()` output from the SDK —
timings, HTTP failures, cache warnings — with no way to silence it.
This PR introduces a lightweight leveled logger and migrates every
live `print()` call in `YouVersionPlatformCore`, `YouVersionPlatformUI`,
and `YouVersionPlatformReader` to use it.

- **New:** `YouVersionPlatformLogger` (public, in `Core`). Levels mirror
  `os.Logger`: `.debug`, `.info`, `.notice`, `.error`, `.fault`, plus `.off`.
  Default is `.error` so client consoles stay quiet by default.
- **Apple platforms** route messages through `os.Logger` under subsystem
  `com.youversion.platform-sdk`, so they appear in Xcode's debug console
  and in Console.app and can be filtered by subsystem/category.
- **Linux** (Core tests) falls back to `print`.
- **44 call-site migrations** across Core/UI/Reader, classified by intent:
  - Timings (`loadSuggestedLanguages got … in … seconds.`, etc.) → `.debug`
  - HTTP/network/parse failures, `Failed to fetch highlights …` → `.error`
  - Cache write/remove warnings, "Removing cached version …" → `.notice`
- Preview stubs (`#Preview {}` blocks), `#if false` tracing branches,
  and `/* TEMPORARY */` commented-out code are intentionally left as
  plain `print`.

## Client usage

```swift
// See everything while debugging:
YouVersionPlatformLogger.level = .debug

// Silence the SDK completely:
YouVersionPlatformLogger.level = .off
```

## Test plan

- [x] `swift test` — 224/224 tests pass
- [x] `swiftlint --strict` — 0 violations
- [ ] Verify noisy messages (`Failed to fetch highlights for chapter …`,
      `loadSuggestedLanguages got …`, `fetchBibleVersionMinimalInfo got …`)
      no longer appear in the client app's Xcode console at the default level
- [ ] Verify raising `YouVersionPlatformLogger.level = .debug` restores
      the messages in Xcode's console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `YouVersionPlatformLogger` — a clean, leveled logger that replaces 44 unconditional `print()` calls across `Core`, `UI`, and `Reader` with properly classified log calls. The implementation is well-crafted: `@autoclosure` ensures expensive string interpolations are skipped when filtered, `nonisolated(unsafe)` correctly handles Swift 6 global-state concurrency, and `privacy: .public` appropriately marks SDK diagnostic messages visible in Console.app without redaction.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — the change is additive, all 224 tests pass, and there are no logic changes to existing behavior.

All 44 call-site migrations are mechanical replacements with no behavioral changes. The new logger is correctly designed: lazy evaluation via @autoclosure, proper level ordering with .off capping at rawValue 5, and platform-appropriate routing. No P0 or P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/Logging/YouVersionPlatformLogger.swift | New logger: well-structured enum with leveled API, @autoclosure for lazy evaluation, nonisolated(unsafe) level var, os.Logger on Apple / print fallback on Linux. The `case .off: break` inside the switch is required for exhaustiveness and harmless. |
| Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift | Adds YouVersionPlatformCore import; migrates missing-font print to .notice — deliberate classification, lower-severity than a hard error. |
| Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift | Six error prints cleanly migrated to .error with consistent Highlights category; no logic changes. |
| Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift | Cache-removal warnings correctly classified as .notice; fetch error as .error. Clean migration with no logic changes. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Timing prints migrated to .debug and error prints to .error with Reader category; correct classification throughout. |
| Sources/YouVersionPlatformUI/Views/BibleTextView.swift | Single print call for unexpected load error migrated to .error; already imported YouVersionPlatformCore. |
| Sources/YouVersionPlatformUI/Views/VotdView.swift | Two error paths migrated to .error under VOTD category; already imported YouVersionPlatformCore. |
| Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift | Timing prints migrated to .debug, HTTP error prints migrated to .error — classifications are accurate. |
| Sources/YouVersionPlatformCore/APIs/Bible/Highlights.swift | 401 and unexpected-status paths migrated to .error under Highlights category. |
| Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift | HTTP error prints migrated to .error under BibleVersions category. |
| Sources/YouVersionPlatformCore/APIs/Languages/Languages.swift | Three HTTP error prints migrated to .error under Languages category. |
| Sources/YouVersionPlatformCore/APIs/Users/Users.swift | Token status and nonce mismatch prints migrated to .error under Auth category. |
| Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift | Token refresh failure and HTTP errors migrated to .error under API category. |
| Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift | Cache write and remove warnings migrated to .notice under ChapterCache — appropriate for non-critical storage warnings. |
| Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift | Highlight load failure migrated to .error under Highlights category. |
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Generic print(error) migrated to .error; already imported YouVersionPlatformCore. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift | Color-to-hex conversion failures and chapter load error migrated to .error under Reader category. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift | Timing debug logs and error logs correctly classified; @autoclosure ensures string formatting skipped when filtered. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Caller: YouVersionPlatformLogger.debug/info/notice/error/fault(message, category)"]
    B["@autoclosure wraps message — not yet evaluated"]
    C{"level >= YouVersionPlatformLogger.level?"}
    D["Return early — string never constructed"]
    E["Evaluate message() — string formatted now"]
    F{"canImport(os)?"}
    G["Logger(subsystem: 'com.youversion.platform-sdk', category: category)"]
    H["os.Logger.debug/info/notice/error/fault(text, privacy: .public)"]
    I["Xcode console + Console.app"]
    J["print('[YouVersionPlatform][level][category] text')"]
    K["Linux stdout / CI logs"]

    A --> B --> C
    C -- No --> D
    C -- Yes --> E --> F
    F -- Yes / Apple --> G --> H --> I
    F -- No / Linux --> J --> K
```

<sub>Reviews (2): Last reviewed commit: ["chore(logging): include level in Linux f..."](https://github.com/youversion/platform-sdk-swift/commit/d13c116dce337222e44ace657abcd21bef606adb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28659598)</sub>

<!-- /greptile_comment -->