### PR TITLE
refactor: extract the version picker UI and view model

### DIFF
--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -83,14 +83,6 @@ public struct BibleReaderView: View {
         .foregroundStyle(viewModel.readerTextPrimaryColor)
         .background(viewModel.readerCanvasPrimaryColor)
         .alert(
-            viewModel.textForGenericAlertTitle,
-            isPresented: $viewModel.showGenericAlert
-        ) {
-            Button(viewModel.textForGenericAlertOKButton) { }
-        } message: {
-            Text(viewModel.textForGenericAlertBody)
-        }
-        .alert(
             String.localized("signOut.question"),
             isPresented: $viewModel.showSignOutConfirmation
         ) {

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -119,11 +119,6 @@ public struct BibleReaderView: View {
         .sheet(isPresented: $viewModel.showingSignInSheet) {
             signInView
         }
-        .sheet(isPresented: $viewModel.showingVersionsStack) {
-            BibleReaderVersionsStack()
-                .presentationDragIndicator(.visible)
-                .presentationDetents([.large])
-        }
         .onChange(of: viewModel.startSignInFlow) { _, newValue in
             if newValue {
                 startSignIn()
@@ -316,6 +311,7 @@ public struct BibleReaderView: View {
     // MARK: - Action handlers
 
     private func startSignIn() {
+        // TODO: move this code into BibleReaderViewModel
         Task {
             do {
                 viewModel.startSignInFlow = false

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
@@ -82,28 +82,55 @@ public struct BibleReaderHeaderView: View {
     private var halfPillPickers: some View {
         if let version = viewModel.version {
             let title = viewModel.showBookIntro ? introString : bookAndChapter
-            BibleReaderHalfPillPickersView(
-                bookAndChapter: title,
-                versionAbbreviation: version.localizedAbbreviation ?? version.abbreviation ?? String(version.id),
-                handleChapterTap: { viewModel.showingBookPicker.toggle() },
-                handleVersionTap: { viewModel.handlePickersVersionTap() },
-                foregroundColor: viewModel.readerTextPrimaryColor,
-                buttonColor: viewModel.readerButtonPrimaryColor,
-                backgroundColor: viewModel.readerCanvasPrimaryColor,
-                compactMode: false
-            )
+            if let versionsViewModel = viewModel.versionsViewModel {
+                @Bindable var bindableVersionsViewModel = versionsViewModel
+
+                halfPillPickersView(
+                    bookAndChapter: title,
+                    versionAbbreviation: version.localizedAbbreviation ?? version.abbreviation ?? String(version.id),
+                    handleChapterTap: { viewModel.showingBookPicker.toggle() },
+                    handleVersionTap: { versionsViewModel.handlePickersVersionTap() }
+                )
+                .sheet(isPresented: $bindableVersionsViewModel.showingVersionsStack) {
+                    BibleReaderVersionsStack()
+                        .environment(versionsViewModel)
+                        .presentationDragIndicator(.visible)
+                        .presentationDetents([.large])
+                }
+            } else {
+                halfPillPickersView(
+                    bookAndChapter: title,
+                    versionAbbreviation: version.localizedAbbreviation ?? version.abbreviation ?? String(version.id),
+                    handleChapterTap: { viewModel.showingBookPicker.toggle() },
+                    handleVersionTap: {}
+                )
+            }
         } else {
-            BibleReaderHalfPillPickersView(
+            halfPillPickersView(
                 bookAndChapter: "",
                 versionAbbreviation: "",
                 handleChapterTap: {},
-                handleVersionTap: {},
-                foregroundColor: viewModel.readerTextPrimaryColor,
-                buttonColor: viewModel.readerButtonPrimaryColor,
-                backgroundColor: viewModel.readerCanvasPrimaryColor,
-                compactMode: false
+                handleVersionTap: {}
             )
         }
+    }
+
+    private func halfPillPickersView(
+        bookAndChapter: String,
+        versionAbbreviation: String,
+        handleChapterTap: @escaping () -> Void,
+        handleVersionTap: @escaping () -> Void
+    ) -> some View {
+        BibleReaderHalfPillPickersView(
+            bookAndChapter: bookAndChapter,
+            versionAbbreviation: versionAbbreviation,
+            handleChapterTap: handleChapterTap,
+            handleVersionTap: handleVersionTap,
+            foregroundColor: viewModel.readerTextPrimaryColor,
+            buttonColor: viewModel.readerButtonPrimaryColor,
+            backgroundColor: viewModel.readerCanvasPrimaryColor,
+            compactMode: false
+        )
     }
 
     private var bookAndChapter: String {

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
@@ -94,7 +94,7 @@ public struct BibleReaderHeaderView: View {
                 bookAndChapter: title,
                 versionAbbreviation: version.localizedAbbreviation ?? version.abbreviation ?? String(version.id),
                 handleChapterTap: { viewModel.showingBookPicker.toggle() },
-                handleVersionTap: { viewModel.versionsViewModel.handlePickersVersionTap() }
+                handleVersionTap: { viewModel.versionsViewModel.openVersionsStack(currentBibleLanguage: version.languageTag ?? "en") }
             )
         } else {
             halfPillPickersView(

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
@@ -23,6 +23,7 @@ public struct BibleReaderHeaderView: View {
 
     public var body: some View {
         @Bindable var viewModel = viewModel
+        @Bindable var bindableVersionsViewModel = viewModel.versionsViewModel
 
         HStack {
             if showChrome {
@@ -76,13 +77,18 @@ public struct BibleReaderHeaderView: View {
                 ProgressView()
             }
         }
+        .sheet(isPresented: $bindableVersionsViewModel.showingVersionsStack) {
+            BibleReaderVersionsStack()
+                .environment(viewModel.versionsViewModel)
+                .presentationDragIndicator(.visible)
+                .presentationDetents([.large])
+        }
     }
 
     @ViewBuilder
     private var halfPillPickers: some View {
         if let version = viewModel.version {
             let title = viewModel.showBookIntro ? introString : bookAndChapter
-            @Bindable var bindableVersionsViewModel = viewModel.versionsViewModel
 
             halfPillPickersView(
                 bookAndChapter: title,
@@ -90,12 +96,6 @@ public struct BibleReaderHeaderView: View {
                 handleChapterTap: { viewModel.showingBookPicker.toggle() },
                 handleVersionTap: { viewModel.versionsViewModel.handlePickersVersionTap() }
             )
-            .sheet(isPresented: $bindableVersionsViewModel.showingVersionsStack) {
-                BibleReaderVersionsStack()
-                    .environment(viewModel.versionsViewModel)
-                    .presentationDragIndicator(.visible)
-                    .presentationDetents([.large])
-            }
         } else {
             halfPillPickersView(
                 bookAndChapter: "",

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
@@ -82,28 +82,19 @@ public struct BibleReaderHeaderView: View {
     private var halfPillPickers: some View {
         if let version = viewModel.version {
             let title = viewModel.showBookIntro ? introString : bookAndChapter
-            if let versionsViewModel = viewModel.versionsViewModel {
-                @Bindable var bindableVersionsViewModel = versionsViewModel
+            @Bindable var bindableVersionsViewModel = viewModel.versionsViewModel
 
-                halfPillPickersView(
-                    bookAndChapter: title,
-                    versionAbbreviation: version.localizedAbbreviation ?? version.abbreviation ?? String(version.id),
-                    handleChapterTap: { viewModel.showingBookPicker.toggle() },
-                    handleVersionTap: { versionsViewModel.handlePickersVersionTap() }
-                )
-                .sheet(isPresented: $bindableVersionsViewModel.showingVersionsStack) {
-                    BibleReaderVersionsStack()
-                        .environment(versionsViewModel)
-                        .presentationDragIndicator(.visible)
-                        .presentationDetents([.large])
-                }
-            } else {
-                halfPillPickersView(
-                    bookAndChapter: title,
-                    versionAbbreviation: version.localizedAbbreviation ?? version.abbreviation ?? String(version.id),
-                    handleChapterTap: { viewModel.showingBookPicker.toggle() },
-                    handleVersionTap: {}
-                )
+            halfPillPickersView(
+                bookAndChapter: title,
+                versionAbbreviation: version.localizedAbbreviation ?? version.abbreviation ?? String(version.id),
+                handleChapterTap: { viewModel.showingBookPicker.toggle() },
+                handleVersionTap: { viewModel.versionsViewModel.handlePickersVersionTap() }
+            )
+            .sheet(isPresented: $bindableVersionsViewModel.showingVersionsStack) {
+                BibleReaderVersionsStack()
+                    .environment(viewModel.versionsViewModel)
+                    .presentationDragIndicator(.visible)
+                    .presentationDetents([.large])
             }
         } else {
             halfPillPickersView(

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderMyVersionsListItem.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderMyVersionsListItem.swift
@@ -3,7 +3,7 @@ import YouVersionPlatformCore
 import YouVersionPlatformUI
 
 struct BibleReaderMyVersionsListItem: View, AbbreviationSplitting {
-    @Environment(BibleReaderViewModel.self) private var viewModel
+    @Environment(BibleVersionsViewModel.self) private var viewModel
     let item: BibleVersion
 
     var body: some View {
@@ -131,7 +131,7 @@ struct BibleReaderMyVersionsListItem: View, AbbreviationSplitting {
     VStack {
         Divider()
         BibleReaderMyVersionsListItem(
-            item: BibleReaderViewModel.preview.myVersions.first!
+            item: BibleVersionsViewModel.preview.myVersions.first!
         )
         Divider()
     }

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderMyVersionsListItem.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderMyVersionsListItem.swift
@@ -135,5 +135,5 @@ struct BibleReaderMyVersionsListItem: View, AbbreviationSplitting {
         )
         Divider()
     }
-    .environment(BibleReaderViewModel.preview)
+    .environment(BibleVersionsViewModel.preview)
 }

--- a/Sources/YouVersionPlatformReader/Components/BibleVersionOverviewListItem.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleVersionOverviewListItem.swift
@@ -3,7 +3,7 @@ import YouVersionPlatformCore
 import YouVersionPlatformUI
 
 struct BibleVersionOverviewListItem: View, AbbreviationSplitting {
-    @Environment(BibleReaderViewModel.self) private var viewModel
+    @Environment(BibleVersionsViewModel.self) private var viewModel
     let item: BibleVersion
 
     var body: some View {
@@ -55,7 +55,7 @@ struct BibleVersionOverviewListItem: View, AbbreviationSplitting {
     VStack {
         Divider()
         BibleVersionOverviewListItem(item: BibleVersion.preview)
-            .environment(BibleReaderViewModel.preview)
+            .environment(BibleVersionsViewModel.preview)
         Divider()
     }
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderLanguagesView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderLanguagesView.swift
@@ -166,5 +166,5 @@ struct BibleReaderLanguagesView: View {
 
 #Preview {
     BibleReaderLanguagesView()
-        .environment(BibleReaderViewModel.preview)
+        .environment(BibleVersionsViewModel.preview)
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderLanguagesView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderLanguagesView.swift
@@ -81,7 +81,7 @@ struct BibleReaderLanguagesView: View {
             }
 
         }
-        .task {
+        .onAppear {
 #if canImport(UIKit)
             UISegmentedControl.appearance().tintColor = UIColor(viewModel.readerButtonPrimaryColor)
             UISegmentedControl.appearance().selectedSegmentTintColor = UIColor(viewModel.readerButtonContrastColor)

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderLanguagesView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderLanguagesView.swift
@@ -1,16 +1,7 @@
 import SwiftUI
 
 struct BibleReaderLanguagesView: View {
-    @Environment(BibleReaderViewModel.self) private var viewModel
-
-    init(viewModel: BibleReaderViewModel) {
-#if canImport(UIKit)
-        UISegmentedControl.appearance().tintColor = UIColor(viewModel.readerButtonPrimaryColor)
-        UISegmentedControl.appearance().selectedSegmentTintColor = UIColor(viewModel.readerButtonContrastColor)
-        UISegmentedControl.appearance().setTitleTextAttributes([.foregroundColor: UIColor(viewModel.readerTextPrimaryColor)], for: .normal)
-        UISegmentedControl.appearance().setTitleTextAttributes([.foregroundColor: UIColor(viewModel.readerTextInvertedColor)], for: .selected)
-#endif
-    }
+    @Environment(BibleVersionsViewModel.self) private var viewModel
 
     enum Segment: String, CaseIterable, Identifiable {
         case suggested
@@ -90,6 +81,14 @@ struct BibleReaderLanguagesView: View {
             }
 
         }
+        .task {
+#if canImport(UIKit)
+            UISegmentedControl.appearance().tintColor = UIColor(viewModel.readerButtonPrimaryColor)
+            UISegmentedControl.appearance().selectedSegmentTintColor = UIColor(viewModel.readerButtonContrastColor)
+            UISegmentedControl.appearance().setTitleTextAttributes([.foregroundColor: UIColor(viewModel.readerTextPrimaryColor)], for: .normal)
+            UISegmentedControl.appearance().setTitleTextAttributes([.foregroundColor: UIColor(viewModel.readerTextInvertedColor)], for: .selected)
+#endif
+        }
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
@@ -166,6 +165,6 @@ struct BibleReaderLanguagesView: View {
 }
 
 #Preview {
-    BibleReaderLanguagesView(viewModel: BibleReaderViewModel.preview)
+    BibleReaderLanguagesView()
         .environment(BibleReaderViewModel.preview)
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderMyVersionsView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderMyVersionsView.swift
@@ -71,5 +71,5 @@ public struct BibleReaderMyVersionsView: View {
 
 #Preview {
     BibleReaderMyVersionsView()
-        .environment(BibleReaderViewModel.preview)
+        .environment(BibleVersionsViewModel.preview)
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderMyVersionsView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderMyVersionsView.swift
@@ -3,7 +3,7 @@ import YouVersionPlatformCore
 import YouVersionPlatformUI
 
 public struct BibleReaderMyVersionsView: View {
-    @Environment(BibleReaderViewModel.self) private var viewModel
+    @Environment(BibleVersionsViewModel.self) private var viewModel
 
     public var body: some View {
         VStack {

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionInfoView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionInfoView.swift
@@ -218,5 +218,5 @@ struct BibleReaderVersionInfoView: View {
 
 #Preview {
     BibleReaderVersionInfoView()
-        .environment(BibleReaderViewModel.preview)
+        .environment(BibleVersionsViewModel.preview)
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionInfoView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionInfoView.swift
@@ -3,7 +3,7 @@ import YouVersionPlatformCore
 import YouVersionPlatformUI
 
 struct BibleReaderVersionInfoView: View {
-    @Environment(BibleReaderViewModel.self) private var viewModel
+    @Environment(BibleVersionsViewModel.self) private var viewModel
     @Environment(\.openURL) private var openURL
 
     @State private var isVersionDownloaded: Bool?

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionListView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionListView.swift
@@ -3,7 +3,7 @@ import YouVersionPlatformCore
 import YouVersionPlatformUI
 
 public struct BibleReaderVersionListView: View {
-    @Environment(BibleReaderViewModel.self) private var viewModel
+    @Environment(BibleVersionsViewModel.self) private var viewModel
     @State private var searchText = ""
 
     public var body: some View {
@@ -135,5 +135,5 @@ public struct BibleReaderVersionListView: View {
 
 #Preview {
     BibleReaderVersionListView()
-        .environment(BibleReaderViewModel.preview)
+        .environment(BibleVersionsViewModel.preview)
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionsStack.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionsStack.swift
@@ -2,14 +2,14 @@ import SwiftUI
 import YouVersionPlatformCore
 
 struct BibleReaderVersionsStack: View {
-    @Environment(BibleReaderViewModel.self) private var viewModel
+    @Environment(BibleVersionsViewModel.self) private var viewModel
 
     var body: some View {
         @Bindable var bindableViewModel = viewModel
 
         NavigationStack(path: $bindableViewModel.versionsPickerStack) {
             rootView
-                .navigationDestination(for: BibleReaderViewModel.VersionsPickerScreen.self) { screen in
+                .navigationDestination(for: BibleVersionsViewModel.VersionsPickerScreen.self) { screen in
                     destinationView(for: screen)
                 }
         }
@@ -34,7 +34,7 @@ struct BibleReaderVersionsStack: View {
     }
 
     @ViewBuilder
-    private func destinationView(for screen: BibleReaderViewModel.VersionsPickerScreen) -> some View {
+    private func destinationView(for screen: BibleVersionsViewModel.VersionsPickerScreen) -> some View {
         switch screen {
         case .myVersions:
             BibleReaderMyVersionsView()
@@ -45,7 +45,7 @@ struct BibleReaderVersionsStack: View {
         case .versionDownload:
             BibleVersionDownloadView()
         case .languages:
-            BibleReaderLanguagesView(viewModel: viewModel)
+            BibleReaderLanguagesView()
         }
     }
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionsStack.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionsStack.swift
@@ -13,6 +13,14 @@ struct BibleReaderVersionsStack: View {
                     destinationView(for: screen)
                 }
         }
+        .alert(
+            viewModel.textForGenericAlertTitle,
+            isPresented: $bindableViewModel.showGenericAlert
+        ) {
+            Button(viewModel.textForGenericAlertOKButton) { }
+        } message: {
+            Text(viewModel.textForGenericAlertBody)
+        }
     }
 
     @ViewBuilder

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionsStack.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionsStack.swift
@@ -60,5 +60,5 @@ struct BibleReaderVersionsStack: View {
 
 #Preview {
     BibleReaderVersionsStack()
-        .environment(BibleReaderViewModel.preview)
+        .environment(BibleVersionsViewModel.preview)
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleVersionDownloadView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleVersionDownloadView.swift
@@ -87,5 +87,5 @@ struct BibleVersionDownloadView: View {
 
 #Preview {
     BibleVersionDownloadView()
-        .environment(BibleReaderViewModel.preview)
+        .environment(BibleVersionsViewModel.preview)
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleVersionDownloadView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleVersionDownloadView.swift
@@ -3,7 +3,7 @@ import YouVersionPlatformCore
 import YouVersionPlatformUI
 
 struct BibleVersionDownloadView: View {
-    @Environment(BibleReaderViewModel.self) private var viewModel
+    @Environment(BibleVersionsViewModel.self) private var viewModel
     @Environment(\.openURL) private var openURL
 
     var body: some View {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift
@@ -11,8 +11,12 @@ extension BibleVersionsViewModel {
 
     public func myVersionMoreInfoMenuTapped(_ versionId: Int) {
         Task {
-            selectedVersion = try await versionRepository.version(withId: versionId)
-            versionsStackPush(to: .versionInfo)
+            do {
+                selectedVersion = try await versionRepository.version(withId: versionId)
+                versionsStackPush(to: .versionInfo)
+            } catch {
+                handleVersionLoadingError(error)
+            }
         }
     }
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import YouVersionPlatformCore
 import YouVersionPlatformUI
 
-extension BibleReaderViewModel {
+extension BibleVersionsViewModel {
 
     public func myVersionItemTapped(_ versionId: Int) {
         switchToVersion(versionId)
@@ -72,7 +72,8 @@ extension BibleReaderViewModel {
             if await YouVersionAPI.hasValidToken() {
                 finalDownloadButtonTapped(version: version)
             } else if YouVersionPlatformConfiguration.isSignInEnabled {
-                startSignInFlow = true
+                // TODO MOVE startSignInFlow = true
+                onSignInRequired?()
             } else {
                 assertionFailure("YouVersion sign-in must be enabled to download Bible versions.")
             }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift
@@ -72,7 +72,6 @@ extension BibleVersionsViewModel {
             if await YouVersionAPI.hasValidToken() {
                 finalDownloadButtonTapped(version: version)
             } else if YouVersionPlatformConfiguration.isSignInEnabled {
-                // TODO MOVE startSignInFlow = true
                 onSignInRequired?()
             } else {
                 assertionFailure("YouVersion sign-in must be enabled to download Bible versions.")

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -211,10 +211,10 @@ extension BibleReaderViewModel {
         isChangingChapter = true
         removeVerseSelection()
         do {
-            if version?.id != reference.versionId {
+            if version?.id != reference.versionId, let versionRepository = versionsViewModel?.versionRepository {
                 let newVersion = try await versionRepository.version(withId: reference.versionId)
                 version = newVersion
-                myVersions.insert(newVersion)
+                versionsViewModel?.myVersions.insert(newVersion)
             }
             self.reference = reference
             self.showBookIntro = showIntro

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -211,10 +211,10 @@ extension BibleReaderViewModel {
         isChangingChapter = true
         removeVerseSelection()
         do {
-            if version?.id != reference.versionId, let versionRepository = versionsViewModel?.versionRepository {
-                let newVersion = try await versionRepository.version(withId: reference.versionId)
+            if version?.id != reference.versionId {
+                let newVersion = try await versionsViewModel.versionRepository.version(withId: reference.versionId)
                 version = newVersion
-                versionsViewModel?.myVersions.insert(newVersion)
+                versionsViewModel.myVersions.insert(newVersion)
             }
             self.reference = reference
             self.showBookIntro = showIntro

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Preview.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Preview.swift
@@ -11,8 +11,6 @@ extension BibleReaderViewModel {
 
         let previewVersion = BibleVersion.preview
         vm.version = previewVersion
-        vm.myVersions = [previewVersion]
-        vm.selectedVersion = previewVersion
 
         let footnoteReference = BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 21, verse: 1)
         vm.footnotesToDisplay = [

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
@@ -36,8 +36,12 @@ extension BibleVersionsViewModel {
 
     public func switchToVersion(_ versionId: Int) {
         Task {
-            let version = try await versionRepository.version(withId: versionId)
-            onVersionChange(version)
+            do {
+                let version = try await versionRepository.version(withId: versionId)
+                onVersionChange(version)
+            } catch {
+                handleVersionLoadingError(error)
+            }
         }
     }
 
@@ -52,10 +56,7 @@ extension BibleVersionsViewModel {
                 selectedVersion = version
                 versionsStackPush(to: .versionInfo)
             } catch {
-                YouVersionPlatformLogger.error("Error loading version: \(error)", category: "Reader")
-                showGenericAlert = true
-                textForGenericAlertTitle = .localized("generic.error")
-                textForGenericAlertBody = .localized("reader.versionAccessErrorBody")
+                handleVersionLoadingError(error)
             }
         }
     }
@@ -119,6 +120,13 @@ extension BibleVersionsViewModel {
             return name
         }
         return names.first?.value
+    }
+
+    private func handleVersionLoadingError(_ error: Error) {
+        YouVersionPlatformLogger.error("Error loading version: \(error)", category: "Reader")
+        showGenericAlert = true
+        textForGenericAlertTitle = .localized("generic.error")
+        textForGenericAlertBody = .localized("reader.versionAccessErrorBody")
     }
 
 }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
@@ -122,7 +122,7 @@ extension BibleVersionsViewModel {
         return names.first?.value
     }
 
-    private func handleVersionLoadingError(_ error: Error) {
+    func handleVersionLoadingError(_ error: Error) {
         YouVersionPlatformLogger.error("Error loading version: \(error)", category: "Reader")
         showGenericAlert = true
         textForGenericAlertTitle = .localized("generic.error")

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
@@ -37,7 +37,7 @@ extension BibleVersionsViewModel {
     public func switchToVersion(_ versionId: Int) {
         Task {
             let version = try await versionRepository.version(withId: versionId)
-            await onVersionChange(version)
+            onVersionChange(version)
         }
     }
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
@@ -5,7 +5,7 @@ import YouVersionPlatformUI
 extension BibleVersionsViewModel {
 
     public var activeLanguage: String {
-        chosenLanguage ?? currentBibleVersion?.languageTag ?? "en"
+        chosenLanguage ?? currentBibleVersionLanguage ?? "en"
     }
 
     public var bibleVersionStatisticsPromo: String {
@@ -113,7 +113,7 @@ extension BibleVersionsViewModel {
         if let currentLanguage, let name = names[currentLanguage] {
             return name
         }
-        if let bibleLanguage = currentBibleVersion?.languageTag, let name = names[bibleLanguage] {
+        if let bibleLanguage = currentBibleVersionLanguage, let name = names[bibleLanguage] {
             return name
         }
         if let name = names["en"] {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
@@ -2,10 +2,10 @@ import SwiftUI
 import YouVersionPlatformCore
 import YouVersionPlatformUI
 
-extension BibleReaderViewModel {
+extension BibleVersionsViewModel {
 
     public var activeLanguage: String {
-        chosenLanguage ?? version?.languageTag ?? "en"
+        chosenLanguage ?? currentBibleVersion?.languageTag ?? "en"
     }
 
     public var bibleVersionStatisticsPromo: String {
@@ -36,8 +36,8 @@ extension BibleReaderViewModel {
 
     public func switchToVersion(_ versionId: Int) {
         Task {
-            let ref = BibleReference(versionId: versionId, bookUSFM: reference.bookUSFM, chapter: reference.chapter)
-            await onHeaderSelectionChange(ref, showIntro: false)
+            let version = try await versionRepository.version(withId: versionId)
+            await onVersionChange(version)
         }
     }
 
@@ -109,7 +109,7 @@ extension BibleReaderViewModel {
         if let currentLanguage, let name = names[currentLanguage] {
             return name
         }
-        if let bibleLanguage = version?.languageTag, let name = names[bibleLanguage] {
+        if let bibleLanguage = currentBibleVersion?.languageTag, let name = names[bibleLanguage] {
             return name
         }
         if let name = names["en"] {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsPicker.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsPicker.swift
@@ -18,10 +18,11 @@ extension BibleVersionsViewModel {
         versionsPickerStack.removeLast()
     }
 
-    func handlePickersVersionTap() {
+    func openVersionsStack(currentBibleLanguage: String) {
         Task {
             await permittedVersionsListing()
         }
+        currentBibleVersionLanguage = currentBibleLanguage
         fetchVersionsInLanguage(code: activeLanguage)
         chosenLanguage = nil  // reset the search field
         versionsPickerStack.removeAll()

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsPicker.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsPicker.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import YouVersionPlatformCore
 
-extension BibleReaderViewModel {
+extension BibleVersionsViewModel {
 
     // MARK: - VersionsPicker functions, for Version selection and manipulation
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -23,7 +23,7 @@ final class BibleReaderViewModel {
         }
     }
     let highlightsViewModel: BibleHighlightsViewModel
-    var versionsViewModel: BibleVersionsViewModel?
+    var versionsViewModel: BibleVersionsViewModel
     var version: BibleVersion?
     let onVerseTap: ((BibleReference) -> Void)?
 
@@ -52,16 +52,14 @@ final class BibleReaderViewModel {
 
         self.onVerseTap = onVerseTap
         self.highlightsViewModel = highlightsViewModel ?? BibleHighlightsViewModel()
-        self.versionsViewModel = versionsViewModel
+        self.versionsViewModel = versionsViewModel ?? BibleVersionsViewModel { _ in }
+        self.versionsViewModel.onVersionChange = onVersionChange
+        self.versionsViewModel.onSignInRequired = onSignInRequired
 
         loadUserSettingsFromStorage()  // will overwrite colorTheme, fontFamily, etc.
-        ReaderFonts.installFontsIfNeeded()
+        self.versionsViewModel.colorTheme = colorTheme
 
-        Task {
-            self.versionsViewModel = self.versionsViewModel ?? BibleVersionsViewModel(onVersionChange: onVersionChange)
-            self.versionsViewModel?.onSignInRequired = onSignInRequired
-            self.versionsViewModel?.colorTheme = colorTheme
-        }
+        ReaderFonts.installFontsIfNeeded()
     }
     
     func onVersionChange(version: BibleVersion) {
@@ -189,11 +187,11 @@ final class BibleReaderViewModel {
 
     // MARK: Colors
 
-    var colorTheme: ReaderTheme?
+    var colorTheme: ReaderTheme? = ReaderTheme.theme()
 
     func setColorTheme(_ theme: ReaderTheme) {
         colorTheme = theme
-        versionsViewModel?.colorTheme = theme
+        versionsViewModel.colorTheme = theme
         saveUserSettingsToStorage()
     }
 
@@ -229,3 +227,4 @@ final class BibleReaderViewModel {
         isSignedIn = false
     }
 }
+

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -227,4 +227,3 @@ final class BibleReaderViewModel {
         isSignedIn = false
     }
 }
-

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -53,15 +53,15 @@ final class BibleReaderViewModel {
         self.onVerseTap = onVerseTap
         self.highlightsViewModel = highlightsViewModel ?? BibleHighlightsViewModel()
         self.versionsViewModel = versionsViewModel
+
+        loadUserSettingsFromStorage()  // will overwrite colorTheme, fontFamily, etc.
+        ReaderFonts.installFontsIfNeeded()
+
         Task {
             self.versionsViewModel = self.versionsViewModel ?? BibleVersionsViewModel(onVersionChange: onVersionChange)
             self.versionsViewModel?.onSignInRequired = onSignInRequired
+            self.versionsViewModel?.colorTheme = colorTheme
         }
-        self.colorTheme = ReaderTheme.theme()
-
-        loadUserSettingsFromStorage()  // will overwrite colorTheme, fontFamily, etc.
-
-        ReaderFonts.installFontsIfNeeded()
     }
     
     func onVersionChange(version: BibleVersion) {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -233,6 +233,4 @@ final class BibleReaderViewModel {
         highlightsViewModel.reset()
         isSignedIn = false
     }
-
-
 }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -9,7 +9,6 @@ import YouVersionPlatformUI
 final class BibleReaderViewModel {
     private let userDefaultsKeyForBibleReference = "bible-reader-view--reference"
     private let userDefaultsKeyForBibleDisplayIntro = "bible-reader-view--displayintro"
-    private let userDefaultsKeyForMyVersions = "bible-reader-view--my-versions"
     private let userDefaultsKeyForReaderSettings = "bible-reader-view--readersettings"
     var reference: BibleReference {
         didSet {
@@ -24,14 +23,16 @@ final class BibleReaderViewModel {
         }
     }
     let highlightsViewModel: BibleHighlightsViewModel
+    var versionsViewModel: BibleVersionsViewModel?
     var version: BibleVersion?
-    let versionRepository = BibleVersionRepository()
     let onVerseTap: ((BibleReference) -> Void)?
 
-    init(reference: BibleReference? = nil, highlightsViewModel: BibleHighlightsViewModel? = nil, onVerseTap: ((BibleReference) -> Void)? = nil) {
-        // grab the saved data first, because initializing myVersions will clear the saved data.
-        let savedIds = UserDefaults.standard.array(forKey: userDefaultsKeyForMyVersions) as? [Int] ?? []
-
+    init(
+        reference: BibleReference? = nil,
+        highlightsViewModel: BibleHighlightsViewModel? = nil,
+        versionsViewModel: BibleVersionsViewModel? = nil,
+        onVerseTap: ((BibleReference) -> Void)? = nil
+    ) {
         if let reference {
             self.reference = reference
             self.showBookIntro = false
@@ -43,7 +44,7 @@ final class BibleReaderViewModel {
             } else {
                 // no specified or saved version, so, pick a downloaded one, else a safe default.
                 let downloads = VersionDownloadCache.downloadedVersions
-                let versionId = reference?.versionId ?? downloads.first ?? savedIds.first ?? 3034
+                let versionId = reference?.versionId ?? downloads.first /*?? savedIds.first  TODO */ ?? 3034
                 self.reference = BibleReference(versionId: versionId, bookUSFM: "JHN", chapter: 1)
                 self.showBookIntro = false
             }
@@ -51,19 +52,28 @@ final class BibleReaderViewModel {
 
         self.onVerseTap = onVerseTap
         self.highlightsViewModel = highlightsViewModel ?? BibleHighlightsViewModel()
+        self.versionsViewModel = versionsViewModel
+        Task {
+            self.versionsViewModel = self.versionsViewModel ?? BibleVersionsViewModel(onVersionChange: onVersionChange)
+            self.versionsViewModel?.onSignInRequired = onSignInRequired
+        }
         self.colorTheme = ReaderTheme.theme()
-        self.myVersions = []
-        self.suggestedLanguagesList = []
 
         loadUserSettingsFromStorage()  // will overwrite colorTheme, fontFamily, etc.
 
         ReaderFonts.installFontsIfNeeded()
+    }
+    
+    func onVersionChange(version: BibleVersion) {
+        self.version = version
+        self.reference = BibleReference(versionId: version.id, bookUSFM: reference.bookUSFM, chapter: reference.chapter)
         Task {
-            await loadVersionIfNeeded(savedIds: savedIds)
-            await restoreMyVersions(savedIds: savedIds)
-            await loadSuggestedLanguages()
-            await removeUnpermittedVersions()
+            await onHeaderSelectionChange(reference, showIntro: false)
         }
+    }
+    
+    func onSignInRequired() {
+        startSignInFlow = true
     }
 
     func loadUserSettingsFromStorage() {
@@ -101,96 +111,6 @@ final class BibleReaderViewModel {
             self.lineSpacing = lineSpacing
             self.colorTheme = colorTheme
         }
-    }
-
-    private func removeUnpermittedVersions() async {
-        guard let permittedVersions = await permittedVersionsListing() else {
-            return  // when offline, we don't get a list, but don't delete anything!
-        }
-        let permittedIds = Set(permittedVersions.map(\.id))
-        await versionRepository.removeUnpermittedVersions(permittedIds: permittedIds)
-
-        for version in self.myVersions where !permittedIds.contains(version.id) {
-            self.myVersions.remove(version)
-        }
-        if !permittedIds.contains(reference.versionId) {
-            await selectFallbackVersion(savedIds: Array(self.myVersions.map(\.id)))
-        }
-    }
-
-    private func restoreMyVersions(savedIds: [Int]) async {
-        for id in savedIds {
-            if let version = try? await versionRepository.versionIfCached(id) {
-                self.myVersions.insert(version)
-            }
-        }
-
-        // downloaded versions must also be in MyVersions, otherwise they couldn't be deleted.
-        let downloads = VersionDownloadCache.downloadedVersions
-        for id in downloads {
-            if self.myVersions.contains(where: { $0.id == id }) {
-                continue
-            }
-            if let version = try? await versionRepository.versionIfCached(id) {
-                self.myVersions.insert(version)
-            }
-        }
-    }
-
-    private func loadVersionIfNeeded(savedIds: [Int]) async {
-        if self.version == nil || self.version!.id != reference.versionId {
-            do {
-                version = try await versionRepository.version(withId: reference.versionId)
-                if let version {
-                    self.myVersions.insert(version)
-                }
-            } catch YouVersionAPIError.notPermitted {
-                await selectFallbackVersion(savedIds: savedIds)
-            } catch {
-                print("Error loading default version: \(error)")
-            }
-        }
-    }
-
-    private func selectFallbackVersion(savedIds: [Int]) async {
-        guard let nextBestVersion = await findAnyAcceptableVersion(savedIds: Set(savedIds)),
-        let version = try? await versionRepository.version(withId: nextBestVersion)
-        else {
-            // bring up the UI, let the user choose.
-            versionsStackPush(to: .moreVersions)
-          return
-        }
-        self.version = version
-        self.reference = BibleReference(versionId: version.id, bookUSFM: reference.bookUSFM, chapter: reference.chapter)
-        self.myVersions.insert(version)
-    }
-
-    private func findAnyAcceptableVersion(savedIds: Set<Int>) async -> Int? {
-        let downloads = VersionDownloadCache.downloadedVersions
-        if !downloads.isEmpty {
-            return downloads.first!
-        }
-
-        if let versions = try? await YouVersionAPI.Bible.versions() {
-            // are any of the permitted versions in their myVersions list?
-            for version in versions where savedIds.contains(version.id) {
-                return version.id
-            }
-
-            // For now, fall back to a Bible in English.
-            // It would be better to search for a bible in the device's language,
-            // before defaulting to English.
-            if let version = versions.first(where: { $0.languageTag == "en" }) {
-                return version.id
-            }
-
-            if let version = versions.first {
-                return version.id
-            }
-        } else {
-            print("Could not fetch the permitted versions")
-        }
-        return nil  // at this point we must be offline or the app has been shut down. Give up.
     }
 
     var showGenericAlert = false
@@ -278,6 +198,7 @@ final class BibleReaderViewModel {
 
     func setColorTheme(_ theme: ReaderTheme) {
         colorTheme = theme
+        versionsViewModel?.colorTheme = theme
         saveUserSettingsToStorage()
     }
 
@@ -313,163 +234,5 @@ final class BibleReaderViewModel {
         isSignedIn = false
     }
 
-    // MARK: - Versions list
 
-    /// Maps from a languageCode to a list of BibleVersion objects for that language.
-    var versionsInLanguage: [String: [BibleVersion]] = [:]
-
-    /// Holds minimal information about all Bible versions available to this app, in all languages.
-    var permittedVersionsList: [YouVersionAPI.Bible.BibleVersionMinimalInfo]?
-
-    /// Returns minimal information about all Bible versions available to this app, in all languages.
-    /// On error or when offline, returns nil
-    func permittedVersionsListing() async -> [YouVersionAPI.Bible.BibleVersionMinimalInfo]? {
-        if let permittedVersionsList {
-            return permittedVersionsList
-        }
-
-        let time1 = Date()
-        let versions = try? await YouVersionAPI.Bible.permittedVersions(forLanguageTag: nil)
-        let elapsed = Date().timeIntervalSince(time1)
-        print("fetchBibleVersionMinimalInfo got \(versions?.count ?? -999) in \(String(format: "%.2f", elapsed)) seconds.")
-
-        if let versions {
-            await MainActor.run {
-                if self.permittedVersionsList == nil {
-                    self.permittedVersionsList = versions
-                }
-            }
-        }
-        return versions
-    }
-
-    private var versionsBeingFetched: Set<String> = []
-
-    /// Causes data to be fetched, if necessary, to fill out `versionsInLanguage` for the given language code.
-    /// The fetch happens in a separate task. UI should observe `versionsInLanguage` and update when it does.
-    func fetchVersionsInLanguage(code: String) {
-        guard versionsInLanguage[code] == nil else {
-            return  // no need to fetch: we already have the data
-        }
-        guard !versionsBeingFetched.contains(code) else {
-            return
-        }
-        versionsBeingFetched.insert(code)
-        Task {
-            let time1 = Date()
-            if let unsortedVersions = try? await YouVersionAPI.Bible.versions(forLanguageTag: code) {
-                let elapsed = Date().timeIntervalSince(time1)
-                print("fetchVersionsInLanguage('\(code)') got \(unsortedVersions.count) in \(String(format: "%.2f", elapsed)) seconds.")
-                let sortedVersions = unsortedVersions.sorted {
-                    let a = $0.localizedTitle ?? $0.title ?? $0.localizedAbbreviation ?? $0.abbreviation ?? String($0.id)
-                    let b = $1.localizedTitle ?? $1.title ?? $1.localizedAbbreviation ?? $1.abbreviation ?? String($1.id)
-                    return a < b
-                }
-                await MainActor.run {
-                    self.versionsInLanguage[code] = sortedVersions
-                }
-            }
-            _ = await MainActor.run {
-                versionsBeingFetched.remove(code)
-            }
-        }
-    }
-
-    var showFullProgressViewOverlay = false
-
-    // MARK: - My Versions
-    var myVersions: Set<BibleVersion> = [] {
-        didSet {
-            Task {
-                // The below iteration must be run in a Task to avoid view re-creation loops.
-                let ids = myVersions.map { $0.id }
-                UserDefaults.standard.set(ids, forKey: userDefaultsKeyForMyVersions)
-            }
-        }
-    }
-
-    var showVersionInfoSharingAlert = false
-    var showVersionInfoSharingText = ""
-
-    // MARK: - Languages picking
-
-    var suggestedLanguagesList: [LanguageOverview]
-    var chosenLanguage: String?
-    var languageNames: [String: String] = [:]
-
-    private func loadSuggestedLanguages() async {
-        let region = Locale.current.region?.identifier ?? "US"
-        do {
-            let time1 = Date()
-            suggestedLanguagesList = try await YouVersionAPI.Languages.languages(country: region, fields: ["language", "display_names"])
-            let elapsed = Date().timeIntervalSince(time1)
-            print("loadSuggestedLanguages got \(suggestedLanguagesList.count) in \(String(format: "%.2f", elapsed)) seconds.")
-        } catch {
-            print("Error fetching languages: \(error.localizedDescription)")
-        }
-    }
-
-    /// Returns languages likely to be ones the user will want. Doesn't return any for which we have no Bible versions.
-    var suggestedLanguages: [String] {
-        guard !self.suggestedLanguagesList.isEmpty else {
-            return ["en", "es"]
-        }
-        let codes = extractLanguageCodes(languages: self.suggestedLanguagesList)
-        guard let versionsInfo = permittedVersionsList else {
-            return codes
-        }
-        let ret = codes.filter { code in
-            versionsInfo.isEmpty || versionsInfo.contains(where: { $0.languageTag == code })
-        }
-        return ret
-    }
-
-    func languageName(_ lang: String) -> String {
-        languageNames[lang] ?? Locale.current.localizedString(forLanguageCode: lang) ?? lang
-    }
-
-    /// Returns language codes from the list, preferring the 3-letter language codes
-    private func extractLanguageCodes(languages: [LanguageOverview]) -> [String] {
-        let languageCodes = languages.compactMap { $0.language }
-
-        // Remove duplicates while preserving order
-        var seen = Set<String>()
-        return languageCodes.filter { languageCode in
-            if seen.contains(languageCode) {
-                return false
-            } else {
-                seen.insert(languageCode)
-                return true
-            }
-        }
-    }
-
-    // MARK: - VersionsPicker settings, for Version selection and manipulation
-
-    enum VersionsPickerScreen: Hashable {
-        case myVersions
-        case moreVersions
-        case versionInfo
-        case versionDownload
-        case languages
-    }
-
-    var showingVersionsStack = false
-    var versionsPickerStack: [VersionsPickerScreen] = []
-
-    var selectedVersion: BibleVersion?
-
-    var organizationInfo: [String: Organization] = [:]
-
-    func organizationName(id: String) -> String? {
-        guard let org = organizationInfo[id] else {
-            Task {
-                if let data = try? await YouVersionAPI.Organizations.organization(id: id) {
-                    organizationInfo[id] = data
-                }
-            }
-            return nil
-        }
-        return org.name
-    }
 }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -56,7 +56,9 @@ final class BibleReaderViewModel {
         self.verseSelectionStyle = verseSelectionStyle
         self.highlightsViewModel = highlightsViewModel ?? BibleHighlightsViewModel()
         self.versionsViewModel = versionsViewModel ?? BibleVersionsViewModel { _ in }
-        self.versionsViewModel.onVersionChange = onVersionChange
+        self.versionsViewModel.onVersionChange = { [weak self] version in
+            self?.onVersionChange(version: version)
+        }
         self.versionsViewModel.onSignInRequired = onSignInRequired
 
         loadUserSettingsFromStorage()  // will overwrite colorTheme, fontFamily, etc.

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -113,11 +113,6 @@ final class BibleReaderViewModel {
         }
     }
 
-    var showGenericAlert = false
-    var textForGenericAlertTitle = ""
-    var textForGenericAlertBody = ""
-    private(set) var textForGenericAlertOKButton = "OK"
-
     // MARK: - UI state of the Reader itself
     var showChrome = true
     var lastScrollOffset: CGFloat = 0

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -59,7 +59,9 @@ final class BibleReaderViewModel {
         self.versionsViewModel.onVersionChange = { [weak self] version in
             self?.onVersionChange(version: version)
         }
-        self.versionsViewModel.onSignInRequired = onSignInRequired
+        self.versionsViewModel.onSignInRequired = { [weak self] in
+            self?.onSignInRequired()
+        }
 
         loadUserSettingsFromStorage()  // will overwrite colorTheme, fontFamily, etc.
         self.versionsViewModel.colorTheme = colorTheme

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
@@ -14,7 +14,7 @@ final class BibleVersionsViewModel {
     var onSignInRequired: (() -> Void)?
     var colorTheme: ReaderTheme?
     
-    var currentBibleVersion: BibleVersion?
+    var currentBibleVersionLanguage: String?
     
     var showGenericAlert = false
     var textForGenericAlertTitle = ""

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
@@ -77,18 +77,24 @@ final class BibleVersionsViewModel {
     }
     
     private func loadVersion(versionId: Int?, savedIds: [Int]) async {
-        guard let versionId else {
-            await selectFallbackVersion(savedIds: savedIds)
-            return
+        // Resolve the desired version if possible; otherwise fall back once at the end
+        var loadedVersion: BibleVersion?
+
+        if let id = versionId {
+            do {
+                loadedVersion = try await versionRepository.version(withId: id)
+            } catch YouVersionAPIError.notPermitted {
+                // Leave loadedVersion as nil; we'll fall back below
+            } catch {
+                print("Error loading default version: \(error)")
+            }
         }
-        do {
-            let version = try await versionRepository.version(withId: versionId)
+
+        if let version = loadedVersion {
             self.myVersions.insert(version)
             onVersionChange(version)
-        } catch YouVersionAPIError.notPermitted {
+        } else {
             await selectFallbackVersion(savedIds: savedIds)
-        } catch {
-            print("Error loading default version: \(error)")
         }
     }
     

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
@@ -38,10 +38,6 @@ final class BibleVersionsViewModel {
         }
     }
     
-    public func openVersionPicker(currentBibleVersion: BibleVersion?) {
-        self.currentBibleVersion = currentBibleVersion
-    }
-    
     private func removeUnpermittedVersions(initialVersionId: Int?) async {
         guard let permittedVersions = await permittedVersionsListing() else {
             return  // when offline, we don't get a list, but don't delete anything!

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
@@ -9,7 +9,6 @@ import YouVersionPlatformUI
 final class BibleVersionsViewModel {
     private let userDefaultsKeyForMyVersions = "bible-reader-view--my-versions"
     let versionRepository = BibleVersionRepository()
-    /// called when the user has chosen a new version (or their first). The caller should ensure their current reference exists in this new version and choose a new one if not.
     var onVersionChange: ((BibleVersion) -> Void)
     /// called when the user chooses to download a version and they're not yet signed in.
     var onSignInRequired: (() -> Void)?
@@ -17,12 +16,12 @@ final class BibleVersionsViewModel {
     
     var currentBibleVersion: BibleVersion?
     
-    // TODO add the .alert() to our root button, along with all the sheets.
     var showGenericAlert = false
     var textForGenericAlertTitle = ""
     var textForGenericAlertBody = ""
     private(set) var textForGenericAlertOKButton = "OK"
     
+    /// onVersionChange: called when the user has chosen a new version (or their first). The caller should ensure their current reference exists in this new version and choose a new one if not.
     init (initialVersionId: Int? = nil, onVersionChange: @escaping (BibleVersion) -> Void) {
         // grab the saved data first, because initializing myVersions will clear the saved data.
         let savedIds = UserDefaults.standard.array(forKey: userDefaultsKeyForMyVersions) as? [Int] ?? []

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
@@ -293,12 +293,12 @@ final class BibleVersionsViewModel {
         }
         return org.name
     }
-    
+
     // MARK: - Preview helper
 
     public static var preview: BibleVersionsViewModel {
         // Create a minimal BibleVersionsViewModel for preview purposes
-        let vm = BibleVersionsViewModel() { version in
+        let vm = BibleVersionsViewModel { version in
             print("Selected version: \(version.id)")
         }
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
@@ -1,0 +1,311 @@
+import CoreText
+import Foundation
+import SwiftUI
+import YouVersionPlatformCore
+import YouVersionPlatformUI
+
+@MainActor
+@Observable
+final class BibleVersionsViewModel {
+    private let userDefaultsKeyForMyVersions = "bible-reader-view--my-versions"
+    let versionRepository = BibleVersionRepository()
+    /// called when the user has chosen a new version (or their first). The caller should ensure their current reference exists in this new version and choose a new one if not.
+    var onVersionChange: ((BibleVersion) -> Void)
+    /// called when the user chooses to download a version and they're not yet signed in.
+    var onSignInRequired: (() -> Void)?
+    var colorTheme: ReaderTheme?
+    
+    var currentBibleVersion: BibleVersion?
+    
+    // TODO add the .alert() to our root button, along with all the sheets.
+    var showGenericAlert = false
+    var textForGenericAlertTitle = ""
+    var textForGenericAlertBody = ""
+    private(set) var textForGenericAlertOKButton = "OK"
+    
+    init (initialVersionId: Int? = nil, onVersionChange: @escaping (BibleVersion) -> Void) {
+        // grab the saved data first, because initializing myVersions will clear the saved data.
+        let savedIds = UserDefaults.standard.array(forKey: userDefaultsKeyForMyVersions) as? [Int] ?? []
+        
+        self.myVersions = []
+        self.suggestedLanguagesList = []
+        self.onVersionChange = onVersionChange
+        
+        Task {
+            await loadVersion(versionId: initialVersionId, savedIds: savedIds)
+            await restoreMyVersions(savedIds: savedIds)
+            await loadSuggestedLanguages()
+            await removeUnpermittedVersions(initialVersionId: initialVersionId)
+        }
+    }
+    
+    public func openVersionPicker(currentBibleVersion: BibleVersion?) {
+        self.currentBibleVersion = currentBibleVersion
+    }
+    
+    private func removeUnpermittedVersions(initialVersionId: Int?) async {
+        guard let permittedVersions = await permittedVersionsListing() else {
+            return  // when offline, we don't get a list, but don't delete anything!
+        }
+        let permittedIds = Set(permittedVersions.map(\.id))
+        await versionRepository.removeUnpermittedVersions(permittedIds: permittedIds)
+        
+        for version in self.myVersions where !permittedIds.contains(version.id) {
+            self.myVersions.remove(version)
+        }
+        if let initialVersionId, !permittedIds.contains(initialVersionId) {
+            await selectFallbackVersion(savedIds: Array(self.myVersions.map(\.id)))
+        }
+    }
+    
+    private func restoreMyVersions(savedIds: [Int]) async {
+        for id in savedIds {
+            if let version = try? await versionRepository.versionIfCached(id) {
+                self.myVersions.insert(version)
+            }
+        }
+        
+        // downloaded versions must also be in MyVersions, otherwise they couldn't be deleted.
+        let downloads = VersionDownloadCache.downloadedVersions
+        for id in downloads {
+            if self.myVersions.contains(where: { $0.id == id }) {
+                continue
+            }
+            if let version = try? await versionRepository.versionIfCached(id) {
+                self.myVersions.insert(version)
+            }
+        }
+    }
+    
+    private func loadVersion(versionId: Int?, savedIds: [Int]) async {
+        guard let versionId else {
+            await selectFallbackVersion(savedIds: savedIds)
+            return
+        }
+        do {
+            let version = try await versionRepository.version(withId: versionId)
+            self.myVersions.insert(version)
+            onVersionChange(version)
+        } catch YouVersionAPIError.notPermitted {
+            await selectFallbackVersion(savedIds: savedIds)
+        } catch {
+            print("Error loading default version: \(error)")
+        }
+    }
+    
+    private func selectFallbackVersion(savedIds: [Int]) async {
+        guard let nextBestVersion = await findAnyAcceptableVersion(savedIds: Set(savedIds)),
+              let version = try? await versionRepository.version(withId: nextBestVersion)
+        else {
+            // bring up the UI, let the user choose.
+            versionsStackPush(to: .moreVersions)
+            return
+        }
+        onVersionChange(version)
+        
+        self.myVersions.insert(version)
+    }
+    
+    private func findAnyAcceptableVersion(savedIds: Set<Int>) async -> Int? {
+        let downloads = VersionDownloadCache.downloadedVersions
+        if !downloads.isEmpty {
+            return downloads.first!
+        }
+        
+        if let versions = try? await YouVersionAPI.Bible.versions() {
+            // are any of the permitted versions in their myVersions list?
+            for version in versions where savedIds.contains(version.id) {
+                return version.id
+            }
+            
+            // For now, fall back to a Bible in English.
+            // It would be better to search for a bible in the device's language,
+            // before defaulting to English.
+            if let version = versions.first(where: { $0.languageTag == "en" }) {
+                return version.id
+            }
+            
+            if let version = versions.first {
+                return version.id
+            }
+        } else {
+            print("Could not fetch the permitted versions")
+        }
+        return nil  // at this point we must be offline or the app has been shut down. Give up.
+    }
+    
+    // MARK: - Versions list
+    
+    /// Maps from a languageCode to a list of BibleVersion objects for that language.
+    var versionsInLanguage: [String: [BibleVersion]] = [:]
+    
+    /// Holds minimal information about all Bible versions available to this app, in all languages.
+    var permittedVersionsList: [YouVersionAPI.Bible.BibleVersionMinimalInfo]?
+    
+    /// Returns minimal information about all Bible versions available to this app, in all languages.
+    /// On error or when offline, returns nil
+    func permittedVersionsListing() async -> [YouVersionAPI.Bible.BibleVersionMinimalInfo]? {
+        if let permittedVersionsList {
+            return permittedVersionsList
+        }
+        
+        let time1 = Date()
+        let versions = try? await YouVersionAPI.Bible.permittedVersions(forLanguageTag: nil)
+        let elapsed = Date().timeIntervalSince(time1)
+        print("fetchBibleVersionMinimalInfo got \(versions?.count ?? -999) in \(String(format: "%.2f", elapsed)) seconds.")
+        
+        if let versions {
+            await MainActor.run {
+                if self.permittedVersionsList == nil {
+                    self.permittedVersionsList = versions
+                }
+            }
+        }
+        return versions
+    }
+    
+    private var versionsBeingFetched: Set<String> = []
+    
+    /// Causes data to be fetched, if necessary, to fill out `versionsInLanguage` for the given language code.
+    /// The fetch happens in a separate task. UI should observe `versionsInLanguage` and update when it does.
+    func fetchVersionsInLanguage(code: String) {
+        guard versionsInLanguage[code] == nil else {
+            return  // no need to fetch: we already have the data
+        }
+        guard !versionsBeingFetched.contains(code) else {
+            return
+        }
+        versionsBeingFetched.insert(code)
+        Task {
+            let time1 = Date()
+            if let unsortedVersions = try? await YouVersionAPI.Bible.versions(forLanguageTag: code) {
+                let elapsed = Date().timeIntervalSince(time1)
+                print("fetchVersionsInLanguage('\(code)') got \(unsortedVersions.count) in \(String(format: "%.2f", elapsed)) seconds.")
+                let sortedVersions = unsortedVersions.sorted {
+                    let a = $0.localizedTitle ?? $0.title ?? $0.localizedAbbreviation ?? $0.abbreviation ?? String($0.id)
+                    let b = $1.localizedTitle ?? $1.title ?? $1.localizedAbbreviation ?? $1.abbreviation ?? String($1.id)
+                    return a < b
+                }
+                await MainActor.run {
+                    self.versionsInLanguage[code] = sortedVersions
+                }
+            }
+            _ = await MainActor.run {
+                versionsBeingFetched.remove(code)
+            }
+        }
+    }
+    
+    var showFullProgressViewOverlay = false
+    
+    // MARK: - My Versions
+    var myVersions: Set<BibleVersion> = [] {
+        didSet {
+            Task {
+                // The below iteration must be run in a Task to avoid view re-creation loops.
+                let ids = myVersions.map { $0.id }
+                UserDefaults.standard.set(ids, forKey: userDefaultsKeyForMyVersions)
+            }
+        }
+    }
+    
+    var showVersionInfoSharingAlert = false
+    var showVersionInfoSharingText = ""
+    
+    // MARK: - Languages picking
+    
+    var suggestedLanguagesList: [LanguageOverview]
+    var chosenLanguage: String?
+    var languageNames: [String: String] = [:]
+    
+    private func loadSuggestedLanguages() async {
+        let region = Locale.current.region?.identifier ?? "US"
+        do {
+            let time1 = Date()
+            suggestedLanguagesList = try await YouVersionAPI.Languages.languages(country: region, fields: ["language", "display_names"])
+            let elapsed = Date().timeIntervalSince(time1)
+            print("loadSuggestedLanguages got \(suggestedLanguagesList.count) in \(String(format: "%.2f", elapsed)) seconds.")
+        } catch {
+            print("Error fetching languages: \(error.localizedDescription)")
+        }
+    }
+    
+    /// Returns languages likely to be ones the user will want. Doesn't return any for which we have no Bible versions.
+    var suggestedLanguages: [String] {
+        guard !self.suggestedLanguagesList.isEmpty else {
+            return ["en", "es"]
+        }
+        let codes = extractLanguageCodes(languages: self.suggestedLanguagesList)
+        guard let versionsInfo = permittedVersionsList else {
+            return codes
+        }
+        let ret = codes.filter { code in
+            versionsInfo.isEmpty || versionsInfo.contains(where: { $0.languageTag == code })
+        }
+        return ret
+    }
+    
+    func languageName(_ lang: String) -> String {
+        languageNames[lang] ?? Locale.current.localizedString(forLanguageCode: lang) ?? lang
+    }
+    
+    /// Returns language codes from the list, preferring the 3-letter language codes
+    private func extractLanguageCodes(languages: [LanguageOverview]) -> [String] {
+        let languageCodes = languages.compactMap { $0.language }
+        
+        // Remove duplicates while preserving order
+        var seen = Set<String>()
+        return languageCodes.filter { languageCode in
+            if seen.contains(languageCode) {
+                return false
+            } else {
+                seen.insert(languageCode)
+                return true
+            }
+        }
+    }
+    
+    // MARK: - VersionsPicker settings, for Version selection and manipulation
+    
+    enum VersionsPickerScreen: Hashable {
+        case myVersions
+        case moreVersions
+        case versionInfo
+        case versionDownload
+        case languages
+    }
+    
+    var showingVersionsStack = false
+    var versionsPickerStack: [VersionsPickerScreen] = []
+    
+    var selectedVersion: BibleVersion?
+    
+    var organizationInfo: [String: Organization] = [:]
+    
+    func organizationName(id: String) -> String? {
+        guard let org = organizationInfo[id] else {
+            Task {
+                if let data = try? await YouVersionAPI.Organizations.organization(id: id) {
+                    organizationInfo[id] = data
+                }
+            }
+            return nil
+        }
+        return org.name
+    }
+    
+    // MARK: - Preview helper
+
+    public static var preview: BibleVersionsViewModel {
+        // Create a minimal BibleVersionsViewModel for preview purposes
+        let vm = BibleVersionsViewModel() { version in
+            print("Selected version: \(version.id)")
+        }
+
+        let previewVersion = BibleVersion.preview
+        vm.myVersions = [previewVersion]
+        vm.selectedVersion = previewVersion
+
+        return vm
+    }
+}

--- a/Sources/YouVersionPlatformReader/ViewModels/ReaderThemes.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/ReaderThemes.swift
@@ -26,7 +26,13 @@ struct ReaderTheme: Identifiable {
     }
 }
 
-extension BibleReaderViewModel {
+@MainActor
+protocol ReaderThemeProviding {
+    var colorTheme: ReaderTheme? { get }
+}
+
+@MainActor
+extension ReaderThemeProviding {
     func colorForScheme(light: Color, dark: Color) -> Color {
         colorTheme?.colorScheme == .dark ? dark : light
     }
@@ -123,100 +129,6 @@ extension BibleReaderViewModel {
     }
 }
 
-// TODO: don't duplicate code.
-extension BibleVersionsViewModel {
-    func colorForScheme(light: Color, dark: Color) -> Color {
-        colorTheme?.colorScheme == .dark ? dark : light
-    }
+extension BibleReaderViewModel: ReaderThemeProviding {}
 
-    var readerCanvasPrimaryColor: Color {
-        colorTheme?.background ?? (colorTheme?.colorScheme != .dark ? readerWhiteColor : readerBlackColor)
-    }
-
-    var readerTextPrimaryColor: Color {
-        colorTheme?.foreground ?? (colorTheme?.colorScheme != .dark ? readerBlackColor : readerWhiteColor)
-    }
-
-    var readerVerseNumColor: Color {
-        colorTheme?.colorScheme != .dark ? Color(hex: "#9d9d9d") : Color(hex: "#636161")
-    }
-
-    var readerTextMutedColor: Color {
-        readerTextPrimaryColor == readerWhiteColor ? Color(hex: "#636161") : Color(hex: "#bfbdbd")
-    }
-
-    var readerSurfacePrimaryColor: Color {
-        colorForScheme(
-            light: Color(hex: "f6f4f4"),
-            dark: Color(hex: "232121")
-        )
-    }
-
-    var readerSurfaceTertiaryColor: Color {
-        colorForScheme(
-            light: Color(hex: "EDEBEB"),
-            dark: Color(hex: "353333")
-        )
-    }
-
-    var readerBorderPrimaryColor: Color {
-        colorForScheme(
-            light: Color(hex: "dddbdb"),
-            dark: Color(hex: "474545")
-        )
-    }
-
-    var readerBorderSecondaryColor: Color {
-        colorForScheme(
-            light: Color(hex: "bfbdbd"),
-            dark: Color(hex: "636161")
-        )
-    }
-
-    var readerButtonPrimaryColor: Color {
-        colorForScheme(
-            light: Color(hex: "#edebeb"),
-            dark: Color(hex: "#353333")
-        )
-    }
-
-    var readerButtonSecondaryColor: Color {
-        colorForScheme(
-            light: Color(hex: "dddbdb"),
-            dark: Color(hex: "474545")
-        )
-    }
-
-    var readerButtonContrastColor: Color {
-        colorForScheme(
-            light: Color(hex: "121212"),
-            dark: Color(hex: "edebeb")
-        )
-    }
-
-    var readerTextInvertedColor: Color {
-        colorForScheme(
-            light: readerWhiteColor,
-            dark: readerBlackColor
-        )
-    }
-
-    var readerWhiteColor: Color {
-        Color(hex: "#ffffff")
-    }
-
-    var readerBlackColor: Color {
-        Color(hex: "#121212")
-    }
-
-    var readerDropShadowColor: Color {
-        Color(hex: "#777777").opacity(0.5)
-    }
-
-    var readerWordsOfChristColor: Color {
-        colorForScheme(
-            light: Color(hex: "#ff3d4d"),
-            dark: Color(hex: "#F04C59")
-        )
-    }
-}
+extension BibleVersionsViewModel: ReaderThemeProviding {}

--- a/Sources/YouVersionPlatformReader/ViewModels/ReaderThemes.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/ReaderThemes.swift
@@ -122,3 +122,103 @@ extension BibleReaderViewModel {
         )
     }
 }
+
+
+// TODO: don't duplicate code.
+extension BibleVersionsViewModel {
+    func colorForScheme(light: Color, dark: Color) -> Color {
+        colorTheme?.colorScheme == .dark ? dark : light
+    }
+
+    var readerCanvasPrimaryColor: Color {
+        colorTheme?.background ?? (colorTheme?.colorScheme != .dark ? readerWhiteColor : readerBlackColor)
+    }
+
+    var readerTextPrimaryColor: Color {
+        colorTheme?.foreground ?? (colorTheme?.colorScheme != .dark ? readerBlackColor : readerWhiteColor)
+    }
+
+    var readerVerseNumColor: Color {
+        colorTheme?.colorScheme != .dark ? Color(hex: "#9d9d9d") : Color(hex: "#636161")
+    }
+
+    var readerTextMutedColor: Color {
+        readerTextPrimaryColor == readerWhiteColor ? Color(hex: "#636161") : Color(hex: "#bfbdbd")
+    }
+
+    var readerSurfacePrimaryColor: Color {
+        colorForScheme(
+            light: Color(hex: "f6f4f4"),
+            dark: Color(hex: "232121")
+        )
+    }
+
+    var readerSurfaceTertiaryColor: Color {
+        colorForScheme(
+            light: Color(hex: "EDEBEB"),
+            dark: Color(hex: "353333")
+        )
+    }
+
+    var readerBorderPrimaryColor: Color {
+        colorForScheme(
+            light: Color(hex: "dddbdb"),
+            dark: Color(hex: "474545")
+        )
+    }
+
+    var readerBorderSecondaryColor: Color {
+        colorForScheme(
+            light: Color(hex: "bfbdbd"),
+            dark: Color(hex: "636161")
+        )
+    }
+
+    var readerButtonPrimaryColor: Color {
+        colorForScheme(
+            light: Color(hex: "#edebeb"),
+            dark: Color(hex: "#353333")
+        )
+    }
+
+    var readerButtonSecondaryColor: Color {
+        colorForScheme(
+            light: Color(hex: "dddbdb"),
+            dark: Color(hex: "474545")
+        )
+    }
+
+    var readerButtonContrastColor: Color {
+        colorForScheme(
+            light: Color(hex: "121212"),
+            dark: Color(hex: "edebeb")
+        )
+    }
+
+    var readerTextInvertedColor: Color {
+        colorForScheme(
+            light: readerWhiteColor,
+            dark: readerBlackColor
+        )
+    }
+
+    var readerWhiteColor: Color {
+        Color(hex: "#ffffff")
+    }
+
+    var readerBlackColor: Color {
+        Color(hex: "#121212")
+    }
+
+    var readerDropShadowColor: Color {
+        Color(hex: "#777777").opacity(0.5)
+    }
+
+    var readerWordsOfChristColor: Color {
+        colorForScheme(
+            light: Color(hex: "#ff3d4d"),
+            dark: Color(hex: "#F04C59")
+        )
+    }
+}
+

--- a/Sources/YouVersionPlatformReader/ViewModels/ReaderThemes.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/ReaderThemes.swift
@@ -123,7 +123,6 @@ extension BibleReaderViewModel {
     }
 }
 
-
 // TODO: don't duplicate code.
 extension BibleVersionsViewModel {
     func colorForScheme(light: Color, dark: Color) -> Color {
@@ -221,4 +220,3 @@ extension BibleVersionsViewModel {
         )
     }
 }
-


### PR DESCRIPTION
## Description

Refactor step 1 (the big step) to allow the version picking UI to be used outside of Reader, with all related UI e.g. the language list, version info views, and downloading UI.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [ ] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [x] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

**Migration Guide:**

No changes should be required.

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] All commit messages follow [conventional commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the appropriate section in documentation (if needed)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts version-picking UI and its logic from `BibleReaderViewModel` into a new, standalone `BibleVersionsViewModel`, enabling the version picker to be reused outside of `BibleReaderView`. The refactor is well-structured — the new `BibleVersionsViewModel` cleanly consolidates version loading, language selection, "my versions" state, and navigation, while adopting `ReaderThemeProviding` to share color logic without duplication.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing a handful of open items from prior review rounds; new findings in this pass are all P2.

Prior review rounds identified two unresolved P1 issues — the version picker sheet being unreachable when `version == nil`, and `initialVersionId` not forwarded to `BibleVersionsViewModel` — that still appear unaddressed in the current head SHA. New findings in this pass are limited to P2 style/design suggestions. Score stays at 4 until those two prior items are confirmed closed.

`BibleReaderViewModel.swift` (initialVersionId forwarding), `BibleReaderHeaderView.swift` (sheet placement when version is nil), `BibleVersionsViewModel.swift` (currentBibleVersionLanguage in selectFallbackVersion path).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift | New class: core of the refactor, handles version loading, language lists, my-versions, and picker navigation state — solid overall, but `currentBibleVersionLanguage` is only set via `openVersionsStack`, not during `selectFallbackVersion`, leaving the language list defaulting to "en" when the picker opens automatically. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Refactored to delegate version-picking responsibility to `BibleVersionsViewModel`; retain-cycle risk on `onSignInRequired` correctly fixed with `[weak self]`, but externally-provided `versionsViewModel` callbacks are silently replaced, and `initialVersionId` is not forwarded to the new vm. |
| Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift | Version-picker sheet moved here, creating a risk where the sheet binding is unreachable when `viewModel.version == nil` (e.g., first-launch fallback path) since `BibleReaderHeaderView` is only rendered when `version != nil`. |
| Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionsStack.swift | New NavigationStack-based container for all version picker screens; clean extraction, minor redundant double-if guard on `showFullProgressViewOverlay`. |
| Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionListView.swift | Migrated to `BibleVersionsViewModel` environment; minor redundant `languageTag` guard inside `filteredVersions` search path. |
| Sources/YouVersionPlatformReader/Sheets/BibleVersionDownloadView.swift | Migrated to `BibleVersionsViewModel` environment; has a minor force-unwrap on a hardcoded privacy URL literal. |
| Sources/YouVersionPlatformReader/ViewModels/ReaderThemes.swift | Added `BibleVersionsViewModel: ReaderThemeProviding` conformance, enabling consistent themed colors across picker views without duplicating color logic. |

</details>



<h3>Class Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class BibleReaderViewModel {
        +reference: BibleReference
        +version: BibleVersion?
        +versionsViewModel: BibleVersionsViewModel
        +onVersionChange(version)
        +onSignInRequired()
    }

    class BibleVersionsViewModel {
        +myVersions: Set~BibleVersion~
        +showingVersionsStack: Bool
        +versionsPickerStack: [VersionsPickerScreen]
        +onVersionChange: (BibleVersion)->Void
        +onSignInRequired: (()->Void)?
        +switchToVersion(id)
        +openVersionsStack(lang)
        +versionsStackPush(screen)
        +versionsStackPop()
    }

    class BibleReaderView {
        -viewModel: BibleReaderViewModel
    }

    class BibleReaderHeaderView {
        +sheet: BibleReaderVersionsStack
    }

    class BibleReaderVersionsStack {
        +NavigationStack
    }

    class ReaderThemeProviding {
        <<protocol>>
        +colorTheme: ReaderTheme?
        +readerCanvasPrimaryColor
        +readerTextPrimaryColor
    }

    BibleReaderViewModel --> BibleVersionsViewModel : owns (strong ref)
    BibleVersionsViewModel ..> BibleReaderViewModel : onVersionChange (weak)
    BibleReaderView --> BibleReaderViewModel : @State
    BibleReaderView --> BibleReaderHeaderView : renders
    BibleReaderHeaderView --> BibleReaderVersionsStack : sheet
    BibleReaderVersionsStack --> BibleVersionsViewModel : @Environment
    BibleReaderViewModel ..|> ReaderThemeProviding
    BibleVersionsViewModel ..|> ReaderThemeProviding
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift`, line 12-16 ([link](https://github.com/youversion/platform-sdk-swift/blob/9cfe90a6cd5e3af46077f72a830ce284c2640bec/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift#L12-L16)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Unhandled error in `myVersionMoreInfoMenuTapped`**

   `try` is used without a `do-catch`, so any error thrown by `versionRepository.version(withId:)` (network failure, `notPermitted`, etc.) is silently swallowed — the `Task` terminates with no alert and `versionsStackPush` is never called. The user taps "More Info" and nothing happens.

   `handleVersionPickerTap` just a few lines away in `BibleReaderViewModel+VersionsList.swift` shows the right pattern:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift
   Line: 12-16

   Comment:
   **Unhandled error in `myVersionMoreInfoMenuTapped`**

   `try` is used without a `do-catch`, so any error thrown by `versionRepository.version(withId:)` (network failure, `notPermitted`, etc.) is silently swallowed — the `Task` terminates with no alert and `versionsStackPush` is never called. The user taps "More Info" and nothing happens.

   `handleVersionPickerTap` just a few lines away in `BibleReaderViewModel+VersionsList.swift` shows the right pattern:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift`, line 13-17 ([link](https://github.com/youversion/platform-sdk-swift/blob/09b7359574cd33648485861f2234e3a7f9a6e5be/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift#L13-L17)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Silent error discard in `myVersionMoreInfoMenuTapped`**

   `try` inside a bare `Task {}` with no `catch` means any error from `versionRepository.version(withId:)` is silently swallowed — `selectedVersion` is never set, `versionsStackPush` is never called, and the user sees nothing happen. The "handle loading error" commit already fixed `switchToVersion` with `do/catch`; this function was missed.

   

   (`handleVersionLoadingError` is `private` to `BibleVersionsViewModel+VersionsList.swift`, so the error handling is inlined above, but moving that helper to `internal` would keep things DRY.)

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift
   Line: 13-17

   Comment:
   **Silent error discard in `myVersionMoreInfoMenuTapped`**

   `try` inside a bare `Task {}` with no `catch` means any error from `versionRepository.version(withId:)` is silently swallowed — `selectedVersion` is never set, `versionsStackPush` is never called, and the user sees nothing happen. The "handle loading error" commit already fixed `switchToVersion` with `do/catch`; this function was missed.

   

   (`handleVersionLoadingError` is `private` to `BibleVersionsViewModel+VersionsList.swift`, so the error handling is inlined above, but moving that helper to `internal` would keep things DRY.)

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift`, line 12-17 ([link](https://github.com/youversion/platform-sdk-swift/blob/4da8290d507a820ccc412bb8d34d2b53fd258384/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift#L12-L17)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Silently swallowed error in `myVersionMoreInfoMenuTapped`**

   If `versionRepository.version(withId:)` throws (network failure, `notPermitted`, etc.), the `Task` propagates the error with no `catch`, so `versionsStackPush` is never called and the user receives no feedback — the tap appears to do nothing. Compare with `handleVersionPickerTap` (which has the same structure) where errors are caught and routed to `handleVersionLoadingError`. This one was missed in the same refactor.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift
   Line: 12-17

   Comment:
   **Silently swallowed error in `myVersionMoreInfoMenuTapped`**

   If `versionRepository.version(withId:)` throws (network failure, `notPermitted`, etc.), the `Task` propagates the error with no `catch`, so `versionsStackPush` is never called and the user receives no feedback — the tap appears to do nothing. Compare with `handleVersionPickerTap` (which has the same structure) where errors are caught and routed to `handleVersionLoadingError`. This one was missed in the same refactor.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionsStack.swift
Line: 33-38

Comment:
**Duplicate condition guard on `showFullProgressViewOverlay`**

The condition is checked twice in sequence, leading to two separate `if`-blocks for the same state. These can be merged into a single branch so the intent is immediately clear.

```suggestion
                if viewModel.showFullProgressViewOverlay {
                    Color.gray.opacity(0.2)
                    ProgressView()
                }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: Sources/YouVersionPlatformReader/Sheets/BibleVersionDownloadView.swift
Line: 76

Comment:
**Force-unwrap on a hardcoded URL literal**

While the literal is correct today, a force-unwrap is a habit worth avoiding even for known-good strings. Consider using `URL(string:)` with a fallback or `guard`:

```suggestion
                if let privacyURL = URL(string: "https://bible.com/privacy") {
                    openURL(privacyURL)
                }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionListView.swift
Line: 111-130

Comment:
**Redundant `languageTag` filter in `filteredVersions`**

`versionsList` is fetched from `viewModel.versionsInLanguage[language]`, so every element in that list already belongs to `language`. The `guard v.languageTag == language` check inside the `filter` closure (line 122–123) can never be false, and can be safely removed to simplify the code.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
Line: 58-64

Comment:
**Externally-provided `versionsViewModel` callbacks are silently replaced**

When a caller passes in a pre-configured `BibleVersionsViewModel`, both its `onVersionChange` and `onSignInRequired` closures are unconditionally overwritten here. Any callback the external caller set will be lost without warning.

This doesn't affect current usage (the public `BibleReaderView` init never passes a vm), but the `versionsViewModel` parameter exists specifically to enable reuse outside the reader, so external callers will likely configure these callbacks. The init should either document that it takes ownership and replaces callbacks, or compose with any existing closures:

```swift
let existingOnVersionChange = self.versionsViewModel.onVersionChange
self.versionsViewModel.onVersionChange = { [weak self] version in
    existingOnVersionChange(version)
    self?.onVersionChange(version: version)
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (9): Last reviewed commit: ["Merge branch &#39;main&#39; into df/extract\_vers..."](https://github.com/youversion/platform-sdk-swift/commit/92cb2510fdb0288fe28786d79efb5dab1704690d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28680264)</sub>

<!-- /greptile_comment -->