### PR TITLE
tests: create BibleVersionRepositoryProtocol and use it for BibleVers…

### DIFF
--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -9,6 +9,27 @@ public protocol BibleVersionAPIClient: Sendable {
     func version(withId id: Int) async throws -> BibleVersion
 }
 
+/// Abstraction over Bible version lookup and download operations.
+public protocol BibleVersionRepositoryProtocol: Sendable {
+    /// Returns a cached version when one is already available locally.
+    func versionIfCached(_ id: Int) async throws -> BibleVersion?
+
+    /// Returns a Bible version, loading it when needed.
+    func version(withId id: Int) async throws -> BibleVersion
+
+    /// Downloads a version for offline access.
+    func downloadVersion(withId id: Int) async throws
+
+    /// Returns the current download status for a version.
+    func downloadStatus(for id: Int) -> BibleVersionRepository.BibleVersionDownloadStatus
+
+    /// Removes a version from every local cache.
+    func removeVersion(withId versionId: Int) async
+
+    /// Removes every locally stored version that is no longer permitted.
+    func removeUnpermittedVersions(permittedIds: Set<Int>) async
+}
+
 public protocol BibleVersionCaching: Sendable {
     func version(withId id: Int) async -> BibleVersion?
     func addVersion(_ version: BibleVersion) async
@@ -222,7 +243,7 @@ public actor VersionDownloadCache: BibleVersionCaching {
 
 }
 
-public actor BibleVersionRepository: Observable {
+public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol {
 
     public static let shared = BibleVersionRepository()
 

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -6,26 +6,31 @@ import YouVersionPlatformCore
 @MainActor
 @Observable
 public final class BibleVersionsViewModel {
-    private let userDefaultsKeyForMyVersions = "bible-reader-view--my-versions"
-    private var hasLoadedInitialState = false
-    public let versionRepository = BibleVersionRepository()
     public var onVersionChange: ((BibleVersion) -> Void)
     /// called when the user chooses to download a version and they're not yet signed in.
     public var onSignInRequired: (() -> Void)?
     public var colorTheme: ReaderTheme?
-    
+
+    public let versionRepository: any BibleVersionRepositoryProtocol
+
     var currentBibleVersionLanguage: String?
-    
     var showGenericAlert = false
     var textForGenericAlertTitle = ""
     var textForGenericAlertBody = ""
     private(set) var textForGenericAlertOKButton = "OK"
     
+    private let userDefaultsKeyForMyVersions = "bible-reader-view--my-versions"
+    private var hasLoadedInitialState = false
+
     /// onVersionChange: called when the user has chosen a new version (or their first). The caller should ensure their current reference exists in this new version and choose a new one if not.
-    public init(onVersionChange: @escaping (BibleVersion) -> Void) {
+    public init(
+        onVersionChange: @escaping (BibleVersion) -> Void,
+        versionRepository: any BibleVersionRepositoryProtocol = BibleVersionRepository.shared
+    ) {
         self.myVersions = []
         self.suggestedLanguagesList = []
         self.onVersionChange = onVersionChange
+        self.versionRepository = versionRepository
     }
 
     /// Loads the initial version data once for this model instance.

--- a/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import Testing
+@testable import YouVersionPlatformCore
+@testable import YouVersionPlatformUI
+
+private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
+    var versionById: [Int: BibleVersion] = [:]
+    var cachedVersionById: [Int: BibleVersion] = [:]
+    var thrownError: Error?
+    var downloadedIds: [Int] = []
+
+    func setVersion(_ version: BibleVersion) {
+        versionById[version.id] = version
+    }
+
+    func setCachedVersion(_ version: BibleVersion) {
+        cachedVersionById[version.id] = version
+    }
+
+    func setThrownError(_ error: Error?) {
+        thrownError = error
+    }
+
+    func versionIfCached(_ id: Int) async throws -> BibleVersion? {
+        if let thrownError {
+            throw thrownError
+        }
+        return cachedVersionById[id]
+    }
+
+    func version(withId id: Int) async throws -> BibleVersion {
+        if let thrownError {
+            throw thrownError
+        }
+        if let version = versionById[id] {
+            return version
+        }
+        throw NSError(domain: "BibleVersionsViewModelTests", code: id)
+    }
+
+    func downloadVersion(withId id: Int) async throws {
+        if let thrownError {
+            throw thrownError
+        }
+        downloadedIds.append(id)
+    }
+
+    nonisolated func downloadStatus(for id: Int) -> BibleVersionRepository.BibleVersionDownloadStatus {
+        .notDownloadable
+    }
+
+    func removeVersion(withId versionId: Int) async {
+    }
+
+    func removeUnpermittedVersions(permittedIds: Set<Int>) async {
+    }
+}
+
+@MainActor
+@Suite struct BibleVersionsViewModelTests {
+    @Test
+    func initUsesSharedRepositoryByDefault() {
+        let viewModel = BibleVersionsViewModel { _ in }
+
+        #expect(viewModel.versionRepository is BibleVersionRepository)
+    }
+
+    @Test
+    func switchToVersionUsesInjectedRepository() async {
+        let repository = MockBibleVersionRepository()
+        let version = makeBibleVersion(id: 111)
+        await repository.setVersion(version)
+        var changedVersion: BibleVersion?
+        let viewModel = BibleVersionsViewModel(
+            onVersionChange: { changedVersion = $0 },
+            versionRepository: repository
+        )
+
+        viewModel.switchToVersion(version.id)
+        await waitFor { changedVersion == version }
+
+        #expect(changedVersion == version)
+        #expect(viewModel.showGenericAlert == false)
+    }
+
+    @Test
+    func switchToVersionShowsAlertWhenRepositoryThrows() async {
+        let repository = MockBibleVersionRepository()
+        await repository.setThrownError(NSError(domain: "BibleVersionsViewModelTests", code: 99))
+        let viewModel = BibleVersionsViewModel(
+            onVersionChange: { _ in Issue.record("onVersionChange should not be called") },
+            versionRepository: repository
+        )
+
+        viewModel.switchToVersion(111)
+        await waitFor { viewModel.showGenericAlert }
+
+        #expect(viewModel.showGenericAlert)
+        #expect(viewModel.textForGenericAlertTitle == .localized("generic.error"))
+        #expect(viewModel.textForGenericAlertBody == .localized("reader.versionAccessErrorBody"))
+    }
+
+    @Test
+    func handleVersionPickerTapLoadsSelectedVersionAndPushesInfoScreen() async {
+        let repository = MockBibleVersionRepository()
+        let version = makeBibleVersion(id: 222)
+        await repository.setVersion(version)
+        let viewModel = BibleVersionsViewModel(
+            onVersionChange: { _ in },
+            versionRepository: repository
+        )
+
+        viewModel.handleVersionPickerTap(version.id)
+        await waitFor { viewModel.selectedVersion == version }
+
+        #expect(viewModel.selectedVersion == version)
+        #expect(viewModel.versionsPickerStack == [.versionInfo])
+        #expect(viewModel.showingVersionsStack)
+        #expect(viewModel.showFullProgressViewOverlay == false)
+    }
+
+    @Test
+    func myVersionMoreInfoMenuTappedUsesInjectedRepository() async {
+        let repository = MockBibleVersionRepository()
+        let version = makeBibleVersion(id: 333)
+        await repository.setVersion(version)
+        let viewModel = BibleVersionsViewModel(
+            onVersionChange: { _ in },
+            versionRepository: repository
+        )
+
+        viewModel.myVersionMoreInfoMenuTapped(version.id)
+        await waitFor { viewModel.selectedVersion == version }
+
+        #expect(viewModel.selectedVersion == version)
+        #expect(viewModel.versionsPickerStack == [.versionInfo])
+        #expect(viewModel.showingVersionsStack)
+    }
+
+    @Test
+    func myVersionDownloadMenuTappedShowsAlertWhenRepositoryCannotLoadVersion() async {
+        let repository = MockBibleVersionRepository()
+        let viewModel = BibleVersionsViewModel(
+            onVersionChange: { _ in Issue.record("onVersionChange should not be called") },
+            versionRepository: repository
+        )
+
+        viewModel.myVersionDownloadMenuTapped(444)
+        await waitFor { viewModel.showGenericAlert }
+
+        #expect(viewModel.showGenericAlert)
+        #expect(viewModel.textForGenericAlertTitle == .localized("generic.error"))
+        #expect(viewModel.textForGenericAlertBody == .localized("myVersions.downloadErrorBody"))
+    }
+
+    private func makeBibleVersion(id: Int) -> BibleVersion {
+        BibleVersion(
+            id: id,
+            abbreviation: "XYZ\(id)",
+            promotionalContent: nil,
+            copyright: nil,
+            languageTag: "en",
+            localizedAbbreviation: "Xyz\(id)",
+            localizedTitle: "The Something Bible \(id)",
+            readerFooter: nil,
+            readerFooterUrl: nil,
+            title: "Something Bible \(id)",
+            organizationId: nil,
+            bookCodes: nil,
+            books: nil,
+            textDirection: "ltr"
+        )
+    }
+
+    private func waitFor(
+        timeoutNanoseconds: UInt64 = 1_000_000_000,
+        condition: @escaping @MainActor () -> Bool
+    ) async {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if condition() {
+                return
+            }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        Issue.record("Timed out waiting for condition")
+    }
+}


### PR DESCRIPTION
tests: create BibleVersionRepositoryProtocol and use it for BibleVersionsViewModelTests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `BibleVersionRepositoryProtocol` to decouple `BibleVersionsViewModel` from the concrete `BibleVersionRepository`, enabling dependency injection and making the ViewModel properly testable. It also fixes an existing issue where each ViewModel instance created its own repository, replacing that with the shared singleton as the default.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style suggestions that do not affect runtime behaviour.

The protocol and conformance are correct, the DI wiring is clean, the default is now the correct shared singleton (fixing a latent bug), and the new tests are well-structured with proper async coordination. The only finding is a P2 design suggestion about the nested enum leaking through the protocol.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift | Adds BibleVersionRepositoryProtocol with 6 methods; BibleVersionRepository now conforms. Minor design nit: downloadStatus return type still references the concrete class's nested enum. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift | versionRepository now typed as any BibleVersionRepositoryProtocol with dependency injection; default switched from new BibleVersionRepository() to BibleVersionRepository.shared (correct singleton reuse). |
| Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift | New test file with 6 well-structured tests covering switchToVersion, handleVersionPickerTap, myVersionMoreInfoMenuTapped, and myVersionDownloadMenuTapped using a clean MockBibleVersionRepository actor. |

</details>

<h3>Class Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class BibleVersionRepositoryProtocol {
        <<protocol>>
        +versionIfCached(id: Int) BibleVersion?
        +version(withId id: Int) BibleVersion
        +downloadVersion(withId id: Int)
        +downloadStatus(for id: Int) BibleVersionDownloadStatus
        +removeVersion(withId versionId: Int)
        +removeUnpermittedVersions(permittedIds: Set~Int~)
    }

    class BibleVersionRepository {
        <<actor>>
        +static shared: BibleVersionRepository
        -apiClient: BibleVersionAPIClient
        -memoryCache: BibleVersionCaching
        -diskCache: BibleVersionCaching
        -downloadCache: BibleVersionCaching
    }

    class MockBibleVersionRepository {
        <<actor, private>>
        +versionById: [Int: BibleVersion]
        +cachedVersionById: [Int: BibleVersion]
        +thrownError: Error?
        +downloadedIds: [Int]
    }

    class BibleVersionsViewModel {
        <<class, MainActor>>
        +versionRepository: any BibleVersionRepositoryProtocol
        +init(onVersionChange:versionRepository:)
        +switchToVersion(versionId: Int)
        +handleVersionPickerTap(versionId: Int)
    }

    BibleVersionRepositoryProtocol <|.. BibleVersionRepository : conforms
    BibleVersionRepositoryProtocol <|.. MockBibleVersionRepository : conforms (tests)
    BibleVersionsViewModel --> BibleVersionRepositoryProtocol : depends on
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
Line: 24

Comment:
**Protocol leaks concrete type via nested enum**

`downloadStatus(for:)` returns `BibleVersionRepository.BibleVersionDownloadStatus`, meaning any type that implements or depends on `BibleVersionRepositoryProtocol` must also import/know about the concrete `BibleVersionRepository` class — partly defeating the purpose of the protocol abstraction. Lifting `BibleVersionDownloadStatus` out of `BibleVersionRepository` (or adding a top-level `typealias`) would make the protocol self-contained.

```swift
// Option: make the enum a top-level type
public enum BibleVersionDownloadStatus: Sendable {
    case downloadable
    case downloaded
    case notDownloadable
}

// Protocol method becomes:
func downloadStatus(for id: Int) -> BibleVersionDownloadStatus
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["tests: create BibleVersionRepositoryProt..."](https://github.com/youversion/platform-sdk-swift/commit/d1e212d6886f217bbad4f9aa8251823d5e56a821) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29316979)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->