### PR TITLE
refactor(api): fetch version metadata and index concurrently

### DIFF
--- a/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
@@ -12,32 +12,22 @@ public extension YouVersionAPI.Bible {
     static func version(versionId: Int, accessToken providedToken: String? = nil, session: URLSession = .shared) async throws -> BibleVersion {
         let accessToken = providedToken ?? YouVersionPlatformConfiguration.accessToken
 
-        let time1 = Date()
-        let basic = try await basicVersion(versionId: versionId, accessToken: accessToken, session: session)
-        let time2 = Date()
-        let index = try await versionIndex(versionId: versionId, accessToken: accessToken, session: session)
-        let time3 = Date()
+        async let metadata = basicVersion(versionId: versionId, accessToken: accessToken, session: session)
+        async let index = versionIndex(versionId: versionId, accessToken: accessToken, session: session)
 
-        let elapsed1 = time2.timeIntervalSince(time1)
-        let elapsed2 = time3.timeIntervalSince(time2)
-        YouVersionPlatformLogger.debug(
-            "Version \(versionId) fetched in \(String(format: "%.1f", elapsed1)) and \(String(format: "%.1f", elapsed2)) seconds.",
-            category: "BibleVersion"
-        )
-
-        return BibleVersion(
-            id: basic.id,
-            abbreviation: basic.abbreviation,
-            promotionalContent: basic.promotionalContent,
-            copyright: basic.copyright,
-            languageTag: basic.languageTag,
-            localizedAbbreviation: basic.localizedAbbreviation,
-            localizedTitle: basic.localizedTitle,
-            readerFooter: basic.readerFooter,
-            readerFooterUrl: basic.readerFooterUrl,
-            title: basic.title,
-            organizationId: basic.organizationId,
-            bookCodes: basic.bookCodes,
+        return try await BibleVersion(
+            id: metadata.id,
+            abbreviation: metadata.abbreviation,
+            promotionalContent: metadata.promotionalContent,
+            copyright: metadata.copyright,
+            languageTag: metadata.languageTag,
+            localizedAbbreviation: metadata.localizedAbbreviation,
+            localizedTitle: metadata.localizedTitle,
+            readerFooter: metadata.readerFooter,
+            readerFooterUrl: metadata.readerFooterUrl,
+            title: metadata.title,
+            organizationId: metadata.organizationId,
+            bookCodes: metadata.bookCodes,
             books: index.books,
             textDirection: index.text_direction,
         )


### PR DESCRIPTION
## Summary

`YouVersionAPI.Bible.version(versionId:)` was fetching the version's
metadata and index sequentially — two independent HTTP calls that have
no dependency on each other. Switching to `async let` lets them race in
parallel, roughly halving cold-fetch latency.

While I was in there, I also:
- Dropped the leftover timing instrumentation (`time1/time2/time3`,
  `elapsed1/elapsed2`, and the `YouVersionPlatformLogger.debug(...)`
  call) that was there for early-development profiling.
- Renamed the local `basic` to `metadata` — the old name was vague; the
  new name pairs naturally with `index`.

## Test plan

- [x] `swift test` — 224/224 tests pass
- [x] `swiftlint --strict` — 0 violations
- [ ] Manual: open the reader in a client app, switch Bible versions,
      confirm chapter/version metadata still loads correctly (cold
      cache + warm cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors `YouVersionAPI.Bible.version(versionId:)` to fetch version metadata and the version index concurrently using `async let`, replacing the previous sequential awaits. It also cleans up leftover timing instrumentation and renames the local `basic` variable to the more descriptive `metadata`. The concurrency change is implemented correctly — both child tasks are structured under the same parent, errors propagate cleanly, and all types involved are `Sendable`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the concurrency refactor is correct and the only finding is a pre-existing stale doc line.

All changed logic is correct: `async let` structured concurrency is applied properly, `Sendable` conformance holds across types, error propagation follows Swift's cancellation model, and the removed timing code is clearly development scaffolding. The single comment is a P2 doc cleanup.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift | Switches sequential awaits to `async let` for concurrent metadata + index fetches; removes timing instrumentation; renames `basic` → `metadata`. Logic and structured-concurrency usage are correct; one pre-existing stale doc line flagged. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant version as "version()"
    participant basicVersion as "basicVersion()"
    participant versionIndex as "versionIndex()"
    participant API

    Caller->>version: "version(versionId:)"
    Note over version: async let — both start concurrently
    par
        version->>basicVersion: "async let metadata"
        basicVersion->>API: "GET /versions/{id}"
        API-->>basicVersion: "BibleVersion JSON"
        basicVersion-->>version: "BibleVersion (metadata)"
    and
        version->>versionIndex: "async let index"
        versionIndex->>API: "GET /versions/{id}/index"
        API-->>versionIndex: "BibleVersionIndex JSON"
        versionIndex-->>version: "BibleVersionIndex (index)"
    end
    Note over version: try await — awaits both, merges fields
    version-->>Caller: "BibleVersion (merged)"
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift`, line 44 ([link](https://github.com/youversion/platform-sdk-swift/blob/2175ad7055a52132347253d26a769963fcb5ab7c/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift#L44)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale `Returns` doc on `basicVersion`**

   The docstring says "The raw `Data` containing the version metadata," but the function signature (line 51) returns `BibleVersion`, not `Data` — the decoding step is already inside `basicVersion`. This predates the PR but is surfaced by the new concurrent call pattern where callers now interact directly with the `metadata` result.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
   Line: 44

   Comment:
   **Stale `Returns` doc on `basicVersion`**

   The docstring says "The raw `Data` containing the version metadata," but the function signature (line 51) returns `BibleVersion`, not `Data` — the decoding step is already inside `basicVersion`. This predates the PR but is surfaced by the new concurrent call pattern where callers now interact directly with the `metadata` result.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
Line: 44

Comment:
**Stale `Returns` doc on `basicVersion`**

The docstring says "The raw `Data` containing the version metadata," but the function signature (line 51) returns `BibleVersion`, not `Data` — the decoding step is already inside `basicVersion`. This predates the PR but is surfaced by the new concurrent call pattern where callers now interact directly with the `metadata` result.

```suggestion
    /// - Returns: A decoded `BibleVersion` containing the version metadata.
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into bdm/concurrent-..."](https://github.com/youversion/platform-sdk-swift/commit/2175ad7055a52132347253d26a769963fcb5ab7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28668749)</sub>

<!-- /greptile_comment -->