### PR TITLE
feat(reader): improve verse actions animation and respect accessibility Reduce Motion setting

### DIFF
--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -11,6 +11,7 @@ public struct BibleReaderView: View {
 
     @Environment(\.openURL) private var openURL
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let fontSettingsDetent = PresentationDetent.height(360)
     let fontListDetent = PresentationDetent.height(480)
@@ -80,7 +81,7 @@ public struct BibleReaderView: View {
                 if viewModel.showingVerseActionsDrawer {
                     verseActionDrawer
                         .frame(maxWidth: viewModel.readerMaxWidth, maxHeight: .infinity, alignment: .bottom)
-                        .transition(.move(edge: .bottom))
+                        .transition(reduceMotion ? .opacity : .move(edge: .bottom))
                 }
             }
         }
@@ -132,6 +133,11 @@ public struct BibleReaderView: View {
             if newValue {
                 startSignIn()
             }
+        }
+        .onChange(of: reduceMotion, initial: true) { _, newValue in
+            viewModel.verseActionsDrawerAnimation = newValue
+                ? .easeInOut(duration: 0.2)
+                : .smooth(duration: 0.3)
         }
         .environment(viewModel)
         .environment(\.colorScheme, viewModel.colorTheme?.colorScheme ?? .dark)

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -59,7 +59,9 @@ extension BibleReaderViewModel {
 
     func removeVerseSelection() {
         selectedVerses.removeAll()
-        showingVerseActionsDrawer = false
+        withAnimation(verseActionsDrawerAnimation) {
+            showingVerseActionsDrawer = false
+        }
     }
 
     func handleScroll(offset: CGFloat) {
@@ -99,8 +101,8 @@ extension BibleReaderViewModel {
             } else {
                 selectedVerses.insert(reference)
             }
-            withAnimation(.interpolatingSpring(stiffness: 300, damping: 25)) {
-                showingVerseActionsDrawer = !self.selectedVerses.isEmpty
+            withAnimation(verseActionsDrawerAnimation) {
+                showingVerseActionsDrawer = !selectedVerses.isEmpty
             }
         } else if YouVersionPlatformConfiguration.isSignInEnabled {
             showingSignInSheet = true

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -211,6 +211,7 @@ final class BibleReaderViewModel {
     var showingFootnotes = false
     var showingIntroFootnoteSheet = false
     var showingVerseActionsDrawer = false
+    var verseActionsDrawerAnimation: Animation = .smooth(duration: 0.3)
     var selectedVerses: Set<BibleReference> = []
 
     var showingBookPicker = false


### PR DESCRIPTION
## Summary
- Swaps the verse actions drawer's bouncy `interpolatingSpring` for `.smooth(duration: 0.3)`, which matches the non-bouncy curve Apple uses for system bottom sheets.
- Applies the same animation to drawer dismissal, so tapping Copy (or any other action that clears the selection) now slides the drawer out instead of snapping.
- Honors the **Reduce Motion** accessibility setting: when enabled, the drawer crossfades with `.opacity` on a short `.easeInOut(duration: 0.2)` curve; when disabled, it slides from the bottom as before.

## Implementation notes
- Added `verseActionsDrawerAnimation: Animation` on `BibleReaderViewModel`, set from `BibleReaderView` via `@Environment(\.accessibilityReduceMotion)` + `.onChange(of:initial:)`. Keeps the `withAnimation` calls inside the view model (where they already live) while letting the view drive the environment-aware animation choice, so the value live-updates if the user toggles Reduce Motion mid-session.
- Transition on the drawer view is conditional: `.opacity` when Reduce Motion is on, `.move(edge: .bottom)` otherwise.

## Test plan
- [x] `swift build` — clean.
- [x] `swiftlint --strict` — 0 violations.
- [ ] Sample App: Reduce Motion **off** — tap verse: drawer slides up smoothly, no bounce. Tap Copy: drawer slides back down with the same curve.
- [ ] Sample App: Reduce Motion **on** (Settings → Accessibility → Motion → Reduce Motion) — tap verse: drawer crossfades in. Tap Copy: drawer crossfades out.
- [ ] Toggle Reduce Motion while the reader is open — next drawer presentation picks up the new animation without needing to relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the bouncy `interpolatingSpring` on the verse actions drawer with a polished `.smooth(duration: 0.3)` curve, adds a matching dismissal animation, and honours the system Reduce Motion setting via a conditional `.opacity` / `.move(edge: .bottom)` transition paired with a short `.easeInOut(duration: 0.2)` curve. The architecture is well-chosen: `BibleReaderView` owns the environment read and propagates the animation into the view model via `onChange(of:initial:)`, so Reduce Motion toggles live without relaunching.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive, well-scoped animation improvements with no behavioural regressions.

The only finding is a P2 style suggestion about extracting duplicated animation duration literals into constants. No logic errors, no data-integrity concerns, and no security implications.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Adds `accessibilityReduceMotion` environment read, conditional `.opacity`/`.move` transition, and `onChange` to keep the view model's animation in sync — clean approach, minor duration duplication with the view model default. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Adds `verseActionsDrawerAnimation` property with a sensible `.smooth(duration: 0.3)` default; the `0.3` literal is duplicated from the view's `onChange` initializer. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift | Replaces hardcoded `.interpolatingSpring` with the environment-driven `verseActionsDrawerAnimation` in both show and dismiss paths; `removeVerseSelection` now animates the drawer out consistently. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Env as Environment(accessibilityReduceMotion)
    participant View as BibleReaderView
    participant VM as BibleReaderViewModel

    Env->>View: onChange(reduceMotion, initial: true)
    View->>VM: verseActionsDrawerAnimation = .easeInOut(0.2) or .smooth(0.3)

    Note over View,VM: User taps a verse
    VM->>VM: handleVerseTap()
    VM->>VM: withAnimation(verseActionsDrawerAnimation) showingVerseActionsDrawer = true
    View->>View: transition(.opacity) or transition(.move(edge: .bottom))

    Note over View,VM: User taps Copy / clears selection
    VM->>VM: removeVerseSelection()
    VM->>VM: withAnimation(verseActionsDrawerAnimation) showingVerseActionsDrawer = false
    View->>View: Reverse transition animates drawer out
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: Sources/YouVersionPlatformReader/BibleReaderView.swift
Line: 137-141

Comment:
**Extract shared animation durations into constants**

The `0.3` duration value appears both here and as the default initializer value for `verseActionsDrawerAnimation` in `BibleReaderViewModel.swift` (line 214). Per the project's animation constant rule, extracting these into named constants avoids silent drift if one value is updated but not the other.

```swift
// e.g. in BibleReaderViewModel or a shared constants file:
private static let drawerAnimationDuration: Double = 0.3
private static let drawerReducedMotionDuration: Double = 0.2

var verseActionsDrawerAnimation: Animation = .smooth(duration: drawerAnimationDuration)
```

Then in the `onChange`:
```swift
viewModel.verseActionsDrawerAnimation = newValue
    ? .easeInOut(duration: BibleReaderViewModel.drawerReducedMotionDuration)
    : .smooth(duration: BibleReaderViewModel.drawerAnimationDuration)
```

**Rule Used:** When animation durations or intervals are used in ... ([source](https://app.greptile.com/review/custom-context?memory=00bcfdf4-5522-4e37-8c97-8088892db6f7))

**Learned From**
[lifechurch/youversion/user-applications/mobile/bible-ios#4801](https://gitlab.com/lifechurch/youversion/user-applications/mobile/bible-ios/-/merge_requests/4801)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(reader): improve verse actions anim..."](https://github.com/youversion/platform-sdk-swift/commit/e3ba2bd10926f7f5defba7bbfb49ae64c3c5756e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28978942)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - When animation durations or intervals are used in ... ([source](https://app.greptile.com/review/custom-context?memory=00bcfdf4-5522-4e37-8c97-8088892db6f7))

**Learned From**
[lifechurch/youversion/user-applications/mobile/bible-ios#4801](https://gitlab.com/lifechurch/youversion/user-applications/mobile/bible-ios/-/merge_requests/4801)

<!-- /greptile_comment -->