### PR TITLE
refactor: enforce Swift style and clean up dead code

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,14 +2,14 @@ custom_rules:
 
   font_style_syntax: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "" # rule name. optional.
     regex: "(L|l)abel\\.font = StyleGuide\\.FontStyle\\.[^\n]*\\.font" # matching pattern 
     message: "Use label.apply(fontStyle:)" # violation message. optional.
 
   func_set_up: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "" # rule name. optional.
     regex: "func (setup)" # matching pattern 
     capture_group: 1
@@ -17,14 +17,14 @@ custom_rules:
 
   func_name_space: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Function Name Space" # rule name. optional.
     regex: "func [^\\(\\s=<>]+\\s+\\(.*\\)" # matching pattern
     message: "Remove space after function name before parentheses" # violation message. optional.
 
   uicontrol_state_usage: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "UIControl.State() Usage" # rule name. optional.
     regex: "(UIControl.State\\(\\))" # matching pattern 
     capture_group: 1
@@ -32,7 +32,7 @@ custom_rules:
 
   indexpath_casting: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "IndexPath Casting" # rule name. optional.
     regex: "(indexPath as NSIndexPath)" # matching pattern 
     capture_group: 1
@@ -40,7 +40,7 @@ custom_rules:
 
   nullable_singleton: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Nullable Singleton" # rule name. optional.
     regex: "\\.shared\\(\\)(\\?)" # matching pattern 
     capture_group: 1
@@ -48,7 +48,7 @@ custom_rules:
 
   internal_default: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Internal Default" # rule name. optional.
     regex: "(internal )" # matching pattern 
     capture_group: 1
@@ -56,7 +56,7 @@ custom_rules:
 
   commonly_misspelled_words: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Commonly Misspelled Words" # rule name. optional.
     regex: "([aA]naltyics|[pP]redicitive|[sS]eperator|[bB]oarder)" # matching pattern 
     capture_group: 1
@@ -64,7 +64,7 @@ custom_rules:
 
   view_lifecycle_order_1: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 1" # rule name. optional.
     regex: "(viewWillAppear)\\([\\s\\S]*viewDidLoad\\(" # matching pattern 
     capture_group: 1
@@ -72,7 +72,7 @@ custom_rules:
 
   view_lifecycle_order_2: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 2" # rule name. optional.
     regex: "(viewDidAppear)\\([\\s\\S]*viewWillAppear\\(" # matching pattern 
     capture_group: 1
@@ -80,7 +80,7 @@ custom_rules:
 
   view_lifecycle_order_3: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 3" # rule name. optional.
     regex: "(viewWillDisappear)\\([\\s\\S]*viewWillAppear\\(" # matching pattern 
     capture_group: 1
@@ -88,7 +88,7 @@ custom_rules:
 
   view_lifecycle_order_4: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 4" # rule name. optional.
     regex: "(viewDidDisappear)\\([\\s\\S]*viewWillDisappear\\(" # matching pattern 
     capture_group: 1
@@ -96,7 +96,7 @@ custom_rules:
 
   view_lifecycle_order_5: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 5" # rule name. optional.
     regex: "(viewDidDisappear)\\([\\s\\S]*viewDidAppear\\(" # matching pattern 
     capture_group: 1
@@ -104,7 +104,7 @@ custom_rules:
 
   view_lifecycle_order_6: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 6" # rule name. optional.
     regex: "(viewDidAppear)\\([\\s\\S]*viewDidLoad\\(" # matching pattern 
     capture_group: 1
@@ -112,7 +112,7 @@ custom_rules:
 
   view_lifecycle_order_7: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 7" # rule name. optional.
     regex: "(viewDidLoad)\\([\\s\\S]* loadView\\(" # matching pattern 
     capture_group: 1
@@ -120,7 +120,7 @@ custom_rules:
 
   view_lifecycle_order_8: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 8" # rule name. optional.
     regex: "(viewDidLoad)\\([\\s\\S]* init\\(" # matching pattern 
     capture_group: 1
@@ -128,7 +128,7 @@ custom_rules:
 
   view_lifecycle_order_9: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 9" # rule name. optional.
     regex: "(viewWillDisappear)\\([\\s\\S]* viewDidAppear\\(" # matching pattern 
     capture_group: 1
@@ -136,7 +136,7 @@ custom_rules:
 
   view_lifecycle_order_10: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 10" # rule name. optional.
     regex: "(viewDidLayoutSubviews)\\([\\s\\S]* viewWillLayoutSubviews\\(" # matching pattern 
     capture_group: 1
@@ -144,7 +144,7 @@ custom_rules:
 
   view_lifecycle_order_11: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 11" # rule name. optional.
     regex: "(func loadView)\\([\\s\\S]* init\\(" # matching pattern 
     capture_group: 1
@@ -152,7 +152,7 @@ custom_rules:
 
   view_lifecycle_order_12: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 12" # rule name. optional.
     regex: "(viewIsAppearing)\\([\\s\\S]* viewDidLoad\\(" # matching pattern 
     capture_group: 1
@@ -160,7 +160,7 @@ custom_rules:
 
   view_lifecycle_order_13: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 13" # rule name. optional.
     regex: "(viewIsAppearing)\\([\\s\\S]* viewWillAppear\\(" # matching pattern 
     capture_group: 1
@@ -168,7 +168,7 @@ custom_rules:
 
   view_lifecycle_order_14: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 14" # rule name. optional.
     regex: "(viewDidAppear)\\([\\s\\S]* viewIsAppearing\\(" # matching pattern 
     capture_group: 1
@@ -176,7 +176,7 @@ custom_rules:
 
   view_lifecycle_order_15: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 15" # rule name. optional.
     regex: "(viewWillDisappear)\\([\\s\\S]* viewIsAppearing\\(" # matching pattern 
     capture_group: 1
@@ -184,7 +184,7 @@ custom_rules:
 
   view_lifecycle_order_16: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 16" # rule name. optional.
     regex: "(viewDidDisappear)\\([\\s\\S]* viewIsAppearing\\(" # matching pattern 
     capture_group: 1
@@ -192,7 +192,7 @@ custom_rules:
 
   old_constraints_api: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Adding Constraints the Old Way" # rule name. optional.
     regex: "addConstraint[s]{0,1}" # matching pattern 
     match_kinds:
@@ -201,7 +201,7 @@ custom_rules:
 
   init_abuse: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Init Abuse" # rule name. optional.
     regex: "(\\b[A-Z_]\\w*\\b|\\s)(\\.init)\\(" # matching pattern 
     match_kinds:
@@ -211,21 +211,21 @@ custom_rules:
 
   confusing_logic: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Confusing Logic" # rule name. optional.
     regex: "\\?\\? 0 > 0" # matching pattern
     message: "There has to be a better way" # violation message. optional.
 
   extraneous_logic: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Extraneous Logic" # rule name. optional.
     regex: "(\\? true : false|\\? false : true)" # matching pattern
     message: "Use the condition itself" # violation message. optional.
 
   visual_format: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Visual Format Constraints" # rule name. optional.
     regex: "withVisualFormat" # matching pattern
     match_kinds:
@@ -234,7 +234,7 @@ custom_rules:
 
   touch_up_inside: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "TouchUpInside -> PrimaryActionTriggered" # rule name. optional.
     regex: "for: .touchUpInside" # matching pattern
     match_kinds:
@@ -244,7 +244,7 @@ custom_rules:
 
   no_system_font: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "No Direct System Font Use" # rule name. optional.
     regex: "UIFont.(systemFont|boldSystemFont)" # matching pattern
     match_kinds:
@@ -254,7 +254,7 @@ custom_rules:
 
   back_bar_button_item: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Back Bar Button Item" # rule name. optional.
     regex: "backBarButtonItem =" # matching pattern
     match_kinds:
@@ -264,7 +264,7 @@ custom_rules:
 
   system_bar_button_items: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "System Bar Button Item" # rule name. optional.
     regex: "barButtonSystemItem:" # matching pattern
     match_kinds:
@@ -274,7 +274,7 @@ custom_rules:
 
   var_over_func: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Var Over Func" # rule name. optional.
     regex: "[A-Za-z0-9]+\\(\\) ->" # matching pattern
     match_kinds:
@@ -284,7 +284,7 @@ custom_rules:
 
   private_set_syntax: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Private Set Syntax" # rule name. optional.
     regex: "private \\(set\\)" # matching pattern
     match_kinds:
@@ -294,7 +294,7 @@ custom_rules:
 
   author_attribution: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Author Attribution" # rule name. optional.
     regex: "\\/\\/  Created by" # matching pattern
     match_kinds:
@@ -304,7 +304,7 @@ custom_rules:
 
   private_static_syntax: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Private Static Syntax" # rule name. optional.
     regex: "static private" # matching pattern
     match_kinds:
@@ -315,7 +315,7 @@ custom_rules:
 
   notification_name_raw_value: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Notification.Name Raw Value" # rule name. optional.
     regex: "Notification.Name\\((rawValue:)" # matching pattern
     capture_group: 1
@@ -324,7 +324,7 @@ custom_rules:
 
   notification_name_over_nsnotification_name: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Notification > NSNotification" # rule name. optional.
     regex: "(NS)Notification.Name" # matching pattern
     capture_group: 1
@@ -333,7 +333,7 @@ custom_rules:
 
   var_func_blank_line: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Blank Line In Top Of Var/Func" # rule name. optional.
     regex: "(var |func |init\\()[^\\n]*\\{\\n\\s*(\\n)" # matching pattern
     capture_group: 2
@@ -342,7 +342,7 @@ custom_rules:
 
   remove_synchronize: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Synchronize Function is Unnecessary" # rule name. optional.
     regex: "(UserDefaults.standard.synchronize)" # matching pattern
     capture_group: 1
@@ -350,7 +350,7 @@ custom_rules:
 
   image_tinting: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Tinting Image Directly" # rule name. optional.
     regex: "(View\\??\\.image|\\.setImage\\()[^\\n]+?(\\.withTintColor)\\(([^\\n]+|\\))"
     capture_group: 2
@@ -359,7 +359,7 @@ custom_rules:
 
   unnecessary_type_specification: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Unnecessary Type Specification" # rule name. optional.
     regex: "(var|let) \\S+: (Bool|Int|String) = (?!\\{)"
     capture_group: 2
@@ -368,7 +368,7 @@ custom_rules:
 
   else_on_newline: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Else On Newline" # rule name. optional.
     regex: "\\}\\n\\s*(else)" # matching pattern
     capture_group: 1
@@ -377,7 +377,7 @@ custom_rules:
 
   catch_on_newline: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Catch On Newline" # rule name. optional.
     regex: "\\}\\n\\s*(catch) " # matching pattern
     capture_group: 1
@@ -386,7 +386,7 @@ custom_rules:
 
   aspect_ratio_constraint_1: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Aspect Ratio Constraint" # rule name. optional.
     regex: "(\\S+)\\.widthAnchor\\.constraint\\(equalTo: \\1\\.heightAnchor" # matching pattern
     message: "Use UIView.aspectRatioConstraint(withMultiplier:)" # violation message. optional.
@@ -394,7 +394,7 @@ custom_rules:
 
   aspect_ratio_constraint_2: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Aspect Ratio Constraint" # rule name. optional.
     regex: "(\\S+)\\.heightAnchor\\.constraint\\(equalTo: \\1\\.widthAnchor" # matching pattern
     message: "Use UIView.aspectRatioConstraint(withMultiplier:)" # violation message. optional.
@@ -402,7 +402,7 @@ custom_rules:
 
   string_initializer: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Empty String Initializer" # rule name. optional.
     regex: " String\\(\\)" # matching pattern
     message: "Use an empty String literal" # violation message. optional.
@@ -410,7 +410,7 @@ custom_rules:
 
   is_kind_check: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Is Kind Check" # rule name. optional.
     regex: "\\.isKind\\(of:" # matching pattern
     message: "Use 'object is Type'" # violation message. optional.
@@ -418,7 +418,7 @@ custom_rules:
 
   legacy_transformation: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Legacy Transformation" # rule name. optional.
     regex: "(transformedSet|transformedArray)" # matching pattern
     capture_group: 1
@@ -427,7 +427,7 @@ custom_rules:
 
   inline_block: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Inline Block" # rule name. optional.
     regex: "(var|let) \\S+:[^\\n]*->[^\\n]* = \\{" # matching pattern
     message: "Use a local function" # violation message. optional.
@@ -435,7 +435,7 @@ custom_rules:
 
   value_for_key_path: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Value For Key Path" # rule name. optional.
     regex: "(value\\(forKeyPath:)" # matching pattern
     capture_group: 1
@@ -444,7 +444,7 @@ custom_rules:
 
   async_api_design: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Async API Design" # rule name. optional.
     regex: "func (get|request|fetch|load)[^\\n]+? async (throws )?-> [^\\n]+?\\{" # matching pattern
     capture_group: 1
@@ -453,7 +453,7 @@ custom_rules:
 
   attributed_string_keys: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Attributed String Keys" # rule name. optional.
     regex: "(addAttribute\\(NSAttributedString.Key|addAttributes\\(\\[NSAttributedString.Key)" # matching pattern
     capture_group: 1
@@ -462,7 +462,7 @@ custom_rules:
 
   legacy_nsindexpath: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Legacy NSIndexPath" # rule name. optional.
     regex: "(NSIndexPath)" # matching pattern
     capture_group: 1
@@ -471,7 +471,7 @@ custom_rules:
 
   redundant_argument_name: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Redundant Argument Name" # rule name. optional.
     regex: "func [a-zA-Z]+?([a-z]+)\\(([A-Za-z]\\1):" # matching pattern
     capture_group: 2
@@ -480,7 +480,7 @@ custom_rules:
 
   optional_closure_check: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Optional Closure Check" # rule name. optional.
     regex: "if let ([a-zA-Z]+)[\\s]*? \\{\\s+(\\1)\\(\\)" # matching pattern
     capture_group: 2
@@ -489,7 +489,7 @@ custom_rules:
 
   legacy_model_class: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Legacy Model Class" # rule name. optional.
     regex: "(SRBAutomappingModelObject)" # matching pattern
     capture_group: 1
@@ -498,7 +498,7 @@ custom_rules:
 
   common_debug_statements: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Common Debug Statements" # rule name. optional.
     regex: "(Task.sleep|!!!)" # matching pattern
     capture_group: 1
@@ -507,7 +507,7 @@ custom_rules:
 
   swiftui_localization: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "SwiftUI Localization" # rule name. optional.
     regex: "\\W(Text|TextField|SecureField|Button|Label|Toggle|Picker|Menu|confirmationDialog|navigationTitle|navigationBarTitle|alert)\\((NSLocalizedString)" # matching pattern
     capture_group: 2
@@ -516,7 +516,7 @@ custom_rules:
 
   ambiguous_dateformatter: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Ambiguous DateFormatter" # rule name. optional.
     regex: " (DateFormatter\\(\\))" # matching pattern
     capture_group: 1
@@ -525,23 +525,23 @@ custom_rules:
   
   swiftui_fullscreencover: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "SwiftUI sheet view modifier" # rule name. optional.
     regex: "\\.fullScreenCover\\(" # matching pattern
     message: "Please use the yvFullScreenCover view modifier" # violation message. optional.
     severity: error # violation severity. optional.
 
-  no_import_red: # rule identifier
+  snake_case_property: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
-    name: "No Direct RED Import" # rule name. optional.
-    regex: "^\\s*import\\s+RED\\s*$" # matching pattern - matches "import RED" but not "import class RED.iOSDate"
-    message: "Don't import the entire RED module. Use specific imports like 'import class RED.iOSDate' instead." # violation message. optional.
+    name: "Snake Case Property" # rule name. optional.
+    regex: "\\b(let|var)\\s+([a-z][a-z0-9]*_[a-zA-Z0-9_]+)" # matching pattern
+    capture_group: 2
+    message: "Use camelCase for property names. Map to snake_case JSON keys via CodingKeys." # violation message. optional.
     severity: error # violation severity. optional.
 
   reduce_motion_guard: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Reduce Motion Guard" # rule name. optional.
     regex: "(withAnimation\\s*\\(\\s*\\.|\\.animation\\s*\\(\\s*\\.|\\.transition\\s*\\(\\s*\\.|Transaction\\s*\\(\\s*animation:\\s*\\.)" # matching pattern - a literal animation (dot-prefixed) passed directly to the call is a hint it's unguarded; guarded forms pass a ternary or derived property.
     capture_group: 1
@@ -603,7 +603,6 @@ opt_in_rules: # some rules are only opt-in
 # included: # paths to include during linting. `--path` is ignored if present.
 #   - Source
 excluded: # paths to ignore during linting. Takes precedence over `included`.
-  - Tests
   - Package.swift
   - Sources/Utilities/ThreadSafeDictionary.swift
   - '**/derived_data'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ Use for large tasks or risky changes (SDK updates, major API adoption):
 - Prefer idiomatic, industry standard Swift style. Follow https://www.swift.org/documentation/api-design-guidelines/.
 - Don't make whitespace-only changes.
 - Prefer async-await to completion block-based API design.
-- Async functions with return values should have names that are noun phrases describing the return value rather than verb phrases and should never begin with "get", "load", or "request".
+- Async functions with return values should have names that are noun phrases describing the return value rather than verb phrases and should never begin with "get", "load", "fetch", or "request".
 - Don't add inline comments inside functions, but don't delete existing inline comments.
 - Do add DocC comments to new, non-private functions, but not on SwiftUI initializers and body.
 - Make access controls on properties and functions as strict as they can be (private, fileprivate, private(set), etc).
@@ -97,6 +97,43 @@ Use for large tasks or risky changes (SDK updates, major API adoption):
 - Public-facing types should generally include "YouVersion" in their name (e.g. `YouVersionBigButtonStyle`, `SignInWithYouVersionView`) to disambiguate from client-local types.
 - Class, struct, enum entity names should always be in PascalCase.
 - Property and function names should always be in camelCase.
+- Prefer Swift Concurrency over Combine.
+- Prefer `@Observable` to `ObservableObject`.
+- ALWAYS mark ViewModel types as `@MainActor`.
+- NEVER use locks (NSLock, etc.); prefer actors for isolation.
+- For computed values with no arguments, prefer `var` over `func`.
+- Don't specify `internal` — it's the default.
+- No author attribution comment blocks (`// Created by`).
+- Sort imports alphabetically.
+- `else`/`catch` on the same line as the closing brace (`} else {`, `} catch {`).
+- No blank lines at the top of `var`/`func`/`init` blocks.
+- Always have one blank line between functions.
+- Let the compiler infer types when possible.
+- Use `""` over `String()` for empty strings.
+- Use `private(set)` not `private (set)`.
+- Use `private static` not `static private`.
+- Don't use a comma between logical expressions when `&&` will suffice.
+- Don't override methods or initializers only to call `super`.
+- Do not add a `deinit` solely to remove `NotificationCenter` observers — it's unnecessary.
+- When using `guard`, the `return`/`continue` belongs on a new line.
+- Don't use `guard` in an overridden method to return early.
+- Use existing localized strings if possible; prompt the user before adding new strings.
+- Use Swift Testing for unit tests, not XCTest.
+- NEVER create objects starting with `.init(...)`.
+- Code MUST support iOS 17 but can branch using `if #available(iOS ##.#, *)` checks.
+- Stored properties should be declared before all initializers.
+- Derived properties and functions should be declared after all initializers.
+- Use `Notification.Name("name")` not `Notification.Name(rawValue:)`, and `Notification.Name` not `NSNotification.Name`.
+- Use local functions instead of inline closure blocks (`let x: () -> T = { ... }`).
+- Don't unwrap optional closures with `if let` — use `closure?()`.
+- Don't leave commented-out code in place.
+
+### SwiftUI-Specific Rules
+
+- Mark `@State` properties `private`.
+- Do not use the suffix "Widget" for SwiftUI view names, as it conflicts with iOS home screen widgets (WidgetKit); use a more descriptive name instead.
+- Use Dynamic Type text styles (`.body`, `.callout`, `.footnote`, etc.) instead of `.font(.system(size:))` so fonts adapt to the user's preferred text size.
+- When using `Font.custom`, always include the `relativeTo:` parameter (e.g., `Font.custom("MyFont", size: 16, relativeTo: .callout)`) so custom fonts scale with Dynamic Type.
 
 ## Localization
 

--- a/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
@@ -29,7 +29,7 @@ public extension YouVersionAPI.Bible {
             organizationId: metadata.organizationId,
             bookCodes: metadata.bookCodes,
             books: index.books,
-            textDirection: index.text_direction,
+            textDirection: index.textDirection,
         )
     }
 
@@ -156,7 +156,12 @@ public extension YouVersionAPI.Bible {
     // MARK: - utility structs
 
     private struct BibleVersionIndex: Codable {
-        let text_direction: String?
+        let textDirection: String?
         let books: [BibleBook]?
+
+        enum CodingKeys: String, CodingKey {
+            case textDirection = "text_direction"
+            case books
+        }
     }
 }

--- a/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift
@@ -55,7 +55,7 @@ public extension YouVersionAPI.Bible {
             } else {
                 let responseObject = try JSONDecoder().decode(BibleVersionsResponse.self, from: data)
                 allResults.append(contentsOf: responseObject.data)
-                pageToken = responseObject.next_page_token
+                pageToken = responseObject.nextPageToken
                 if responseObject.data.isEmpty {
                     pageToken = nil
                 }
@@ -90,7 +90,11 @@ public extension YouVersionAPI.Bible {
 
     private struct BibleVersionsResponse: Decodable {
         let data: [BibleVersion]
-        let next_page_token: String?
-        let total_size: Int?
+        let nextPageToken: String?
+
+        enum CodingKeys: String, CodingKey {
+            case data
+            case nextPageToken = "next_page_token"
+        }
     }
 }

--- a/Sources/YouVersionPlatformCore/APIs/Languages/Languages.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Languages/Languages.swift
@@ -99,7 +99,7 @@ public extension YouVersionAPI {
 
                 let responseObject = try JSONDecoder().decode(LanguagesResponse.self, from: data)
                 allResults.append(contentsOf: responseObject.data)
-                pageToken = responseObject.next_page_token
+                pageToken = responseObject.nextPageToken
             } while pageToken != nil
 
             return allResults
@@ -107,8 +107,14 @@ public extension YouVersionAPI {
 
         private struct LanguagesResponse: Decodable {
             let data: [LanguageOverview]
-            let next_page_token: String?
-            let total_size: Int?
+            let nextPageToken: String?
+            let totalSize: Int?
+
+            enum CodingKeys: String, CodingKey {
+                case data
+                case nextPageToken = "next_page_token"
+                case totalSize = "total_size"
+            }
         }
     }
 }

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -10,11 +10,10 @@ public struct BibleReaderView: View {
 #endif
 
     @Environment(\.openURL) private var openURL
-    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    let fontSettingsDetent = PresentationDetent.height(360)
-    let fontListDetent = PresentationDetent.height(480)
+    private let fontSettingsDetent = PresentationDetent.height(360)
+    private let fontListDetent = PresentationDetent.height(480)
     @State private var selectedDetent: PresentationDetent
     @State private var detents: Set<PresentationDetent>
 
@@ -283,7 +282,7 @@ public struct BibleReaderView: View {
     }
 
 #if !os(tvOS)
-    class ContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
+    final class ContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
         func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
 #if canImport(UIKit)
             guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
@@ -300,7 +299,7 @@ public struct BibleReaderView: View {
 #endif
 
     /// Helper to detect scroll offset in ScrollView
-    struct ScrollOffsetPreferenceKey: PreferenceKey {
+    private struct ScrollOffsetPreferenceKey: PreferenceKey {
         typealias Value = CGFloat
         static var defaultValue: Value { .zero }
         static func reduce(value: inout Value, nextValue: () -> Value) {

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift
@@ -30,7 +30,6 @@ struct BibleReaderDrawer: View {
                 .padding(.horizontal, 24)
             }
             .padding(.bottom, 32)
-            //swipeUpLabel  // uncomment this once we support swipe, and have something to show!
         }
         .foregroundStyle(viewModel.readerTextMutedColor)
         .background(viewModel.readerCanvasPrimaryColor)
@@ -106,14 +105,6 @@ struct BibleReaderDrawer: View {
         drawerButton(imageName: "square.on.square", text: .localized("verseActions.copy")) {
             viewModel.handleVerseActionCopy()
         }
-    }
-
-    var swipeUpLabel: some View {
-        HStack {
-            Image(systemName: "chevron.up")
-            Text(String.localized("verseActions.swipeUpLabel"))
-        }
-        .font(ReaderFonts.fontCaptionsL)
     }
 }
 

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
@@ -3,7 +3,9 @@ import YouVersionPlatformCore
 
 public struct BibleReaderHeaderView: View {
     @Environment(BibleReaderViewModel.self) private var viewModel
+#if canImport(UIKit)
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+#endif
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let showChrome: Bool

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderMyVersionsListItem.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderMyVersionsListItem.swift
@@ -57,12 +57,7 @@ struct BibleReaderMyVersionsListItem: View, AbbreviationSplitting {
             }
 
             Spacer()
-            // TEMPORARY
-//            if viewModel.versionRepository.downloadStatus(for: item.id) != .downloaded {
-//                Image(systemName: "cloud")
-//                    .foregroundStyle(viewModel.readerTextMutedColor)
-//                    .padding(.trailing, 8)
-//            }
+            
             ellipsisMenuButton
         }
         .contentShape(Rectangle())

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderMyVersionsListItem.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderMyVersionsListItem.swift
@@ -57,7 +57,7 @@ struct BibleReaderMyVersionsListItem: View, AbbreviationSplitting {
             }
 
             Spacer()
-            
+
             ellipsisMenuButton
         }
         .contentShape(Rectangle())

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+MyVersions.swift
@@ -50,8 +50,6 @@ extension BibleVersionsViewModel {
     public func myVersionRemoveDownloadMenuTapped(_ versionId: Int) {
         Task {
             await versionRepository.removeVersion(withId: versionId)
-            // no need to do the following, as versionRepository handles it:
-            //try await BibleChapterRepository.shared.removeVersion(version: version)
         }
     }
 
@@ -93,8 +91,6 @@ extension BibleVersionsViewModel {
             let versionName = version.localizedTitle ?? version.title ?? .localized("myVersions.defaultVersionName")
             do {
                 try await versionRepository.downloadVersion(withId: version.id)
-                // TEMPORARY removal
-                //try await BibleChapterRepository.shared.download(version: version)
                 showGenericAlert = true
                 textForGenericAlertTitle = .localized("myVersions.downloadCompleteTitle")
                 textForGenericAlertBody = String(format: .localized("myVersions.downloadCompleteBodyFormat"), versionName)

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift
@@ -3,7 +3,6 @@ import YouVersionPlatformCore
 import YouVersionPlatformUI
 
 extension BibleVersionsViewModel {
-
     public var activeLanguage: String {
         chosenLanguage ?? currentBibleVersionLanguage ?? "en"
     }
@@ -25,12 +24,6 @@ extension BibleVersionsViewModel {
         if versionRepository.downloadStatus(for: id) == .downloaded {
             return .downloaded
         }
-        // TEMPORARY
-//        if let overview = permittedVersions.first(where: { $0.id == id }) {
-//            if overview.downloadable == true {
-//                return .downloadable
-//            }
-//        }
         return .notDownloadable
     }
 
@@ -89,7 +82,7 @@ extension BibleVersionsViewModel {
     }
 
     public func languageTapped() {
-        if permittedVersionsList == nil || permittedVersionsList!.isEmpty {
+        if permittedVersionsList?.isEmpty ?? true {
             showGenericAlert = true
             textForGenericAlertTitle = .localized("generic.error")
             textForGenericAlertBody = .localized("reader.availableLanguagesErrorBody")
@@ -128,5 +121,4 @@ extension BibleVersionsViewModel {
         textForGenericAlertTitle = .localized("generic.error")
         textForGenericAlertBody = .localized("reader.versionAccessErrorBody")
     }
-
 }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -28,6 +28,41 @@ final class BibleReaderViewModel {
     let onVerseTap: ((BibleReference) -> Void)?
     let verseSelectionStyle: VerseSelectionStyle
 
+    // MARK: - UI state of the Reader itself
+    var showChrome = true
+    var lastScrollOffset: CGFloat = 0
+    var scrollToTop = false
+    var isChangingChapter = false
+    var showingSignInSheet = false
+    var showingFontSettings = false
+    var showingFontList = false
+    var showingFootnotes = false
+    var showingIntroFootnoteSheet = false
+    var showingVerseActionsDrawer = false
+    var isReduceMotionEnabled = false
+    var selectedVerses: Set<BibleReference> = []
+    var showingBookPicker = false
+    private var showingChapterPicker = false
+    var headerExpandedBookCode: String?
+    var footnotesToDisplay: [BibleFootnote] = []
+    let readerMaxWidth = CGFloat(700)  // of the reader and the verse action drawer, maybe others
+
+    // MARK: - Font settings
+
+    private var fontFamily: String? = ReaderFonts.defaultFontFamily
+    private var fontSize: CGFloat? = ReaderFonts.defaultFontSize
+    private var lineSpacing = ReaderFonts.defaultLineSpacing
+
+    // MARK: - Colors
+
+    private(set) var colorTheme: ReaderTheme? = ReaderTheme.theme()
+
+    // MARK: - Sign In & Out
+
+    var startSignInFlow = false
+    private(set) var isSignedIn = false
+    var showSignOutConfirmation = false
+
     init(
         reference: BibleReference? = nil,
         highlightsViewModel: BibleHighlightsViewModel? = nil,
@@ -68,15 +103,37 @@ final class BibleReaderViewModel {
 
         ReaderFonts.installFontsIfNeeded()
     }
-    
+
+    var verseActionsDrawerAnimation: Animation {
+        isReduceMotionEnabled ? .easeInOut(duration: 0.2) : .smooth(duration: 0.3)
+    }
+
+    var textOptions: BibleTextOptions {
+        ReaderFonts.installFontsIfNeeded()
+        let ourFontSize = fontSize ?? 18
+        return BibleTextOptions(
+            fontFamily: fontFamily ?? "Georgia",
+            fontSize: ourFontSize,
+            // TODO: maybe have one of these spacings be a delta added to the other:
+            lineSpacing: lineSpacing,
+            paragraphSpacing: lineSpacing,
+            textColor: readerTextPrimaryColor,
+            verseNumColor: readerVerseNumColor,
+            wocColor: readerWordsOfChristColor,
+            footnoteMode: .image,
+            footnoteMarker: nil,
+            verseSelectionStyle: verseSelectionStyle
+        )
+    }
+
     func onVersionChange(version: BibleVersion) {
         self.version = version
-        self.reference = BibleReference(versionId: version.id, bookUSFM: reference.bookUSFM, chapter: reference.chapter)
+        reference = BibleReference(versionId: version.id, bookUSFM: reference.bookUSFM, chapter: reference.chapter)
         Task {
             await onHeaderSelectionChange(reference, showIntro: false)
         }
     }
-    
+
     func onSignInRequired() {
         startSignInFlow = true
     }
@@ -103,67 +160,6 @@ final class BibleReaderViewModel {
         if let data = try? JSONEncoder().encode(settings) {
             UserDefaults.standard.set(data, forKey: userDefaultsKeyForReaderSettings)
         }
-    }
-
-    private class ReaderSettings: Codable {
-        let fontFamily: String?
-        let fontSize: CGFloat?
-        let lineSpacing: CGFloat?
-        let colorTheme: Int?
-        init(fontFamily: String?, fontSize: CGFloat?, lineSpacing: CGFloat?, colorTheme: Int?) {
-            self.fontFamily = fontFamily
-            self.fontSize = fontSize
-            self.lineSpacing = lineSpacing
-            self.colorTheme = colorTheme
-        }
-    }
-
-    // MARK: - UI state of the Reader itself
-    var showChrome = true
-    var lastScrollOffset: CGFloat = 0
-    var scrollToTop = false
-    var isChangingChapter = false
-    var showingSignInSheet = false
-    var showingFontSettings = false
-    var showingFontList = false
-    var showingFootnotes = false
-    var showingIntroFootnoteSheet = false
-    var showingVerseActionsDrawer = false
-    var isReduceMotionEnabled = false
-    var verseActionsDrawerAnimation: Animation {
-        isReduceMotionEnabled ? .easeInOut(duration: 0.2) : .smooth(duration: 0.3)
-    }
-    var selectedVerses: Set<BibleReference> = []
-
-    var showingBookPicker = false
-    private var showingChapterPicker = false
-    var headerExpandedBookCode: String?
-    var footnotesToDisplay: [BibleFootnote] = []
-
-    let readerMaxWidth = CGFloat(700)  // of the reader and the verse action drawer, maybe others
-
-    // MARK: - Font settings
-
-    private var fontFamily: String? = ReaderFonts.defaultFontFamily
-    private var fontSize: CGFloat? = ReaderFonts.defaultFontSize
-    private var lineSpacing = ReaderFonts.defaultLineSpacing
-
-    var textOptions: BibleTextOptions {
-        ReaderFonts.installFontsIfNeeded()
-        let ourFontSize = fontSize ?? 18
-        return BibleTextOptions(
-            fontFamily: fontFamily ?? "Georgia",
-            fontSize: ourFontSize,
-            // TODO: maybe have one of these spacings be a delta added to the other:
-            lineSpacing: lineSpacing,
-            paragraphSpacing: lineSpacing,
-            textColor: readerTextPrimaryColor,
-            verseNumColor: readerVerseNumColor,
-            wocColor: readerWordsOfChristColor,
-            footnoteMode: .image,
-            footnoteMarker: nil,
-            verseSelectionStyle: verseSelectionStyle
-        )
     }
 
     func openFontSettings() {
@@ -197,21 +193,11 @@ final class BibleReaderViewModel {
         saveUserSettingsToStorage()
     }
 
-    // MARK: Colors
-
-    var colorTheme: ReaderTheme? = ReaderTheme.theme()
-
     func setColorTheme(_ theme: ReaderTheme) {
         colorTheme = theme
         versionsViewModel.colorTheme = theme
         saveUserSettingsToStorage()
     }
-
-    // MARK: - Sign In & Out
-
-    var startSignInFlow = false
-    private(set) var isSignedIn = false
-    var showSignOutConfirmation = false
 
     func updateSignInState() {
         Task {
@@ -237,5 +223,12 @@ final class BibleReaderViewModel {
         YouVersionAPI.Users.signOut()
         highlightsViewModel.reset()
         isSignedIn = false
+    }
+
+    private struct ReaderSettings: Codable {
+        let fontFamily: String?
+        let fontSize: CGFloat?
+        let lineSpacing: CGFloat?
+        let colorTheme: Int?
     }
 }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift
@@ -22,7 +22,7 @@ final class BibleVersionsViewModel {
     private(set) var textForGenericAlertOKButton = "OK"
     
     /// onVersionChange: called when the user has chosen a new version (or their first). The caller should ensure their current reference exists in this new version and choose a new one if not.
-    init (initialVersionId: Int? = nil, onVersionChange: @escaping (BibleVersion) -> Void) {
+    init(initialVersionId: Int? = nil, onVersionChange: @escaping (BibleVersion) -> Void) {
         // grab the saved data first, because initializing myVersions will clear the saved data.
         let savedIds = UserDefaults.standard.array(forKey: userDefaultsKeyForMyVersions) as? [Int] ?? []
         
@@ -45,29 +45,29 @@ final class BibleVersionsViewModel {
         let permittedIds = Set(permittedVersions.map(\.id))
         await versionRepository.removeUnpermittedVersions(permittedIds: permittedIds)
         
-        for version in self.myVersions where !permittedIds.contains(version.id) {
-            self.myVersions.remove(version)
+        for version in myVersions where !permittedIds.contains(version.id) {
+            myVersions.remove(version)
         }
         if let initialVersionId, !permittedIds.contains(initialVersionId) {
-            await selectFallbackVersion(savedIds: Array(self.myVersions.map(\.id)))
+            await selectFallbackVersion(savedIds: Array(myVersions.map(\.id)))
         }
     }
     
     private func restoreMyVersions(savedIds: [Int]) async {
         for id in savedIds {
             if let version = try? await versionRepository.versionIfCached(id) {
-                self.myVersions.insert(version)
+                myVersions.insert(version)
             }
         }
-        
+
         // downloaded versions must also be in MyVersions, otherwise they couldn't be deleted.
         let downloads = VersionDownloadCache.downloadedVersions
         for id in downloads {
-            if self.myVersions.contains(where: { $0.id == id }) {
+            if myVersions.contains(where: { $0.id == id }) {
                 continue
             }
             if let version = try? await versionRepository.versionIfCached(id) {
-                self.myVersions.insert(version)
+                myVersions.insert(version)
             }
         }
     }
@@ -87,7 +87,7 @@ final class BibleVersionsViewModel {
         }
 
         if let version = loadedVersion {
-            self.myVersions.insert(version)
+            myVersions.insert(version)
             onVersionChange(version)
         } else {
             await selectFallbackVersion(savedIds: savedIds)
@@ -103,8 +103,8 @@ final class BibleVersionsViewModel {
             return
         }
         onVersionChange(version)
-        
-        self.myVersions.insert(version)
+
+        myVersions.insert(version)
     }
     
     private func findAnyAcceptableVersion(savedIds: Set<Int>) async -> Int? {
@@ -141,7 +141,7 @@ final class BibleVersionsViewModel {
     var versionsInLanguage: [String: [BibleVersion]] = [:]
     
     /// Holds minimal information about all Bible versions available to this app, in all languages.
-    var permittedVersionsList: [YouVersionAPI.Bible.BibleVersionMinimalInfo]?
+    private(set) var permittedVersionsList: [YouVersionAPI.Bible.BibleVersionMinimalInfo]?
     
     /// Returns minimal information about all Bible versions available to this app, in all languages.
     /// On error or when offline, returns nil
@@ -221,7 +221,7 @@ final class BibleVersionsViewModel {
     
     // MARK: - Languages picking
     
-    var suggestedLanguagesList: [LanguageOverview]
+    private(set) var suggestedLanguagesList: [LanguageOverview]
     var chosenLanguage: String?
     var languageNames: [String: String] = [:]
     
@@ -242,10 +242,10 @@ final class BibleVersionsViewModel {
     
     /// Returns languages likely to be ones the user will want. Doesn't return any for which we have no Bible versions.
     var suggestedLanguages: [String] {
-        guard !self.suggestedLanguagesList.isEmpty else {
+        guard !suggestedLanguagesList.isEmpty else {
             return ["en", "es"]
         }
-        let codes = extractLanguageCodes(languages: self.suggestedLanguagesList)
+        let codes = extractLanguageCodes(languages: suggestedLanguagesList)
         guard let versionsInfo = permittedVersionsList else {
             return codes
         }

--- a/Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift
+++ b/Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift
@@ -39,16 +39,14 @@ public struct BibleTextFonts {
         verseNumBaselineOffset = baseSize * 0.3
         let boldFamilyName: String
         let italicFamilyName: String
-        //let boldItalicFamilyName: String
+        
         if familyName.hasSuffix("-Regular") {
             let base = familyName.split(separator: "-").dropLast().joined(separator: "-")
             boldFamilyName = base + "-Bold"
             italicFamilyName = base + "-Italic"
-            //boldItalicFamilyName = base + "-BoldItalic"
         } else {
             boldFamilyName = familyName
             italicFamilyName = familyName
-            //boldItalicFamilyName = familyName
         }
 
         let larger = Font.custom(familyName, fixedSize: baseSize * 1.1)

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleTextBlock.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleTextBlock.swift
@@ -8,8 +8,6 @@ public struct BibleTextBlock: Identifiable {
     public let rows: [[BibleAttributedString]]  // If it's a table, these are present instead of "text".
     public let firstLineHeadIndent: Int  // The indentation of the first line of the paragraph. Always >= 0.
     public let headIndent: Int  // The indentation of the paragraph’s lines other than the first. Always >= 0.
-    //let tailIndent: Int  // If positive, this value is the distance from the leading margin (for example,
-    //the left margin in left-to-right text). If 0 or negative, it’s the distance from the trailing margin.
     public let marginTop: CGFloat
     public let alignment: TextAlignment
     public let footnotes: [BibleFootnote]

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift
@@ -624,10 +624,6 @@ public struct BibleTextAttributes: AttributeScope {
     let bibleTextCategory: BibleTextCategoryAttribute
 }
 
-//extension AttributeScopes {
-//    var bibleTextAttributes: BibleTextAttributes.Type { BibleTextAttributes.self }
-//}
-
 // This extension allows our code to say "myString.bibleReference = ..."
 public extension AttributeDynamicLookup {
     subscript<T: AttributedStringKey>(

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,0 +1,3 @@
+only_rules:
+  - custom_rules
+  - snake_case_property

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests.swift
@@ -76,26 +76,26 @@ func testCompare_SameBookDifferentChapters() {
 
 @Test
 func testCompare_SameChapterDifferentVerses() {
-    let gen1_1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
-    let gen1_2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 2)
-    
-    #expect(gen1_1 < gen1_2)
-    #expect(gen1_2 > gen1_1)
+    let gen1Verse1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+    let gen1Verse2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 2)
+
+    #expect(gen1Verse1 < gen1Verse2)
+    #expect(gen1Verse2 > gen1Verse1)
 }
 
 @Test
 func testCompare_Ranges() {
-    let gen1_1to3 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
-    let gen1_2to4 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 2, verseEnd: 4)
-    
+    let gen1Verses1to3 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
+    let gen1Verses2to4 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 2, verseEnd: 4)
+
     // Compare based on starting verse first
-    #expect(gen1_1to3 < gen1_2to4)
-    
+    #expect(gen1Verses1to3 < gen1Verses2to4)
+
     // Same starting verse, compare end verse
-    let gen1_1to3_2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
-    let gen1_1to4 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 4)
-    
-    #expect(gen1_1to3_2 < gen1_1to4)    // 1-3 < 1-4
+    let gen1Verses1to3Again = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
+    let gen1Verses1to4 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 4)
+
+    #expect(gen1Verses1to3Again < gen1Verses1to4)    // 1-3 < 1-4
 }
 
 @Test

--- a/Tests/YouVersionPlatformCoreTests/HighlightsAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/HighlightsAPITests.swift
@@ -46,7 +46,17 @@ extension URLRequest {
         let (session, token) = HTTPMocking.makeSession()
         defer { HTTPMocking.clear(token: token) }
 
-        struct Body: Decodable { let bible_id: Int; let passage_id: String; let color: String }
+        struct Body: Decodable {
+            let bibleId: Int
+            let passageId: String
+            let color: String
+
+            enum CodingKeys: String, CodingKey {
+                case bibleId = "bible_id"
+                case passageId = "passage_id"
+                case color
+            }
+        }
         var captured: URLRequest?
         var capturedJSONBody: Any?
 
@@ -72,8 +82,8 @@ extension URLRequest {
         let jsonBody = try #require(capturedJSONBody)
         let jsonData = try JSONSerialization.data(withJSONObject: jsonBody)
         let decoded = try JSONDecoder().decode(Body.self, from: jsonData)
-        #expect(decoded.bible_id == 1)
-        #expect(decoded.passage_id == "GEN.1.1")
+        #expect(decoded.bibleId == 1)
+        #expect(decoded.passageId == "GEN.1.1")
         #expect(decoded.color == "ff00ff")
         #expect(result)
     }

--- a/Tests/YouVersionPlatformCoreTests/LanguagesAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/LanguagesAPITests.swift
@@ -41,7 +41,7 @@ import Testing
             )
         ]
 
-        let responseData = try JSONEncoder().encode(LanguagesResponse(data: expectedLanguages, next_page_token: nil, total_size: nil))
+        let responseData = try JSONEncoder().encode(LanguagesResponse(data: expectedLanguages, nextPageToken: nil, totalSize: nil))
         var capturedRequest: URLRequest?
 
         HTTPMocking.setHandler(token: token) { request in
@@ -84,7 +84,7 @@ import Testing
             )
         ]
 
-        let responseData = try JSONEncoder().encode(LanguagesResponse(data: expectedLanguages, next_page_token: nil, total_size: nil))
+        let responseData = try JSONEncoder().encode(LanguagesResponse(data: expectedLanguages, nextPageToken: nil, totalSize: nil))
         var capturedRequest: URLRequest?
 
         HTTPMocking.setHandler(token: token) { request in
@@ -168,7 +168,7 @@ import Testing
         let (session, token) = HTTPMocking.makeSession()
         defer { HTTPMocking.clear(token: token) }
 
-        let emptyResponse = LanguagesResponse(data: [], next_page_token: nil, total_size: nil)
+        let emptyResponse = LanguagesResponse(data: [], nextPageToken: nil, totalSize: nil)
         let responseData = try JSONEncoder().encode(emptyResponse)
 
         HTTPMocking.setHandler(token: token) { request in
@@ -183,7 +183,13 @@ import Testing
     // Helper struct for encoding test responses
     private struct LanguagesResponse: Encodable {
         let data: [LanguageOverview]
-        let next_page_token: String?
-        let total_size: Int?
+        let nextPageToken: String?
+        let totalSize: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case data
+            case nextPageToken = "next_page_token"
+            case totalSize = "total_size"
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Expanded `AGENTS.md` with Swift/SwiftUI style rules ported from the `loop-ios` guidelines (e.g. prefer `@Observable`, `@MainActor` ViewModels, actors over locks, `private(set)` spacing, member ordering, Dynamic Type, etc.).
- Added a `snake_case_property` SwiftLint rule (error severity) and arranged a nested `Tests/.swiftlint.yml` so the rule is enforced on tests too without bringing along unrelated built-in rule noise. Existing per-rule test-exclusion regexes updated from `.*Test\.swift` to `.*Tests?\.swift` since the old pattern didn't actually match `FooTests.swift`.
- Removed the unused `no_import_red` rule.
- Applied the new rules across the codebase:
  - `ReaderSettings` class → struct.
  - `BibleReaderViewModel`: stored properties consolidated above the initializer; `colorTheme` → `private(set)`; unnecessary `self.` dropped.
  - `BibleVersionsViewModel`: `init (` → `init(`; `permittedVersionsList` / `suggestedLanguagesList` → `private(set)`; unnecessary `self.` dropped.
  - `BibleReaderView`: `fontSettingsDetent` / `fontListDetent` → `private`; `ContextProvider` → `final class`; `ScrollOffsetPreferenceKey` → `private`.
  - `BibleReaderViewModel+VersionsList`: dropped an unsafe `permittedVersionsList!` force-unwrap; tidied blank lines.
- Renamed snake_case properties to camelCase (`text_direction`, `next_page_token`, `total_size` and two test helpers) using `CodingKeys` so the JSON wire format is preserved. Renamed snake_case local test vars in `BibleReferenceTests`.
- Removed commented-out and unused code flagged by periphery/manual audit (swipeUpLabel, dead comment blocks in `BibleReaderMyVersionsListItem`, `BibleReaderViewModel+MyVersions`, `BibleTextFonts`, `BibleTextBlock`, `BibleVersionRendering`).

## Test plan
- [x] \`swift build\` — clean.
- [x] \`swiftlint --strict\` — 0 violations across 121 files (sources + tests).
- [x] \`swift test\` — 224/224 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a thorough style-enforcement and dead-code cleanup pass: it ports Swift/SwiftUI guidelines into `AGENTS.md`, introduces a `snake_case_property` SwiftLint rule (with a nested `Tests/.swiftlint.yml`), renames all snake_case properties to camelCase while preserving JSON wire format via `CodingKeys`, tightens access control (`private(set)`, `private let`, `final class`), consolidates stored properties above initializers, and removes a significant amount of commented-out code. All 224 tests pass and SwiftLint reports 0 violations across 121 files. The two open questions from previous review threads — the `#if canImport(UIKit)` guard for `horizontalSizeClass` on tvOS, and the silent removal of `total_size` from `BibleVersionsResponse` — remain worth resolving before merge.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining open items are P2 and were flagged in previous review threads.

The PR is a well-scoped style and cleanup refactor with no logic changes to business logic. The build is clean, 224/224 tests pass, and SwiftLint shows 0 violations. The two lingering concerns (tvOS `horizontalSizeClass` guard, `total_size` removal asymmetry) are carryover P2 threads from the previous review — they do not introduce new defects in this diff and don't block merge.

`Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift` (tvOS guard) and `Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift` (`total_size` removal) — both already discussed in prior review threads.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .swiftlint.yml | Updated all per-rule exclusion regexes from `.*Test\.swift` to `.*Tests?\.swift`, replaced `no_import_red` with `snake_case_property` (camelCase enforcement), and removed `Tests` from the global `excluded` paths so the new `Tests/.swiftlint.yml` can own test linting. |
| Tests/.swiftlint.yml | New nested SwiftLint config restricting tests to `only_rules: [custom_rules, snake_case_property]`; `snake_case_property` is a custom rule identifier and may be silently ignored as a built-in rule by SwiftLint (flagged in previous review thread). |
| Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift | Renamed `next_page_token` → `nextPageToken` with CodingKeys; `total_size` removed entirely (no CodingKey), creating asymmetry with `Languages.swift` which retains `totalSize` — already flagged in previous review. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Stored properties consolidated above `init`; `ReaderSettings` class → struct; `colorTheme` made `private(set)`; unnecessary `self.` dropped; clean reorganization. |
| Sources/YouVersionPlatformReader/ViewModels/BibleVersionsViewModel.swift | `init (` → `init(`; `permittedVersionsList` and `suggestedLanguagesList` made `private(set)`; `self.` removed throughout. |
| Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift | `horizontalSizeClass` guarded with `#if canImport(UIKit)` — tvOS also imports UIKit but `horizontalSizeClass` is unavailable there; `#if !os(tvOS)` may be more appropriate (flagged in previous review). |
| Sources/YouVersionPlatformReader/BibleReaderView.swift | `fontSettingsDetent`/`fontListDetent` → `private let`; `ContextProvider` → `final class`; `ScrollOffsetPreferenceKey` → `private struct`; unused `colorScheme` environment removed. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+VersionsList.swift | Dropped unsafe `permittedVersionsList!` force-unwrap in favour of `permittedVersionsList?.isEmpty ?? true`; dead commented-out code removed. |
| Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift | Removed unused `swipeUpLabel` computed view property and its dead call-site comment. |
| Tests/YouVersionPlatformCoreTests/HighlightsAPITests.swift | Local `Body` struct updated to camelCase with CodingKeys; JSON wire format (`bible_id`, `passage_id`) preserved for correct decoding in assertions. |
| Tests/YouVersionPlatformCoreTests/LanguagesAPITests.swift | Helper `LanguagesResponse` updated to camelCase with CodingKeys; Encodable wire format (`next_page_token`, `total_size`) correctly matches what the production Decodable struct expects. |
| Tests/YouVersionPlatformCoreTests/BibleReferenceTests.swift | Local test variables renamed from snake_case (`gen1_1`, `gen1_1to3`) to camelCase (`gen1Verse1`, `gen1Verses1to3`) — consistent with the new style rules. |
| AGENTS.md | Added comprehensive Swift/SwiftUI style rules covering concurrency, Observable, MainActor, member ordering, Dynamic Type, and more. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[API Response JSON] -->|snake_case keys| B[CodingKeys enum]
    B -->|textDirection| C[BibleVersionIndex]
    B -->|nextPageToken| D[BibleVersionsResponse]
    B -->|nextPageToken + totalSize| E[LanguagesResponse]
    C --> F[BibleVersionAPI]
    D --> F
    E --> G[Languages API]

    H[SwiftLint root config] -->|excluded: Tests removed| I[Tests/.swiftlint.yml]
    H -->|snake_case_property rule| J[Sources/**/*.swift]
    I -->|only_rules: custom_rules| K[Tests/**/*.swift]

    L[BibleReaderViewModel] -->|private set| M[colorTheme]
    N[BibleVersionsViewModel] -->|private set| O[permittedVersionsList]
    N -->|private set| P[suggestedLanguagesList]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift`, line 88-98 ([link](https://github.com/youversion/platform-sdk-swift/blob/325ac61db501b5227b01cdb4045b6248201a2b69/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift#L88-L98)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`total_size` silently dropped — inconsistent with `Languages.swift`**

   `BibleVersionsResponse.total_size` was removed entirely rather than renamed to `totalSize`, while the parallel `LanguagesResponse` in `Languages.swift` keeps `totalSize`. Both types come from the same pagination API family, so this inconsistency looks unintentional. If `total_size` in the Bible-versions response is genuinely unused and will never be needed, a comment explaining that choice would help future readers. Otherwise consider keeping parity with the languages response.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift
   Line: 88-98

   Comment:
   **`total_size` silently dropped — inconsistent with `Languages.swift`**

   `BibleVersionsResponse.total_size` was removed entirely rather than renamed to `totalSize`, while the parallel `LanguagesResponse` in `Languages.swift` keeps `totalSize`. Both types come from the same pagination API family, so this inconsistency looks unintentional. If `total_size` in the Bible-versions response is genuinely unused and will never be needed, a comment explaining that choice would help future readers. Otherwise consider keeping parity with the languages response.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift`, line 801-803 ([link](https://github.com/youversion/platform-sdk-swift/blob/325ac61db501b5227b01cdb4045b6248201a2b69/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift#L801-L803)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`#if canImport(UIKit)` may not be the right guard for `horizontalSizeClass`**

   SwiftUI's `\.horizontalSizeClass` environment value is marked `@available(tvOS, unavailable)`, yet tvOS *does* import UIKit — so `#if canImport(UIKit)` would include the property on tvOS builds and likely cause a compilation error there. The rest of the codebase uses `#if !os(tvOS)` (e.g. `ContextProvider` in `BibleReaderView.swift`), which is the appropriate guard here. Could you verify this compiles cleanly with a tvOS scheme? Does this compile on a tvOS build scheme? If `horizontalSizeClass` is unavailable on tvOS and tvOS does import UIKit, the guard would need to be `#if !os(tvOS)` instead.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
   Line: 801-803

   Comment:
   **`#if canImport(UIKit)` may not be the right guard for `horizontalSizeClass`**

   SwiftUI's `\.horizontalSizeClass` environment value is marked `@available(tvOS, unavailable)`, yet tvOS *does* import UIKit — so `#if canImport(UIKit)` would include the property on tvOS builds and likely cause a compilation error there. The rest of the codebase uses `#if !os(tvOS)` (e.g. `ContextProvider` in `BibleReaderView.swift`), which is the appropriate guard here. Could you verify this compiles cleanly with a tvOS scheme? Does this compile on a tvOS build scheme? If `horizontalSizeClass` is unavailable on tvOS and tvOS does import UIKit, the guard would need to be `#if !os(tvOS)` instead.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["style: drop trailing whitespace on blank..."](https://github.com/youversion/platform-sdk-swift/commit/44c5590ea936b7a971373a14860ea0997646ee94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29308764)</sub>

<!-- /greptile_comment -->