### PR TITLE
refactor(reader): remove unnecessary #available guards around ToolbarItemPlacement.title

### DIFF
--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderLanguagesView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderLanguagesView.swift
@@ -98,12 +98,10 @@ struct BibleReaderLanguagesView: View {
         }
         .toolbar {
 #if os(iOS)
-            if #available(iOS 15, *) {
-                ToolbarItem(placement: .title) {
-                    Text(String.localized("languageList.title"))
-                        .fontWeight(.medium)
-                        .foregroundStyle(viewModel.readerTextPrimaryColor)
-                }
+            ToolbarItem(placement: .title) {
+                Text(String.localized("languageList.title"))
+                    .fontWeight(.medium)
+                    .foregroundStyle(viewModel.readerTextPrimaryColor)
             }
 #endif
             ToolbarItem(placement: .automatic) {

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderMyVersionsView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderMyVersionsView.swift
@@ -37,12 +37,10 @@ public struct BibleReaderMyVersionsView: View {
         #endif
         .toolbar {
 #if os(iOS)
-            if #available(iOS 15, *) {
-                ToolbarItem(placement: .title) {
-                    Text(String.localized("myVersions.title"))
-                        .fontWeight(.medium)
-                        .foregroundStyle(viewModel.readerTextPrimaryColor)
-                }
+            ToolbarItem(placement: .title) {
+                Text(String.localized("myVersions.title"))
+                    .fontWeight(.medium)
+                    .foregroundStyle(viewModel.readerTextPrimaryColor)
             }
 #endif
             ToolbarItem(placement: .automatic) {

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionListView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionListView.swift
@@ -43,12 +43,10 @@ public struct BibleReaderVersionListView: View {
         }
 #if os(iOS)
         .toolbar {
-            if #available(iOS 15, *) {
-                ToolbarItem(placement: .title) {
-                    Text(viewModel.bibleVersionStatisticsPromo)
-                        .fontWeight(.medium)
-                        .foregroundStyle(viewModel.readerTextPrimaryColor)
-                }
+            ToolbarItem(placement: .title) {
+                Text(viewModel.bibleVersionStatisticsPromo)
+                    .fontWeight(.medium)
+                    .foregroundStyle(viewModel.readerTextPrimaryColor)
             }
         }
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
## Summary

Three toolbar sheets (`BibleReaderLanguagesView`, `BibleReaderMyVersionsView`,
`BibleReaderVersionListView`) were gated like:

\`\`\`swift
#if os(iOS)
if #available(iOS 15, *) {
    ToolbarItem(placement: .title) { ... }
}
#endif
\`\`\`

The `#available(iOS 15, *)` guard was always vacuous:

- The package's minimum is **iOS 17** (`Package.swift:104`).
- `ToolbarItemPlacement.title` is declared `@_alwaysEmitIntoClient` back to **iOS 14**, and SwiftUI internally resolves it to `.principal` on iOS < 26. So there's nothing for the SDK user to gate.

Drop the `#available` wrappers. The `#if os(iOS)` compile-time guards stay — `.title` is unavailable on macOS / tvOS / watchOS / visionOS, and the package builds for macOS 15 and tvOS 18 too.

No behavior change on any runtime.

## Test plan

- [x] `swift test` — 224/224 pass
- [x] `swiftlint --strict` — 0 violations
- [ ] Manual: open the Reader's languages / my versions / version list sheets, confirm the centered title still renders on iOS 17, 18, and 26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the redundant `if #available(iOS 15, *)` wrappers from the three Reader sheet toolbar items, since the package's minimum deployment target is iOS 17 (confirmed in `Package.swift:104`), making the guard always vacuously true. The `#if os(iOS)` compile-time guards are correctly preserved, as `ToolbarItemPlacement.title` is not available on macOS, tvOS, or watchOS.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure dead-code removal with no runtime behavior change.

All three changes are identical and correct: the `#available(iOS 15, *)` check is always true given the iOS 17 minimum deployment target verified in Package.swift, so removing it is a no-op at runtime. The `#if os(iOS)` platform guards that are actually load-bearing remain intact. No logic, data, or API contract is altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/Sheets/BibleReaderLanguagesView.swift | Removes vacuous `#available(iOS 15, *)` guard around `ToolbarItem(placement: .title)`; `#if os(iOS)` compile-time guard retained correctly. |
| Sources/YouVersionPlatformReader/Sheets/BibleReaderMyVersionsView.swift | Removes vacuous `#available(iOS 15, *)` guard around `ToolbarItem(placement: .title)`; `#if os(iOS)` compile-time guard retained correctly. |
| Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionListView.swift | Removes vacuous `#available(iOS 15, *)` guard around `ToolbarItem(placement: .title)`; `#if os(iOS)` compile-time guard retained correctly. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Build toolbar block] --> B{os iOS?}
    B -->|No - macOS tvOS watchOS| C[Skip ToolbarItem title]
    B -->|Yes - iOS| D{Before: available iOS 15?}
    D -->|Always true on iOS 17+| E[ToolbarItem placement .title]
    B -->|Yes - iOS After| F[ToolbarItem placement .title directly]
    E --> G[Centered title rendered]
    F --> G
```

<sub>Reviews (2): Last reviewed commit: ["refactor(reader): remove unnecessary #av..."](https://github.com/youversion/platform-sdk-swift/commit/befb652e61926a06b87151fe30e0bc29a6b0ecd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28687581)</sub>

<!-- /greptile_comment -->