### PR TITLE
ci(release): pin release job to macos-26 with explicit Xcode setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,13 @@ jobs:
 
   release:
     needs: test
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

The `release` job in `.github/workflows/release.yml` was running on
`macos-latest`. GitHub still points `macos-latest` at `macos-15`
(Xcode 16 / iOS 18 SDK), so `pod lib lint` of `YouVersionPlatformReader`
fails to compile any SwiftUI API that requires the **Xcode 26** SDK —
notably `ToolbarItemPlacement.title`, which is back-deployed to iOS 14
via `@_alwaysEmitIntoClient` but only *emitted* by Xcode 26.

This is why the 4.4.0 release job failed on
https://github.com/youversion/platform-sdk-swift/actions/runs/24525869303/job/71696328944
with three `type 'ToolbarItemPlacement' has no member 'title'` errors.

The `test` job at the top of the same workflow was already pinned to
`macos-26` with `maxim-lobanov/setup-xcode@v1` — the release job was an
oversight because `pod lib lint` is the only step in the release flow
that actually compiles Swift.

## Change

- `runs-on: macos-latest` → `runs-on: macos-26`
- Add the `maxim-lobanov/setup-xcode@v1` step with `xcode-version: ${{ env.XCODE_VERSION }}` (which resolves to `latest-stable`)

Mirrors the `test` job's toolchain setup verbatim.

## Test plan

- [ ] Next merge to `main` kicks off the release workflow and the `release` job succeeds past the `pod lib lint YouVersionPlatformReader` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the failing `release` job by pinning it to `macos-26` and adding `maxim-lobanov/setup-xcode@v1` (resolving to `latest-stable` via `XCODE_VERSION`), exactly mirroring the already-working `test` job's toolchain setup. The root cause — `pod lib lint` compiling against Xcode 16's SDK and missing `ToolbarItemPlacement.title` — is correctly addressed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, well-motivated change that mirrors a proven pattern from the `test` job.

The two-line change (runner pin + setup-xcode step) directly mirrors the existing working `test` job config. No logic changes, no new secrets, no altered release semantics. All remaining observations are P2 or lower.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Pins `release` job runner to `macos-26` and adds `maxim-lobanov/setup-xcode@v1` to match the `test` job's toolchain setup, fixing `pod lib lint` compilation failures against Xcode 26 SDK APIs. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(release): pin release job to macos-26..."](https://github.com/youversion/platform-sdk-swift/commit/f4612cc2d917d557b94d6b90c67c1e185579a85a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28687671)</sub>

<!-- /greptile_comment -->