### PR TITLE
feat: actually add the button

### DIFF
--- a/Examples/SampleApp/CardView.swift
+++ b/Examples/SampleApp/CardView.swift
@@ -7,16 +7,18 @@ struct CardView: View {
             reference: BibleReference(
                 versionId: 3034, bookUSFM: "2CO", chapter: 1, verseStart: 3, verseEnd: 4
             ),
-            fontSize: 18
+            fontSize: 18,
+            showVersionPicker: true
         )
     }
 }
 
 #Preview {
     VStack {
+        Divider()
         CardView()
+        Divider()
         Spacer()
     }
     .padding(.vertical, 8)
-    .background(.blue)
 }

--- a/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
@@ -104,6 +104,29 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         }
     }
 
+    /// Returns whether this reference is available in the provided Bible version metadata.
+    public func existsIn(version: BibleVersion) -> Bool {
+        let normalizedBookUSFM = bookUSFM.uppercased()
+        guard version.bookUSFMs.contains(where: { $0.uppercased() == normalizedBookUSFM }) else {
+            return false
+        }
+
+        guard let book = version.book(with: normalizedBookUSFM) else {
+            return true
+        }
+
+        guard let chapters = book.chapters else {
+            return true
+        }
+
+        let chapterText = String(chapter)
+        return chapters.contains { chapterMetadata in
+            chapterMetadata.id == chapterText ||
+            chapterMetadata.title == chapterText ||
+            chapterMetadata.passageId == chapterUSFM
+        }
+    }
+
     public func overlaps(with otherReference: BibleReference) -> Bool {
         guard versionId == otherReference.versionId &&
                 bookUSFM == otherReference.bookUSFM else {

--- a/Sources/YouVersionPlatformUI/Objects/BibleVersion+Additions.swift
+++ b/Sources/YouVersionPlatformUI/Objects/BibleVersion+Additions.swift
@@ -48,7 +48,7 @@ public extension BibleVersion {
 
     private func titleChunks(for reference: BibleReference) -> [String] {
         let bookUSFM = reference.bookUSFM
-        let bookName = bookName(bookUSFM) ?? ""
+        let bookName = bookName(bookUSFM) ?? bookUSFM
 
         let hasOneChapter = chapterLabels(bookUSFM).count == 1
         let chapterSeparator = hasOneChapter ? " " : ":"

--- a/Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings
+++ b/Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings
@@ -121,6 +121,17 @@
         }
       }
     },
+    "bibleCard.unavailableReference" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This passage is unavailable in the selected Bible version."
+          }
+        }
+      }
+    },
     "download.agreeButton" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
@@ -2,13 +2,21 @@ import SwiftUI
 import YouVersionPlatformCore
 
 public struct BibleCardView: View {
-    public let reference: BibleReference
+    @State private var reference: BibleReference
     @State private var version: BibleVersion?
     private let textOptions: BibleTextOptions
     @Environment(\.colorScheme) private var colorScheme
     @State private var showingCopyrightSheet = false
+    @State private var showVersionPicker: Bool
+    private let onVersionChange: ((BibleVersion) -> Void)?
 
-    public init(reference: BibleReference, fontFamily: String = "STIX Two Text", fontSize: CGFloat = 23) {
+    public init(
+        reference: BibleReference,
+        fontFamily: String = "STIX Two Text",
+        fontSize: CGFloat = 23,
+        showVersionPicker: Bool = false,
+        onVersionChange: ((BibleVersion) -> Void)? = nil
+    ) {
         self.reference = reference
         self.version = nil
         self.textOptions = BibleTextOptions(
@@ -17,13 +25,46 @@ public struct BibleCardView: View {
             textColor: Color.primary,
             verseNumColor: Color.secondary
         )
+        self.showVersionPicker = showVersionPicker
+        self.onVersionChange = onVersionChange
     }
-
+    
+    func update(version: BibleVersion) {
+        self.version = version
+        // TODO Check if the book, chapter, and/or range is present in this version. Show error if not.
+        reference = BibleReference(
+            versionId: version.id,
+            bookUSFM: reference.bookUSFM,
+            chapter: reference.chapter,
+            verseStart: reference.verseStart ?? 1,
+            verseEnd: reference.verseEnd ?? 999  // TODO better
+        )
+        onVersionChange?(version)
+    }
+    
     public var body: some View {
         VStack(spacing: 16) {
             HStack {
                 headerReference
                 Spacer()
+                if showVersionPicker {
+                    BibleVersionPickingButton(initialVersionId: reference.versionId) { version in
+                        update(version: version)
+                        // TODO
+                        //                    } label: { //versionId in
+                        //                        Text(version?.localizedAbbreviation ?? "")
+                        //                        .font(.system(size: 14))
+                        //                        .fontWeight(.bold)
+                        //                        .padding(.vertical, 8)
+                        //                        .padding(.horizontal, 16)
+                        //                        .frame(minWidth: 50)
+                        //                        .background(
+                        //                            Capsule()
+                        //                                .fill(colorScheme == .dark ? Color(hex: "#353333") : Color(hex: "#edebeb"))  // readerButtonPrimaryColor
+                        //                        )
+                        
+                    }
+                }
             }
             BibleTextView(reference, textOptions: textOptions)
             HStack(alignment: .top) {
@@ -47,7 +88,7 @@ public struct BibleCardView: View {
         .sheet(isPresented: $showingCopyrightSheet) {
             ScrollView {
                 Text(version?.localizedTitle ?? version?.title ?? "")
-                    .font(Font.system(size: 20, weight: .bold))  // YouVersion HeaderM
+                    .font(YouVersionFonts.fontHeaderM)
                     .padding(.vertical)
                 Text(version?.promotionalContent ?? version?.copyright ?? "")
                     .padding()
@@ -64,21 +105,17 @@ public struct BibleCardView: View {
     private var backgroundColor: Color {
         colorScheme == .dark ? Color(hex: "#121212") : Color(hex: "#ffffff")
     }
-
+    
     private var headerReference: some View {
         if let version {
             let refText = version.displayTitle(for: reference)
             return Text(refText)
-                .font(fontEyebrowS.smallCaps())
+                .font(YouVersionFonts.fontEyebrowS.smallCaps())
                 .tracking(1.5)
         }
         return Text("")
     }
-
-    private var fontEyebrowS: Font {
-        Font.system(size: 11, weight: .bold)
-    }
-
+    
     private var copyrightView: some View {
         let copyright = version?.copyright ?? version?.promotionalContent ?? ""
         return Text(copyright)
@@ -88,13 +125,13 @@ public struct BibleCardView: View {
             .minimumScaleFactor(0.7)
             .lineLimit(4)
     }
-
+    
     private var bibleAppLogo: some View {
         Image("BibleAppLogotype@3x", bundle: .YouVersionUIBundle)
             .resizable()
             .frame(width: 106, height: 24)
     }
-
+    
 }
 
 #Preview {
@@ -105,7 +142,7 @@ public struct BibleCardView: View {
             )
         )
         .environment(\.colorScheme, .dark)
-
+        
         BibleCardView(
             reference: BibleReference(
                 versionId: BibleVersion.preview.id, bookUSFM: "JHN", chapter: 1, verseStart: 2, verseEnd: 2

--- a/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
@@ -4,10 +4,11 @@ import YouVersionPlatformCore
 public struct BibleCardView: View {
     @State private var reference: BibleReference
     @State private var version: BibleVersion?
+    @State private var isReferenceUnavailable = false
     private let textOptions: BibleTextOptions
     @Environment(\.colorScheme) private var colorScheme
     @State private var showingCopyrightSheet = false
-    @State private var showVersionPicker: Bool
+    private let showVersionPicker: Bool
     private let onVersionChange: ((BibleVersion) -> Void)?
 
     public init(
@@ -29,16 +30,11 @@ public struct BibleCardView: View {
         self.onVersionChange = onVersionChange
     }
     
-    func update(version: BibleVersion) {
+    private func update(version: BibleVersion) {
+        let updatedReference = referenceForVersionId(version.id)
         self.version = version
-        // TODO Check if the book, chapter, and/or range is present in this version. Show error if not.
-        reference = BibleReference(
-            versionId: version.id,
-            bookUSFM: reference.bookUSFM,
-            chapter: reference.chapter,
-            verseStart: reference.verseStart ?? 1,
-            verseEnd: reference.verseEnd ?? 999  // TODO better
-        )
+        reference = updatedReference
+        isReferenceUnavailable = !updatedReference.existsIn(version: version)
         onVersionChange?(version)
     }
     
@@ -50,23 +46,14 @@ public struct BibleCardView: View {
                 if showVersionPicker {
                     BibleVersionPickingButton(initialVersionId: reference.versionId) { version in
                         update(version: version)
-                        // TODO
-                        //                    } label: { //versionId in
-                        //                        Text(version?.localizedAbbreviation ?? "")
-                        //                        .font(.system(size: 14))
-                        //                        .fontWeight(.bold)
-                        //                        .padding(.vertical, 8)
-                        //                        .padding(.horizontal, 16)
-                        //                        .frame(minWidth: 50)
-                        //                        .background(
-                        //                            Capsule()
-                        //                                .fill(colorScheme == .dark ? Color(hex: "#353333") : Color(hex: "#edebeb"))  // readerButtonPrimaryColor
-                        //                        )
-                        
                     }
                 }
             }
-            BibleTextView(reference, textOptions: textOptions)
+            if isReferenceUnavailable {
+                unavailableReferenceView
+            } else {
+                BibleTextView(reference, textOptions: textOptions)
+            }
             HStack(alignment: .top) {
                 copyrightView
                     .padding(.trailing, 16)
@@ -82,7 +69,10 @@ public struct BibleCardView: View {
         .foregroundStyle(foregroundColor)
         .task {
             if version == nil {
-                version = try? await BibleVersionRepository.shared.version(withId: reference.versionId)
+                if let loadedVersion = try? await BibleVersionRepository.shared.version(withId: reference.versionId) {
+                    version = loadedVersion
+                    isReferenceUnavailable = !reference.existsIn(version: loadedVersion)
+                }
             }
         }
         .sheet(isPresented: $showingCopyrightSheet) {
@@ -104,6 +94,15 @@ public struct BibleCardView: View {
     
     private var backgroundColor: Color {
         colorScheme == .dark ? Color(hex: "#121212") : Color(hex: "#ffffff")
+    }
+
+    private var unavailableReferenceView: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+            Text(String.localized("bibleCard.unavailableReference"))
+                .multilineTextAlignment(.leading)
+        }
+        .frame(maxWidth: .infinity, minHeight: 80, alignment: .leading)
     }
     
     private var headerReference: some View {
@@ -130,6 +129,34 @@ public struct BibleCardView: View {
         Image("BibleAppLogotype@3x", bundle: .YouVersionUIBundle)
             .resizable()
             .frame(width: 106, height: 24)
+    }
+
+    private func referenceForVersionId(_ versionId: Int) -> BibleReference {
+        if let verseStart = reference.verseStart {
+            let verseEnd = reference.verseEnd ?? verseStart
+            if verseStart == verseEnd {
+                return BibleReference(
+                    versionId: versionId,
+                    bookUSFM: reference.bookUSFM,
+                    chapter: reference.chapter,
+                    verse: verseStart
+                )
+            }
+
+            return BibleReference(
+                versionId: versionId,
+                bookUSFM: reference.bookUSFM,
+                chapter: reference.chapter,
+                verseStart: verseStart,
+                verseEnd: verseEnd
+            )
+        }
+
+        return BibleReference(
+            versionId: versionId,
+            bookUSFM: reference.bookUSFM,
+            chapter: reference.chapter
+        )
     }
     
 }

--- a/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
@@ -70,6 +70,9 @@ public struct BibleCardView: View {
         .task {
             if version == nil {
                 if let loadedVersion = try? await BibleVersionRepository.shared.version(withId: reference.versionId) {
+                    guard version == nil else {
+                        return
+                    }
                     version = loadedVersion
                     isReferenceUnavailable = !reference.existsIn(version: loadedVersion)
                 }

--- a/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
@@ -39,7 +39,7 @@ public struct BibleCardView: View {
     }
     
     public var body: some View {
-        VStack(spacing: 16) {
+        VStack(alignment: .leading, spacing: 16) {
             HStack {
                 headerReference
                 Spacer()

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionDownloadView.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionDownloadView.swift
@@ -10,7 +10,7 @@ struct BibleVersionDownloadView: View {
 
         VStack {
             if let version = viewModel.selectedVersion {
-                Text(version.localizedAbbreviation ?? "")
+                Text(version.localizedAbbreviation ?? version.abbreviation ?? "")
                     .font(YouVersionFonts.preferredBibleTextFont(size: 64))
                 Text(version.localizedTitle ?? version.title ?? "")
                     .font(YouVersionFonts.fontHeaderS)

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift
@@ -3,8 +3,7 @@ import YouVersionPlatformCore
 
 public struct BibleVersionPickingButton: View {
     @State private var versionsViewModel: BibleVersionsViewModel
-    @State private var currentVersionId: Int
-    @State private var currentVersionAbbreviation: String?
+    @State private var version: BibleVersion?
     private let initialVersionId: Int
     private let onVersionChange: ((BibleVersion) -> Void)?
 
@@ -13,7 +12,6 @@ public struct BibleVersionPickingButton: View {
         onVersionChange: ((BibleVersion) -> Void)? = nil
     ) {
         self.initialVersionId = initialVersionId
-        self.currentVersionId = initialVersionId
         self.versionsViewModel = BibleVersionsViewModel { _ in }
         self.onVersionChange = onVersionChange
     }
@@ -22,9 +20,9 @@ public struct BibleVersionPickingButton: View {
         @Bindable var bindableVersionsViewModel = versionsViewModel
 
         Button {
-            versionsViewModel.openVersionsStack(currentBibleLanguage: versionsViewModel.currentBibleVersionLanguage ?? "en")
+            versionsViewModel.openVersionsStack(currentBibleLanguage: version?.languageTag ?? "en")
         } label: {
-            Text(currentVersionAbbreviation ?? " ")
+            Text(version?.localizedAbbreviation ?? version?.abbreviation ?? " ")
                 .font(.system(size: 14, weight: .semibold))
                 .frame(minWidth: 30)
         }
@@ -40,20 +38,10 @@ public struct BibleVersionPickingButton: View {
             versionsViewModel.onVersionChange = handleVersionChange
             await versionsViewModel.loadInitialState(initialVersionId: initialVersionId)
         }
-        .onChange(of: currentVersionId, initial: true) { _, newVersionId in
-            Task {
-                let captured = newVersionId
-                if let version = try? await BibleVersionRepository.shared.version(withId: captured) {
-                    guard currentVersionId == captured else { return }
-                    self.currentVersionAbbreviation = version.localizedAbbreviation ?? "\(captured)"
-                }
-            }
-        }
     }
 
     private func handleVersionChange(_ version: BibleVersion) {
-        currentVersionId = version.id
-        versionsViewModel.currentBibleVersionLanguage = version.languageTag
+        self.version = version
         onVersionChange?(version)
     }
 }

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift
@@ -42,8 +42,10 @@ public struct BibleVersionPickingButton: View {
         }
         .onChange(of: currentVersionId, initial: true) { _, newVersionId in
             Task {
-                if let version = try? await BibleVersionRepository.shared.version(withId: newVersionId) {
-                    self.currentVersionAbbreviation = version.localizedAbbreviation ?? "\(newVersionId)"
+                let captured = newVersionId
+                if let version = try? await BibleVersionRepository.shared.version(withId: captured) {
+                    guard currentVersionId == captured else { return }
+                    self.currentVersionAbbreviation = version.localizedAbbreviation ?? "\(captured)"
                 }
             }
         }

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import YouVersionPlatformCore
+
+public struct BibleVersionPickingButton: View {
+    @State private var versionsViewModel: BibleVersionsViewModel
+    @State private var currentVersionId: Int
+    @State private var currentVersionAbbreviation: String?
+    private let initialVersionId: Int
+    private let onVersionChange: ((BibleVersion) -> Void)?
+
+    public init(
+        initialVersionId: Int,
+        onVersionChange: ((BibleVersion) -> Void)? = nil
+    ) {
+        self.initialVersionId = initialVersionId
+        self.currentVersionId = initialVersionId
+        self.versionsViewModel = BibleVersionsViewModel { _ in }
+        self.onVersionChange = onVersionChange
+    }
+
+    public var body: some View {
+        @Bindable var bindableVersionsViewModel = versionsViewModel
+
+        Button {
+            versionsViewModel.openVersionsStack(currentBibleLanguage: versionsViewModel.currentBibleVersionLanguage ?? "en")
+        } label: {
+            Text(currentVersionAbbreviation ?? " ")
+                .font(.system(size: 14, weight: .semibold))
+                .frame(minWidth: 30)
+        }
+        .foregroundStyle(Color.primary)
+        .buttonStyle(.bordered)
+        .sheet(isPresented: $bindableVersionsViewModel.showingVersionsStack) {
+            BibleVersionsStack()
+                .environment(versionsViewModel)
+                .presentationDragIndicator(.visible)
+                .presentationDetents([.large])
+        }
+        .task {
+            versionsViewModel.onVersionChange = handleVersionChange
+            await versionsViewModel.loadInitialState(initialVersionId: initialVersionId)
+        }
+        .onChange(of: currentVersionId, initial: true) { _, newVersionId in
+            Task {
+                if let version = try? await BibleVersionRepository.shared.version(withId: newVersionId) {
+                    self.currentVersionAbbreviation = version.localizedAbbreviation ?? "\(newVersionId)"
+                }
+            }
+        }
+    }
+
+    private func handleVersionChange(_ version: BibleVersion) {
+        currentVersionId = version.id
+        versionsViewModel.currentBibleVersionLanguage = version.languageTag
+        onVersionChange?(version)
+    }
+}
+
+#Preview {
+    BibleVersionPickingButton(initialVersionId: 3034)
+}

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_existsIn.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_existsIn.swift
@@ -24,6 +24,27 @@ struct BibleReferenceExistsInTests {
     }
 
     @Test
+    func existsInReturnsTrueForChapterOnlyReferenceWhenChapterIsPresent() {
+        let reference = BibleReference(versionId: 206, bookUSFM: "GEN", chapter: 1)
+
+        #expect(reference.existsIn(version: Self.fixtureVersion))
+    }
+
+    @Test
+    func existsInReturnsFalseForChapterOnlyReferenceWhenBookIsMissing() {
+        let reference = BibleReference(versionId: 206, bookUSFM: "ABC", chapter: 1)
+
+        #expect(!reference.existsIn(version: Self.fixtureVersion))
+    }
+
+    @Test
+    func existsInReturnsFalseForChapterOnlyReferenceWhenChapterIsMissing() {
+        let reference = BibleReference(versionId: 206, bookUSFM: "GEN", chapter: 51)
+
+        #expect(!reference.existsIn(version: Self.fixtureVersion))
+    }
+
+    @Test
     func existsInReturnsFalseWhenBookIsMissing() {
         let reference = BibleReference(versionId: 206, bookUSFM: "ABC", chapter: 1, verse: 1)
 

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_existsIn.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_existsIn.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+@testable import YouVersionPlatformCore
+
+struct BibleReferenceExistsInTests {
+
+    private static let fixtureVersion: BibleVersion = {
+        guard let url = Bundle.module.url(forResource: "bible_206", withExtension: "json") else {
+            fatalError("Missing bible_206.json fixture in test bundle")
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            return try JSONDecoder().decode(BibleVersion.self, from: data)
+        } catch {
+            fatalError("Failed to decode bible_206.json: \(error)")
+        }
+    }()
+
+    @Test
+    func existsInReturnsTrueWhenBookAndChapterArePresent() {
+        let reference = BibleReference(versionId: 206, bookUSFM: "GEN", chapter: 1, verse: 1)
+
+        #expect(reference.existsIn(version: Self.fixtureVersion))
+    }
+
+    @Test
+    func existsInReturnsFalseWhenBookIsMissing() {
+        let reference = BibleReference(versionId: 206, bookUSFM: "ABC", chapter: 1, verse: 1)
+
+        #expect(!reference.existsIn(version: Self.fixtureVersion))
+    }
+
+    @Test
+    func existsInReturnsFalseWhenChapterIsMissing() {
+        let reference = BibleReference(versionId: 206, bookUSFM: "GEN", chapter: 51, verse: 1)
+
+        #expect(!reference.existsIn(version: Self.fixtureVersion))
+    }
+
+    @Test
+    func existsInTreatsMissingChapterMetadataAsAvailable() {
+        let version = BibleVersion(
+            id: 206,
+            abbreviation: "TEST",
+            promotionalContent: nil,
+            copyright: nil,
+            languageTag: "en",
+            localizedAbbreviation: "TEST",
+            localizedTitle: "Test Version",
+            readerFooter: nil,
+            readerFooterUrl: nil,
+            title: "Test Version",
+            organizationId: nil,
+            bookCodes: ["GEN"],
+            books: nil,
+            textDirection: "ltr"
+        )
+        let reference = BibleReference(versionId: 206, bookUSFM: "GEN", chapter: 99, verse: 1)
+
+        #expect(reference.existsIn(version: version))
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up the `BibleVersionPickingButton` inside `BibleCardView`, adds `existsIn(version:)` to `BibleReference` so the card can detect when a chosen version doesn't contain the current passage, and covers both paths with a solid test suite. The race-condition guard in `.task` (checking `version == nil` both before and after the async fetch) is handled correctly, and the new localization key matches its call-site.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only a minor style suggestion remains.

All findings are P2. The logic for version switching, race-condition handling, unavailability detection, and tests are all correct. The single open comment (chapterUSFM return type) is a readability nit with no runtime impact.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/Bible/BibleReference.swift | Added `existsIn(version:)` and `chapterUSFM` property; `chapterUSFM` is typed `String?` but always returns non-nil — minor style issue. |
| Sources/YouVersionPlatformUI/Views/BibleCardView.swift | Added version picker button, `isReferenceUnavailable` state, `update(version:)` callback, and a race-condition guard in `.task` — all look correct. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift | New public button view that lazily loads the initial version and forwards version-change events; `onVersionChange` wiring discussed and confirmed correct in prior thread. |
| Tests/YouVersionPlatformCoreTests/BibleReferenceTests_existsIn.swift | Good coverage: verse references, chapter-only references (addressing prior review), missing book, missing chapter, and nil chapter metadata all tested. |
| Examples/SampleApp/CardView.swift | Added `showVersionPicker: true` to the sample app's `BibleCardView` — the minimal change that wires up the demo. |
| Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings | Added `bibleCard.unavailableReference` English string — key matches the call-site in `BibleCardView`. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionDownloadView.swift | Minor changes; hardcoded `URL(string: "https://bible.com/privacy")!` force-unwrap is pre-existing and low-risk for a known-valid constant URL. |
| Sources/YouVersionPlatformUI/Objects/BibleVersion+Additions.swift | Utility extensions for share URL, display title, and book name — no issues found. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant BibleCardView
    participant BibleVersionPickingButton
    participant BibleVersionsViewModel
    participant BibleVersionRepository

    BibleCardView->>BibleVersionRepository: version(withId:) [.task]
    BibleVersionRepository-->>BibleCardView: BibleVersion
    BibleCardView->>BibleCardView: isReferenceUnavailable = !existsIn(version:)

    User->>BibleVersionPickingButton: tap
    BibleVersionPickingButton->>BibleVersionsViewModel: openVersionsStack(currentBibleLanguage:)
    BibleVersionsViewModel-->>BibleVersionPickingButton: showingVersionsStack = true

    User->>BibleVersionsViewModel: select version
    BibleVersionsViewModel->>BibleVersionPickingButton: onVersionChange(version)
    BibleVersionPickingButton->>BibleCardView: onVersionChange(version)
    BibleCardView->>BibleCardView: update(version:)
    BibleCardView->>BibleReference: existsIn(version:)
    BibleReference-->>BibleCardView: Bool
    BibleCardView->>BibleCardView: isReferenceUnavailable updated
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/YouVersionPlatformUI/Views/BibleCardView.swift`, line 77-85 ([link](https://github.com/youversion/platform-sdk-swift/blob/20daa8ed573481b0a1b723ad115397fa9e8c7966/Sources/YouVersionPlatformUI/Views/BibleCardView.swift#L77-L85)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Post-await guard missing — user selection can still be overwritten**

   `if version == nil` is evaluated before the `await`, so it doesn't protect the write that happens after the network call returns. If `BibleVersionPickingButton` fires `handleVersionChange` (via `BibleVersionsViewModel.loadVersion` → `onVersionChange`) while `BibleVersionRepository.shared.version(withId:)` is still in-flight, `version = loadedVersion` will silently clobber whatever the picker already set.

   A second guard after the `await` closes the window:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformUI/Views/BibleCardView.swift
   Line: 77-85

   Comment:
   **Post-await guard missing — user selection can still be overwritten**

   `if version == nil` is evaluated before the `await`, so it doesn't protect the write that happens after the network call returns. If `BibleVersionPickingButton` fires `handleVersionChange` (via `BibleVersionsViewModel.loadVersion` → `onVersionChange`) while `BibleVersionRepository.shared.version(withId:)` is still in-flight, `version = loadedVersion` will silently clobber whatever the picker already set.

   A second guard after the `await` closes the window:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: Sources/YouVersionPlatformCore/Bible/BibleReference.swift
Line: 90-92

Comment:
**`chapterUSFM` always returns a non-nil value**

The computed property is declared as `String?` but the string interpolation body can never produce `nil`. Callers and the compiler will treat the result as optional when a plain `String` is sufficient — and the comparison `chapterMetadata.passageId == chapterUSFM` inside `existsIn` reads a little oddly as an optional-to-optional equality. Tightening the type to `String` would make the intent clearer.

```suggestion
    public var chapterUSFM: String {
        "\(bookUSFM.uppercased()).\(chapter)"
    }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["error handling improvement"](https://github.com/youversion/platform-sdk-swift/commit/7a03ee0b97fa80e7f083234ab7d1e4d147c4f899) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29181461)</sub>

<!-- /greptile_comment -->