### PR TITLE
refactor: rename classes (BibleReader* to BibleVersions*), and create YouVersionFonts

### DIFF
--- a/Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import YouVersionPlatformCore
+import YouVersionPlatformUI
 
 struct BibleReaderDrawer: View {
     @Environment(BibleReaderViewModel.self) private var viewModel
@@ -93,7 +94,7 @@ struct BibleReaderDrawer: View {
         .background(RoundedRectangle(cornerRadius: 12)
             .fill(viewModel.readerSurfaceTertiaryColor))
         .foregroundStyle(viewModel.readerTextPrimaryColor)
-        .font(ReaderFonts.fontLabelM)
+        .font(YouVersionFonts.fontLabelM)
     }
 
     private func drawerButton(imageName: String, text: String, action: @escaping () -> Void) -> some View {
@@ -113,7 +114,7 @@ struct BibleReaderDrawer: View {
             Image(systemName: "chevron.up")
             Text(String.localized("verseActions.swipeUpLabel"))
         }
-        .font(ReaderFonts.fontCaptionsL)
+        .font(YouVersionFonts.fontCaptionsL)
     }
 }
 

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import YouVersionPlatformCore
+import YouVersionPlatformUI
 
 public struct BibleReaderHeaderView: View {
     @Environment(BibleReaderViewModel.self) private var viewModel
@@ -79,7 +80,7 @@ public struct BibleReaderHeaderView: View {
             }
         }
         .sheet(isPresented: $bindableVersionsViewModel.showingVersionsStack) {
-            BibleReaderVersionsStack()
+            BibleVersionsStack()
                 .environment(viewModel.versionsViewModel)
                 .presentationDragIndicator(.visible)
                 .presentationDetents([.large])

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderMyVersionsListItem.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderMyVersionsListItem.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import YouVersionPlatformCore
 import YouVersionPlatformUI
 
-struct BibleReaderMyVersionsListItem: View, AbbreviationSplitting {
+struct BibleVersionsMyVersionsListItem: View, AbbreviationSplitting {
     @Environment(BibleVersionsViewModel.self) private var viewModel
     let item: BibleVersion
 
@@ -14,7 +14,7 @@ struct BibleReaderMyVersionsListItem: View, AbbreviationSplitting {
                 let (letters, numbers) = splitAbbreviation(abbreviation)
 
                 Text(letters)
-                    .font(ReaderFonts.preferredBibleTextFont(size: 20))
+                    .font(YouVersionFonts.preferredBibleTextFont(size: 20))
                     .fontWeight(.semibold)
                     .padding(.horizontal, 4)
                     .lineLimit(1)
@@ -22,7 +22,7 @@ struct BibleReaderMyVersionsListItem: View, AbbreviationSplitting {
 
                 if !numbers.isEmpty {
                     Text(numbers)
-                        .font(ReaderFonts.preferredBibleTextFont(size: 10).weight(.semibold))
+                        .font(YouVersionFonts.preferredBibleTextFont(size: 10).weight(.semibold))
                         .lineLimit(1)
                 }
             }
@@ -130,7 +130,7 @@ struct BibleReaderMyVersionsListItem: View, AbbreviationSplitting {
 #Preview {
     VStack {
         Divider()
-        BibleReaderMyVersionsListItem(
+        BibleVersionsMyVersionsListItem(
             item: BibleVersionsViewModel.preview.myVersions.first!
         )
         Divider()

--- a/Sources/YouVersionPlatformReader/Components/BibleVersionOverviewListItem.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleVersionOverviewListItem.swift
@@ -14,7 +14,7 @@ struct BibleVersionOverviewListItem: View, AbbreviationSplitting {
                 let (letters, numbers) = splitAbbreviation(abbreviation)
 
                 Text(letters)
-                    .font(ReaderFonts.preferredBibleTextFont(size: 15))
+                    .font(YouVersionFonts.preferredBibleTextFont(size: 15))
                     .foregroundStyle(viewModel.readerTextPrimaryColor)
                     .fontWeight(.semibold)
                     .padding(.horizontal, 4)
@@ -23,7 +23,7 @@ struct BibleVersionOverviewListItem: View, AbbreviationSplitting {
 
                 if !numbers.isEmpty {
                     Text(numbers)
-                        .font(ReaderFonts.preferredBibleTextFont(size: 10).weight(.semibold))
+                        .font(YouVersionFonts.preferredBibleTextFont(size: 10).weight(.semibold))
                         .foregroundStyle(viewModel.readerTextPrimaryColor)
                         .lineLimit(1)
                 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import YouVersionPlatformCore
+import YouVersionPlatformUI
 
 struct BibleReaderFontListView: View {
     @Environment(BibleReaderViewModel.self) private var viewModel
@@ -25,12 +26,12 @@ struct BibleReaderFontListView: View {
             ScrollView {
                 VStack(alignment: .leading) {
                     Text(String.localized("fontList.suggested"))
-                        .font(ReaderFonts.fontHeaderM)
+                        .font(YouVersionFonts.fontHeaderM)
                     fontList(for: ReaderFonts.suggestedFamilies)
                     Divider()
                         .padding(.bottom, 8)
                     Text(String.localized("fontList.others"))
-                        .font(ReaderFonts.fontHeaderM)
+                        .font(YouVersionFonts.fontHeaderM)
                     fontList(for: ReaderFonts.otherFamilies)
                 }
                 .padding(.horizontal)

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import YouVersionPlatformCore
+import YouVersionPlatformUI
 
 struct BibleReaderFontSettingsView: View {
     @Environment(BibleReaderViewModel.self) private var viewModel

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFootnotesView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFootnotesView.swift
@@ -23,7 +23,7 @@ struct BibleReaderFootnotesView: View {
             if let version = viewModel.version,
                 let reference = viewModel.footnotesToDisplay.first?.reference {
                 Text(version.displayTitle(for: reference))
-                    .font(ReaderFonts.fontHeaderS)
+                    .font(YouVersionFonts.fontHeaderS)
                     .padding(.bottom)
                 ScrollView {
                     BibleTextView(reference, textOptions: textOptions)
@@ -36,7 +36,7 @@ struct BibleReaderFootnotesView: View {
                             let txt = footnote.text.setFont(.footnote, from: BibleTextFonts(familyName: "San Francisco", baseSize: 15))
                             HStack(alignment: .firstTextBaseline) {
                                 Text(character + ".")
-                                    .font(ReaderFonts.fontLabelS)
+                                    .font(YouVersionFonts.fontLabelS)
                                 Text(txt.asAttributedString)
                                     .multilineTextAlignment(.leading)
                             }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderIntroFootnoteView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderIntroFootnoteView.swift
@@ -8,7 +8,7 @@ struct BibleReaderIntroFootnoteView: View {
         ScrollView {
             VStack(alignment: .leading) {
                 Text(String.localized("reader.footnoteTitle"))
-                    .font(ReaderFonts.fontHeaderS)
+                    .font(YouVersionFonts.fontHeaderS)
                     .padding(.bottom)
                 ForEach(Array(viewModel.footnotesToDisplay.enumerated()), id: \.offset) { index, footnote in
                     let txt = footnote.text.setFont(.footnote, from: BibleTextFonts(familyName: "San Francisco", baseSize: 15))

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderLanguagesView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderLanguagesView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
+import YouVersionPlatformUI
 
-struct BibleReaderLanguagesView: View {
+struct BibleVersionsLanguagesView: View {
     @Environment(BibleVersionsViewModel.self) private var viewModel
 
     enum Segment: String, CaseIterable, Identifiable {
@@ -61,7 +62,7 @@ struct BibleReaderLanguagesView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     if selectedSegment == .suggested {
                         Text(String.localized("languageList.regional"))
-                            .font(ReaderFonts.fontHeaderM)
+                            .font(YouVersionFonts.fontHeaderM)
                             .padding(.leading)
                     }
                     ForEach(languageCodes, id: \.self) { language in
@@ -163,6 +164,6 @@ struct BibleReaderLanguagesView: View {
 }
 
 #Preview {
-    BibleReaderLanguagesView()
+    BibleVersionsLanguagesView()
         .environment(BibleVersionsViewModel.preview)
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderMyVersionsView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderMyVersionsView.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 import YouVersionPlatformCore
-import YouVersionPlatformUI
 
-public struct BibleReaderMyVersionsView: View {
+public struct BibleVersionsMyVersionsView: View {
     @Environment(BibleVersionsViewModel.self) private var viewModel
 
     public var body: some View {
@@ -10,7 +9,7 @@ public struct BibleReaderMyVersionsView: View {
             ScrollView {
                 VStack(spacing: 0) {
                     ForEach(sortedMyVersions, id: \.id) { v in
-                        BibleReaderMyVersionsListItem(item: v)
+                        BibleVersionsMyVersionsListItem(item: v)
                             .padding(.vertical, 6)
                     }
                 }
@@ -68,6 +67,6 @@ public struct BibleReaderMyVersionsView: View {
 }
 
 #Preview {
-    BibleReaderMyVersionsView()
+    BibleVersionsMyVersionsView()
         .environment(BibleVersionsViewModel.preview)
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionInfoView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionInfoView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import YouVersionPlatformCore
 import YouVersionPlatformUI
 
-struct BibleReaderVersionInfoView: View {
+struct BibleVersionsVersionInfoView: View {
     @Environment(BibleVersionsViewModel.self) private var viewModel
     @Environment(\.openURL) private var openURL
 
@@ -22,7 +22,7 @@ struct BibleReaderVersionInfoView: View {
                     if let urlstring = version.readerFooterUrl,
                        let url = URL(string: urlstring) {
                         Text(String.localized("versionInfo.detailsLabel"))
-                            .font(ReaderFonts.fontHeaderS)
+                            .font(YouVersionFonts.fontHeaderS)
                             .foregroundStyle(viewModel.readerTextMutedColor)
                         HStack {
                             Image(systemName: "globe")
@@ -74,15 +74,15 @@ struct BibleReaderVersionInfoView: View {
         VStack {
             if let version = viewModel.selectedVersion {
                 Text(version.localizedAbbreviation ?? version.abbreviation ?? "")
-                    .font(ReaderFonts.preferredBibleTextFont(size: 64))
+                    .font(YouVersionFonts.preferredBibleTextFont(size: 64))
                     .padding(.bottom, 8)
                 Text(version.localizedTitle ?? version.title ?? "")
-                    .font(ReaderFonts.fontHeaderM)
+                    .font(YouVersionFonts.fontHeaderM)
                     .multilineTextAlignment(.center)
                     .foregroundStyle(viewModel.readerTextPrimaryColor)
                     .padding(.bottom, 4)
                 Text(publisherLine(for: version))
-                    .font(ReaderFonts.fontLabelM)
+                    .font(YouVersionFonts.fontLabelM)
                     .multilineTextAlignment(.center)
                     .foregroundStyle(viewModel.readerTextMutedColor)
             }
@@ -217,6 +217,6 @@ struct BibleReaderVersionInfoView: View {
 }
 
 #Preview {
-    BibleReaderVersionInfoView()
+    BibleVersionsVersionInfoView()
         .environment(BibleVersionsViewModel.preview)
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionListView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionListView.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 import YouVersionPlatformCore
-import YouVersionPlatformUI
 
-public struct BibleReaderVersionListView: View {
+public struct BibleVersionsVersionListView: View {
     @Environment(BibleVersionsViewModel.self) private var viewModel
     @State private var searchText = ""
 
@@ -132,6 +131,6 @@ public struct BibleReaderVersionListView: View {
 }
 
 #Preview {
-    BibleReaderVersionListView()
+    BibleVersionsVersionListView()
         .environment(BibleVersionsViewModel.preview)
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionsStack.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionsStack.swift
@@ -1,10 +1,13 @@
 import SwiftUI
 import YouVersionPlatformCore
 
-struct BibleReaderVersionsStack: View {
+public struct BibleVersionsStack: View {
     @Environment(BibleVersionsViewModel.self) private var viewModel
 
-    var body: some View {
+    public init() {
+    }
+    
+    public var body: some View {
         @Bindable var bindableViewModel = viewModel
 
         NavigationStack(path: $bindableViewModel.versionsPickerStack) {
@@ -26,10 +29,10 @@ struct BibleReaderVersionsStack: View {
     @ViewBuilder
     private var rootView: some View {
         if viewModel.myVersions.count > 1 {
-            BibleReaderMyVersionsView()
+            BibleVersionsMyVersionsView()
         } else {
             ZStack {
-                BibleReaderVersionListView()
+                BibleVersionsVersionListView()
                 if viewModel.showFullProgressViewOverlay {
                     Color.gray.opacity(0.2)
                 }
@@ -45,20 +48,20 @@ struct BibleReaderVersionsStack: View {
     private func destinationView(for screen: BibleVersionsViewModel.VersionsPickerScreen) -> some View {
         switch screen {
         case .myVersions:
-            BibleReaderMyVersionsView()
+            BibleVersionsMyVersionsView()
         case .moreVersions:
-            BibleReaderVersionListView()
+            BibleVersionsVersionListView()
         case .versionInfo:
-            BibleReaderVersionInfoView()
+            BibleVersionsVersionInfoView()
         case .versionDownload:
             BibleVersionDownloadView()
         case .languages:
-            BibleReaderLanguagesView()
+            BibleVersionsLanguagesView()
         }
     }
 }
 
 #Preview {
-    BibleReaderVersionsStack()
+    BibleVersionsStack()
         .environment(BibleVersionsViewModel.preview)
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleVersionDownloadView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleVersionDownloadView.swift
@@ -12,14 +12,14 @@ struct BibleVersionDownloadView: View {
         VStack {
             if let version = viewModel.selectedVersion {
                 Text(version.localizedAbbreviation ?? "")
-                    .font(ReaderFonts.preferredBibleTextFont(size: 64))
+                    .font(YouVersionFonts.preferredBibleTextFont(size: 64))
                 Text(version.localizedTitle ?? version.title ?? "")
-                    .font(ReaderFonts.fontHeaderS)
+                    .font(YouVersionFonts.fontHeaderS)
 
                 HStack {
                     Text(String.localized("download.agreementParagraph"))
                         .padding()
-                        .font(ReaderFonts.fontCaptionsL)
+                        .font(YouVersionFonts.fontCaptionsL)
                     Button(action: {
                         viewModel.versionDownloadInfoButtonTapped(for: version)
                     }) {
@@ -30,7 +30,7 @@ struct BibleVersionDownloadView: View {
                 .padding(.horizontal, 32)
 
                 Text(String.localized("download.callToAction"))
-                    .font(ReaderFonts.fontHeaderS)
+                    .font(YouVersionFonts.fontHeaderS)
 
                 Button(action: {
                     viewModel.versionDownloadViewAccepted(for: version)

--- a/Sources/YouVersionPlatformReader/Utilities/CustomBackButton.swift
+++ b/Sources/YouVersionPlatformReader/Utilities/CustomBackButton.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import YouVersionPlatformUI
 
 extension View {
     func customBackButton(action: @escaping () -> Void) -> some View {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import YouVersionPlatformCore
-import YouVersionPlatformUI
 
 extension BibleVersionsViewModel {
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import YouVersionPlatformCore
-import YouVersionPlatformUI
 
 extension BibleVersionsViewModel {
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsPicker.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsPicker.swift
@@ -18,7 +18,7 @@ extension BibleVersionsViewModel {
         versionsPickerStack.removeLast()
     }
 
-    func openVersionsStack(currentBibleLanguage: String) {
+    public func openVersionsStack(currentBibleLanguage: String) {
         Task {
             await permittedVersionsListing()
         }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -6,7 +6,7 @@ import YouVersionPlatformUI
 
 @MainActor
 @Observable
-final class BibleReaderViewModel {
+final class BibleReaderViewModel: ReaderThemeProviding {
     private let userDefaultsKeyForBibleReference = "bible-reader-view--reference"
     private let userDefaultsKeyForBibleDisplayIntro = "bible-reader-view--displayintro"
     private let userDefaultsKeyForReaderSettings = "bible-reader-view--readersettings"
@@ -55,6 +55,7 @@ final class BibleReaderViewModel {
         self.onVerseTap = onVerseTap
         self.verseSelectionStyle = verseSelectionStyle
         self.highlightsViewModel = highlightsViewModel ?? BibleHighlightsViewModel()
+        let shouldLoadVersionsViewModel = versionsViewModel == nil
         self.versionsViewModel = versionsViewModel ?? BibleVersionsViewModel { _ in }
         self.versionsViewModel.onVersionChange = { [weak self] version in
             self?.onVersionChange(version: version)
@@ -67,6 +68,13 @@ final class BibleReaderViewModel {
         self.versionsViewModel.colorTheme = colorTheme
 
         ReaderFonts.installFontsIfNeeded()
+
+        if shouldLoadVersionsViewModel {
+            let initialVersionId = self.reference.versionId
+            Task { [weak self] in
+                await self?.versionsViewModel.loadInitialState(initialVersionId: initialVersionId)
+            }
+        }
     }
     
     func onVersionChange(version: BibleVersion) {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
@@ -2,17 +2,17 @@ import CoreText
 import Foundation
 import SwiftUI
 import YouVersionPlatformCore
-import YouVersionPlatformUI
 
 @MainActor
 @Observable
-final class BibleVersionsViewModel {
+public final class BibleVersionsViewModel {
     private let userDefaultsKeyForMyVersions = "bible-reader-view--my-versions"
-    let versionRepository = BibleVersionRepository()
-    var onVersionChange: ((BibleVersion) -> Void)
+    private var hasLoadedInitialState = false
+    public let versionRepository = BibleVersionRepository()
+    public var onVersionChange: ((BibleVersion) -> Void)
     /// called when the user chooses to download a version and they're not yet signed in.
-    var onSignInRequired: (() -> Void)?
-    var colorTheme: ReaderTheme?
+    public var onSignInRequired: (() -> Void)?
+    public var colorTheme: ReaderTheme?
     
     var currentBibleVersionLanguage: String?
     
@@ -22,20 +22,26 @@ final class BibleVersionsViewModel {
     private(set) var textForGenericAlertOKButton = "OK"
     
     /// onVersionChange: called when the user has chosen a new version (or their first). The caller should ensure their current reference exists in this new version and choose a new one if not.
-    init (initialVersionId: Int? = nil, onVersionChange: @escaping (BibleVersion) -> Void) {
-        // grab the saved data first, because initializing myVersions will clear the saved data.
-        let savedIds = UserDefaults.standard.array(forKey: userDefaultsKeyForMyVersions) as? [Int] ?? []
-        
+    public init(onVersionChange: @escaping (BibleVersion) -> Void) {
         self.myVersions = []
         self.suggestedLanguagesList = []
         self.onVersionChange = onVersionChange
-        
-        Task {
-            await loadVersion(versionId: initialVersionId, savedIds: savedIds)
-            await restoreMyVersions(savedIds: savedIds)
-            await loadSuggestedLanguages()
-            await removeUnpermittedVersions(initialVersionId: initialVersionId)
+    }
+
+    /// Loads the initial version data once for this model instance.
+    public func loadInitialState(initialVersionId: Int? = nil) async {
+        guard !hasLoadedInitialState else {
+            return
         }
+        hasLoadedInitialState = true
+
+        // Grab the saved data first, because initializing myVersions clears the saved data.
+        let savedIds = UserDefaults.standard.array(forKey: userDefaultsKeyForMyVersions) as? [Int] ?? []
+
+        await loadVersion(versionId: initialVersionId, savedIds: savedIds)
+        await restoreMyVersions(savedIds: savedIds)
+        await loadSuggestedLanguages()
+        await removeUnpermittedVersions(initialVersionId: initialVersionId)
     }
     
     private func removeUnpermittedVersions(initialVersionId: Int?) async {
@@ -206,7 +212,7 @@ final class BibleVersionsViewModel {
     var showFullProgressViewOverlay = false
     
     // MARK: - My Versions
-    var myVersions: Set<BibleVersion> = [] {
+    public var myVersions: Set<BibleVersion> = [] {
         didSet {
             Task {
                 // The below iteration must be run in a Task to avoid view re-creation loops.
@@ -285,7 +291,7 @@ final class BibleVersionsViewModel {
         case languages
     }
     
-    var showingVersionsStack = false
+    public var showingVersionsStack = false
     var versionsPickerStack: [VersionsPickerScreen] = []
     
     var selectedVersion: BibleVersion?
@@ -303,7 +309,7 @@ final class BibleVersionsViewModel {
         }
         return org.name
     }
-
+    
     // MARK: - Preview helper
 
     public static var preview: BibleVersionsViewModel {

--- a/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
@@ -95,23 +95,7 @@ public enum ReaderFonts {
     static let defaultFontSize: CGFloat = 21
     static let defaultLineSpacing: CGFloat = 12
 
-    // MARK: - UI Fonts
-
-    static let fontSystemM = Font.system(size: 18, weight: .medium)
-    static let fontHeaderM = Font.system(size: 20, weight: .bold)
-    static let fontHeaderS = Font.system(size: 16, weight: .bold)
-    static let fontEyebrowS = Font.system(size: 11, weight: .bold)
-    static let fontLabelM = Font.system(size: 13, weight: .medium)
-    static let fontLabelS = Font.system(size: 11, weight: .medium)
-    static let fontCaptionsL = Font.system(size: 13)
-    static let fontCaptionsS = Font.system(size: 11)
-
     // MARK: - Utility Functions
-
-    /// For YouVersion uses of the Untitled font, we will use Baskerville as a fallback
-    static func preferredBibleTextFont(size: CGFloat) -> Font {
-        Font.custom("Baskerville", size: size)
-    }
 
     static func nextSmallerSize(currentSize: CGFloat) -> CGFloat? {
         let currentSizeInt = Int(currentSize)

--- a/Sources/YouVersionPlatformReader/ViewModels/ReaderThemes.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/ReaderThemes.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-public struct ReaderTheme: Identifiable, Sendable {
+public struct ReaderTheme: Identifiable, Equatable, Sendable {
     public let id: Int
     public let foreground: Color
     public let background: Color

--- a/Sources/YouVersionPlatformReader/ViewModels/ReaderThemes.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/ReaderThemes.swift
@@ -1,17 +1,17 @@
 import Foundation
 import SwiftUI
 
-struct ReaderTheme: Identifiable {
-    let id: Int
-    let foreground: Color
-    let background: Color
-    let colorScheme: ColorScheme
+public struct ReaderTheme: Identifiable, Sendable {
+    public let id: Int
+    public let foreground: Color
+    public let background: Color
+    public let colorScheme: ColorScheme
 
-    static func == (lhs: ReaderTheme, rhs: ReaderTheme) -> Bool {
+    public static func == (lhs: ReaderTheme, rhs: ReaderTheme) -> Bool {
         lhs.foreground == rhs.foreground && lhs.background == rhs.background
     }
 
-    static let allThemes: [ReaderTheme] = [
+    public static let allThemes: [ReaderTheme] = [
         ReaderTheme(id: 1, foreground: Color(hex: "#121212"), background: Color(hex: "#ffffff"), colorScheme: .light),
         ReaderTheme(id: 2, foreground: Color(hex: "#121212"), background: Color(hex: "#f6efee"), colorScheme: .light),
         ReaderTheme(id: 3, foreground: Color(hex: "#121212"), background: Color(hex: "#edefef"), colorScheme: .light),
@@ -21,114 +21,112 @@ struct ReaderTheme: Identifiable {
         ReaderTheme(id: 7, foreground: Color(hex: "#ffffff"), background: Color(hex: "#121212"), colorScheme: .dark)
     ]
 
-    static func theme(withId: Int? = nil) -> ReaderTheme {
+    public static func theme(withId: Int? = nil) -> ReaderTheme {
         allThemes.first(where: { $0.id == withId }) ?? allThemes.first!
     }
 }
 
 @MainActor
-protocol ReaderThemeProviding {
+public protocol ReaderThemeProviding {
     var colorTheme: ReaderTheme? { get }
 }
 
 @MainActor
 extension ReaderThemeProviding {
-    func colorForScheme(light: Color, dark: Color) -> Color {
+    public func colorForScheme(light: Color, dark: Color) -> Color {
         colorTheme?.colorScheme == .dark ? dark : light
     }
 
-    var readerCanvasPrimaryColor: Color {
+    public var readerCanvasPrimaryColor: Color {
         colorTheme?.background ?? (colorTheme?.colorScheme != .dark ? readerWhiteColor : readerBlackColor)
     }
 
-    var readerTextPrimaryColor: Color {
+    public var readerTextPrimaryColor: Color {
         colorTheme?.foreground ?? (colorTheme?.colorScheme != .dark ? readerBlackColor : readerWhiteColor)
     }
 
-    var readerVerseNumColor: Color {
+    public var readerVerseNumColor: Color {
         colorTheme?.colorScheme != .dark ? Color(hex: "#9d9d9d") : Color(hex: "#636161")
     }
 
-    var readerTextMutedColor: Color {
+    public var readerTextMutedColor: Color {
         readerTextPrimaryColor == readerWhiteColor ? Color(hex: "#636161") : Color(hex: "#bfbdbd")
     }
 
-    var readerSurfacePrimaryColor: Color {
+    public var readerSurfacePrimaryColor: Color {
         colorForScheme(
             light: Color(hex: "f6f4f4"),
             dark: Color(hex: "232121")
         )
     }
 
-    var readerSurfaceTertiaryColor: Color {
+    public var readerSurfaceTertiaryColor: Color {
         colorForScheme(
             light: Color(hex: "EDEBEB"),
             dark: Color(hex: "353333")
         )
     }
 
-    var readerBorderPrimaryColor: Color {
+    public var readerBorderPrimaryColor: Color {
         colorForScheme(
             light: Color(hex: "dddbdb"),
             dark: Color(hex: "474545")
         )
     }
 
-    var readerBorderSecondaryColor: Color {
+    public var readerBorderSecondaryColor: Color {
         colorForScheme(
             light: Color(hex: "bfbdbd"),
             dark: Color(hex: "636161")
         )
     }
 
-    var readerButtonPrimaryColor: Color {
+    public var readerButtonPrimaryColor: Color {
         colorForScheme(
             light: Color(hex: "#edebeb"),
             dark: Color(hex: "#353333")
         )
     }
 
-    var readerButtonSecondaryColor: Color {
+    public var readerButtonSecondaryColor: Color {
         colorForScheme(
             light: Color(hex: "dddbdb"),
             dark: Color(hex: "474545")
         )
     }
 
-    var readerButtonContrastColor: Color {
+    public var readerButtonContrastColor: Color {
         colorForScheme(
             light: Color(hex: "121212"),
             dark: Color(hex: "edebeb")
         )
     }
 
-    var readerTextInvertedColor: Color {
+    public var readerTextInvertedColor: Color {
         colorForScheme(
             light: readerWhiteColor,
             dark: readerBlackColor
         )
     }
 
-    var readerWhiteColor: Color {
+    public var readerWhiteColor: Color {
         Color(hex: "#ffffff")
     }
 
-    var readerBlackColor: Color {
+    public var readerBlackColor: Color {
         Color(hex: "#121212")
     }
 
-    var readerDropShadowColor: Color {
+    public var readerDropShadowColor: Color {
         Color(hex: "#777777").opacity(0.5)
     }
 
-    var readerWordsOfChristColor: Color {
+    public var readerWordsOfChristColor: Color {
         colorForScheme(
             light: Color(hex: "#ff3d4d"),
             dark: Color(hex: "#F04C59")
         )
     }
 }
-
-extension BibleReaderViewModel: ReaderThemeProviding {}
 
 extension BibleVersionsViewModel: ReaderThemeProviding {}

--- a/Sources/YouVersionPlatformUI/Utilities/YouVersionFonts.swift
+++ b/Sources/YouVersionPlatformUI/Utilities/YouVersionFonts.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+public enum YouVersionFonts {
+    public static let fontSystemM = Font.system(size: 18, weight: .medium)
+    public static let fontHeaderM = Font.system(size: 20, weight: .bold)
+    public static let fontHeaderS = Font.system(size: 16, weight: .bold)
+    public static let fontEyebrowS = Font.system(size: 11, weight: .bold)
+    public static let fontLabelM = Font.system(size: 13, weight: .medium)
+    public static let fontLabelS = Font.system(size: 11, weight: .medium)
+    public static let fontCaptionsL = Font.system(size: 13)
+    public static let fontCaptionsS = Font.system(size: 11)
+
+    /// For YouVersion uses of the Untitled font, use Baskerville as a fallback.
+    public static func preferredBibleTextFont(size: CGFloat) -> Font {
+        Font.custom("Baskerville", size: size)
+    }
+}

--- a/Sources/YouVersionPlatformUI/Views/SignInWithYouVersionView.swift
+++ b/Sources/YouVersionPlatformUI/Views/SignInWithYouVersionView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import YouVersionPlatformCore
+import YouVersionPlatformUI
 
 /// A reusable sign-in prompt view. Reads ``YouVersionPlatformConfiguration/appName``
 /// and ``YouVersionPlatformConfiguration/signInPromptMessage`` from the global configuration.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames `BibleReader*` views and sheets to `BibleVersions*` to better reflect their purpose, extracts UI font constants from `ReaderFonts` into a new public `YouVersionFonts` enum in `YouVersionPlatformUI`, and makes `BibleVersionsViewModel` public with a decoupled `loadInitialState` async method. The overall refactor is clean and well-scoped, with one build-breaking issue to address.

- `import YouVersionPlatformUI` was added to `SignInWithYouVersionView.swift`, which is itself inside the `YouVersionPlatformUI` module — this self-import creates a circular dependency that will fail the build and should be removed.

<h3>Confidence Score: 4/5</h3>

One build-breaking self-import in `SignInWithYouVersionView.swift` must be removed before merging.

The rename and font-extraction work is clean and correct. The single blocking issue is a spurious `import YouVersionPlatformUI` added to a file that lives inside that module, which will prevent the package from compiling.

Sources/YouVersionPlatformUI/Views/SignInWithYouVersionView.swift — self-import introduced in this PR.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformUI/Views/SignInWithYouVersionView.swift | Self-import of `YouVersionPlatformUI` added to a file within that same module — will break the build. |
| Sources/YouVersionPlatformUI/Utilities/YouVersionFonts.swift | New public enum consolidating UI font constants and `preferredBibleTextFont` from `ReaderFonts`, now accessible across modules. |
| Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift | Made public; init simplified and async loading moved to `loadInitialState(initialVersionId:)`; `myVersions` and `showingVersionsStack` are now `public`. |
| Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift | UI font constants and `preferredBibleTextFont` removed from `ReaderFonts` (moved to `YouVersionFonts`); font installation and size/spacing logic unchanged. |
| Sources/YouVersionPlatformReader/ViewModels/ReaderThemes.swift | `ReaderTheme` made `public` with `Equatable` and `Sendable` conformances declared; all members promoted to `public`. |
| Sources/YouVersionPlatformReader/Sheets/BibleReaderVersionsStack.swift | Renamed to `BibleVersionsStack`; all internal view references updated to `BibleVersions*` counterparts. |
| Sources/YouVersionPlatformReader/Components/BibleReaderMyVersionsListItem.swift | Renamed to `BibleVersionsMyVersionsListItem`; `ReaderFonts` font calls replaced with `YouVersionFonts`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph YouVersionPlatformUI
        YVF["YouVersionFonts\n(new: font constants\n+ preferredBibleTextFont)"]
        SIVY["SignInWithYouVersionView\n⚠️ +import YouVersionPlatformUI"]
    end

    subgraph YouVersionPlatformReader
        RF["ReaderFonts\n(font install + sizes only)"]
        BVsVM["BibleVersionsViewModel\n(public, loadInitialState async)"]
        BVsStack["BibleVersionsStack\n(renamed from BibleReaderVersionsStack)"]
        Sheets["BibleVersions* sheets\n(renamed from BibleReader*)"]
        BRVM["BibleReaderViewModel\n(calls loadInitialState)"]
    end

    YVF -->|replaces font constants| RF
    BRVM -->|Task await| BVsVM
    BVsStack --> Sheets
    BVsStack -->|environment| BVsVM
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: Sources/YouVersionPlatformUI/Views/SignInWithYouVersionView.swift
Line: 3

Comment:
**Self-import will break the build**

`SignInWithYouVersionView.swift` lives inside the `YouVersionPlatformUI` module, so adding `import YouVersionPlatformUI` here creates a circular dependency. SPM must compile the module before any file inside it can import it, which means this import will cause a build failure. The file doesn't reference any symbol that requires this import — it can be removed safely.

```suggestion
import YouVersionPlatformCore
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["add Equatable"](https://github.com/youversion/platform-sdk-swift/commit/c7c5fd041eb608f1de11acb90a8ceb5a3d102dc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29136920)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->