### PR TITLE
ci: add public API stability check

### DIFF
--- a/.api-baseline/YouVersionPlatformCore.json
+++ b/.api-baseline/YouVersionPlatformCore.json
@@ -1,0 +1,20808 @@
+{
+  "ABIRoot": {
+    "kind": "Root",
+    "name": "YouVersionPlatformCore",
+    "printedName": "YouVersionPlatformCore",
+    "children": [
+      {
+        "kind": "Import",
+        "name": "CryptoKit",
+        "printedName": "CryptoKit",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformCore"
+      },
+      {
+        "kind": "Import",
+        "name": "Foundation",
+        "printedName": "Foundation",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformCore"
+      },
+      {
+        "kind": "Import",
+        "name": "Observation",
+        "printedName": "Observation",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformCore"
+      },
+      {
+        "kind": "Import",
+        "name": "SwiftUI",
+        "printedName": "SwiftUI",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformCore"
+      },
+      {
+        "kind": "Import",
+        "name": "_Concurrency",
+        "printedName": "_Concurrency",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformCore"
+      },
+      {
+        "kind": "Import",
+        "name": "_StringProcessing",
+        "printedName": "_StringProcessing",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformCore"
+      },
+      {
+        "kind": "Import",
+        "name": "_SwiftConcurrencyShims",
+        "printedName": "_SwiftConcurrencyShims",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformCore"
+      },
+      {
+        "kind": "Import",
+        "name": "os",
+        "printedName": "os",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformCore"
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "HighlightPaginatedResponse",
+        "printedName": "HighlightPaginatedResponse",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "data",
+            "printedName": "data",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.HighlightResponse]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "HighlightResponse",
+                    "printedName": "YouVersionPlatformCore.HighlightResponse",
+                    "usr": "s:22YouVersionPlatformCore17HighlightResponseV"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore26HighlightPaginatedResponseV4dataSayAA0eG0VGvp",
+            "mangledName": "$s22YouVersionPlatformCore26HighlightPaginatedResponseV4dataSayAA0eG0VGvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.HighlightResponse]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "HighlightResponse",
+                        "printedName": "YouVersionPlatformCore.HighlightResponse",
+                        "usr": "s:22YouVersionPlatformCore17HighlightResponseV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore26HighlightPaginatedResponseV4dataSayAA0eG0VGvg",
+                "mangledName": "$s22YouVersionPlatformCore26HighlightPaginatedResponseV4dataSayAA0eG0VGvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "nextPageToken",
+            "printedName": "nextPageToken",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore26HighlightPaginatedResponseV13nextPageTokenSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore26HighlightPaginatedResponseV13nextPageTokenSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore26HighlightPaginatedResponseV13nextPageTokenSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore26HighlightPaginatedResponseV13nextPageTokenSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "encode",
+            "printedName": "encode(to:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Encoder",
+                "printedName": "any Swift.Encoder",
+                "usr": "s:s7EncoderP"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore26HighlightPaginatedResponseV6encode2toys7Encoder_p_tKF",
+            "mangledName": "$s22YouVersionPlatformCore26HighlightPaginatedResponseV6encode2toys7Encoder_p_tKF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "HighlightPaginatedResponse",
+                "printedName": "YouVersionPlatformCore.HighlightPaginatedResponse",
+                "usr": "s:22YouVersionPlatformCore26HighlightPaginatedResponseV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore26HighlightPaginatedResponseV4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore26HighlightPaginatedResponseV4fromACs7Decoder_p_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore26HighlightPaginatedResponseV",
+        "mangledName": "$s22YouVersionPlatformCore26HighlightPaginatedResponseV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "HighlightResponse",
+        "printedName": "HighlightResponse",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "id",
+            "printedName": "id",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore17HighlightResponseV2idSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV2idSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore17HighlightResponseV2idSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV2idSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "bibleId",
+            "printedName": "bibleId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore17HighlightResponseV7bibleIdSivp",
+            "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV7bibleIdSivp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore17HighlightResponseV7bibleIdSivg",
+                "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV7bibleIdSivg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "passageId",
+            "printedName": "passageId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore17HighlightResponseV9passageIdSSvp",
+            "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV9passageIdSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore17HighlightResponseV9passageIdSSvg",
+                "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV9passageIdSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "color",
+            "printedName": "color",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore17HighlightResponseV5colorSSvp",
+            "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV5colorSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore17HighlightResponseV5colorSSvg",
+                "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV5colorSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "userId",
+            "printedName": "userId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore17HighlightResponseV6userIdSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV6userIdSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore17HighlightResponseV6userIdSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV6userIdSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "createTime",
+            "printedName": "createTime",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore17HighlightResponseV10createTimeSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV10createTimeSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore17HighlightResponseV10createTimeSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV10createTimeSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "updateTime",
+            "printedName": "updateTime",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore17HighlightResponseV10updateTimeSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV10updateTimeSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore17HighlightResponseV10updateTimeSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV10updateTimeSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "encode",
+            "printedName": "encode(to:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Encoder",
+                "printedName": "any Swift.Encoder",
+                "usr": "s:s7EncoderP"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore17HighlightResponseV6encode2toys7Encoder_p_tKF",
+            "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV6encode2toys7Encoder_p_tKF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "HighlightResponse",
+                "printedName": "YouVersionPlatformCore.HighlightResponse",
+                "usr": "s:22YouVersionPlatformCore17HighlightResponseV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore17HighlightResponseV4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV4fromACs7Decoder_p_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore17HighlightResponseV",
+        "mangledName": "$s22YouVersionPlatformCore17HighlightResponseV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "LanguageOverview",
+        "printedName": "LanguageOverview",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "id",
+            "printedName": "id",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore16LanguageOverviewV2idSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV2idSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore16LanguageOverviewV2idSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV2idSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "language",
+            "printedName": "language",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore16LanguageOverviewV8languageSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV8languageSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore16LanguageOverviewV8languageSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV8languageSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "script",
+            "printedName": "script",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore16LanguageOverviewV6scriptSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV6scriptSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore16LanguageOverviewV6scriptSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV6scriptSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "scriptName",
+            "printedName": "scriptName",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore16LanguageOverviewV10scriptNameSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV10scriptNameSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore16LanguageOverviewV10scriptNameSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV10scriptNameSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "aliases",
+            "printedName": "aliases",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[Swift.String]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore16LanguageOverviewV7aliasesSaySSGSgvp",
+            "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV7aliasesSaySSGSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "[Swift.String]?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Array",
+                        "printedName": "[Swift.String]",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:Sa"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore16LanguageOverviewV7aliasesSaySSGSgvg",
+                "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV7aliasesSaySSGSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "displayNames",
+            "printedName": "displayNames",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[Swift.String : Swift.String?]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Dictionary",
+                    "printedName": "[Swift.String : Swift.String?]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Optional",
+                        "printedName": "Swift.String?",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:Sq"
+                      }
+                    ],
+                    "usr": "s:SD"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore16LanguageOverviewV12displayNamesSDyS2SSgGSgvp",
+            "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV12displayNamesSDyS2SSgGSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "[Swift.String : Swift.String?]?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Dictionary",
+                        "printedName": "[Swift.String : Swift.String?]",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Optional",
+                            "printedName": "Swift.String?",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
+                              }
+                            ],
+                            "usr": "s:Sq"
+                          }
+                        ],
+                        "usr": "s:SD"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore16LanguageOverviewV12displayNamesSDyS2SSgGSgvg",
+                "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV12displayNamesSDyS2SSgGSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "scripts",
+            "printedName": "scripts",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[Swift.String]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore16LanguageOverviewV7scriptsSaySSGSgvp",
+            "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV7scriptsSaySSGSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "[Swift.String]?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Array",
+                        "printedName": "[Swift.String]",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:Sa"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore16LanguageOverviewV7scriptsSaySSGSgvg",
+                "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV7scriptsSaySSGSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "variants",
+            "printedName": "variants",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[Swift.String]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore16LanguageOverviewV8variantsSaySSGSgvp",
+            "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV8variantsSaySSGSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "[Swift.String]?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Array",
+                        "printedName": "[Swift.String]",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:Sa"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore16LanguageOverviewV8variantsSaySSGSgvg",
+                "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV8variantsSaySSGSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "countries",
+            "printedName": "countries",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[Swift.String]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore16LanguageOverviewV9countriesSaySSGSgvp",
+            "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV9countriesSaySSGSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "[Swift.String]?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Array",
+                        "printedName": "[Swift.String]",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:Sa"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore16LanguageOverviewV9countriesSaySSGSgvg",
+                "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV9countriesSaySSGSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "textDirection",
+            "printedName": "textDirection",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore16LanguageOverviewV13textDirectionSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV13textDirectionSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore16LanguageOverviewV13textDirectionSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV13textDirectionSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "defaultBibleId",
+            "printedName": "defaultBibleId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Int?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore16LanguageOverviewV14defaultBibleIdSiSgvp",
+            "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV14defaultBibleIdSiSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.Int?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore16LanguageOverviewV14defaultBibleIdSiSgvg",
+                "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV14defaultBibleIdSiSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(id:language:script:scriptName:aliases:displayNames:scripts:variants:countries:textDirection:defaultBibleId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "LanguageOverview",
+                "printedName": "YouVersionPlatformCore.LanguageOverview",
+                "usr": "s:22YouVersionPlatformCore16LanguageOverviewV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[Swift.String]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[Swift.String : Swift.String]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Dictionary",
+                    "printedName": "[Swift.String : Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:SD"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[Swift.String]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[Swift.String]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[Swift.String]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "hasDefaultArg": true,
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Int?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore16LanguageOverviewV2id8language6script0I4Name7aliases12displayNames7scripts8variants9countries13textDirection14defaultBibleIdACSSSg_A3OSaySSGSgSDyS2SGSgA3QSSSiSgtcfc",
+            "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV2id8language6script0I4Name7aliases12displayNames7scripts8variants9countries13textDirection14defaultBibleIdACSSSg_A3OSaySSGSgSDyS2SGSgA3QSSSiSgtcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "==",
+            "printedName": "==(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "LanguageOverview",
+                "printedName": "YouVersionPlatformCore.LanguageOverview",
+                "usr": "s:22YouVersionPlatformCore16LanguageOverviewV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "LanguageOverview",
+                "printedName": "YouVersionPlatformCore.LanguageOverview",
+                "usr": "s:22YouVersionPlatformCore16LanguageOverviewV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore16LanguageOverviewV2eeoiySbAC_ACtFZ",
+            "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV2eeoiySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "encode",
+            "printedName": "encode(to:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Encoder",
+                "printedName": "any Swift.Encoder",
+                "usr": "s:s7EncoderP"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore16LanguageOverviewV6encode2toys7Encoder_p_tKF",
+            "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV6encode2toys7Encoder_p_tKF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "LanguageOverview",
+                "printedName": "YouVersionPlatformCore.LanguageOverview",
+                "usr": "s:22YouVersionPlatformCore16LanguageOverviewV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore16LanguageOverviewV4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV4fromACs7Decoder_p_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore16LanguageOverviewV",
+        "mangledName": "$s22YouVersionPlatformCore16LanguageOverviewV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "Organization",
+        "printedName": "Organization",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "id",
+            "printedName": "id",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore12OrganizationV2idSSvp",
+            "mangledName": "$s22YouVersionPlatformCore12OrganizationV2idSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore12OrganizationV2idSSvg",
+                "mangledName": "$s22YouVersionPlatformCore12OrganizationV2idSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "parentOrganizationId",
+            "printedName": "parentOrganizationId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore12OrganizationV06parentE2IdSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore12OrganizationV06parentE2IdSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore12OrganizationV06parentE2IdSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore12OrganizationV06parentE2IdSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "name",
+            "printedName": "name",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore12OrganizationV4nameSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore12OrganizationV4nameSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore12OrganizationV4nameSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore12OrganizationV4nameSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "description",
+            "printedName": "description",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore12OrganizationV11descriptionSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore12OrganizationV11descriptionSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore12OrganizationV11descriptionSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore12OrganizationV11descriptionSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "email",
+            "printedName": "email",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore12OrganizationV5emailSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore12OrganizationV5emailSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore12OrganizationV5emailSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore12OrganizationV5emailSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "phone",
+            "printedName": "phone",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore12OrganizationV5phoneSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore12OrganizationV5phoneSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore12OrganizationV5phoneSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore12OrganizationV5phoneSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "primaryLanguage",
+            "printedName": "primaryLanguage",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore12OrganizationV15primaryLanguageSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore12OrganizationV15primaryLanguageSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore12OrganizationV15primaryLanguageSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore12OrganizationV15primaryLanguageSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "websiteUrl",
+            "printedName": "websiteUrl",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore12OrganizationV10websiteUrlSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore12OrganizationV10websiteUrlSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore12OrganizationV10websiteUrlSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore12OrganizationV10websiteUrlSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "address",
+            "printedName": "address",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore12OrganizationV7addressSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore12OrganizationV7addressSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore12OrganizationV7addressSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore12OrganizationV7addressSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(id:parentOrganizationId:name:description:email:phone:primaryLanguage:websiteUrl:address:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Organization",
+                "printedName": "YouVersionPlatformCore.Organization",
+                "usr": "s:22YouVersionPlatformCore12OrganizationV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore12OrganizationV2id06parentE2Id4name11description5email5phone15primaryLanguage10websiteUrl7addressACSS_SSSgA7Mtcfc",
+            "mangledName": "$s22YouVersionPlatformCore12OrganizationV2id06parentE2Id4name11description5email5phone15primaryLanguage10websiteUrl7addressACSS_SSSgA7Mtcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "==",
+            "printedName": "==(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Organization",
+                "printedName": "YouVersionPlatformCore.Organization",
+                "usr": "s:22YouVersionPlatformCore12OrganizationV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Organization",
+                "printedName": "YouVersionPlatformCore.Organization",
+                "usr": "s:22YouVersionPlatformCore12OrganizationV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore12OrganizationV2eeoiySbAC_ACtFZ",
+            "mangledName": "$s22YouVersionPlatformCore12OrganizationV2eeoiySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "encode",
+            "printedName": "encode(to:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Encoder",
+                "printedName": "any Swift.Encoder",
+                "usr": "s:s7EncoderP"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore12OrganizationV6encode2toys7Encoder_p_tKF",
+            "mangledName": "$s22YouVersionPlatformCore12OrganizationV6encode2toys7Encoder_p_tKF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Organization",
+                "printedName": "YouVersionPlatformCore.Organization",
+                "usr": "s:22YouVersionPlatformCore12OrganizationV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore12OrganizationV4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore12OrganizationV4fromACs7Decoder_p_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore12OrganizationV",
+        "mangledName": "$s22YouVersionPlatformCore12OrganizationV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "URLBuilder",
+        "printedName": "URLBuilder",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "organizationsURL",
+            "printedName": "organizationsURL(id:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO16organizationsURL2id10Foundation0G0VSgSS_tFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO16organizationsURL2id10Foundation0G0VSgSS_tFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "votdURL",
+            "printedName": "votdURL(dayOfYear:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO7votdURL9dayOfYear10Foundation0G0VSgSi_tFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO7votdURL9dayOfYear10Foundation0G0VSgSi_tFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionURL",
+            "printedName": "versionURL(versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO10versionURL0F2Id10Foundation0G0VSgSi_tFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO10versionURL0F2Id10Foundation0G0VSgSi_tFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIndexURL",
+            "printedName": "versionIndexURL(versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO15versionIndexURL0F2Id10Foundation0H0VSgSi_tFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO15versionIndexURL0F2Id10Foundation0H0VSgSi_tFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionBooksURL",
+            "printedName": "versionBooksURL(versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO15versionBooksURL0F2Id10Foundation0H0VSgSi_tFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO15versionBooksURL0F2Id10Foundation0H0VSgSi_tFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionBookChaptersURL",
+            "printedName": "versionBookChaptersURL(versionId:book:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO22versionBookChaptersURL0F2Id4book10Foundation0I0VSgSi_SStFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO22versionBookChaptersURL0F2Id4book10Foundation0I0VSgSi_SStFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "passageURL",
+            "printedName": "passageURL(reference:format:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "hasDefaultArg": true,
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO10passageURL9reference6format10Foundation0G0VSgAA14BibleReferenceV_SStFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO10passageURL9reference6format10Foundation0G0VSgAA14BibleReferenceV_SStFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "passageIntroURL",
+            "printedName": "passageIntroURL(versionId:passageId:format:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "hasDefaultArg": true,
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO15passageIntroURL9versionId0fJ06format10Foundation0H0VSgSi_S2StFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO15passageIntroURL9versionId0fJ06format10Foundation0H0VSgSi_S2StFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionsURL",
+            "printedName": "versionsURL(languageRanges:fields:pageSize:pageToken:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.String]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.String]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Int?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO11versionsURL14languageRanges6fields8pageSize0K5Token10Foundation0G0VSgSaySSG_AMSiSgSSSgtFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO11versionsURL14languageRanges6fields8pageSize0K5Token10Foundation0G0VSgSaySSG_AMSiSgSSSgtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "highlightsURL",
+            "printedName": "highlightsURL",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO13highlightsURL10Foundation0G0VSgvpZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO13highlightsURL10Foundation0G0VSgvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Foundation.URL?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "URL",
+                        "printedName": "Foundation.URL",
+                        "usr": "s:10Foundation3URLV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore10URLBuilderO13highlightsURL10Foundation0G0VSgvgZ",
+                "mangledName": "$s22YouVersionPlatformCore10URLBuilderO13highlightsURL10Foundation0G0VSgvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "highlightsURL",
+            "printedName": "highlightsURL(bibleId:passageId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO13highlightsURL7bibleId07passageI010Foundation0G0VSgSi_SStFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO13highlightsURL7bibleId07passageI010Foundation0G0VSgSi_SStFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "highlightsDeleteURL",
+            "printedName": "highlightsDeleteURL(bibleId:passageId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO19highlightsDeleteURL7bibleId07passageJ010Foundation0H0VSgSi_SStFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO19highlightsDeleteURL7bibleId07passageJ010Foundation0H0VSgSi_SStFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "languagesURL",
+            "printedName": "languagesURL(country:fields:pageSize:pageToken:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.String]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Int?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO12languagesURL7country6fields8pageSize0J5Token10Foundation0G0VSgSSSg_SaySSGSiSgAMtFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO12languagesURL7country6fields8pageSize0J5Token10Foundation0G0VSgSSSg_SaySSGSiSgAMtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:22YouVersionPlatformCore10URLBuilderO",
+        "mangledName": "$s22YouVersionPlatformCore10URLBuilderO",
+        "moduleName": "YouVersionPlatformCore",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "SignInWithYouVersionPKCEParameters",
+        "printedName": "SignInWithYouVersionPKCEParameters",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "codeVerifier",
+            "printedName": "codeVerifier",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB14PKCEParametersV12codeVerifierSSvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB14PKCEParametersV12codeVerifierSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB14PKCEParametersV12codeVerifierSSvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB14PKCEParametersV12codeVerifierSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "codeChallenge",
+            "printedName": "codeChallenge",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB14PKCEParametersV13codeChallengeSSvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB14PKCEParametersV13codeChallengeSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB14PKCEParametersV13codeChallengeSSvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB14PKCEParametersV13codeChallengeSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "state",
+            "printedName": "state",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB14PKCEParametersV5stateSSvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB14PKCEParametersV5stateSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB14PKCEParametersV5stateSSvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB14PKCEParametersV5stateSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "nonce",
+            "printedName": "nonce",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB14PKCEParametersV5nonceSSvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB14PKCEParametersV5nonceSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB14PKCEParametersV5nonceSSvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB14PKCEParametersV5nonceSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(codeVerifier:codeChallenge:state:nonce:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionPKCEParameters",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionPKCEParameters",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB14PKCEParametersV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB14PKCEParametersV12codeVerifier0I9Challenge5state5nonceACSS_S3Stcfc",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB14PKCEParametersV12codeVerifier0I9Challenge5state5nonceACSS_S3Stcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore010SignInWithaB14PKCEParametersV",
+        "mangledName": "$s22YouVersionPlatformCore010SignInWithaB14PKCEParametersV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "SignInWithYouVersionPKCEAuthorizationError",
+        "printedName": "SignInWithYouVersionPKCEAuthorizationError",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "unableToConstructAuthorizeURL",
+            "printedName": "unableToConstructAuthorizeURL",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.SignInWithYouVersionPKCEAuthorizationError.Type) -> YouVersionPlatformCore.SignInWithYouVersionPKCEAuthorizationError",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPKCEAuthorizationError",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPKCEAuthorizationError",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPKCEAuthorizationError.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SignInWithYouVersionPKCEAuthorizationError",
+                        "printedName": "YouVersionPlatformCore.SignInWithYouVersionPKCEAuthorizationError",
+                        "usr": "s:22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO29unableToConstructAuthorizeURLyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO29unableToConstructAuthorizeURLyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Function",
+            "name": "__derived_enum_equals",
+            "printedName": "__derived_enum_equals(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionPKCEAuthorizationError",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionPKCEAuthorizationError",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionPKCEAuthorizationError",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionPKCEAuthorizationError",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO21__derived_enum_equalsySbAC_ACtFZ",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO21__derived_enum_equalsySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Implements",
+              "Semantics"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hash",
+            "printedName": "hash(into:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Hasher",
+                "printedName": "Swift.Hasher",
+                "paramValueOwnership": "InOut",
+                "usr": "s:s6HasherV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO4hash4intoys6HasherVz_tF",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO4hash4intoys6HasherVz_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "hashValue",
+            "printedName": "hashValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO9hashValueSivp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO9hashValueSivp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO9hashValueSivg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO9hashValueSivg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO",
+        "mangledName": "$s22YouVersionPlatformCore010SignInWithaB22PKCEAuthorizationErrorO",
+        "moduleName": "YouVersionPlatformCore",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Error",
+            "printedName": "Error",
+            "usr": "s:s5ErrorP",
+            "mangledName": "$ss5ErrorP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "SignInWithYouVersionPKCEAuthorizationRequest",
+        "printedName": "SignInWithYouVersionPKCEAuthorizationRequest",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "url",
+            "printedName": "url",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "URL",
+                "printedName": "Foundation.URL",
+                "usr": "s:10Foundation3URLV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB24PKCEAuthorizationRequestV3url10Foundation3URLVvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB24PKCEAuthorizationRequestV3url10Foundation3URLVvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB24PKCEAuthorizationRequestV3url10Foundation3URLVvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB24PKCEAuthorizationRequestV3url10Foundation3URLVvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "parameters",
+            "printedName": "parameters",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionPKCEParameters",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionPKCEParameters",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB14PKCEParametersV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB24PKCEAuthorizationRequestV10parametersAA0efgaB14PKCEParametersVvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB24PKCEAuthorizationRequestV10parametersAA0efgaB14PKCEParametersVvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPKCEParameters",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPKCEParameters",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB14PKCEParametersV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB24PKCEAuthorizationRequestV10parametersAA0efgaB14PKCEParametersVvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB24PKCEAuthorizationRequestV10parametersAA0efgaB14PKCEParametersVvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore010SignInWithaB24PKCEAuthorizationRequestV",
+        "mangledName": "$s22YouVersionPlatformCore010SignInWithaB24PKCEAuthorizationRequestV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "SignInWithYouVersionPKCEAuthorizationRequestBuilder",
+        "printedName": "SignInWithYouVersionPKCEAuthorizationRequestBuilder",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "make",
+            "printedName": "make(appKey:permissions:redirectURL:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionPKCEAuthorizationRequest",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionPKCEAuthorizationRequest",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB24PKCEAuthorizationRequestV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<YouVersionPlatformCore.SignInWithYouVersionPermission>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPermission",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                  }
+                ],
+                "usr": "s:Sh"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "URL",
+                "printedName": "Foundation.URL",
+                "usr": "s:10Foundation3URLV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB31PKCEAuthorizationRequestBuilderO4make6appKey11permissions11redirectURLAA0efgabhI0VSS_ShyAA0efgaB10PermissionOG10Foundation0P0VtKFZ",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB31PKCEAuthorizationRequestBuilderO4make6appKey11permissions11redirectURLAA0efgabhI0VSS_ShyAA0efgaB10PermissionOG10Foundation0P0VtKFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "tokenURLRequest",
+            "printedName": "tokenURLRequest(code:codeVerifier:redirectUri:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "URLRequest",
+                "printedName": "Foundation.URLRequest",
+                "usr": "s:10Foundation10URLRequestV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB31PKCEAuthorizationRequestBuilderO15tokenURLRequest4code0M8Verifier11redirectUri10Foundation0L0VSS_S2StKFZ",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB31PKCEAuthorizationRequestBuilderO15tokenURLRequest4code0M8Verifier11redirectUri10Foundation0L0VSS_S2StKFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:22YouVersionPlatformCore010SignInWithaB31PKCEAuthorizationRequestBuilderO",
+        "mangledName": "$s22YouVersionPlatformCore010SignInWithaB31PKCEAuthorizationRequestBuilderO",
+        "moduleName": "YouVersionPlatformCore",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "SignInWithYouVersionPermission",
+        "printedName": "SignInWithYouVersionPermission",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "openid",
+            "printedName": "openid",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.SignInWithYouVersionPermission.Type) -> YouVersionPlatformCore.SignInWithYouVersionPermission",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPermission",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SignInWithYouVersionPermission",
+                        "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                        "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO6openidyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO6openidyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "profile",
+            "printedName": "profile",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.SignInWithYouVersionPermission.Type) -> YouVersionPlatformCore.SignInWithYouVersionPermission",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPermission",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SignInWithYouVersionPermission",
+                        "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                        "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO7profileyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO7profileyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "email",
+            "printedName": "email",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.SignInWithYouVersionPermission.Type) -> YouVersionPlatformCore.SignInWithYouVersionPermission",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPermission",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SignInWithYouVersionPermission",
+                        "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                        "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO5emailyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO5emailyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "description",
+            "printedName": "description",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO11descriptionSSvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO11descriptionSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO11descriptionSSvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO11descriptionSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(rawValue:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPermission",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueACSgSS_tcfc",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueACSgSS_tcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "declAttributes": [
+              "Inlinable"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "AllCases",
+            "printedName": "AllCases",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPermission",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8AllCasesa",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8AllCasesa",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "RawValue",
+            "printedName": "RawValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8RawValuea",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8RawValuea",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true
+          },
+          {
+            "kind": "Var",
+            "name": "allCases",
+            "printedName": "allCases",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPermission",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8allCasesSayACGvpZ",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8allCasesSayACGvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SignInWithYouVersionPermission",
+                        "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                        "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8allCasesSayACGvgZ",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8allCasesSayACGvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "rawValue",
+            "printedName": "rawValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueSSvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueSSvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Inlinable"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO",
+        "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO",
+        "moduleName": "YouVersionPlatformCore",
+        "enumRawTypeName": "String",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "CaseIterable",
+            "printedName": "CaseIterable",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "AllCases",
+                "printedName": "AllCases",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SignInWithYouVersionPermission",
+                        "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                        "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:s12CaseIterableP",
+            "mangledName": "$ss12CaseIterableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomStringConvertible",
+            "printedName": "CustomStringConvertible",
+            "usr": "s:s23CustomStringConvertibleP",
+            "mangledName": "$ss23CustomStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "RawRepresentable",
+            "printedName": "RawRepresentable",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "RawValue",
+                "printedName": "RawValue",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:SY",
+            "mangledName": "$sSY"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "SignInWithYouVersionResult",
+        "printedName": "SignInWithYouVersionResult",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "accessToken",
+            "printedName": "accessToken",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV11accessTokenSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV11accessTokenSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV11accessTokenSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV11accessTokenSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "expiryDate",
+            "printedName": "expiryDate",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.Date?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Date",
+                    "printedName": "Foundation.Date",
+                    "usr": "s:10Foundation4DateV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV10expiryDate10Foundation0J0VSgvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV10expiryDate10Foundation0J0VSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Foundation.Date?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Date",
+                        "printedName": "Foundation.Date",
+                        "usr": "s:10Foundation4DateV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV10expiryDate10Foundation0J0VSgvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV10expiryDate10Foundation0J0VSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "refreshToken",
+            "printedName": "refreshToken",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV12refreshTokenSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV12refreshTokenSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV12refreshTokenSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV12refreshTokenSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "idToken",
+            "printedName": "idToken",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV7idTokenSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV7idTokenSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV7idTokenSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV7idTokenSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "permissions",
+            "printedName": "permissions",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPermission",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV11permissionsSayAA0efgaB10PermissionOGvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV11permissionsSayAA0efgaB10PermissionOGvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SignInWithYouVersionPermission",
+                        "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                        "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV11permissionsSayAA0efgaB10PermissionOGvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV11permissionsSayAA0efgaB10PermissionOGvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "yvpUserId",
+            "printedName": "yvpUserId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV9yvpUserIdSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV9yvpUserIdSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV9yvpUserIdSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV9yvpUserIdSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "name",
+            "printedName": "name",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV4nameSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV4nameSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV4nameSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV4nameSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "profilePicture",
+            "printedName": "profilePicture",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV14profilePictureSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV14profilePictureSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV14profilePictureSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV14profilePictureSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "email",
+            "printedName": "email",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV5emailSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV5emailSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV5emailSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV5emailSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(accessToken:expiresIn:refreshToken:idToken:permissions:yvpUserId:name:profilePicture:email:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionResult",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPermission",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV11accessToken07expiresF007refreshJ002idJ011permissions9yvpUserId4name14profilePicture5emailACSSSg_A3MSayAA0efgaB10PermissionOGA4Mtcfc",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV11accessToken07expiresF007refreshJ002idJ011permissions9yvpUserId4name14profilePicture5emailACSSSg_A3MSayAA0efgaB10PermissionOGA4Mtcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(accessToken:refreshToken:idToken:expiryDate:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionResult",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.Date?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Date",
+                    "printedName": "Foundation.Date",
+                    "usr": "s:10Foundation4DateV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV11accessToken07refreshJ002idJ010expiryDateACSSSg_A2H10Foundation0N0VSgtcfc",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV11accessToken07refreshJ002idJ010expiryDateACSSSg_A2H10Foundation0N0VSgtcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV",
+        "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "YouVersionUserInfo",
+        "printedName": "YouVersionUserInfo",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "firstName",
+            "printedName": "firstName",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0aB8UserInfoV9firstNameSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore0aB8UserInfoV9firstNameSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0aB8UserInfoV9firstNameSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore0aB8UserInfoV9firstNameSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "lastName",
+            "printedName": "lastName",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0aB8UserInfoV8lastNameSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore0aB8UserInfoV8lastNameSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0aB8UserInfoV8lastNameSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore0aB8UserInfoV8lastNameSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "userId",
+            "printedName": "userId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0aB8UserInfoV6userIdSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore0aB8UserInfoV6userIdSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0aB8UserInfoV6userIdSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore0aB8UserInfoV6userIdSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "avatarUrlFormat",
+            "printedName": "avatarUrlFormat",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0aB8UserInfoV15avatarUrlFormatSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore0aB8UserInfoV15avatarUrlFormatSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0aB8UserInfoV15avatarUrlFormatSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore0aB8UserInfoV15avatarUrlFormatSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "avatarUrl",
+            "printedName": "avatarUrl",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0aB8UserInfoV9avatarUrl10Foundation3URLVSgvp",
+            "mangledName": "$s22YouVersionPlatformCore0aB8UserInfoV9avatarUrl10Foundation3URLVSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Foundation.URL?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "URL",
+                        "printedName": "Foundation.URL",
+                        "usr": "s:10Foundation3URLV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0aB8UserInfoV9avatarUrl10Foundation3URLVSgvg",
+                "mangledName": "$s22YouVersionPlatformCore0aB8UserInfoV9avatarUrl10Foundation3URLVSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "encode",
+            "printedName": "encode(to:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Encoder",
+                "printedName": "any Swift.Encoder",
+                "usr": "s:s7EncoderP"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0aB8UserInfoV6encode2toys7Encoder_p_tKF",
+            "mangledName": "$s22YouVersionPlatformCore0aB8UserInfoV6encode2toys7Encoder_p_tKF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "YouVersionUserInfo",
+                "printedName": "YouVersionPlatformCore.YouVersionUserInfo",
+                "usr": "s:22YouVersionPlatformCore0aB8UserInfoV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0aB8UserInfoV4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore0aB8UserInfoV4fromACs7Decoder_p_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore0aB8UserInfoV",
+        "mangledName": "$s22YouVersionPlatformCore0aB8UserInfoV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "YouVersionVerseOfTheDay",
+        "printedName": "YouVersionVerseOfTheDay",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "passageId",
+            "printedName": "passageId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0aB13VerseOfTheDayV9passageIdSSvp",
+            "mangledName": "$s22YouVersionPlatformCore0aB13VerseOfTheDayV9passageIdSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0aB13VerseOfTheDayV9passageIdSSvg",
+                "mangledName": "$s22YouVersionPlatformCore0aB13VerseOfTheDayV9passageIdSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "day",
+            "printedName": "day",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0aB13VerseOfTheDayV3daySivp",
+            "mangledName": "$s22YouVersionPlatformCore0aB13VerseOfTheDayV3daySivp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0aB13VerseOfTheDayV3daySivg",
+                "mangledName": "$s22YouVersionPlatformCore0aB13VerseOfTheDayV3daySivg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(passageId:day:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "YouVersionVerseOfTheDay",
+                "printedName": "YouVersionPlatformCore.YouVersionVerseOfTheDay",
+                "usr": "s:22YouVersionPlatformCore0aB13VerseOfTheDayV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0aB13VerseOfTheDayV9passageId3dayACSS_Sitcfc",
+            "mangledName": "$s22YouVersionPlatformCore0aB13VerseOfTheDayV9passageId3dayACSS_Sitcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "preview",
+            "printedName": "preview",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "YouVersionVerseOfTheDay",
+                "printedName": "YouVersionPlatformCore.YouVersionVerseOfTheDay",
+                "usr": "s:22YouVersionPlatformCore0aB13VerseOfTheDayV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0aB13VerseOfTheDayV7previewACvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0aB13VerseOfTheDayV7previewACvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "YouVersionVerseOfTheDay",
+                    "printedName": "YouVersionPlatformCore.YouVersionVerseOfTheDay",
+                    "usr": "s:22YouVersionPlatformCore0aB13VerseOfTheDayV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0aB13VerseOfTheDayV7previewACvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB13VerseOfTheDayV7previewACvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "encode",
+            "printedName": "encode(to:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Encoder",
+                "printedName": "any Swift.Encoder",
+                "usr": "s:s7EncoderP"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0aB13VerseOfTheDayV6encode2toys7Encoder_p_tKF",
+            "mangledName": "$s22YouVersionPlatformCore0aB13VerseOfTheDayV6encode2toys7Encoder_p_tKF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "YouVersionVerseOfTheDay",
+                "printedName": "YouVersionPlatformCore.YouVersionVerseOfTheDay",
+                "usr": "s:22YouVersionPlatformCore0aB13VerseOfTheDayV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0aB13VerseOfTheDayV4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore0aB13VerseOfTheDayV4fromACs7Decoder_p_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore0aB13VerseOfTheDayV",
+        "mangledName": "$s22YouVersionPlatformCore0aB13VerseOfTheDayV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "YouVersionAPI",
+        "printedName": "YouVersionAPI",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "isSignedIn",
+            "printedName": "isSignedIn",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0aB3APIO10isSignedInSbvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0aB3APIO10isSignedInSbvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO10isSignedInSbvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO10isSignedInSbvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "hasValidToken",
+            "printedName": "hasValidToken(session:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "URLSession",
+                "printedName": "Foundation.URLSession",
+                "hasDefaultArg": true,
+                "usr": "c:objc(cs)NSURLSession"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0aB3APIO13hasValidToken7sessionSbSo12NSURLSessionC_tYaFZ",
+            "mangledName": "$s22YouVersionPlatformCore0aB3APIO13hasValidToken7sessionSbSo12NSURLSessionC_tYaFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "TypeDecl",
+            "name": "Bible",
+            "printedName": "Bible",
+            "children": [
+              {
+                "kind": "Function",
+                "name": "version",
+                "printedName": "version(versionId:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO7version0G2Id11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO7version0G2Id11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "isFromExtension": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "basicVersion",
+                "printedName": "basicVersion(versionId:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO05basicB09versionId11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO05basicB09versionId11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "isFromExtension": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "chapter",
+                "printedName": "chapter(reference:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO7chapter9reference11accessToken7sessionSSAA0F9ReferenceV_SSSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO7chapter9reference11accessToken7sessionSSAA0F9ReferenceV_SSSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "isFromExtension": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "introMaterial",
+                "printedName": "introMaterial(versionId:passageId:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO13introMaterial9versionId07passageJ011accessToken7sessionSSSi_S2SSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO13introMaterial9versionId07passageJ011accessToken7sessionSSSi_S2SSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "isFromExtension": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "versions",
+                "printedName": "versions(forLanguageTag:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.BibleVersion]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVersion",
+                        "printedName": "YouVersionPlatformCore.BibleVersion",
+                        "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO8versions14forLanguageTag11accessToken7sessionSayAA0fB0VGSSSg_AMSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO8versions14forLanguageTag11accessToken7sessionSayAA0fB0VGSSSg_AMSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "isFromExtension": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "TypeDecl",
+                "name": "BibleVersionMinimalInfo",
+                "printedName": "BibleVersionMinimalInfo",
+                "children": [
+                  {
+                    "kind": "Var",
+                    "name": "id",
+                    "printedName": "id",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "declKind": "Var",
+                    "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO0fB11MinimalInfoV2idSivp",
+                    "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO0fB11MinimalInfoV2idSivp",
+                    "moduleName": "YouVersionPlatformCore",
+                    "declAttributes": [
+                      "HasStorage"
+                    ],
+                    "isLet": true,
+                    "hasStorage": true,
+                    "accessors": [
+                      {
+                        "kind": "Accessor",
+                        "name": "Get",
+                        "printedName": "Get()",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Int",
+                            "printedName": "Swift.Int",
+                            "usr": "s:Si"
+                          }
+                        ],
+                        "declKind": "Accessor",
+                        "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO0fB11MinimalInfoV2idSivg",
+                        "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO0fB11MinimalInfoV2idSivg",
+                        "moduleName": "YouVersionPlatformCore",
+                        "implicit": true,
+                        "declAttributes": [
+                          "Transparent"
+                        ],
+                        "accessorKind": "get"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "Var",
+                    "name": "languageTag",
+                    "printedName": "languageTag",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Optional",
+                        "printedName": "Swift.String?",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:Sq"
+                      }
+                    ],
+                    "declKind": "Var",
+                    "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO0fB11MinimalInfoV11languageTagSSSgvp",
+                    "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO0fB11MinimalInfoV11languageTagSSSgvp",
+                    "moduleName": "YouVersionPlatformCore",
+                    "declAttributes": [
+                      "HasStorage"
+                    ],
+                    "isLet": true,
+                    "hasStorage": true,
+                    "accessors": [
+                      {
+                        "kind": "Accessor",
+                        "name": "Get",
+                        "printedName": "Get()",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Optional",
+                            "printedName": "Swift.String?",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
+                              }
+                            ],
+                            "usr": "s:Sq"
+                          }
+                        ],
+                        "declKind": "Accessor",
+                        "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO0fB11MinimalInfoV11languageTagSSSgvg",
+                        "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO0fB11MinimalInfoV11languageTagSSSgvg",
+                        "moduleName": "YouVersionPlatformCore",
+                        "implicit": true,
+                        "declAttributes": [
+                          "Transparent"
+                        ],
+                        "accessorKind": "get"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "Function",
+                    "name": "__derived_struct_equals",
+                    "printedName": "__derived_struct_equals(_:_:)",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Bool",
+                        "printedName": "Swift.Bool",
+                        "usr": "s:Sb"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVersionMinimalInfo",
+                        "printedName": "YouVersionPlatformCore.YouVersionAPI.Bible.BibleVersionMinimalInfo",
+                        "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO0fB11MinimalInfoV"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVersionMinimalInfo",
+                        "printedName": "YouVersionPlatformCore.YouVersionAPI.Bible.BibleVersionMinimalInfo",
+                        "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO0fB11MinimalInfoV"
+                      }
+                    ],
+                    "declKind": "Func",
+                    "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO0fB11MinimalInfoV23__derived_struct_equalsySbAG_AGtFZ",
+                    "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO0fB11MinimalInfoV23__derived_struct_equalsySbAG_AGtFZ",
+                    "moduleName": "YouVersionPlatformCore",
+                    "static": true,
+                    "implicit": true,
+                    "declAttributes": [
+                      "Implements"
+                    ],
+                    "funcSelfKind": "NonMutating"
+                  }
+                ],
+                "declKind": "Struct",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO0fB11MinimalInfoV",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO0fB11MinimalInfoV",
+                "moduleName": "YouVersionPlatformCore",
+                "isFromExtension": true,
+                "conformances": [
+                  {
+                    "kind": "Conformance",
+                    "name": "Copyable",
+                    "printedName": "Copyable",
+                    "usr": "s:s8CopyableP",
+                    "mangledName": "$ss8CopyableP"
+                  },
+                  {
+                    "kind": "Conformance",
+                    "name": "Equatable",
+                    "printedName": "Equatable",
+                    "usr": "s:SQ",
+                    "mangledName": "$sSQ"
+                  },
+                  {
+                    "kind": "Conformance",
+                    "name": "Escapable",
+                    "printedName": "Escapable",
+                    "usr": "s:s9EscapableP",
+                    "mangledName": "$ss9EscapableP"
+                  },
+                  {
+                    "kind": "Conformance",
+                    "name": "Sendable",
+                    "printedName": "Sendable",
+                    "usr": "s:s8SendableP",
+                    "mangledName": "$ss8SendableP"
+                  },
+                  {
+                    "kind": "Conformance",
+                    "name": "SendableMetatype",
+                    "printedName": "SendableMetatype",
+                    "usr": "s:s16SendableMetatypeP",
+                    "mangledName": "$ss16SendableMetatypeP"
+                  }
+                ]
+              },
+              {
+                "kind": "Function",
+                "name": "permittedVersions",
+                "printedName": "permittedVersions(forLanguageTag:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.YouVersionAPI.Bible.BibleVersionMinimalInfo]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVersionMinimalInfo",
+                        "printedName": "YouVersionPlatformCore.YouVersionAPI.Bible.BibleVersionMinimalInfo",
+                        "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO0fB11MinimalInfoV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO17permittedVersions14forLanguageTag11accessToken7sessionSayAE0fB11MinimalInfoVGSSSg_AMSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO17permittedVersions14forLanguageTag11accessToken7sessionSayAE0fB11MinimalInfoVGSSSg_AMSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "isFromExtension": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              }
+            ],
+            "declKind": "Enum",
+            "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO",
+            "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO",
+            "moduleName": "YouVersionPlatformCore",
+            "isFromExtension": true,
+            "isEnumExhaustive": true,
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              }
+            ]
+          },
+          {
+            "kind": "TypeDecl",
+            "name": "Highlights",
+            "printedName": "Highlights",
+            "children": [
+              {
+                "kind": "Function",
+                "name": "createHighlight",
+                "printedName": "createHighlight(bibleId:passageId:color:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO10HighlightsO15createHighlight7bibleId07passageJ05color11accessToken7sessionSbSi_S3SSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO10HighlightsO15createHighlight7bibleId07passageJ05color11accessToken7sessionSbSi_S3SSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "getHighlights",
+                "printedName": "getHighlights(bibleId:passageId:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.HighlightResponse]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "HighlightResponse",
+                        "printedName": "YouVersionPlatformCore.HighlightResponse",
+                        "usr": "s:22YouVersionPlatformCore17HighlightResponseV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO10HighlightsO03getF07bibleId07passageI011accessToken7sessionSayAA17HighlightResponseVGSi_S2SSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO10HighlightsO03getF07bibleId07passageI011accessToken7sessionSayAA17HighlightResponseVGSi_S2SSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "updateHighlight",
+                "printedName": "updateHighlight(bibleId:passageId:color:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO10HighlightsO15updateHighlight7bibleId07passageJ05color11accessToken7sessionSbSi_S3SSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO10HighlightsO15updateHighlight7bibleId07passageJ05color11accessToken7sessionSbSi_S3SSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "deleteHighlight",
+                "printedName": "deleteHighlight(bibleId:passageId:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO10HighlightsO15deleteHighlight7bibleId07passageJ011accessToken7sessionSbSi_S2SSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO10HighlightsO15deleteHighlight7bibleId07passageJ011accessToken7sessionSbSi_S2SSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              }
+            ],
+            "declKind": "Enum",
+            "usr": "s:22YouVersionPlatformCore0aB3APIO10HighlightsO",
+            "mangledName": "$s22YouVersionPlatformCore0aB3APIO10HighlightsO",
+            "moduleName": "YouVersionPlatformCore",
+            "isFromExtension": true,
+            "isEnumExhaustive": true,
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              }
+            ]
+          },
+          {
+            "kind": "TypeDecl",
+            "name": "Languages",
+            "printedName": "Languages",
+            "children": [
+              {
+                "kind": "Function",
+                "name": "languages",
+                "printedName": "languages(country:fields:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.LanguageOverview]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "LanguageOverview",
+                        "printedName": "YouVersionPlatformCore.LanguageOverview",
+                        "usr": "s:22YouVersionPlatformCore16LanguageOverviewV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sa"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO9LanguagesO9languages7country6fields11accessToken7sessionSayAA16LanguageOverviewVGSSSg_SaySSGANSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO9LanguagesO9languages7country6fields11accessToken7sessionSayAA16LanguageOverviewVGSSSg_SaySSGANSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              }
+            ],
+            "declKind": "Enum",
+            "usr": "s:22YouVersionPlatformCore0aB3APIO9LanguagesO",
+            "mangledName": "$s22YouVersionPlatformCore0aB3APIO9LanguagesO",
+            "moduleName": "YouVersionPlatformCore",
+            "isFromExtension": true,
+            "isEnumExhaustive": true,
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              }
+            ]
+          },
+          {
+            "kind": "TypeDecl",
+            "name": "Organizations",
+            "printedName": "Organizations",
+            "children": [
+              {
+                "kind": "Function",
+                "name": "organization",
+                "printedName": "organization(id:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Organization",
+                    "printedName": "YouVersionPlatformCore.Organization",
+                    "usr": "s:22YouVersionPlatformCore12OrganizationV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO13OrganizationsO12organization2id7sessionAA12OrganizationVSS_So12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO13OrganizationsO12organization2id7sessionAA12OrganizationVSS_So12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              }
+            ],
+            "declKind": "Enum",
+            "usr": "s:22YouVersionPlatformCore0aB3APIO13OrganizationsO",
+            "mangledName": "$s22YouVersionPlatformCore0aB3APIO13OrganizationsO",
+            "moduleName": "YouVersionPlatformCore",
+            "isFromExtension": true,
+            "isEnumExhaustive": true,
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              }
+            ]
+          },
+          {
+            "kind": "TypeDecl",
+            "name": "Users",
+            "printedName": "Users",
+            "children": [
+              {
+                "kind": "Function",
+                "name": "getSignInResult",
+                "printedName": "getSignInResult(from:state:codeVerifier:redirectUri:nonce:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionResult",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO15getSignInResult4from5state12codeVerifier11redirectUri5nonce7sessionAA0hi4WithabJ0V10Foundation3URLV_S4SSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO15getSignInResult4from5state12codeVerifier11redirectUri5nonce7sessionAA0hi4WithabJ0V10Foundation3URLV_S4SSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "performRefresh",
+                "printedName": "performRefresh(with:idToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionResult",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO14performRefresh4with7idToken7sessionAA010SignInWithaB6ResultVSS_SSSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO14performRefresh4with7idToken7sessionAA010SignInWithaB6ResultVSS_SSSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Var",
+                "name": "currentUserId",
+                "printedName": "currentUserId",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO13currentUserIdSSSgvpZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO13currentUserIdSSSgvpZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Optional",
+                        "printedName": "Swift.String?",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:Sq"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO13currentUserIdSSSgvgZ",
+                    "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO13currentUserIdSSSgvgZ",
+                    "moduleName": "YouVersionPlatformCore",
+                    "static": true,
+                    "accessorKind": "get"
+                  }
+                ]
+              },
+              {
+                "kind": "Var",
+                "name": "currentUserName",
+                "printedName": "currentUserName",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO15currentUserNameSSSgvpZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO15currentUserNameSSSgvpZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Optional",
+                        "printedName": "Swift.String?",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:Sq"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO15currentUserNameSSSgvgZ",
+                    "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO15currentUserNameSSSgvgZ",
+                    "moduleName": "YouVersionPlatformCore",
+                    "static": true,
+                    "accessorKind": "get"
+                  }
+                ]
+              },
+              {
+                "kind": "Var",
+                "name": "currentUserEmail",
+                "printedName": "currentUserEmail",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO16currentUserEmailSSSgvpZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO16currentUserEmailSSSgvpZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Optional",
+                        "printedName": "Swift.String?",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:Sq"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO16currentUserEmailSSSgvgZ",
+                    "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO16currentUserEmailSSSgvgZ",
+                    "moduleName": "YouVersionPlatformCore",
+                    "static": true,
+                    "accessorKind": "get"
+                  }
+                ]
+              },
+              {
+                "kind": "Var",
+                "name": "currentUserProfilePicture",
+                "printedName": "currentUserProfilePicture",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO25currentUserProfilePictureSSSgvpZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO25currentUserProfilePictureSSSgvpZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Optional",
+                        "printedName": "Swift.String?",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:Sq"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO25currentUserProfilePictureSSSgvgZ",
+                    "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO25currentUserProfilePictureSSSgvgZ",
+                    "moduleName": "YouVersionPlatformCore",
+                    "static": true,
+                    "accessorKind": "get"
+                  }
+                ]
+              },
+              {
+                "kind": "Function",
+                "name": "signOut",
+                "printedName": "signOut()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO7signOutyyFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO7signOutyyFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "declAttributes": [
+                  "Custom"
+                ],
+                "funcSelfKind": "NonMutating"
+              }
+            ],
+            "declKind": "Enum",
+            "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO",
+            "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO",
+            "moduleName": "YouVersionPlatformCore",
+            "isFromExtension": true,
+            "isEnumExhaustive": true,
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              }
+            ]
+          },
+          {
+            "kind": "TypeDecl",
+            "name": "VOTD",
+            "printedName": "VOTD",
+            "children": [
+              {
+                "kind": "Function",
+                "name": "verseOfTheDay",
+                "printedName": "verseOfTheDay(dayOfYear:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "YouVersionVerseOfTheDay",
+                    "printedName": "YouVersionPlatformCore.YouVersionVerseOfTheDay",
+                    "usr": "s:22YouVersionPlatformCore0aB13VerseOfTheDayV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO4VOTDO13verseOfTheDay03dayH4Year11accessToken7sessionAA0ab5VersehiJ0VSi_SSSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO4VOTDO13verseOfTheDay03dayH4Year11accessToken7sessionAA0ab5VersehiJ0VSi_SSSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              }
+            ],
+            "declKind": "Enum",
+            "usr": "s:22YouVersionPlatformCore0aB3APIO4VOTDO",
+            "mangledName": "$s22YouVersionPlatformCore0aB3APIO4VOTDO",
+            "moduleName": "YouVersionPlatformCore",
+            "isFromExtension": true,
+            "isEnumExhaustive": true,
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:22YouVersionPlatformCore0aB3APIO",
+        "mangledName": "$s22YouVersionPlatformCore0aB3APIO",
+        "moduleName": "YouVersionPlatformCore",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "YouVersionAPIError",
+        "printedName": "YouVersionAPIError",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "missingAuthentication",
+            "printedName": "missingAuthentication",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.YouVersionAPIError.Type) -> YouVersionPlatformCore.YouVersionAPIError",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "YouVersionAPIError",
+                    "printedName": "YouVersionPlatformCore.YouVersionAPIError",
+                    "usr": "s:22YouVersionPlatformCore0aB8APIErrorO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.YouVersionAPIError.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "YouVersionAPIError",
+                        "printedName": "YouVersionPlatformCore.YouVersionAPIError",
+                        "usr": "s:22YouVersionPlatformCore0aB8APIErrorO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore0aB8APIErrorO21missingAuthenticationyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore0aB8APIErrorO21missingAuthenticationyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "notPermitted",
+            "printedName": "notPermitted",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.YouVersionAPIError.Type) -> YouVersionPlatformCore.YouVersionAPIError",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "YouVersionAPIError",
+                    "printedName": "YouVersionPlatformCore.YouVersionAPIError",
+                    "usr": "s:22YouVersionPlatformCore0aB8APIErrorO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.YouVersionAPIError.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "YouVersionAPIError",
+                        "printedName": "YouVersionPlatformCore.YouVersionAPIError",
+                        "usr": "s:22YouVersionPlatformCore0aB8APIErrorO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore0aB8APIErrorO12notPermittedyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore0aB8APIErrorO12notPermittedyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "cannotDownload",
+            "printedName": "cannotDownload",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.YouVersionAPIError.Type) -> YouVersionPlatformCore.YouVersionAPIError",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "YouVersionAPIError",
+                    "printedName": "YouVersionPlatformCore.YouVersionAPIError",
+                    "usr": "s:22YouVersionPlatformCore0aB8APIErrorO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.YouVersionAPIError.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "YouVersionAPIError",
+                        "printedName": "YouVersionPlatformCore.YouVersionAPIError",
+                        "usr": "s:22YouVersionPlatformCore0aB8APIErrorO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore0aB8APIErrorO14cannotDownloadyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore0aB8APIErrorO14cannotDownloadyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "invalidDownload",
+            "printedName": "invalidDownload",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.YouVersionAPIError.Type) -> YouVersionPlatformCore.YouVersionAPIError",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "YouVersionAPIError",
+                    "printedName": "YouVersionPlatformCore.YouVersionAPIError",
+                    "usr": "s:22YouVersionPlatformCore0aB8APIErrorO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.YouVersionAPIError.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "YouVersionAPIError",
+                        "printedName": "YouVersionPlatformCore.YouVersionAPIError",
+                        "usr": "s:22YouVersionPlatformCore0aB8APIErrorO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore0aB8APIErrorO15invalidDownloadyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore0aB8APIErrorO15invalidDownloadyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "invalidResponse",
+            "printedName": "invalidResponse",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.YouVersionAPIError.Type) -> YouVersionPlatformCore.YouVersionAPIError",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "YouVersionAPIError",
+                    "printedName": "YouVersionPlatformCore.YouVersionAPIError",
+                    "usr": "s:22YouVersionPlatformCore0aB8APIErrorO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.YouVersionAPIError.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "YouVersionAPIError",
+                        "printedName": "YouVersionPlatformCore.YouVersionAPIError",
+                        "usr": "s:22YouVersionPlatformCore0aB8APIErrorO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore0aB8APIErrorO15invalidResponseyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore0aB8APIErrorO15invalidResponseyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Function",
+            "name": "__derived_enum_equals",
+            "printedName": "__derived_enum_equals(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "YouVersionAPIError",
+                "printedName": "YouVersionPlatformCore.YouVersionAPIError",
+                "usr": "s:22YouVersionPlatformCore0aB8APIErrorO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "YouVersionAPIError",
+                "printedName": "YouVersionPlatformCore.YouVersionAPIError",
+                "usr": "s:22YouVersionPlatformCore0aB8APIErrorO"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0aB8APIErrorO21__derived_enum_equalsySbAC_ACtFZ",
+            "mangledName": "$s22YouVersionPlatformCore0aB8APIErrorO21__derived_enum_equalsySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Implements",
+              "Semantics"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hash",
+            "printedName": "hash(into:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Hasher",
+                "printedName": "Swift.Hasher",
+                "paramValueOwnership": "InOut",
+                "usr": "s:s6HasherV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0aB8APIErrorO4hash4intoys6HasherVz_tF",
+            "mangledName": "$s22YouVersionPlatformCore0aB8APIErrorO4hash4intoys6HasherVz_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "hashValue",
+            "printedName": "hashValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0aB8APIErrorO9hashValueSivp",
+            "mangledName": "$s22YouVersionPlatformCore0aB8APIErrorO9hashValueSivp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0aB8APIErrorO9hashValueSivg",
+                "mangledName": "$s22YouVersionPlatformCore0aB8APIErrorO9hashValueSivg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:22YouVersionPlatformCore0aB8APIErrorO",
+        "mangledName": "$s22YouVersionPlatformCore0aB8APIErrorO",
+        "moduleName": "YouVersionPlatformCore",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Error",
+            "printedName": "Error",
+            "usr": "s:s5ErrorP",
+            "mangledName": "$ss5ErrorP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleBook",
+        "printedName": "BibleBook",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "id",
+            "printedName": "id",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore9BibleBookV2idSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore9BibleBookV2idSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore9BibleBookV2idSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore9BibleBookV2idSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "title",
+            "printedName": "title",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore9BibleBookV5titleSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore9BibleBookV5titleSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore9BibleBookV5titleSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore9BibleBookV5titleSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "fullTitle",
+            "printedName": "fullTitle",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore9BibleBookV9fullTitleSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore9BibleBookV9fullTitleSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore9BibleBookV9fullTitleSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore9BibleBookV9fullTitleSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "abbreviation",
+            "printedName": "abbreviation",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore9BibleBookV12abbreviationSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore9BibleBookV12abbreviationSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore9BibleBookV12abbreviationSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore9BibleBookV12abbreviationSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "canon",
+            "printedName": "canon",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore9BibleBookV5canonSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore9BibleBookV5canonSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore9BibleBookV5canonSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore9BibleBookV5canonSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "chapters",
+            "printedName": "chapters",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[YouVersionPlatformCore.BibleChapter]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.BibleChapter]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleChapter",
+                        "printedName": "YouVersionPlatformCore.BibleChapter",
+                        "usr": "s:22YouVersionPlatformCore12BibleChapterV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore9BibleBookV8chaptersSayAA0E7ChapterVGSgvp",
+            "mangledName": "$s22YouVersionPlatformCore9BibleBookV8chaptersSayAA0E7ChapterVGSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "[YouVersionPlatformCore.BibleChapter]?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Array",
+                        "printedName": "[YouVersionPlatformCore.BibleChapter]",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "BibleChapter",
+                            "printedName": "YouVersionPlatformCore.BibleChapter",
+                            "usr": "s:22YouVersionPlatformCore12BibleChapterV"
+                          }
+                        ],
+                        "usr": "s:Sa"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore9BibleBookV8chaptersSayAA0E7ChapterVGSgvg",
+                "mangledName": "$s22YouVersionPlatformCore9BibleBookV8chaptersSayAA0E7ChapterVGSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "intro",
+            "printedName": "intro",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleBookIntro?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleBookIntro",
+                    "printedName": "YouVersionPlatformCore.BibleBookIntro",
+                    "usr": "s:22YouVersionPlatformCore14BibleBookIntroV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore9BibleBookV5introAA0eF5IntroVSgvp",
+            "mangledName": "$s22YouVersionPlatformCore9BibleBookV5introAA0eF5IntroVSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "YouVersionPlatformCore.BibleBookIntro?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleBookIntro",
+                        "printedName": "YouVersionPlatformCore.BibleBookIntro",
+                        "usr": "s:22YouVersionPlatformCore14BibleBookIntroV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore9BibleBookV5introAA0eF5IntroVSgvg",
+                "mangledName": "$s22YouVersionPlatformCore9BibleBookV5introAA0eF5IntroVSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "isCanonical",
+            "printedName": "isCanonical",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore9BibleBookV11isCanonicalSbvp",
+            "mangledName": "$s22YouVersionPlatformCore9BibleBookV11isCanonicalSbvp",
+            "moduleName": "YouVersionPlatformCore",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore9BibleBookV11isCanonicalSbvg",
+                "mangledName": "$s22YouVersionPlatformCore9BibleBookV11isCanonicalSbvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "encode",
+            "printedName": "encode(to:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Encoder",
+                "printedName": "any Swift.Encoder",
+                "usr": "s:s7EncoderP"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore9BibleBookV6encode2toys7Encoder_p_tKF",
+            "mangledName": "$s22YouVersionPlatformCore9BibleBookV6encode2toys7Encoder_p_tKF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleBook",
+                "printedName": "YouVersionPlatformCore.BibleBook",
+                "usr": "s:22YouVersionPlatformCore9BibleBookV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore9BibleBookV4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore9BibleBookV4fromACs7Decoder_p_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore9BibleBookV",
+        "mangledName": "$s22YouVersionPlatformCore9BibleBookV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleBookIntro",
+        "printedName": "BibleBookIntro",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "id",
+            "printedName": "id",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleBookIntroV2idSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleBookIntroV2idSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleBookIntroV2idSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleBookIntroV2idSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "passageId",
+            "printedName": "passageId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleBookIntroV9passageIdSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleBookIntroV9passageIdSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleBookIntroV9passageIdSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleBookIntroV9passageIdSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "title",
+            "printedName": "title",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleBookIntroV5titleSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleBookIntroV5titleSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleBookIntroV5titleSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleBookIntroV5titleSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "encode",
+            "printedName": "encode(to:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Encoder",
+                "printedName": "any Swift.Encoder",
+                "usr": "s:s7EncoderP"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore14BibleBookIntroV6encode2toys7Encoder_p_tKF",
+            "mangledName": "$s22YouVersionPlatformCore14BibleBookIntroV6encode2toys7Encoder_p_tKF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleBookIntro",
+                "printedName": "YouVersionPlatformCore.BibleBookIntro",
+                "usr": "s:22YouVersionPlatformCore14BibleBookIntroV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore14BibleBookIntroV4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore14BibleBookIntroV4fromACs7Decoder_p_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore14BibleBookIntroV",
+        "mangledName": "$s22YouVersionPlatformCore14BibleBookIntroV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleChapter",
+        "printedName": "BibleChapter",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "id",
+            "printedName": "id",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore12BibleChapterV2idSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore12BibleChapterV2idSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore12BibleChapterV2idSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore12BibleChapterV2idSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "passageId",
+            "printedName": "passageId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore12BibleChapterV9passageIdSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore12BibleChapterV9passageIdSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore12BibleChapterV9passageIdSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore12BibleChapterV9passageIdSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "title",
+            "printedName": "title",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore12BibleChapterV5titleSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore12BibleChapterV5titleSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore12BibleChapterV5titleSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore12BibleChapterV5titleSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "verses",
+            "printedName": "verses",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[YouVersionPlatformCore.BibleVerse]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.BibleVerse]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVerse",
+                        "printedName": "YouVersionPlatformCore.BibleVerse",
+                        "usr": "s:22YouVersionPlatformCore10BibleVerseV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore12BibleChapterV6versesSayAA0E5VerseVGSgvp",
+            "mangledName": "$s22YouVersionPlatformCore12BibleChapterV6versesSayAA0E5VerseVGSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "[YouVersionPlatformCore.BibleVerse]?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Array",
+                        "printedName": "[YouVersionPlatformCore.BibleVerse]",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "BibleVerse",
+                            "printedName": "YouVersionPlatformCore.BibleVerse",
+                            "usr": "s:22YouVersionPlatformCore10BibleVerseV"
+                          }
+                        ],
+                        "usr": "s:Sa"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore12BibleChapterV6versesSayAA0E5VerseVGSgvg",
+                "mangledName": "$s22YouVersionPlatformCore12BibleChapterV6versesSayAA0E5VerseVGSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "encode",
+            "printedName": "encode(to:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Encoder",
+                "printedName": "any Swift.Encoder",
+                "usr": "s:s7EncoderP"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore12BibleChapterV6encode2toys7Encoder_p_tKF",
+            "mangledName": "$s22YouVersionPlatformCore12BibleChapterV6encode2toys7Encoder_p_tKF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleChapter",
+                "printedName": "YouVersionPlatformCore.BibleChapter",
+                "usr": "s:22YouVersionPlatformCore12BibleChapterV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore12BibleChapterV4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore12BibleChapterV4fromACs7Decoder_p_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore12BibleChapterV",
+        "mangledName": "$s22YouVersionPlatformCore12BibleChapterV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "ChapterDiskCache",
+        "printedName": "ChapterDiskCache",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC06removeB09versionIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC06removeB09versionIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC",
+        "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "hasMissingDesignatedInitializers": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "ChapterDownloadCache",
+        "printedName": "ChapterDownloadCache",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "chaptersArePresent",
+            "printedName": "chaptersArePresent(versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC18chaptersArePresent9versionIdSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC18chaptersArePresent9versionIdSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC06removeB09versionIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC06removeB09versionIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC",
+        "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "hasMissingDesignatedInitializers": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleChapterRepository",
+        "printedName": "BibleChapterRepository",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "shared",
+            "printedName": "shared",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleChapterRepository",
+                "printedName": "YouVersionPlatformCore.BibleChapterRepository",
+                "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC6sharedACvpZ",
+            "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryC6sharedACvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "Final",
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleChapterRepository",
+                    "printedName": "YouVersionPlatformCore.BibleChapterRepository",
+                    "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC6sharedACvgZ",
+                "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryC6sharedACvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Final",
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "chapter",
+            "printedName": "chapter(withReference:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC7chapter13withReferenceSSAA0eJ0V_tYaKF",
+            "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryC7chapter13withReferenceSSAA0eJ0V_tYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryC06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "ObjectWillChangePublisher",
+            "printedName": "ObjectWillChangePublisher",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "ObservableObjectPublisher",
+                "printedName": "Combine.ObservableObjectPublisher",
+                "usr": "s:7Combine25ObservableObjectPublisherC"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC25ObjectWillChangePublishera",
+            "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryC25ObjectWillChangePublishera",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC",
+        "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryC",
+        "moduleName": "YouVersionPlatformCore",
+        "hasMissingDesignatedInitializers": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "ObservableObject",
+            "printedName": "ObservableObject",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "ObjectWillChangePublisher",
+                "printedName": "ObjectWillChangePublisher",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ObservableObjectPublisher",
+                    "printedName": "Combine.ObservableObjectPublisher",
+                    "usr": "s:7Combine25ObservableObjectPublisherC"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7Combine16ObservableObjectP",
+            "mangledName": "$s7Combine16ObservableObjectP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleHighlight",
+        "printedName": "BibleHighlight",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "reference",
+            "printedName": "reference",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleHighlightV9referenceAA0E9ReferenceVvp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleHighlightV9referenceAA0E9ReferenceVvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleHighlightV9referenceAA0E9ReferenceVvg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleHighlightV9referenceAA0E9ReferenceVvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "color",
+            "printedName": "color",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleHighlightV5colorSSvp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleHighlightV5colorSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleHighlightV5colorSSvg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleHighlightV5colorSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(_:color:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleHighlight",
+                "printedName": "YouVersionPlatformCore.BibleHighlight",
+                "usr": "s:22YouVersionPlatformCore14BibleHighlightV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore14BibleHighlightV_5colorAcA0E9ReferenceV_SStcfc",
+            "mangledName": "$s22YouVersionPlatformCore14BibleHighlightV_5colorAcA0E9ReferenceV_SStcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "debugDescription",
+            "printedName": "debugDescription",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleHighlightV16debugDescriptionSSvp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleHighlightV16debugDescriptionSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleHighlightV16debugDescriptionSSvg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleHighlightV16debugDescriptionSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "__derived_struct_equals",
+            "printedName": "__derived_struct_equals(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleHighlight",
+                "printedName": "YouVersionPlatformCore.BibleHighlight",
+                "usr": "s:22YouVersionPlatformCore14BibleHighlightV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleHighlight",
+                "printedName": "YouVersionPlatformCore.BibleHighlight",
+                "usr": "s:22YouVersionPlatformCore14BibleHighlightV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore14BibleHighlightV23__derived_struct_equalsySbAC_ACtFZ",
+            "mangledName": "$s22YouVersionPlatformCore14BibleHighlightV23__derived_struct_equalsySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Implements"
+            ],
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore14BibleHighlightV",
+        "mangledName": "$s22YouVersionPlatformCore14BibleHighlightV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomDebugStringConvertible",
+            "printedName": "CustomDebugStringConvertible",
+            "usr": "s:s28CustomDebugStringConvertibleP",
+            "mangledName": "$ss28CustomDebugStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleHighlightsCache",
+        "printedName": "BibleHighlightsCache",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "shared",
+            "printedName": "shared",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleHighlightsCache",
+                "printedName": "YouVersionPlatformCore.BibleHighlightsCache",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC6sharedACvpZ",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC6sharedACvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "Final",
+              "HasStorage",
+              "Custom"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleHighlightsCache",
+                    "printedName": "YouVersionPlatformCore.BibleHighlightsCache",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC6sharedACvgZ",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC6sharedACvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Final",
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "TypeDecl",
+            "name": "CachedHighlightState",
+            "printedName": "CachedHighlightState",
+            "children": [
+              {
+                "kind": "Var",
+                "name": "remoteSynced",
+                "printedName": "remoteSynced",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState.Type) -> YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "CachedHighlightState",
+                        "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                        "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "CachedHighlightState",
+                            "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO12remoteSyncedyA2EmF",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO12remoteSyncedyA2EmF",
+                "moduleName": "YouVersionPlatformCore"
+              },
+              {
+                "kind": "Var",
+                "name": "localPendingCreate",
+                "printedName": "localPendingCreate",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState.Type) -> YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "CachedHighlightState",
+                        "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                        "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "CachedHighlightState",
+                            "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO18localPendingCreateyA2EmF",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO18localPendingCreateyA2EmF",
+                "moduleName": "YouVersionPlatformCore"
+              },
+              {
+                "kind": "Var",
+                "name": "localPendingUpdate",
+                "printedName": "localPendingUpdate",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState.Type) -> YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "CachedHighlightState",
+                        "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                        "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "CachedHighlightState",
+                            "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO18localPendingUpdateyA2EmF",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO18localPendingUpdateyA2EmF",
+                "moduleName": "YouVersionPlatformCore"
+              },
+              {
+                "kind": "Var",
+                "name": "localPendingDelete",
+                "printedName": "localPendingDelete",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState.Type) -> YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "CachedHighlightState",
+                        "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                        "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "CachedHighlightState",
+                            "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO18localPendingDeleteyA2EmF",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO18localPendingDeleteyA2EmF",
+                "moduleName": "YouVersionPlatformCore"
+              },
+              {
+                "kind": "Function",
+                "name": "__derived_enum_equals",
+                "printedName": "__derived_enum_equals(_:_:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CachedHighlightState",
+                    "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CachedHighlightState",
+                    "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO21__derived_enum_equalsySbAE_AEtFZ",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO21__derived_enum_equalsySbAE_AEtFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Implements",
+                  "Semantics"
+                ],
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "hash",
+                "printedName": "hash(into:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Hasher",
+                    "printedName": "Swift.Hasher",
+                    "paramValueOwnership": "InOut",
+                    "usr": "s:s6HasherV"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO4hash4intoys6HasherVz_tF",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO4hash4intoys6HasherVz_tF",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Var",
+                "name": "hashValue",
+                "printedName": "hashValue",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO9hashValueSivp",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO9hashValueSivp",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO9hashValueSivg",
+                    "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO9hashValueSivg",
+                    "moduleName": "YouVersionPlatformCore",
+                    "implicit": true,
+                    "accessorKind": "get"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Enum",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO",
+            "moduleName": "YouVersionPlatformCore",
+            "isEnumExhaustive": true,
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Equatable",
+                "printedName": "Equatable",
+                "usr": "s:SQ",
+                "mangledName": "$sSQ"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Hashable",
+                "printedName": "Hashable",
+                "usr": "s:SH",
+                "mangledName": "$sSH"
+              }
+            ]
+          },
+          {
+            "kind": "TypeDecl",
+            "name": "CachedHighlight",
+            "printedName": "CachedHighlight",
+            "children": [
+              {
+                "kind": "Var",
+                "name": "id",
+                "printedName": "id",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UUID",
+                    "printedName": "Foundation.UUID",
+                    "usr": "s:10Foundation4UUIDV"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV2id10Foundation4UUIDVvp",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV2id10Foundation4UUIDVvp",
+                "moduleName": "YouVersionPlatformCore",
+                "declAttributes": [
+                  "HasStorage"
+                ],
+                "isLet": true,
+                "hasStorage": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "UUID",
+                        "printedName": "Foundation.UUID",
+                        "usr": "s:10Foundation4UUIDV"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV2id10Foundation4UUIDVvg",
+                    "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV2id10Foundation4UUIDVvg",
+                    "moduleName": "YouVersionPlatformCore",
+                    "implicit": true,
+                    "declAttributes": [
+                      "Transparent"
+                    ],
+                    "accessorKind": "get"
+                  }
+                ]
+              },
+              {
+                "kind": "Var",
+                "name": "highlight",
+                "printedName": "highlight",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleHighlight",
+                    "printedName": "YouVersionPlatformCore.BibleHighlight",
+                    "usr": "s:22YouVersionPlatformCore14BibleHighlightV"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV9highlightAA0eI0Vvp",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV9highlightAA0eI0Vvp",
+                "moduleName": "YouVersionPlatformCore",
+                "declAttributes": [
+                  "HasStorage"
+                ],
+                "hasStorage": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleHighlight",
+                        "printedName": "YouVersionPlatformCore.BibleHighlight",
+                        "usr": "s:22YouVersionPlatformCore14BibleHighlightV"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV9highlightAA0eI0Vvg",
+                    "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV9highlightAA0eI0Vvg",
+                    "moduleName": "YouVersionPlatformCore",
+                    "implicit": true,
+                    "declAttributes": [
+                      "Transparent"
+                    ],
+                    "accessorKind": "get"
+                  },
+                  {
+                    "kind": "Accessor",
+                    "name": "Set",
+                    "printedName": "Set()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Void",
+                        "printedName": "()"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleHighlight",
+                        "printedName": "YouVersionPlatformCore.BibleHighlight",
+                        "usr": "s:22YouVersionPlatformCore14BibleHighlightV"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV9highlightAA0eI0Vvs",
+                    "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV9highlightAA0eI0Vvs",
+                    "moduleName": "YouVersionPlatformCore",
+                    "implicit": true,
+                    "declAttributes": [
+                      "Transparent"
+                    ],
+                    "accessorKind": "set"
+                  }
+                ]
+              },
+              {
+                "kind": "Var",
+                "name": "state",
+                "printedName": "state",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CachedHighlightState",
+                    "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV5stateAC0hI5StateOvp",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV5stateAC0hI5StateOvp",
+                "moduleName": "YouVersionPlatformCore",
+                "declAttributes": [
+                  "HasStorage"
+                ],
+                "hasStorage": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "CachedHighlightState",
+                        "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                        "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV5stateAC0hI5StateOvg",
+                    "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV5stateAC0hI5StateOvg",
+                    "moduleName": "YouVersionPlatformCore",
+                    "implicit": true,
+                    "declAttributes": [
+                      "Transparent"
+                    ],
+                    "accessorKind": "get"
+                  },
+                  {
+                    "kind": "Accessor",
+                    "name": "Set",
+                    "printedName": "Set()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Void",
+                        "printedName": "()"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "CachedHighlightState",
+                        "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                        "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV5stateAC0hI5StateOvs",
+                    "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV5stateAC0hI5StateOvs",
+                    "moduleName": "YouVersionPlatformCore",
+                    "implicit": true,
+                    "declAttributes": [
+                      "Transparent"
+                    ],
+                    "accessorKind": "set"
+                  }
+                ]
+              },
+              {
+                "kind": "Var",
+                "name": "lastModifiedAt",
+                "printedName": "lastModifiedAt",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Date",
+                    "printedName": "Foundation.Date",
+                    "usr": "s:10Foundation4DateV"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV14lastModifiedAt10Foundation4DateVvp",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV14lastModifiedAt10Foundation4DateVvp",
+                "moduleName": "YouVersionPlatformCore",
+                "declAttributes": [
+                  "HasStorage"
+                ],
+                "hasStorage": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Date",
+                        "printedName": "Foundation.Date",
+                        "usr": "s:10Foundation4DateV"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV14lastModifiedAt10Foundation4DateVvg",
+                    "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV14lastModifiedAt10Foundation4DateVvg",
+                    "moduleName": "YouVersionPlatformCore",
+                    "implicit": true,
+                    "declAttributes": [
+                      "Transparent"
+                    ],
+                    "accessorKind": "get"
+                  },
+                  {
+                    "kind": "Accessor",
+                    "name": "Set",
+                    "printedName": "Set()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Void",
+                        "printedName": "()"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Date",
+                        "printedName": "Foundation.Date",
+                        "usr": "s:10Foundation4DateV"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV14lastModifiedAt10Foundation4DateVvs",
+                    "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV14lastModifiedAt10Foundation4DateVvs",
+                    "moduleName": "YouVersionPlatformCore",
+                    "implicit": true,
+                    "declAttributes": [
+                      "Transparent"
+                    ],
+                    "accessorKind": "set"
+                  }
+                ]
+              },
+              {
+                "kind": "Constructor",
+                "name": "init",
+                "printedName": "init(id:highlight:state:lastModifiedAt:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CachedHighlight",
+                    "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlight",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UUID",
+                    "printedName": "Foundation.UUID",
+                    "hasDefaultArg": true,
+                    "usr": "s:10Foundation4UUIDV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleHighlight",
+                    "printedName": "YouVersionPlatformCore.BibleHighlight",
+                    "usr": "s:22YouVersionPlatformCore14BibleHighlightV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CachedHighlightState",
+                    "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlightState",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20CachedHighlightStateO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Date",
+                    "printedName": "Foundation.Date",
+                    "hasDefaultArg": true,
+                    "usr": "s:10Foundation4DateV"
+                  }
+                ],
+                "declKind": "Constructor",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV2id9highlight5state14lastModifiedAtAE10Foundation4UUIDV_AA0eI0VAC0hI5StateOAJ4DateVtcfc",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV2id9highlight5state14lastModifiedAtAE10Foundation4UUIDV_AA0eI0VAC0hI5StateOAJ4DateVtcfc",
+                "moduleName": "YouVersionPlatformCore",
+                "init_kind": "Designated"
+              },
+              {
+                "kind": "TypeAlias",
+                "name": "ID",
+                "printedName": "ID",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UUID",
+                    "printedName": "Foundation.UUID",
+                    "usr": "s:10Foundation4UUIDV"
+                  }
+                ],
+                "declKind": "TypeAlias",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV2IDa",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV2IDa",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true
+              },
+              {
+                "kind": "Function",
+                "name": "__derived_struct_equals",
+                "printedName": "__derived_struct_equals(_:_:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CachedHighlight",
+                    "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlight",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CachedHighlight",
+                    "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlight",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV23__derived_struct_equalsySbAE_AEtFZ",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV23__derived_struct_equalsySbAE_AEtFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Implements"
+                ],
+                "funcSelfKind": "NonMutating"
+              }
+            ],
+            "declKind": "Struct",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV",
+            "moduleName": "YouVersionPlatformCore",
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Equatable",
+                "printedName": "Equatable",
+                "usr": "s:SQ",
+                "mangledName": "$sSQ"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Identifiable",
+                "printedName": "Identifiable",
+                "children": [
+                  {
+                    "kind": "TypeWitness",
+                    "name": "ID",
+                    "printedName": "ID",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "UUID",
+                        "printedName": "Foundation.UUID",
+                        "usr": "s:10Foundation4UUIDV"
+                      }
+                    ]
+                  }
+                ],
+                "usr": "s:s12IdentifiableP",
+                "mangledName": "$ss12IdentifiableP"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "cachedHighlights",
+            "printedName": "cachedHighlights",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleHighlightsCache.CachedHighlight]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CachedHighlight",
+                    "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlight",
+                    "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC06cachedF0SayAC15CachedHighlightVGvp",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC06cachedF0SayAC15CachedHighlightVGvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasInitialValue",
+              "Final",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.BibleHighlightsCache.CachedHighlight]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "CachedHighlight",
+                        "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlight",
+                        "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC06cachedF0SayAC15CachedHighlightVGvg",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC06cachedF0SayAC15CachedHighlightVGvg",
+                "moduleName": "YouVersionPlatformCore",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              },
+              {
+                "kind": "Accessor",
+                "name": "Set",
+                "printedName": "Set()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.BibleHighlightsCache.CachedHighlight]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "CachedHighlight",
+                        "printedName": "YouVersionPlatformCore.BibleHighlightsCache.CachedHighlight",
+                        "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC15CachedHighlightV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC06cachedF0SayAC15CachedHighlightVGvs",
+                "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC06cachedF0SayAC15CachedHighlightVGvs",
+                "moduleName": "YouVersionPlatformCore",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "set"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleHighlightsCache",
+                "printedName": "YouVersionPlatformCore.BibleHighlightsCache",
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "highlights",
+            "printedName": "highlights(overlapping:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleHighlight]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleHighlight",
+                    "printedName": "YouVersionPlatformCore.BibleHighlight",
+                    "usr": "s:22YouVersionPlatformCore14BibleHighlightV"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC10highlights11overlappingSayAA0E9HighlightVGAA0E9ReferenceV_tF",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC10highlights11overlappingSayAA0E9HighlightVGAA0E9ReferenceV_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hasRecentlyLoadedChapter",
+            "printedName": "hasRecentlyLoadedChapter(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC24hasRecentlyLoadedChapterySbAA0E9ReferenceVF",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC24hasRecentlyLoadedChapterySbAA0E9ReferenceVF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "isChapterLoading",
+            "printedName": "isChapterLoading(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC16isChapterLoadingySbAA0E9ReferenceVF",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC16isChapterLoadingySbAA0E9ReferenceVF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "markChapterAsLoading",
+            "printedName": "markChapterAsLoading(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC20markChapterAsLoadingySbAA0E9ReferenceVF",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC20markChapterAsLoadingySbAA0E9ReferenceVF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "unmarkChapterAsLoading",
+            "printedName": "unmarkChapterAsLoading(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC22unmarkChapterAsLoadingyyAA0E9ReferenceVF",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC22unmarkChapterAsLoadingyyAA0E9ReferenceVF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "recordChapterFetch",
+            "printedName": "recordChapterFetch(_:at:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Date",
+                "printedName": "Foundation.Date",
+                "hasDefaultArg": true,
+                "usr": "s:10Foundation4DateV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC18recordChapterFetch_2atyAA0E9ReferenceV_10Foundation4DateVtF",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC18recordChapterFetch_2atyAA0E9ReferenceV_10Foundation4DateVtF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addHighlights",
+            "printedName": "addHighlights(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleHighlight]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleHighlight",
+                    "printedName": "YouVersionPlatformCore.BibleHighlight",
+                    "usr": "s:22YouVersionPlatformCore14BibleHighlightV"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC03addF0yySayAA0E9HighlightVGF",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC03addF0yySayAA0E9HighlightVGF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeHighlights",
+            "printedName": "removeHighlights(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleReference]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC06removeF0yySayAA0E9ReferenceVGF",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC06removeF0yySayAA0E9ReferenceVGF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "updateHighlightColors",
+            "printedName": "updateHighlightColors(_:newColor:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleReference]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC21updateHighlightColors_8newColorySayAA0E9ReferenceVG_SStF",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC21updateHighlightColors_8newColorySayAA0E9ReferenceVG_SStF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "applyServerHighlights",
+            "printedName": "applyServerHighlights(for:highlights:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleHighlight]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleHighlight",
+                    "printedName": "YouVersionPlatformCore.BibleHighlight",
+                    "usr": "s:22YouVersionPlatformCore14BibleHighlightV"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC011applyServerF03for10highlightsyAA0E9ReferenceV_SayAA0E9HighlightVGtF",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC011applyServerF03for10highlightsyAA0E9ReferenceV_SayAA0E9HighlightVGtF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "reset",
+            "printedName": "reset()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC5resetyyF",
+            "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC5resetyyF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC",
+        "mangledName": "$s22YouVersionPlatformCore20BibleHighlightsCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "declAttributes": [
+          "Final",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Observable",
+            "printedName": "Observable",
+            "usr": "s:11Observation10ObservableP",
+            "mangledName": "$s11Observation10ObservableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleHighlightsAPIProtocol",
+        "printedName": "BibleHighlightsAPIProtocol",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "highlights",
+            "printedName": "highlights(bibleId:passageId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.HighlightResponse]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "HighlightResponse",
+                    "printedName": "YouVersionPlatformCore.HighlightResponse",
+                    "usr": "s:22YouVersionPlatformCore17HighlightResponseV"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore26BibleHighlightsAPIProtocolP10highlights7bibleId07passageJ0SayAA17HighlightResponseVGSi_SStYaKF",
+            "mangledName": "$s22YouVersionPlatformCore26BibleHighlightsAPIProtocolP10highlights7bibleId07passageJ0SayAA17HighlightResponseVGSi_SStYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleHighlightsAPIProtocol>",
+            "protocolReq": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "throwing": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "createHighlight",
+            "printedName": "createHighlight(bibleId:passageId:color:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore26BibleHighlightsAPIProtocolP15createHighlight7bibleId07passageK05colorSbSi_S2StYaKF",
+            "mangledName": "$s22YouVersionPlatformCore26BibleHighlightsAPIProtocolP15createHighlight7bibleId07passageK05colorSbSi_S2StYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleHighlightsAPIProtocol>",
+            "protocolReq": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "throwing": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "updateHighlight",
+            "printedName": "updateHighlight(bibleId:passageId:color:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore26BibleHighlightsAPIProtocolP15updateHighlight7bibleId07passageK05colorSbSi_S2StYaKF",
+            "mangledName": "$s22YouVersionPlatformCore26BibleHighlightsAPIProtocolP15updateHighlight7bibleId07passageK05colorSbSi_S2StYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleHighlightsAPIProtocol>",
+            "protocolReq": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "throwing": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "deleteHighlight",
+            "printedName": "deleteHighlight(bibleId:passageId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore26BibleHighlightsAPIProtocolP15deleteHighlight7bibleId07passageK0SbSi_SStYaKF",
+            "mangledName": "$s22YouVersionPlatformCore26BibleHighlightsAPIProtocolP15deleteHighlight7bibleId07passageK0SbSi_SStYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleHighlightsAPIProtocol>",
+            "protocolReq": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "throwing": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:22YouVersionPlatformCore26BibleHighlightsAPIProtocolP",
+        "mangledName": "$s22YouVersionPlatformCore26BibleHighlightsAPIProtocolP",
+        "moduleName": "YouVersionPlatformCore",
+        "declAttributes": [
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleHighlightsAPI",
+        "printedName": "BibleHighlightsAPI",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleHighlightsAPI",
+                "printedName": "YouVersionPlatformCore.BibleHighlightsAPI",
+                "usr": "s:22YouVersionPlatformCore18BibleHighlightsAPIV"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore18BibleHighlightsAPIVACycfc",
+            "mangledName": "$s22YouVersionPlatformCore18BibleHighlightsAPIVACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "highlights",
+            "printedName": "highlights(bibleId:passageId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.HighlightResponse]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "HighlightResponse",
+                    "printedName": "YouVersionPlatformCore.HighlightResponse",
+                    "usr": "s:22YouVersionPlatformCore17HighlightResponseV"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore18BibleHighlightsAPIV10highlights7bibleId07passageJ0SayAA17HighlightResponseVGSi_SStYaKF",
+            "mangledName": "$s22YouVersionPlatformCore18BibleHighlightsAPIV10highlights7bibleId07passageJ0SayAA17HighlightResponseVGSi_SStYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "createHighlight",
+            "printedName": "createHighlight(bibleId:passageId:color:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore18BibleHighlightsAPIV15createHighlight7bibleId07passageK05colorSbSi_S2StYaKF",
+            "mangledName": "$s22YouVersionPlatformCore18BibleHighlightsAPIV15createHighlight7bibleId07passageK05colorSbSi_S2StYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "updateHighlight",
+            "printedName": "updateHighlight(bibleId:passageId:color:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore18BibleHighlightsAPIV15updateHighlight7bibleId07passageK05colorSbSi_S2StYaKF",
+            "mangledName": "$s22YouVersionPlatformCore18BibleHighlightsAPIV15updateHighlight7bibleId07passageK05colorSbSi_S2StYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "deleteHighlight",
+            "printedName": "deleteHighlight(bibleId:passageId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore18BibleHighlightsAPIV15deleteHighlight7bibleId07passageK0SbSi_SStYaKF",
+            "mangledName": "$s22YouVersionPlatformCore18BibleHighlightsAPIV15deleteHighlight7bibleId07passageK0SbSi_SStYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore18BibleHighlightsAPIV",
+        "mangledName": "$s22YouVersionPlatformCore18BibleHighlightsAPIV",
+        "moduleName": "YouVersionPlatformCore",
+        "declAttributes": [
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleHighlightsAPIProtocol",
+            "printedName": "BibleHighlightsAPIProtocol",
+            "usr": "s:22YouVersionPlatformCore26BibleHighlightsAPIProtocolP",
+            "mangledName": "$s22YouVersionPlatformCore26BibleHighlightsAPIProtocolP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleHighlightsRepositoryProtocol",
+        "printedName": "BibleHighlightsRepositoryProtocol",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "highlights",
+            "printedName": "highlights(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Dictionary",
+                "printedName": "[Swift.String : [YouVersionPlatformCore.BibleHighlight]]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.BibleHighlight]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleHighlight",
+                        "printedName": "YouVersionPlatformCore.BibleHighlight",
+                        "usr": "s:22YouVersionPlatformCore14BibleHighlightV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "usr": "s:SD"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleReference]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore33BibleHighlightsRepositoryProtocolP10highlights3forSDySSSayAA0E9HighlightVGGSayAA0E9ReferenceVG_tYaKF",
+            "mangledName": "$s22YouVersionPlatformCore33BibleHighlightsRepositoryProtocolP10highlights3forSDySSSayAA0E9HighlightVGGSayAA0E9ReferenceVG_tYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleHighlightsRepositoryProtocol>",
+            "protocolReq": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "throwing": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "queueOperation",
+            "printedName": "queueOperation(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "PendingHighlightOperation",
+                "printedName": "YouVersionPlatformCore.PendingHighlightOperation",
+                "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore33BibleHighlightsRepositoryProtocolP14queueOperationyyAA016PendingHighlightJ0VF",
+            "mangledName": "$s22YouVersionPlatformCore33BibleHighlightsRepositoryProtocolP14queueOperationyyAA016PendingHighlightJ0VF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleHighlightsRepositoryProtocol>",
+            "protocolReq": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:22YouVersionPlatformCore33BibleHighlightsRepositoryProtocolP",
+        "mangledName": "$s22YouVersionPlatformCore33BibleHighlightsRepositoryProtocolP",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "OperationResult",
+        "printedName": "OperationResult",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "operationId",
+            "printedName": "operationId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UUID",
+                "printedName": "Foundation.UUID",
+                "usr": "s:10Foundation4UUIDV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore15OperationResultV11operationId10Foundation4UUIDVvp",
+            "mangledName": "$s22YouVersionPlatformCore15OperationResultV11operationId10Foundation4UUIDVvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UUID",
+                    "printedName": "Foundation.UUID",
+                    "usr": "s:10Foundation4UUIDV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore15OperationResultV11operationId10Foundation4UUIDVvg",
+                "mangledName": "$s22YouVersionPlatformCore15OperationResultV11operationId10Foundation4UUIDVvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "success",
+            "printedName": "success",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore15OperationResultV7successSbvp",
+            "mangledName": "$s22YouVersionPlatformCore15OperationResultV7successSbvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore15OperationResultV7successSbvg",
+                "mangledName": "$s22YouVersionPlatformCore15OperationResultV7successSbvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "error",
+            "printedName": "error",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "(any Swift.Error)?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Error",
+                    "printedName": "any Swift.Error",
+                    "usr": "s:s5ErrorP"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore15OperationResultV5errors5Error_pSgvp",
+            "mangledName": "$s22YouVersionPlatformCore15OperationResultV5errors5Error_pSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "(any Swift.Error)?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Error",
+                        "printedName": "any Swift.Error",
+                        "usr": "s:s5ErrorP"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore15OperationResultV5errors5Error_pSgvg",
+                "mangledName": "$s22YouVersionPlatformCore15OperationResultV5errors5Error_pSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "retryCount",
+            "printedName": "retryCount",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore15OperationResultV10retryCountSivp",
+            "mangledName": "$s22YouVersionPlatformCore15OperationResultV10retryCountSivp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore15OperationResultV10retryCountSivg",
+                "mangledName": "$s22YouVersionPlatformCore15OperationResultV10retryCountSivg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(operationId:success:error:retryCount:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OperationResult",
+                "printedName": "YouVersionPlatformCore.OperationResult",
+                "usr": "s:22YouVersionPlatformCore15OperationResultV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "UUID",
+                "printedName": "Foundation.UUID",
+                "usr": "s:10Foundation4UUIDV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "(any Swift.Error)?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Error",
+                    "printedName": "any Swift.Error",
+                    "usr": "s:s5ErrorP"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "hasDefaultArg": true,
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore15OperationResultV11operationId7success5error10retryCountAC10Foundation4UUIDV_Sbs5Error_pSgSitcfc",
+            "mangledName": "$s22YouVersionPlatformCore15OperationResultV11operationId7success5error10retryCountAC10Foundation4UUIDV_Sbs5Error_pSgSitcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore15OperationResultV",
+        "mangledName": "$s22YouVersionPlatformCore15OperationResultV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleHighlightsRepository",
+        "printedName": "BibleHighlightsRepository",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(api:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleHighlightsRepository",
+                "printedName": "YouVersionPlatformCore.BibleHighlightsRepository",
+                "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleHighlightsAPIProtocol",
+                "printedName": "any YouVersionPlatformCore.BibleHighlightsAPIProtocol",
+                "hasDefaultArg": true,
+                "usr": "s:22YouVersionPlatformCore26BibleHighlightsAPIProtocolP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC3apiAcA0eF11APIProtocol_p_tcfc",
+            "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC3apiAcA0eF11APIProtocol_p_tcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "highlights",
+            "printedName": "highlights(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Dictionary",
+                "printedName": "[Swift.String : [YouVersionPlatformCore.BibleHighlight]]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.BibleHighlight]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleHighlight",
+                        "printedName": "YouVersionPlatformCore.BibleHighlight",
+                        "usr": "s:22YouVersionPlatformCore14BibleHighlightV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "usr": "s:SD"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleReference]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC10highlights3forSDySSSayAA0E9HighlightVGGSayAA0E9ReferenceVG_tYaKF",
+            "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC10highlights3forSDySSSayAA0E9HighlightVGGSayAA0E9ReferenceVG_tYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "saveOperations",
+            "printedName": "saveOperations(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Dictionary",
+                "printedName": "[Foundation.UUID : Swift.Bool]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UUID",
+                    "printedName": "Foundation.UUID",
+                    "usr": "s:10Foundation4UUIDV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "usr": "s:SD"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.PendingHighlightOperation]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "PendingHighlightOperation",
+                    "printedName": "YouVersionPlatformCore.PendingHighlightOperation",
+                    "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC14saveOperationsySDy10Foundation4UUIDVSbGSayAA25PendingHighlightOperationVGYaKF",
+            "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC14saveOperationsySDy10Foundation4UUIDVSbGSayAA25PendingHighlightOperationVGYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "queueOperation",
+            "printedName": "queueOperation(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "PendingHighlightOperation",
+                "printedName": "YouVersionPlatformCore.PendingHighlightOperation",
+                "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC14queueOperationyyAA016PendingHighlightI0VF",
+            "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC14queueOperationyyAA016PendingHighlightI0VF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "processQueue",
+            "printedName": "processQueue()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC12processQueueyyYaF",
+            "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC12processQueueyyYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "retryFailedOperations",
+            "printedName": "retryFailedOperations()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC21retryFailedOperationsyyYaF",
+            "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC21retryFailedOperationsyyYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "getOperationResult",
+            "printedName": "getOperationResult(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.OperationResult?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OperationResult",
+                    "printedName": "YouVersionPlatformCore.OperationResult",
+                    "usr": "s:22YouVersionPlatformCore15OperationResultV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "UUID",
+                "printedName": "Foundation.UUID",
+                "usr": "s:10Foundation4UUIDV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC18getOperationResult3forAA0iJ0VSg10Foundation4UUIDV_tF",
+            "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC18getOperationResult3forAA0iJ0VSg10Foundation4UUIDV_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "clearOperationResults",
+            "printedName": "clearOperationResults()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC21clearOperationResultsyyF",
+            "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC21clearOperationResultsyyF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "pendingOperationCount",
+            "printedName": "pendingOperationCount",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC21pendingOperationCountSivp",
+            "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC21pendingOperationCountSivp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC21pendingOperationCountSivg",
+                "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC21pendingOperationCountSivg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "failedOperationCount",
+            "printedName": "failedOperationCount",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC20failedOperationCountSivp",
+            "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC20failedOperationCountSivp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC20failedOperationCountSivg",
+                "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC20failedOperationCountSivg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC",
+        "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC",
+        "moduleName": "YouVersionPlatformCore",
+        "declAttributes": [
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleHighlightsRepositoryProtocol",
+            "printedName": "BibleHighlightsRepositoryProtocol",
+            "usr": "s:22YouVersionPlatformCore33BibleHighlightsRepositoryProtocolP",
+            "mangledName": "$s22YouVersionPlatformCore33BibleHighlightsRepositoryProtocolP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleHighlightsViewModel",
+        "printedName": "BibleHighlightsViewModel",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "shared",
+            "printedName": "shared",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleHighlightsViewModel",
+                "printedName": "YouVersionPlatformCore.BibleHighlightsViewModel",
+                "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC6sharedACvpZ",
+            "mangledName": "$s22YouVersionPlatformCore24BibleHighlightsViewModelC6sharedACvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "Final",
+              "HasStorage",
+              "Custom"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleHighlightsViewModel",
+                    "printedName": "YouVersionPlatformCore.BibleHighlightsViewModel",
+                    "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC6sharedACvgZ",
+                "mangledName": "$s22YouVersionPlatformCore24BibleHighlightsViewModelC6sharedACvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Final",
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(cache:repository:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleHighlightsViewModel",
+                "printedName": "YouVersionPlatformCore.BibleHighlightsViewModel",
+                "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleHighlightsCache",
+                "printedName": "YouVersionPlatformCore.BibleHighlightsCache",
+                "hasDefaultArg": true,
+                "usr": "s:22YouVersionPlatformCore20BibleHighlightsCacheC"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleHighlightsRepositoryProtocol",
+                "printedName": "any YouVersionPlatformCore.BibleHighlightsRepositoryProtocol",
+                "hasDefaultArg": true,
+                "usr": "s:22YouVersionPlatformCore33BibleHighlightsRepositoryProtocolP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC5cache10repositoryAcA0eF5CacheC_AA0eF18RepositoryProtocol_ptcfc",
+            "mangledName": "$s22YouVersionPlatformCore24BibleHighlightsViewModelC5cache10repositoryAcA0eF5CacheC_AA0eF18RepositoryProtocol_ptcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "reset",
+            "printedName": "reset()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC5resetyyF",
+            "mangledName": "$s22YouVersionPlatformCore24BibleHighlightsViewModelC5resetyyF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "highlights",
+            "printedName": "highlights(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleHighlight]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleHighlight",
+                    "printedName": "YouVersionPlatformCore.BibleHighlight",
+                    "usr": "s:22YouVersionPlatformCore14BibleHighlightV"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC10highlights3forSayAA0E9HighlightVGAA0E9ReferenceV_tF",
+            "mangledName": "$s22YouVersionPlatformCore24BibleHighlightsViewModelC10highlights3forSayAA0E9HighlightVGAA0E9ReferenceV_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "ensureHighlightsForChapterLoaded",
+            "printedName": "ensureHighlightsForChapterLoaded(_:forceReload:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC06ensureF16ForChapterLoaded_11forceReloadyAA0E9ReferenceV_SbtF",
+            "mangledName": "$s22YouVersionPlatformCore24BibleHighlightsViewModelC06ensureF16ForChapterLoaded_11forceReloadyAA0E9ReferenceV_SbtF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addHighlights",
+            "printedName": "addHighlights(references:color:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleReference]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC03addF010references5colorySayAA0E9ReferenceVG_SStF",
+            "mangledName": "$s22YouVersionPlatformCore24BibleHighlightsViewModelC03addF010references5colorySayAA0E9ReferenceVG_SStF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeHighlights",
+            "printedName": "removeHighlights(references:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleReference]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC06removeF010referencesySayAA0E9ReferenceVG_tF",
+            "mangledName": "$s22YouVersionPlatformCore24BibleHighlightsViewModelC06removeF010referencesySayAA0E9ReferenceVG_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "updateHighlightColors",
+            "printedName": "updateHighlightColors(references:newColor:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleReference]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC21updateHighlightColors10references8newColorySayAA0E9ReferenceVG_SStF",
+            "mangledName": "$s22YouVersionPlatformCore24BibleHighlightsViewModelC21updateHighlightColors10references8newColorySayAA0E9ReferenceVG_SStF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "ObjectWillChangePublisher",
+            "printedName": "ObjectWillChangePublisher",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "ObservableObjectPublisher",
+                "printedName": "Combine.ObservableObjectPublisher",
+                "usr": "s:7Combine25ObservableObjectPublisherC"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC25ObjectWillChangePublishera",
+            "mangledName": "$s22YouVersionPlatformCore24BibleHighlightsViewModelC25ObjectWillChangePublishera",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC",
+        "mangledName": "$s22YouVersionPlatformCore24BibleHighlightsViewModelC",
+        "moduleName": "YouVersionPlatformCore",
+        "declAttributes": [
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "ObservableObject",
+            "printedName": "ObservableObject",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "ObjectWillChangePublisher",
+                "printedName": "ObjectWillChangePublisher",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ObservableObjectPublisher",
+                    "printedName": "Combine.ObservableObjectPublisher",
+                    "usr": "s:7Combine25ObservableObjectPublisherC"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7Combine16ObservableObjectP",
+            "mangledName": "$s7Combine16ObservableObjectP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "HighlightOperationType",
+        "printedName": "HighlightOperationType",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "add",
+            "printedName": "add",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.HighlightOperationType.Type) -> YouVersionPlatformCore.HighlightOperationType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "HighlightOperationType",
+                    "printedName": "YouVersionPlatformCore.HighlightOperationType",
+                    "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.HighlightOperationType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "HighlightOperationType",
+                        "printedName": "YouVersionPlatformCore.HighlightOperationType",
+                        "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO3addyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore22HighlightOperationTypeO3addyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "remove",
+            "printedName": "remove",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.HighlightOperationType.Type) -> YouVersionPlatformCore.HighlightOperationType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "HighlightOperationType",
+                    "printedName": "YouVersionPlatformCore.HighlightOperationType",
+                    "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.HighlightOperationType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "HighlightOperationType",
+                        "printedName": "YouVersionPlatformCore.HighlightOperationType",
+                        "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO6removeyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore22HighlightOperationTypeO6removeyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "update",
+            "printedName": "update",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.HighlightOperationType.Type) -> YouVersionPlatformCore.HighlightOperationType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "HighlightOperationType",
+                    "printedName": "YouVersionPlatformCore.HighlightOperationType",
+                    "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.HighlightOperationType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "HighlightOperationType",
+                        "printedName": "YouVersionPlatformCore.HighlightOperationType",
+                        "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO6updateyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore22HighlightOperationTypeO6updateyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Function",
+            "name": "__derived_enum_equals",
+            "printedName": "__derived_enum_equals(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "HighlightOperationType",
+                "printedName": "YouVersionPlatformCore.HighlightOperationType",
+                "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "HighlightOperationType",
+                "printedName": "YouVersionPlatformCore.HighlightOperationType",
+                "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO21__derived_enum_equalsySbAC_ACtFZ",
+            "mangledName": "$s22YouVersionPlatformCore22HighlightOperationTypeO21__derived_enum_equalsySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Implements",
+              "Semantics"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hash",
+            "printedName": "hash(into:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Hasher",
+                "printedName": "Swift.Hasher",
+                "paramValueOwnership": "InOut",
+                "usr": "s:s6HasherV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO4hash4intoys6HasherVz_tF",
+            "mangledName": "$s22YouVersionPlatformCore22HighlightOperationTypeO4hash4intoys6HasherVz_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "hashValue",
+            "printedName": "hashValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO9hashValueSivp",
+            "mangledName": "$s22YouVersionPlatformCore22HighlightOperationTypeO9hashValueSivp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO9hashValueSivg",
+                "mangledName": "$s22YouVersionPlatformCore22HighlightOperationTypeO9hashValueSivg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO",
+        "mangledName": "$s22YouVersionPlatformCore22HighlightOperationTypeO",
+        "moduleName": "YouVersionPlatformCore",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "PendingHighlightOperation",
+        "printedName": "PendingHighlightOperation",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "id",
+            "printedName": "id",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UUID",
+                "printedName": "Foundation.UUID",
+                "usr": "s:10Foundation4UUIDV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV2id10Foundation4UUIDVvp",
+            "mangledName": "$s22YouVersionPlatformCore25PendingHighlightOperationV2id10Foundation4UUIDVvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UUID",
+                    "printedName": "Foundation.UUID",
+                    "usr": "s:10Foundation4UUIDV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV2id10Foundation4UUIDVvg",
+                "mangledName": "$s22YouVersionPlatformCore25PendingHighlightOperationV2id10Foundation4UUIDVvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "references",
+            "printedName": "references",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleReference]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV10referencesSayAA14BibleReferenceVGvp",
+            "mangledName": "$s22YouVersionPlatformCore25PendingHighlightOperationV10referencesSayAA14BibleReferenceVGvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.BibleReference]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleReference",
+                        "printedName": "YouVersionPlatformCore.BibleReference",
+                        "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV10referencesSayAA14BibleReferenceVGvg",
+                "mangledName": "$s22YouVersionPlatformCore25PendingHighlightOperationV10referencesSayAA14BibleReferenceVGvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "color",
+            "printedName": "color",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV5colorSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore25PendingHighlightOperationV5colorSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV5colorSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore25PendingHighlightOperationV5colorSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "operationType",
+            "printedName": "operationType",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "HighlightOperationType",
+                "printedName": "YouVersionPlatformCore.HighlightOperationType",
+                "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV13operationTypeAA0fgI0Ovp",
+            "mangledName": "$s22YouVersionPlatformCore25PendingHighlightOperationV13operationTypeAA0fgI0Ovp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "HighlightOperationType",
+                    "printedName": "YouVersionPlatformCore.HighlightOperationType",
+                    "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV13operationTypeAA0fgI0Ovg",
+                "mangledName": "$s22YouVersionPlatformCore25PendingHighlightOperationV13operationTypeAA0fgI0Ovg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "timestamp",
+            "printedName": "timestamp",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Date",
+                "printedName": "Foundation.Date",
+                "usr": "s:10Foundation4DateV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV9timestamp10Foundation4DateVvp",
+            "mangledName": "$s22YouVersionPlatformCore25PendingHighlightOperationV9timestamp10Foundation4DateVvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Date",
+                    "printedName": "Foundation.Date",
+                    "usr": "s:10Foundation4DateV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV9timestamp10Foundation4DateVvg",
+                "mangledName": "$s22YouVersionPlatformCore25PendingHighlightOperationV9timestamp10Foundation4DateVvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(references:color:operationType:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "PendingHighlightOperation",
+                "printedName": "YouVersionPlatformCore.PendingHighlightOperation",
+                "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleReference]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "HighlightOperationType",
+                "printedName": "YouVersionPlatformCore.HighlightOperationType",
+                "usr": "s:22YouVersionPlatformCore22HighlightOperationTypeO"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV10references5color13operationTypeACSayAA14BibleReferenceVG_SSSgAA0fgK0Otcfc",
+            "mangledName": "$s22YouVersionPlatformCore25PendingHighlightOperationV10references5color13operationTypeACSayAA14BibleReferenceVG_SSSgAA0fgK0Otcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "ID",
+            "printedName": "ID",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UUID",
+                "printedName": "Foundation.UUID",
+                "usr": "s:10Foundation4UUIDV"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV2IDa",
+            "mangledName": "$s22YouVersionPlatformCore25PendingHighlightOperationV2IDa",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore25PendingHighlightOperationV",
+        "mangledName": "$s22YouVersionPlatformCore25PendingHighlightOperationV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Identifiable",
+            "printedName": "Identifiable",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "ID",
+                "printedName": "ID",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UUID",
+                    "printedName": "Foundation.UUID",
+                    "usr": "s:10Foundation4UUIDV"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:s12IdentifiableP",
+            "mangledName": "$ss12IdentifiableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleReference",
+        "printedName": "BibleReference",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "versionId",
+            "printedName": "versionId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV9versionIdSivp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV9versionIdSivp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV9versionIdSivg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV9versionIdSivg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "bookUSFM",
+            "printedName": "bookUSFM",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV8bookUSFMSSvp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV8bookUSFMSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV8bookUSFMSSvg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV8bookUSFMSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "chapter",
+            "printedName": "chapter",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV7chapterSivp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV7chapterSivp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV7chapterSivg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV7chapterSivg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "verseStart",
+            "printedName": "verseStart",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Int?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV10verseStartSiSgvp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV10verseStartSiSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.Int?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV10verseStartSiSgvg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV10verseStartSiSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "verseEnd",
+            "printedName": "verseEnd",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Int?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV8verseEndSiSgvp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV8verseEndSiSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.Int?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV8verseEndSiSgvg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV8verseEndSiSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(versionId:bookUSFM:chapter:verse:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Int?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV9versionId8bookUSFM7chapter5verseACSi_SSS2iSgtcfc",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV9versionId8bookUSFM7chapter5verseACSi_SSS2iSgtcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(versionId:bookUSFM:chapter:verseStart:verseEnd:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV9versionId8bookUSFM7chapter10verseStart0L3EndACSi_SSS3itcfc",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV9versionId8bookUSFM7chapter10verseStart0L3EndACSi_SSS3itcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "debugDescription",
+            "printedName": "debugDescription",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV16debugDescriptionSSvp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV16debugDescriptionSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV16debugDescriptionSSvg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV16debugDescriptionSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "isRange",
+            "printedName": "isRange",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV7isRangeSbvp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV7isRangeSbvp",
+            "moduleName": "YouVersionPlatformCore",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV7isRangeSbvg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV7isRangeSbvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "compare",
+            "printedName": "compare(a:b:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV7compare1a1bSiAC_ACtFZ",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV7compare1a1bSiAC_ACtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "<",
+            "printedName": "<(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV1loiySbAC_ACtFZ",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV1loiySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "chapterUSFM",
+            "printedName": "chapterUSFM",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV11chapterUSFMSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV11chapterUSFMSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV11chapterUSFMSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV11chapterUSFMSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "asUSFM",
+            "printedName": "asUSFM",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV6asUSFMSSvp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV6asUSFMSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV6asUSFMSSvg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV6asUSFMSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "existsIn",
+            "printedName": "existsIn(version:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV8existsIn7versionSbAA0eB0V_tF",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV8existsIn7versionSbAA0eB0V_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "overlaps",
+            "printedName": "overlaps(with:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV8overlaps4withSbAC_tF",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV8overlaps4withSbAC_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "contains",
+            "printedName": "contains(with:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV8contains4withSbAC_tF",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV8contains4withSbAC_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "isAdjacentOrOverlapping",
+            "printedName": "isAdjacentOrOverlapping(with:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV23isAdjacentOrOverlapping4withSbAC_tF",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV23isAdjacentOrOverlapping4withSbAC_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "referencesByMerging",
+            "printedName": "referencesByMerging(references:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleReference]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleReference]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV19referencesByMerging0G0SayACGAF_tFZ",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV19referencesByMerging0G0SayACGAF_tFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "referenceByMerging",
+            "printedName": "referenceByMerging(a:b:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV18referenceByMerging1a1bA2C_ACtFZ",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV18referenceByMerging1a1bA2C_ACtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "unvalidatedReference",
+            "printedName": "unvalidatedReference(with:versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleReference?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV011unvalidatedF04with9versionIdACSgSS_SitFZ",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV011unvalidatedF04with9versionIdACSgSS_SitFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "__derived_struct_equals",
+            "printedName": "__derived_struct_equals(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV23__derived_struct_equalsySbAC_ACtFZ",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV23__derived_struct_equalsySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Implements"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "encode",
+            "printedName": "encode(to:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Encoder",
+                "printedName": "any Swift.Encoder",
+                "usr": "s:s7EncoderP"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV6encode2toys7Encoder_p_tKF",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV6encode2toys7Encoder_p_tKF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hash",
+            "printedName": "hash(into:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Hasher",
+                "printedName": "Swift.Hasher",
+                "paramValueOwnership": "InOut",
+                "usr": "s:s6HasherV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV4hash4intoys6HasherVz_tF",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV4hash4intoys6HasherVz_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "hashValue",
+            "printedName": "hashValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV9hashValueSivp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV9hashValueSivp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV9hashValueSivg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV9hashValueSivg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV4fromACs7Decoder_p_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore14BibleReferenceV",
+        "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Comparable",
+            "printedName": "Comparable",
+            "usr": "s:SL",
+            "mangledName": "$sSL"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomDebugStringConvertible",
+            "printedName": "CustomDebugStringConvertible",
+            "usr": "s:s28CustomDebugStringConvertibleP",
+            "mangledName": "$ss28CustomDebugStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleTextNode",
+        "printedName": "BibleTextNode",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "text",
+            "printedName": "text",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore13BibleTextNodeV4textSSvp",
+            "mangledName": "$s22YouVersionPlatformCore13BibleTextNodeV4textSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore13BibleTextNodeV4textSSvg",
+                "mangledName": "$s22YouVersionPlatformCore13BibleTextNodeV4textSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "children",
+            "printedName": "children",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.BibleTextNode]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextNode",
+                    "printedName": "YouVersionPlatformCore.BibleTextNode",
+                    "usr": "s:22YouVersionPlatformCore13BibleTextNodeV"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore13BibleTextNodeV8childrenSayACGvp",
+            "mangledName": "$s22YouVersionPlatformCore13BibleTextNodeV8childrenSayACGvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.BibleTextNode]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextNode",
+                        "printedName": "YouVersionPlatformCore.BibleTextNode",
+                        "usr": "s:22YouVersionPlatformCore13BibleTextNodeV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore13BibleTextNodeV8childrenSayACGvg",
+                "mangledName": "$s22YouVersionPlatformCore13BibleTextNodeV8childrenSayACGvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "classes",
+            "printedName": "classes",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.String]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore13BibleTextNodeV7classesSaySSGvp",
+            "mangledName": "$s22YouVersionPlatformCore13BibleTextNodeV7classesSaySSGvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore13BibleTextNodeV7classesSaySSGvg",
+                "mangledName": "$s22YouVersionPlatformCore13BibleTextNodeV7classesSaySSGvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "attributes",
+            "printedName": "attributes",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Dictionary",
+                "printedName": "[Swift.String : Swift.String]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:SD"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore13BibleTextNodeV10attributesSDyS2SGvp",
+            "mangledName": "$s22YouVersionPlatformCore13BibleTextNodeV10attributesSDyS2SGvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Dictionary",
+                    "printedName": "[Swift.String : Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:SD"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore13BibleTextNodeV10attributesSDyS2SGvg",
+                "mangledName": "$s22YouVersionPlatformCore13BibleTextNodeV10attributesSDyS2SGvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "textSegments",
+            "printedName": "textSegments",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.String]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore13BibleTextNodeV12textSegmentsSaySSGvp",
+            "mangledName": "$s22YouVersionPlatformCore13BibleTextNodeV12textSegmentsSaySSGvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore13BibleTextNodeV12textSegmentsSaySSGvg",
+                "mangledName": "$s22YouVersionPlatformCore13BibleTextNodeV12textSegmentsSaySSGvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(html:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextNode",
+                "printedName": "YouVersionPlatformCore.BibleTextNode",
+                "usr": "s:22YouVersionPlatformCore13BibleTextNodeV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore13BibleTextNodeV4htmlACSS_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore13BibleTextNodeV4htmlACSS_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "throwing": true,
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "type",
+            "printedName": "type",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextNodeType",
+                "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore13BibleTextNodeV4typeAA0efG4TypeOvp",
+            "mangledName": "$s22YouVersionPlatformCore13BibleTextNodeV4typeAA0efG4TypeOvp",
+            "moduleName": "YouVersionPlatformCore",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextNodeType",
+                    "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                    "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore13BibleTextNodeV4typeAA0efG4TypeOvg",
+                "mangledName": "$s22YouVersionPlatformCore13BibleTextNodeV4typeAA0efG4TypeOvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore13BibleTextNodeV",
+        "mangledName": "$s22YouVersionPlatformCore13BibleTextNodeV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleTextNodeType",
+        "printedName": "BibleTextNodeType",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "block",
+            "printedName": "block",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.BibleTextNodeType.Type) -> YouVersionPlatformCore.BibleTextNodeType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextNodeType",
+                    "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                    "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.BibleTextNodeType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextNodeType",
+                        "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                        "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO5blockyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore17BibleTextNodeTypeO5blockyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "table",
+            "printedName": "table",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.BibleTextNodeType.Type) -> YouVersionPlatformCore.BibleTextNodeType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextNodeType",
+                    "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                    "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.BibleTextNodeType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextNodeType",
+                        "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                        "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO5tableyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore17BibleTextNodeTypeO5tableyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "row",
+            "printedName": "row",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.BibleTextNodeType.Type) -> YouVersionPlatformCore.BibleTextNodeType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextNodeType",
+                    "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                    "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.BibleTextNodeType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextNodeType",
+                        "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                        "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO3rowyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore17BibleTextNodeTypeO3rowyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "cell",
+            "printedName": "cell",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.BibleTextNodeType.Type) -> YouVersionPlatformCore.BibleTextNodeType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextNodeType",
+                    "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                    "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.BibleTextNodeType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextNodeType",
+                        "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                        "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO4cellyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore17BibleTextNodeTypeO4cellyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "text",
+            "printedName": "text",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.BibleTextNodeType.Type) -> YouVersionPlatformCore.BibleTextNodeType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextNodeType",
+                    "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                    "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.BibleTextNodeType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextNodeType",
+                        "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                        "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO4textyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore17BibleTextNodeTypeO4textyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "span",
+            "printedName": "span",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.BibleTextNodeType.Type) -> YouVersionPlatformCore.BibleTextNodeType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextNodeType",
+                    "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                    "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.BibleTextNodeType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextNodeType",
+                        "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                        "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO4spanyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore17BibleTextNodeTypeO4spanyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "root",
+            "printedName": "root",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.BibleTextNodeType.Type) -> YouVersionPlatformCore.BibleTextNodeType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextNodeType",
+                    "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                    "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.BibleTextNodeType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextNodeType",
+                        "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                        "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO4rootyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore17BibleTextNodeTypeO4rootyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Function",
+            "name": "__derived_enum_equals",
+            "printedName": "__derived_enum_equals(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextNodeType",
+                "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextNodeType",
+                "printedName": "YouVersionPlatformCore.BibleTextNodeType",
+                "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO21__derived_enum_equalsySbAC_ACtFZ",
+            "mangledName": "$s22YouVersionPlatformCore17BibleTextNodeTypeO21__derived_enum_equalsySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Implements",
+              "Semantics"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hash",
+            "printedName": "hash(into:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Hasher",
+                "printedName": "Swift.Hasher",
+                "paramValueOwnership": "InOut",
+                "usr": "s:s6HasherV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO4hash4intoys6HasherVz_tF",
+            "mangledName": "$s22YouVersionPlatformCore17BibleTextNodeTypeO4hash4intoys6HasherVz_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "hashValue",
+            "printedName": "hashValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO9hashValueSivp",
+            "mangledName": "$s22YouVersionPlatformCore17BibleTextNodeTypeO9hashValueSivp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO9hashValueSivg",
+                "mangledName": "$s22YouVersionPlatformCore17BibleTextNodeTypeO9hashValueSivg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:22YouVersionPlatformCore17BibleTextNodeTypeO",
+        "mangledName": "$s22YouVersionPlatformCore17BibleTextNodeTypeO",
+        "moduleName": "YouVersionPlatformCore",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVerse",
+        "printedName": "BibleVerse",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "id",
+            "printedName": "id",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore10BibleVerseV2idSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore10BibleVerseV2idSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore10BibleVerseV2idSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore10BibleVerseV2idSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "passageId",
+            "printedName": "passageId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore10BibleVerseV9passageIdSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore10BibleVerseV9passageIdSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore10BibleVerseV9passageIdSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore10BibleVerseV9passageIdSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "title",
+            "printedName": "title",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore10BibleVerseV5titleSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore10BibleVerseV5titleSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore10BibleVerseV5titleSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore10BibleVerseV5titleSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "encode",
+            "printedName": "encode(to:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Encoder",
+                "printedName": "any Swift.Encoder",
+                "usr": "s:s7EncoderP"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10BibleVerseV6encode2toys7Encoder_p_tKF",
+            "mangledName": "$s22YouVersionPlatformCore10BibleVerseV6encode2toys7Encoder_p_tKF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVerse",
+                "printedName": "YouVersionPlatformCore.BibleVerse",
+                "usr": "s:22YouVersionPlatformCore10BibleVerseV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore10BibleVerseV4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore10BibleVerseV4fromACs7Decoder_p_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore10BibleVerseV",
+        "mangledName": "$s22YouVersionPlatformCore10BibleVerseV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersion",
+        "printedName": "BibleVersion",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "id",
+            "printedName": "id",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V2idSivp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V2idSivp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V2idSivg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V2idSivg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "abbreviation",
+            "printedName": "abbreviation",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V12abbreviationSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V12abbreviationSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V12abbreviationSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V12abbreviationSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "promotionalContent",
+            "printedName": "promotionalContent",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V18promotionalContentSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V18promotionalContentSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V18promotionalContentSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V18promotionalContentSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "copyright",
+            "printedName": "copyright",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V9copyrightSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V9copyrightSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V9copyrightSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V9copyrightSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "languageTag",
+            "printedName": "languageTag",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V11languageTagSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V11languageTagSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V11languageTagSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V11languageTagSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "localizedAbbreviation",
+            "printedName": "localizedAbbreviation",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V21localizedAbbreviationSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V21localizedAbbreviationSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V21localizedAbbreviationSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V21localizedAbbreviationSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "localizedTitle",
+            "printedName": "localizedTitle",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V14localizedTitleSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V14localizedTitleSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V14localizedTitleSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V14localizedTitleSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerFooter",
+            "printedName": "readerFooter",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V12readerFooterSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V12readerFooterSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V12readerFooterSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V12readerFooterSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerFooterUrl",
+            "printedName": "readerFooterUrl",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V15readerFooterUrlSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V15readerFooterUrlSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V15readerFooterUrlSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V15readerFooterUrlSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "title",
+            "printedName": "title",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V5titleSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V5titleSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V5titleSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V5titleSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "organizationId",
+            "printedName": "organizationId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V14organizationIdSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V14organizationIdSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V14organizationIdSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V14organizationIdSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "bookCodes",
+            "printedName": "bookCodes",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[Swift.String]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V9bookCodesSaySSGSgvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V9bookCodesSaySSGSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "[Swift.String]?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Array",
+                        "printedName": "[Swift.String]",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:Sa"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V9bookCodesSaySSGSgvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V9bookCodesSaySSGSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "books",
+            "printedName": "books",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[YouVersionPlatformCore.BibleBook]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.BibleBook]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleBook",
+                        "printedName": "YouVersionPlatformCore.BibleBook",
+                        "usr": "s:22YouVersionPlatformCore9BibleBookV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V5booksSayAA0E4BookVGSgvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V5booksSayAA0E4BookVGSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "[YouVersionPlatformCore.BibleBook]?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Array",
+                        "printedName": "[YouVersionPlatformCore.BibleBook]",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "BibleBook",
+                            "printedName": "YouVersionPlatformCore.BibleBook",
+                            "usr": "s:22YouVersionPlatformCore9BibleBookV"
+                          }
+                        ],
+                        "usr": "s:Sa"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V5booksSayAA0E4BookVGSgvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V5booksSayAA0E4BookVGSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "textDirection",
+            "printedName": "textDirection",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V13textDirectionSSSgvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V13textDirectionSSSgvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V13textDirectionSSSgvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V13textDirectionSSSgvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "requiresEmailAgreement",
+            "printedName": "requiresEmailAgreement",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V22requiresEmailAgreementSbvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V22requiresEmailAgreementSbvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V22requiresEmailAgreementSbvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V22requiresEmailAgreementSbvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "==",
+            "printedName": "==(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V2eeoiySbAC_ACtFZ",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V2eeoiySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hash",
+            "printedName": "hash(into:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Hasher",
+                "printedName": "Swift.Hasher",
+                "paramValueOwnership": "InOut",
+                "usr": "s:s6HasherV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V4hash4intoys6HasherVz_tF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V4hash4intoys6HasherVz_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "isRightToLeft",
+            "printedName": "isRightToLeft",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V13isRightToLeftSbvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V13isRightToLeftSbvp",
+            "moduleName": "YouVersionPlatformCore",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V13isRightToLeftSbvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V13isRightToLeftSbvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "book",
+            "printedName": "book(with:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleBook?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleBook",
+                    "printedName": "YouVersionPlatformCore.BibleBook",
+                    "usr": "s:22YouVersionPlatformCore9BibleBookV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V4book4withAA0E4BookVSgSS_tF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V4book4withAA0E4BookVSgSS_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "bookUSFMs",
+            "printedName": "bookUSFMs",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.String]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V9bookUSFMsSaySSGvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V9bookUSFMsSaySSGvp",
+            "moduleName": "YouVersionPlatformCore",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V9bookUSFMsSaySSGvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V9bookUSFMsSaySSGvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "reference",
+            "printedName": "reference(with:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleReference?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V9reference4withAA0E9ReferenceVSgSS_tF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V9reference4withAA0E9ReferenceVSgSS_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "chapterLabels",
+            "printedName": "chapterLabels(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.String]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V13chapterLabelsySaySSGSSF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V13chapterLabelsySaySSGSSF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "preview",
+            "printedName": "preview",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V7previewACvpZ",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V7previewACvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V7previewACvgZ",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V7previewACvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "encode",
+            "printedName": "encode(to:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Encoder",
+                "printedName": "any Swift.Encoder",
+                "usr": "s:s7EncoderP"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V6encode2toys7Encoder_p_tKF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V6encode2toys7Encoder_p_tKF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "hashValue",
+            "printedName": "hashValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V9hashValueSivp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V9hashValueSivp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V9hashValueSivg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB0V9hashValueSivg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V4fromACs7Decoder_p_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore05BibleB0V",
+        "mangledName": "$s22YouVersionPlatformCore05BibleB0V",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersionAPIClient",
+        "printedName": "BibleVersionAPIClient",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP7version6withIdAA0eB0VSi_tYaKF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP7version6withIdAA0eB0VSi_tYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionAPIClient>",
+            "protocolReq": true,
+            "throwing": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP",
+        "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP",
+        "moduleName": "YouVersionPlatformCore",
+        "genericSig": "<Self : Swift.Sendable>",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersionRepositoryProtocol",
+        "printedName": "BibleVersionRepositoryProtocol",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "versionIfCached",
+            "printedName": "versionIfCached(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP15versionIfCachedyAA0eB0VSgSiYaKF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB18RepositoryProtocolP15versionIfCachedyAA0eB0VSgSiYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionRepositoryProtocol>",
+            "protocolReq": true,
+            "throwing": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP7version6withIdAA0eB0VSi_tYaKF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB18RepositoryProtocolP7version6withIdAA0eB0VSi_tYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionRepositoryProtocol>",
+            "protocolReq": true,
+            "throwing": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "downloadVersion",
+            "printedName": "downloadVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP08downloadB06withIdySi_tYaKF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB18RepositoryProtocolP08downloadB06withIdySi_tYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionRepositoryProtocol>",
+            "protocolReq": true,
+            "throwing": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "downloadStatus",
+            "printedName": "downloadStatus(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionDownloadStatus",
+                "printedName": "YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP14downloadStatus3forAA0ebF0C0eb8DownloadI0OSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB18RepositoryProtocolP14downloadStatus3forAA0ebF0C0eb8DownloadI0OSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionRepositoryProtocol>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB18RepositoryProtocolP06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionRepositoryProtocol>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB18RepositoryProtocolP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionRepositoryProtocol>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP",
+        "mangledName": "$s22YouVersionPlatformCore05BibleB18RepositoryProtocolP",
+        "moduleName": "YouVersionPlatformCore",
+        "genericSig": "<Self : Swift.Sendable>",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersionCaching",
+        "printedName": "BibleVersionCaching",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP7version6withIdAA0eB0VSgSi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP7version6withIdAA0eB0VSgSi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP03addB0yyAA0eB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP03addB0yyAA0eB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+        "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP",
+        "moduleName": "YouVersionPlatformCore",
+        "genericSig": "<Self : Swift.Sendable>",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionClient",
+        "printedName": "VersionClient",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionClient",
+                "printedName": "YouVersionPlatformCore.VersionClient",
+                "usr": "s:22YouVersionPlatformCore0B6ClientC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B6ClientCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B6ClientCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B6ClientC7version6withIdAA05BibleB0VSi_tYaKF",
+            "mangledName": "$s22YouVersionPlatformCore0B6ClientC7version6withIdAA05BibleB0VSi_tYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final"
+            ],
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B6ClientC",
+        "mangledName": "$s22YouVersionPlatformCore0B6ClientC",
+        "moduleName": "YouVersionPlatformCore",
+        "declAttributes": [
+          "Final"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionAPIClient",
+            "printedName": "BibleVersionAPIClient",
+            "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionMemoryCache",
+        "printedName": "VersionMemoryCache",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionMemoryCache",
+                "printedName": "YouVersionPlatformCore.VersionMemoryCache",
+                "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC03addB0yyAA05BibleB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC03addB0yyAA05BibleB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC",
+        "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionCaching",
+            "printedName": "BibleVersionCaching",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionDiskCache",
+        "printedName": "VersionDiskCache",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionDiskCache",
+                "printedName": "YouVersionPlatformCore.VersionDiskCache",
+                "usr": "s:22YouVersionPlatformCore0B9DiskCacheC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC7version6withIdAA05BibleB0VSgSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC7version6withIdAA05BibleB0VSgSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC03addB0yyAA05BibleB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC03addB0yyAA05BibleB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B9DiskCacheC",
+        "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionCaching",
+            "printedName": "BibleVersionCaching",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionDownloadCache",
+        "printedName": "VersionDownloadCache",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionDownloadCache",
+                "printedName": "YouVersionPlatformCore.VersionDownloadCache",
+                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC7version6withIdAA05BibleB0VSgSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC7version6withIdAA05BibleB0VSgSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC03addB0yyAA05BibleB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC03addB0yyAA05BibleB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC06removeB06withIdySi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC06removeB06withIdySi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "downloadedVersions",
+            "printedName": "downloadedVersions",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "Final"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.Int]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC",
+        "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionCaching",
+            "printedName": "BibleVersionCaching",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersionRepository",
+        "printedName": "BibleVersionRepository",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "shared",
+            "printedName": "shared",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionRepository",
+                "printedName": "YouVersionPlatformCore.BibleVersionRepository",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC6sharedACvpZ",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC6sharedACvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "Final",
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersionRepository",
+                    "printedName": "YouVersionPlatformCore.BibleVersionRepository",
+                    "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC6sharedACvgZ",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC6sharedACvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Final",
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(apiClient:memoryCache:diskCache:downloadCache:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionRepository",
+                "printedName": "YouVersionPlatformCore.BibleVersionRepository",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionAPIClient",
+                "printedName": "any YouVersionPlatformCore.BibleVersionAPIClient",
+                "hasDefaultArg": true,
+                "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionCaching",
+                "printedName": "any YouVersionPlatformCore.BibleVersionCaching",
+                "hasDefaultArg": true,
+                "usr": "s:22YouVersionPlatformCore05BibleB7CachingP"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionCaching",
+                "printedName": "any YouVersionPlatformCore.BibleVersionCaching",
+                "hasDefaultArg": true,
+                "usr": "s:22YouVersionPlatformCore05BibleB7CachingP"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionCaching",
+                "printedName": "any YouVersionPlatformCore.BibleVersionCaching",
+                "hasDefaultArg": true,
+                "usr": "s:22YouVersionPlatformCore05BibleB7CachingP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC9apiClient11memoryCache04diskJ008downloadJ0AcA0eB9APIClient_p_AA0eB7Caching_pAaI_pAaI_ptcfc",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC9apiClient11memoryCache04diskJ008downloadJ0AcA0eB9APIClient_p_AA0eB7Caching_pAaI_pAaI_ptcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIfCached",
+            "printedName": "versionIfCached(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC15versionIfCachedyAA0eB0VSgSiYaKF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC15versionIfCachedyAA0eB0VSgSiYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC7version6withIdAA0eB0VSi_tYaKF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC7version6withIdAA0eB0VSi_tYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "downloadVersion",
+            "printedName": "downloadVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC08downloadB06withIdySi_tYaKF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC08downloadB06withIdySi_tYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "TypeDecl",
+            "name": "BibleVersionDownloadStatus",
+            "printedName": "BibleVersionDownloadStatus",
+            "children": [
+              {
+                "kind": "Var",
+                "name": "downloadable",
+                "printedName": "downloadable",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus.Type) -> YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVersionDownloadStatus",
+                        "printedName": "YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus",
+                        "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "BibleVersionDownloadStatus",
+                            "printedName": "YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus",
+                            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO12downloadableyA2EmF",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO12downloadableyA2EmF",
+                "moduleName": "YouVersionPlatformCore"
+              },
+              {
+                "kind": "Var",
+                "name": "downloaded",
+                "printedName": "downloaded",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus.Type) -> YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVersionDownloadStatus",
+                        "printedName": "YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus",
+                        "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "BibleVersionDownloadStatus",
+                            "printedName": "YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus",
+                            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO10downloadedyA2EmF",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO10downloadedyA2EmF",
+                "moduleName": "YouVersionPlatformCore"
+              },
+              {
+                "kind": "Var",
+                "name": "notDownloadable",
+                "printedName": "notDownloadable",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus.Type) -> YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVersionDownloadStatus",
+                        "printedName": "YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus",
+                        "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "BibleVersionDownloadStatus",
+                            "printedName": "YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus",
+                            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO15notDownloadableyA2EmF",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO15notDownloadableyA2EmF",
+                "moduleName": "YouVersionPlatformCore"
+              },
+              {
+                "kind": "Function",
+                "name": "__derived_enum_equals",
+                "printedName": "__derived_enum_equals(_:_:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersionDownloadStatus",
+                    "printedName": "YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus",
+                    "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersionDownloadStatus",
+                    "printedName": "YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus",
+                    "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO21__derived_enum_equalsySbAE_AEtFZ",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO21__derived_enum_equalsySbAE_AEtFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Implements",
+                  "Semantics"
+                ],
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "hash",
+                "printedName": "hash(into:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Hasher",
+                    "printedName": "Swift.Hasher",
+                    "paramValueOwnership": "InOut",
+                    "usr": "s:s6HasherV"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO4hash4intoys6HasherVz_tF",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO4hash4intoys6HasherVz_tF",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Var",
+                "name": "hashValue",
+                "printedName": "hashValue",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO9hashValueSivp",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO9hashValueSivp",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO9hashValueSivg",
+                    "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO9hashValueSivg",
+                    "moduleName": "YouVersionPlatformCore",
+                    "implicit": true,
+                    "accessorKind": "get"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Enum",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO",
+            "moduleName": "YouVersionPlatformCore",
+            "isEnumExhaustive": true,
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Equatable",
+                "printedName": "Equatable",
+                "usr": "s:SQ",
+                "mangledName": "$sSQ"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Hashable",
+                "printedName": "Hashable",
+                "usr": "s:SH",
+                "mangledName": "$sSH"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Sendable",
+                "printedName": "Sendable",
+                "usr": "s:s8SendableP",
+                "mangledName": "$ss8SendableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "SendableMetatype",
+                "printedName": "SendableMetatype",
+                "usr": "s:s16SendableMetatypeP",
+                "mangledName": "$ss16SendableMetatypeP"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "downloadStatus",
+            "printedName": "downloadStatus(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionDownloadStatus",
+                "printedName": "YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC14downloadStatus3forAC0eb8DownloadH0OSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC14downloadStatus3forAC0eb8DownloadH0OSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC",
+        "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Observable",
+            "printedName": "Observable",
+            "usr": "s:11Observation10ObservableP",
+            "mangledName": "$s11Observation10ObservableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionRepositoryProtocol",
+            "printedName": "BibleVersionRepositoryProtocol",
+            "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB18RepositoryProtocolP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "YouVersionPlatformLogger",
+        "printedName": "YouVersionPlatformLogger",
+        "children": [
+          {
+            "kind": "TypeDecl",
+            "name": "Level",
+            "printedName": "Level",
+            "children": [
+              {
+                "kind": "Var",
+                "name": "debug",
+                "printedName": "debug",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.YouVersionPlatformLogger.Level.Type) -> YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Level",
+                        "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                        "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                            "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO5debugyA2EmF",
+                "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5LevelO5debugyA2EmF",
+                "moduleName": "YouVersionPlatformCore"
+              },
+              {
+                "kind": "Var",
+                "name": "info",
+                "printedName": "info",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.YouVersionPlatformLogger.Level.Type) -> YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Level",
+                        "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                        "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                            "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO4infoyA2EmF",
+                "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5LevelO4infoyA2EmF",
+                "moduleName": "YouVersionPlatformCore"
+              },
+              {
+                "kind": "Var",
+                "name": "notice",
+                "printedName": "notice",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.YouVersionPlatformLogger.Level.Type) -> YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Level",
+                        "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                        "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                            "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO6noticeyA2EmF",
+                "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5LevelO6noticeyA2EmF",
+                "moduleName": "YouVersionPlatformCore"
+              },
+              {
+                "kind": "Var",
+                "name": "error",
+                "printedName": "error",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.YouVersionPlatformLogger.Level.Type) -> YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Level",
+                        "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                        "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                            "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO5erroryA2EmF",
+                "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5LevelO5erroryA2EmF",
+                "moduleName": "YouVersionPlatformCore"
+              },
+              {
+                "kind": "Var",
+                "name": "fault",
+                "printedName": "fault",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.YouVersionPlatformLogger.Level.Type) -> YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Level",
+                        "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                        "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                            "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO5faultyA2EmF",
+                "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5LevelO5faultyA2EmF",
+                "moduleName": "YouVersionPlatformCore"
+              },
+              {
+                "kind": "Var",
+                "name": "off",
+                "printedName": "off",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.YouVersionPlatformLogger.Level.Type) -> YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Level",
+                        "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                        "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                            "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO3offyA2EmF",
+                "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5LevelO3offyA2EmF",
+                "moduleName": "YouVersionPlatformCore"
+              },
+              {
+                "kind": "Function",
+                "name": "<",
+                "printedName": "<(_:_:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Level",
+                    "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                    "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Level",
+                    "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                    "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO1loiySbAE_AEtFZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5LevelO1loiySbAE_AEtFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Constructor",
+                "name": "init",
+                "printedName": "init(rawValue:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Level",
+                        "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                        "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Constructor",
+                "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO8rawValueAESgSi_tcfc",
+                "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5LevelO8rawValueAESgSi_tcfc",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Inlinable"
+                ],
+                "init_kind": "Designated"
+              },
+              {
+                "kind": "TypeAlias",
+                "name": "RawValue",
+                "printedName": "RawValue",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "TypeAlias",
+                "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO8RawValuea",
+                "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5LevelO8RawValuea",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true
+              },
+              {
+                "kind": "Var",
+                "name": "rawValue",
+                "printedName": "rawValue",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO8rawValueSivp",
+                "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5LevelO8rawValueSivp",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO8rawValueSivg",
+                    "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5LevelO8rawValueSivg",
+                    "moduleName": "YouVersionPlatformCore",
+                    "implicit": true,
+                    "declAttributes": [
+                      "Inlinable"
+                    ],
+                    "accessorKind": "get"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Enum",
+            "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO",
+            "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5LevelO",
+            "moduleName": "YouVersionPlatformCore",
+            "enumRawTypeName": "Int",
+            "isEnumExhaustive": true,
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Comparable",
+                "printedName": "Comparable",
+                "usr": "s:SL",
+                "mangledName": "$sSL"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Equatable",
+                "printedName": "Equatable",
+                "usr": "s:SQ",
+                "mangledName": "$sSQ"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Hashable",
+                "printedName": "Hashable",
+                "usr": "s:SH",
+                "mangledName": "$sSH"
+              },
+              {
+                "kind": "Conformance",
+                "name": "RawRepresentable",
+                "printedName": "RawRepresentable",
+                "children": [
+                  {
+                    "kind": "TypeWitness",
+                    "name": "RawValue",
+                    "printedName": "RawValue",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ]
+                  }
+                ],
+                "usr": "s:SY",
+                "mangledName": "$sSY"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Sendable",
+                "printedName": "Sendable",
+                "usr": "s:s8SendableP",
+                "mangledName": "$ss8SendableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "SendableMetatype",
+                "printedName": "SendableMetatype",
+                "usr": "s:s16SendableMetatypeP",
+                "mangledName": "$ss16SendableMetatypeP"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "level",
+            "printedName": "level",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Level",
+                "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC6LoggerO5levelAC5LevelOvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5levelAC5LevelOvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "Nonisolated",
+              "HasStorage"
+            ],
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Level",
+                    "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                    "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC6LoggerO5levelAC5LevelOvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5levelAC5LevelOvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              },
+              {
+                "kind": "Accessor",
+                "name": "Set",
+                "printedName": "Set()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Level",
+                    "printedName": "YouVersionPlatformCore.YouVersionPlatformLogger.Level",
+                    "usr": "s:22YouVersionPlatformCore0abC6LoggerO5LevelO"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC6LoggerO5levelAC5LevelOvsZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5levelAC5LevelOvsZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "set"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "debug",
+            "printedName": "debug(_:category:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "() -> Swift.String",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "typeAttributes": [
+                  "noescape"
+                ]
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "hasDefaultArg": true,
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0abC6LoggerO5debug_8categoryySSyXK_SStFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5debug_8categoryySSyXK_SStFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "info",
+            "printedName": "info(_:category:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "() -> Swift.String",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "typeAttributes": [
+                  "noescape"
+                ]
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "hasDefaultArg": true,
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0abC6LoggerO4info_8categoryySSyXK_SStFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO4info_8categoryySSyXK_SStFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "notice",
+            "printedName": "notice(_:category:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "() -> Swift.String",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "typeAttributes": [
+                  "noescape"
+                ]
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "hasDefaultArg": true,
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0abC6LoggerO6notice_8categoryySSyXK_SStFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO6notice_8categoryySSyXK_SStFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "error",
+            "printedName": "error(_:category:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "() -> Swift.String",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "typeAttributes": [
+                  "noescape"
+                ]
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "hasDefaultArg": true,
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0abC6LoggerO5error_8categoryySSyXK_SStFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5error_8categoryySSyXK_SStFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "fault",
+            "printedName": "fault(_:category:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "() -> Swift.String",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "typeAttributes": [
+                  "noescape"
+                ]
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "hasDefaultArg": true,
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0abC6LoggerO5fault_8categoryySSyXK_SStFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO5fault_8categoryySSyXK_SStFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:22YouVersionPlatformCore0abC6LoggerO",
+        "mangledName": "$s22YouVersionPlatformCore0abC6LoggerO",
+        "moduleName": "YouVersionPlatformCore",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "AbbreviationSplitting",
+        "printedName": "AbbreviationSplitting",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "splitAbbreviation",
+            "printedName": "splitAbbreviation(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Tuple",
+                "printedName": "(letters: Swift.String, numbers: Swift.String)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ]
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore21AbbreviationSplittingPAAE05splitE0ySS7letters_SS7numberstSSF",
+            "mangledName": "$s22YouVersionPlatformCore21AbbreviationSplittingPAAE05splitE0ySS7letters_SS7numberstSSF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.AbbreviationSplitting>",
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:22YouVersionPlatformCore21AbbreviationSplittingP",
+        "mangledName": "$s22YouVersionPlatformCore21AbbreviationSplittingP",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "YouVersionPlatformConfiguration",
+        "printedName": "YouVersionPlatformConfiguration",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "appKey",
+            "printedName": "appKey",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV6appKeySSSgvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV6appKeySSSgvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "Nonisolated",
+              "SetterAccess",
+              "HasStorage"
+            ],
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV6appKeySSSgvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV6appKeySSSgvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "apiHost",
+            "printedName": "apiHost",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV7apiHostSSvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV7apiHostSSvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "Nonisolated",
+              "SetterAccess",
+              "HasStorage"
+            ],
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV7apiHostSSvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV7apiHostSSvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "appName",
+            "printedName": "appName",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV7appNameSSSgvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV7appNameSSSgvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "Nonisolated",
+              "SetterAccess",
+              "HasStorage"
+            ],
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV7appNameSSSgvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV7appNameSSSgvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "signInPromptMessage",
+            "printedName": "signInPromptMessage",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV19signInPromptMessageSSSgvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV19signInPromptMessageSSSgvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "Nonisolated",
+              "SetterAccess",
+              "HasStorage"
+            ],
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV19signInPromptMessageSSSgvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV19signInPromptMessageSSSgvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "isSignInEnabled",
+            "printedName": "isSignInEnabled",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV15isSignInEnabledSbvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV15isSignInEnabledSbvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "Nonisolated",
+              "SetterAccess",
+              "HasStorage"
+            ],
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV15isSignInEnabledSbvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV15isSignInEnabledSbvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "installId",
+            "printedName": "installId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV9installIdSSSgvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV9installIdSSSgvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "Nonisolated",
+              "SetterAccess",
+              "HasStorage"
+            ],
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV9installIdSSSgvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV9installIdSSSgvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "configure",
+            "printedName": "configure(appKey:apiHost:appName:isSignInEnabled:signInPromptMessage:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV9configure6appKey7apiHost0G4Name15isSignInEnabled04signN13PromptMessageySSSg_A2JSbAJtFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV9configure6appKey7apiHost0G4Name15isSignInEnabled04signN13PromptMessageySSSg_A2JSbAJtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "configureSignIn",
+            "printedName": "configureSignIn(appName:signInPromptMessage:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV15configureSignIn7appName04signH13PromptMessageySS_SSSgtFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV15configureSignIn7appName04signH13PromptMessageySS_SSSgtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "saveAuthData",
+            "printedName": "saveAuthData(accessToken:refreshToken:idToken:expiryDate:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.Date?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Date",
+                    "printedName": "Foundation.Date",
+                    "usr": "s:10Foundation4DateV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV12saveAuthData11accessToken07refreshJ002idJ010expiryDateySSSg_A2I10Foundation0N0VSgtFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV12saveAuthData11accessToken07refreshJ002idJ010expiryDateySSSg_A2I10Foundation0N0VSgtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "clearAuthTokens",
+            "printedName": "clearAuthTokens()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV15clearAuthTokensyyFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV15clearAuthTokensyyFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "accessToken",
+            "printedName": "accessToken",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV11accessTokenSSSgvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV11accessTokenSSSgvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV11accessTokenSSSgvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV11accessTokenSSSgvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "authData",
+            "printedName": "authData",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionResult",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV8authDataAA010SignInWithaB6ResultVSgvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV8authDataAA010SignInWithaB6ResultVSgvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SignInWithYouVersionResult",
+                        "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult",
+                        "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV8authDataAA010SignInWithaB6ResultVSgvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV8authDataAA010SignInWithaB6ResultVSgvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV",
+        "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          }
+        ]
+      },
+      {
+        "kind": "Function",
+        "name": "configure",
+        "printedName": "configure(appKey:)",
+        "children": [
+          {
+            "kind": "TypeNominal",
+            "name": "Void",
+            "printedName": "()"
+          },
+          {
+            "kind": "TypeNominal",
+            "name": "String",
+            "printedName": "Swift.String",
+            "usr": "s:SS"
+          }
+        ],
+        "declKind": "Func",
+        "usr": "s:22YouVersionPlatformCore9configure6appKeyySS_tF",
+        "mangledName": "$s22YouVersionPlatformCore9configure6appKeyySS_tF",
+        "moduleName": "YouVersionPlatformCore",
+        "declAttributes": [
+          "Custom"
+        ],
+        "funcSelfKind": "NonMutating"
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "URLRequest",
+        "printedName": "URLRequest",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "youVersion",
+            "printedName": "youVersion(_:accessToken:cachePolicy:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "URLRequest",
+                "printedName": "Foundation.URLRequest",
+                "usr": "s:10Foundation10URLRequestV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "URL",
+                "printedName": "Foundation.URL",
+                "usr": "s:10Foundation3URLV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNameAlias",
+                "name": "CachePolicy",
+                "printedName": "Foundation.URLRequest.CachePolicy",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CachePolicy",
+                    "printedName": "Foundation.NSURLRequest.CachePolicy",
+                    "usr": "c:@E@NSURLRequestCachePolicy"
+                  }
+                ],
+                "hasDefaultArg": true
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:10Foundation10URLRequestV22YouVersionPlatformCoreE03youD0_11accessToken11cachePolicyAcA3URLV_SSSgSo017NSURLRequestCacheK0VtFZ",
+            "mangledName": "$s10Foundation10URLRequestV22YouVersionPlatformCoreE03youD0_11accessToken11cachePolicyAcA3URLV_SSSgSo017NSURLRequestCacheK0VtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:10Foundation10URLRequestV",
+        "mangledName": "$s10Foundation10URLRequestV",
+        "moduleName": "Foundation",
+        "intro_Macosx": "10.10",
+        "intro_iOS": "8.0",
+        "intro_tvOS": "9.0",
+        "intro_watchOS": "2.0",
+        "declAttributes": [
+          "Available",
+          "Available",
+          "Available",
+          "Available"
+        ],
+        "isExternal": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "ReferenceConvertible",
+            "printedName": "ReferenceConvertible",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "ReferenceType",
+                "printedName": "ReferenceType",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "ReferenceType",
+                    "printedName": "Foundation.URLRequest.ReferenceType",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "NSURLRequest",
+                        "printedName": "Foundation.NSURLRequest",
+                        "usr": "c:objc(cs)NSURLRequest"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:10Foundation20ReferenceConvertibleP",
+            "mangledName": "$s10Foundation20ReferenceConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomDebugStringConvertible",
+            "printedName": "CustomDebugStringConvertible",
+            "usr": "s:s28CustomDebugStringConvertibleP",
+            "mangledName": "$ss28CustomDebugStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomReflectable",
+            "printedName": "CustomReflectable",
+            "usr": "s:s17CustomReflectableP",
+            "mangledName": "$ss17CustomReflectableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomStringConvertible",
+            "printedName": "CustomStringConvertible",
+            "usr": "s:s23CustomStringConvertibleP",
+            "mangledName": "$ss23CustomStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      }
+    ],
+    "json_format_version": 8
+  }
+}

--- a/.api-baseline/YouVersionPlatformReader.json
+++ b/.api-baseline/YouVersionPlatformReader.json
@@ -1,0 +1,1296 @@
+{
+  "ABIRoot": {
+    "kind": "Root",
+    "name": "YouVersionPlatformReader",
+    "printedName": "YouVersionPlatformReader",
+    "children": [
+      {
+        "kind": "Import",
+        "name": "CoreText",
+        "printedName": "CoreText",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformReader"
+      },
+      {
+        "kind": "Import",
+        "name": "Foundation",
+        "printedName": "Foundation",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformReader"
+      },
+      {
+        "kind": "Import",
+        "name": "SwiftUI",
+        "printedName": "SwiftUI",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformReader"
+      },
+      {
+        "kind": "Import",
+        "name": "YouVersionPlatformCore",
+        "printedName": "YouVersionPlatformCore",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformReader"
+      },
+      {
+        "kind": "Import",
+        "name": "YouVersionPlatformUI",
+        "printedName": "YouVersionPlatformUI",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformReader"
+      },
+      {
+        "kind": "Import",
+        "name": "_AuthenticationServices_SwiftUI",
+        "printedName": "_AuthenticationServices_SwiftUI",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformReader"
+      },
+      {
+        "kind": "Import",
+        "name": "_Concurrency",
+        "printedName": "_Concurrency",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformReader"
+      },
+      {
+        "kind": "Import",
+        "name": "_StringProcessing",
+        "printedName": "_StringProcessing",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformReader"
+      },
+      {
+        "kind": "Import",
+        "name": "_SwiftConcurrencyShims",
+        "printedName": "_SwiftConcurrencyShims",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformReader"
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleReaderView",
+        "printedName": "BibleReaderView",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(reference:verseSelectionStyle:onVerseTap:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReaderView",
+                "printedName": "YouVersionPlatformReader.BibleReaderView",
+                "usr": "s:24YouVersionPlatformReader05BibleD4ViewV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleReference?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "VerseSelectionStyle",
+                "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                "hasDefaultArg": true,
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "((YouVersionPlatformCore.BibleReference) -> Swift.Void)?",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleReference) -> Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNameAlias",
+                        "name": "Void",
+                        "printedName": "Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Void",
+                            "printedName": "()"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleReference",
+                        "printedName": "YouVersionPlatformCore.BibleReference",
+                        "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:24YouVersionPlatformReader05BibleD4ViewV9reference19verseSelectionStyle10onVerseTapAC0abC4Core0E9ReferenceVSg_0abC2UI0liJ0VyAIcSgtcfc",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD4ViewV9reference19verseSelectionStyle10onVerseTapAC0abC4Core0E9ReferenceVSg_0abC2UI0liJ0VyAIcSgtcfc",
+            "moduleName": "YouVersionPlatformReader",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(reference:appName:signInMessage:verseSelectionStyle:onVerseTap:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReaderView",
+                "printedName": "YouVersionPlatformReader.BibleReaderView",
+                "usr": "s:24YouVersionPlatformReader05BibleD4ViewV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleReference?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "VerseSelectionStyle",
+                "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                "hasDefaultArg": true,
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "((YouVersionPlatformCore.BibleReference) -> Swift.Void)?",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleReference) -> Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNameAlias",
+                        "name": "Void",
+                        "printedName": "Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Void",
+                            "printedName": "()"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleReference",
+                        "printedName": "YouVersionPlatformCore.BibleReference",
+                        "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:24YouVersionPlatformReader05BibleD4ViewV9reference7appName13signInMessage19verseSelectionStyle10onVerseTapAC0abC4Core0E9ReferenceVSg_S2S0abC2UI0qnO0VyAKcSgtcfc",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD4ViewV9reference7appName13signInMessage19verseSelectionStyle10onVerseTapAC0abC4Core0E9ReferenceVSg_S2S0abC2UI0qnO0VyAKcSgtcfc",
+            "moduleName": "YouVersionPlatformReader",
+            "deprecated": true,
+            "declAttributes": [
+              "Preconcurrency",
+              "Available",
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "body",
+            "printedName": "body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:24YouVersionPlatformReader05BibleD4ViewV4bodyQrvp",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD4ViewV4bodyQrvp",
+            "moduleName": "YouVersionPlatformReader",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:24YouVersionPlatformReader05BibleD4ViewV4bodyQrvg",
+                "mangledName": "$s24YouVersionPlatformReader05BibleD4ViewV4bodyQrvg",
+                "moduleName": "YouVersionPlatformReader",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Body",
+            "printedName": "Body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:24YouVersionPlatformReader05BibleD4ViewV4Bodya",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD4ViewV4Bodya",
+            "moduleName": "YouVersionPlatformReader",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:24YouVersionPlatformReader05BibleD4ViewV",
+        "mangledName": "$s24YouVersionPlatformReader05BibleD4ViewV",
+        "moduleName": "YouVersionPlatformReader",
+        "declAttributes": [
+          "Preconcurrency",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "View",
+            "printedName": "View",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Body",
+                "printedName": "Body",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI4ViewP",
+            "mangledName": "$s7SwiftUI4ViewP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleReaderBookAndChapterPickerView",
+        "printedName": "BibleReaderBookAndChapterPickerView",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(expandedBookCode:isPresented:bookCodes:versionId:bookNameProvider:chapterLabelsProvider:introPassageId:onSelectionChange:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReaderBookAndChapterPickerView",
+                "printedName": "YouVersionPlatformReader.BibleReaderBookAndChapterPickerView",
+                "usr": "s:24YouVersionPlatformReader05BibleD24BookAndChapterPickerViewV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Binding",
+                "printedName": "SwiftUI.Binding<Swift.String?>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "usr": "s:7SwiftUI7BindingV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Binding",
+                "printedName": "SwiftUI.Binding<Swift.Bool>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "usr": "s:7SwiftUI7BindingV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.String]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(Swift.String) -> Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ]
+              },
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(Swift.String) -> [Swift.String]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ]
+              },
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(Swift.String) -> Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ]
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "((Swift.Int, Swift.String, Swift.Int?, Swift.String?) -> Swift.Void)?",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(Swift.Int, Swift.String, Swift.Int?, Swift.String?) -> Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNameAlias",
+                        "name": "Void",
+                        "printedName": "Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Void",
+                            "printedName": "()"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Tuple",
+                        "printedName": "(Swift.Int, Swift.String, Swift.Int?, Swift.String?)",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Int",
+                            "printedName": "Swift.Int",
+                            "usr": "s:Si"
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Optional",
+                            "printedName": "Swift.Int?",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Int",
+                                "printedName": "Swift.Int",
+                                "usr": "s:Si"
+                              }
+                            ],
+                            "usr": "s:Sq"
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Optional",
+                            "printedName": "Swift.String?",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
+                              }
+                            ],
+                            "usr": "s:Sq"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:24YouVersionPlatformReader05BibleD24BookAndChapterPickerViewV08expandedF4Code11isPresented9bookCodes9versionId0O12NameProvider013chapterLabelsT0012introPassageR017onSelectionChangeAC7SwiftUI7BindingVySSSgG_ANySbGSaySSGSiAOSScARSScAOSScySi_SSSiSgAOtcSgtcfc",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD24BookAndChapterPickerViewV08expandedF4Code11isPresented9bookCodes9versionId0O12NameProvider013chapterLabelsT0012introPassageR017onSelectionChangeAC7SwiftUI7BindingVySSSgG_ANySbGSaySSGSiAOSScARSScAOSScySi_SSSiSgAOtcSgtcfc",
+            "moduleName": "YouVersionPlatformReader",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "body",
+            "printedName": "body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:24YouVersionPlatformReader05BibleD24BookAndChapterPickerViewV4bodyQrvp",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD24BookAndChapterPickerViewV4bodyQrvp",
+            "moduleName": "YouVersionPlatformReader",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:24YouVersionPlatformReader05BibleD24BookAndChapterPickerViewV4bodyQrvg",
+                "mangledName": "$s24YouVersionPlatformReader05BibleD24BookAndChapterPickerViewV4bodyQrvg",
+                "moduleName": "YouVersionPlatformReader",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Body",
+            "printedName": "Body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:24YouVersionPlatformReader05BibleD24BookAndChapterPickerViewV4Bodya",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD24BookAndChapterPickerViewV4Bodya",
+            "moduleName": "YouVersionPlatformReader",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:24YouVersionPlatformReader05BibleD24BookAndChapterPickerViewV",
+        "mangledName": "$s24YouVersionPlatformReader05BibleD24BookAndChapterPickerViewV",
+        "moduleName": "YouVersionPlatformReader",
+        "declAttributes": [
+          "Preconcurrency",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "View",
+            "printedName": "View",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Body",
+                "printedName": "Body",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI4ViewP",
+            "mangledName": "$s7SwiftUI4ViewP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleReaderHeaderView",
+        "printedName": "BibleReaderHeaderView",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "body",
+            "printedName": "body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:24YouVersionPlatformReader05BibleD10HeaderViewV4bodyQrvp",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD10HeaderViewV4bodyQrvp",
+            "moduleName": "YouVersionPlatformReader",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:24YouVersionPlatformReader05BibleD10HeaderViewV4bodyQrvg",
+                "mangledName": "$s24YouVersionPlatformReader05BibleD10HeaderViewV4bodyQrvg",
+                "moduleName": "YouVersionPlatformReader",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Body",
+            "printedName": "Body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:24YouVersionPlatformReader05BibleD10HeaderViewV4Bodya",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD10HeaderViewV4Bodya",
+            "moduleName": "YouVersionPlatformReader",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:24YouVersionPlatformReader05BibleD10HeaderViewV",
+        "mangledName": "$s24YouVersionPlatformReader05BibleD10HeaderViewV",
+        "moduleName": "YouVersionPlatformReader",
+        "declAttributes": [
+          "Preconcurrency",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "View",
+            "printedName": "View",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Body",
+                "printedName": "Body",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI4ViewP",
+            "mangledName": "$s7SwiftUI4ViewP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleReaderIntroView",
+        "printedName": "BibleReaderIntroView",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "body",
+            "printedName": "body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:24YouVersionPlatformReader05BibleD9IntroViewV4bodyQrvp",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD9IntroViewV4bodyQrvp",
+            "moduleName": "YouVersionPlatformReader",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:24YouVersionPlatformReader05BibleD9IntroViewV4bodyQrvg",
+                "mangledName": "$s24YouVersionPlatformReader05BibleD9IntroViewV4bodyQrvg",
+                "moduleName": "YouVersionPlatformReader",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Body",
+            "printedName": "Body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:24YouVersionPlatformReader05BibleD9IntroViewV4Bodya",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD9IntroViewV4Bodya",
+            "moduleName": "YouVersionPlatformReader",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:24YouVersionPlatformReader05BibleD9IntroViewV",
+        "mangledName": "$s24YouVersionPlatformReader05BibleD9IntroViewV",
+        "moduleName": "YouVersionPlatformReader",
+        "declAttributes": [
+          "Preconcurrency",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "View",
+            "printedName": "View",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Body",
+                "printedName": "Body",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI4ViewP",
+            "mangledName": "$s7SwiftUI4ViewP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "ReaderFonts",
+        "printedName": "ReaderFonts",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "installFontsIfNeeded",
+            "printedName": "installFontsIfNeeded()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:24YouVersionPlatformReader0D5FontsO07installE8IfNeededyyFZ",
+            "mangledName": "$s24YouVersionPlatformReader0D5FontsO07installE8IfNeededyyFZ",
+            "moduleName": "YouVersionPlatformReader",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:24YouVersionPlatformReader0D5FontsO",
+        "mangledName": "$s24YouVersionPlatformReader0D5FontsO",
+        "moduleName": "YouVersionPlatformReader",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "Bundle",
+        "printedName": "Bundle",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "YouVersionReaderBundle",
+            "printedName": "YouVersionReaderBundle",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bundle",
+                "printedName": "Foundation.Bundle",
+                "usr": "c:objc(cs)NSBundle"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:So8NSBundleC24YouVersionPlatformReaderE0bcE6BundleABvpZ",
+            "mangledName": "$sSo8NSBundleC24YouVersionPlatformReaderE0bcE6BundleABvpZ",
+            "moduleName": "YouVersionPlatformReader",
+            "static": true,
+            "declAttributes": [
+              "Final"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bundle",
+                    "printedName": "Foundation.Bundle",
+                    "usr": "c:objc(cs)NSBundle"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:So8NSBundleC24YouVersionPlatformReaderE0bcE6BundleABvgZ",
+                "mangledName": "$sSo8NSBundleC24YouVersionPlatformReaderE0bcE6BundleABvgZ",
+                "moduleName": "YouVersionPlatformReader",
+                "static": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "c:objc(cs)NSBundle",
+        "moduleName": "Foundation",
+        "isOpen": true,
+        "objc_name": "NSBundle",
+        "declAttributes": [
+          "ObjC",
+          "SynthesizedProtocol",
+          "NonSendable",
+          "Sendable",
+          "Dynamic"
+        ],
+        "superclassUsr": "c:objc(cs)NSObject",
+        "isExternal": true,
+        "inheritsConvenienceInitializers": true,
+        "superclassNames": [
+          "ObjectiveC.NSObject"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "NSObjectProtocol",
+            "printedName": "NSObjectProtocol",
+            "usr": "c:objc(pl)NSObject"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CVarArg",
+            "printedName": "CVarArg",
+            "usr": "s:s7CVarArgP",
+            "mangledName": "$ss7CVarArgP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomDebugStringConvertible",
+            "printedName": "CustomDebugStringConvertible",
+            "usr": "s:s28CustomDebugStringConvertibleP",
+            "mangledName": "$ss28CustomDebugStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomStringConvertible",
+            "printedName": "CustomStringConvertible",
+            "usr": "s:s23CustomStringConvertibleP",
+            "mangledName": "$ss23CustomStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      }
+    ],
+    "json_format_version": 8
+  }
+}

--- a/.api-baseline/YouVersionPlatformUI.json
+++ b/.api-baseline/YouVersionPlatformUI.json
@@ -1,0 +1,12873 @@
+{
+  "ABIRoot": {
+    "kind": "Root",
+    "name": "YouVersionPlatformUI",
+    "printedName": "YouVersionPlatformUI",
+    "children": [
+      {
+        "kind": "Import",
+        "name": "AuthenticationServices",
+        "printedName": "AuthenticationServices",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformUI"
+      },
+      {
+        "kind": "Import",
+        "name": "CoreText",
+        "printedName": "CoreText",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformUI"
+      },
+      {
+        "kind": "Import",
+        "name": "Foundation",
+        "printedName": "Foundation",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformUI"
+      },
+      {
+        "kind": "Import",
+        "name": "SwiftUI",
+        "printedName": "SwiftUI",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformUI"
+      },
+      {
+        "kind": "Import",
+        "name": "YouVersionPlatformCore",
+        "printedName": "YouVersionPlatformCore",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformUI"
+      },
+      {
+        "kind": "Import",
+        "name": "_Concurrency",
+        "printedName": "_Concurrency",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformUI"
+      },
+      {
+        "kind": "Import",
+        "name": "_StringProcessing",
+        "printedName": "_StringProcessing",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformUI"
+      },
+      {
+        "kind": "Import",
+        "name": "_SwiftConcurrencyShims",
+        "printedName": "_SwiftConcurrencyShims",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformUI"
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleTextFontOption",
+        "printedName": "BibleTextFontOption",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "textFont",
+            "printedName": "textFont",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFontOption.Type) -> YouVersionPlatformUI.BibleTextFontOption",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFontOption",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                    "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFontOption",
+                        "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO04textG0yA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO04textG0yA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "textFontBold",
+            "printedName": "textFontBold",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFontOption.Type) -> YouVersionPlatformUI.BibleTextFontOption",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFontOption",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                    "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFontOption",
+                        "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO04textG4BoldyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO04textG4BoldyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "textFontItalic",
+            "printedName": "textFontItalic",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFontOption.Type) -> YouVersionPlatformUI.BibleTextFontOption",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFontOption",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                    "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFontOption",
+                        "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO04textG6ItalicyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO04textG6ItalicyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "verseNumFont",
+            "printedName": "verseNumFont",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFontOption.Type) -> YouVersionPlatformUI.BibleTextFontOption",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFontOption",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                    "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFontOption",
+                        "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO08verseNumG0yA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO08verseNumG0yA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "smallCaps",
+            "printedName": "smallCaps",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFontOption.Type) -> YouVersionPlatformUI.BibleTextFontOption",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFontOption",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                    "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFontOption",
+                        "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO9smallCapsyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO9smallCapsyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "header",
+            "printedName": "header",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFontOption.Type) -> YouVersionPlatformUI.BibleTextFontOption",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFontOption",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                    "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFontOption",
+                        "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO6headeryA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO6headeryA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "headerItalic",
+            "printedName": "headerItalic",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFontOption.Type) -> YouVersionPlatformUI.BibleTextFontOption",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFontOption",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                    "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFontOption",
+                        "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO12headerItalicyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO12headerItalicyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "headerSmaller",
+            "printedName": "headerSmaller",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFontOption.Type) -> YouVersionPlatformUI.BibleTextFontOption",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFontOption",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                    "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFontOption",
+                        "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO13headerSmalleryA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO13headerSmalleryA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "headerSmallerItalic",
+            "printedName": "headerSmallerItalic",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFontOption.Type) -> YouVersionPlatformUI.BibleTextFontOption",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFontOption",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                    "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFontOption",
+                        "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO19headerSmallerItalicyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO19headerSmallerItalicyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "header2",
+            "printedName": "header2",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFontOption.Type) -> YouVersionPlatformUI.BibleTextFontOption",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFontOption",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                    "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFontOption",
+                        "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO7header2yA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO7header2yA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "header3",
+            "printedName": "header3",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFontOption.Type) -> YouVersionPlatformUI.BibleTextFontOption",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFontOption",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                    "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFontOption",
+                        "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO7header3yA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO7header3yA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "header4",
+            "printedName": "header4",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFontOption.Type) -> YouVersionPlatformUI.BibleTextFontOption",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFontOption",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                    "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFontOption",
+                        "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO7header4yA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO7header4yA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "footnote",
+            "printedName": "footnote",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFontOption.Type) -> YouVersionPlatformUI.BibleTextFontOption",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFontOption",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                    "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFontOption",
+                        "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO8footnoteyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO8footnoteyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Function",
+            "name": "__derived_enum_equals",
+            "printedName": "__derived_enum_equals(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextFontOption",
+                "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextFontOption",
+                "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO21__derived_enum_equalsySbAC_ACtFZ",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO21__derived_enum_equalsySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Implements",
+              "Semantics"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hash",
+            "printedName": "hash(into:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Hasher",
+                "printedName": "Swift.Hasher",
+                "paramValueOwnership": "InOut",
+                "usr": "s:s6HasherV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO4hash4intoys6HasherVz_tF",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO4hash4intoys6HasherVz_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "hashValue",
+            "printedName": "hashValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO9hashValueSivp",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO9hashValueSivp",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO9hashValueSivg",
+                "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO9hashValueSivg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO",
+        "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO",
+        "moduleName": "YouVersionPlatformUI",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleTextFonts",
+        "printedName": "BibleTextFonts",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "baseSize",
+            "printedName": "baseSize",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "usr": "s:14CoreFoundation7CGFloatV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI14BibleTextFontsV8baseSize14CoreFoundation7CGFloatVvp",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextFontsV8baseSize12CoreGraphics7CGFloatVvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CGFloat",
+                    "printedName": "CoreGraphics.CGFloat",
+                    "usr": "s:14CoreFoundation7CGFloatV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI14BibleTextFontsV8baseSize14CoreFoundation7CGFloatVvg",
+                "mangledName": "$s20YouVersionPlatformUI14BibleTextFontsV8baseSize12CoreGraphics7CGFloatVvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "verseNumBaselineOffset",
+            "printedName": "verseNumBaselineOffset",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "usr": "s:14CoreFoundation7CGFloatV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI14BibleTextFontsV22verseNumBaselineOffset14CoreFoundation7CGFloatVvp",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextFontsV22verseNumBaselineOffset12CoreGraphics7CGFloatVvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CGFloat",
+                    "printedName": "CoreGraphics.CGFloat",
+                    "usr": "s:14CoreFoundation7CGFloatV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI14BibleTextFontsV22verseNumBaselineOffset14CoreFoundation7CGFloatVvg",
+                "mangledName": "$s20YouVersionPlatformUI14BibleTextFontsV22verseNumBaselineOffset12CoreGraphics7CGFloatVvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "font",
+            "printedName": "font(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextFontOption",
+                "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI14BibleTextFontsV4font3for05SwiftD04FontVAA0efK6OptionO_tF",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextFontsV4font3for05SwiftD04FontVAA0efK6OptionO_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(familyName:baseSize:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextFonts",
+                "printedName": "YouVersionPlatformUI.BibleTextFonts",
+                "usr": "s:20YouVersionPlatformUI14BibleTextFontsV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "CoreGraphics.CGFloat?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CGFloat",
+                    "printedName": "CoreGraphics.CGFloat",
+                    "usr": "s:14CoreFoundation7CGFloatV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI14BibleTextFontsV10familyName8baseSizeACSS_14CoreFoundation7CGFloatVSgtcfc",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextFontsV10familyName8baseSizeACSS_12CoreGraphics7CGFloatVSgtcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI14BibleTextFontsV",
+        "mangledName": "$s20YouVersionPlatformUI14BibleTextFontsV",
+        "moduleName": "YouVersionPlatformUI",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "YouVersionFonts",
+        "printedName": "YouVersionFonts",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "fontSystemM",
+            "printedName": "fontSystemM",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "fontHeaderM",
+            "printedName": "fontHeaderM",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO11fontHeaderM05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontHeaderM05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO11fontHeaderM05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontHeaderM05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "fontHeaderS",
+            "printedName": "fontHeaderS",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO11fontHeaderS05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontHeaderS05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO11fontHeaderS05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontHeaderS05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "fontEyebrowS",
+            "printedName": "fontEyebrowS",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO12fontEyebrowS05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12fontEyebrowS05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO12fontEyebrowS05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12fontEyebrowS05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "fontLabelM",
+            "printedName": "fontLabelM",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO10fontLabelM05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10fontLabelM05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO10fontLabelM05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10fontLabelM05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "fontLabelS",
+            "printedName": "fontLabelS",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO10fontLabelS05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10fontLabelS05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO10fontLabelS05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10fontLabelS05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "fontCaptionsL",
+            "printedName": "fontCaptionsL",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO13fontCaptionsL05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13fontCaptionsL05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO13fontCaptionsL05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13fontCaptionsL05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "fontCaptionsS",
+            "printedName": "fontCaptionsS",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO13fontCaptionsS05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13fontCaptionsS05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO13fontCaptionsS05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13fontCaptionsS05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "preferredBibleTextFont",
+            "printedName": "preferredBibleTextFont(size:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "usr": "s:14CoreFoundation7CGFloatV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO22preferredBibleTextFont4size05SwiftD00I0V14CoreFoundation7CGFloatV_tFZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO22preferredBibleTextFont4size05SwiftD00I0V12CoreGraphics7CGFloatV_tFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:20YouVersionPlatformUI0aB5FontsO",
+        "mangledName": "$s20YouVersionPlatformUI0aB5FontsO",
+        "moduleName": "YouVersionPlatformUI",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleCardView",
+        "printedName": "BibleCardView",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(reference:fontFamily:fontSize:showVersionPicker:onVersionChange:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleCardView",
+                "printedName": "YouVersionPlatformUI.BibleCardView",
+                "usr": "s:20YouVersionPlatformUI13BibleCardViewV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "hasDefaultArg": true,
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "hasDefaultArg": true,
+                "usr": "s:14CoreFoundation7CGFloatV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "((YouVersionPlatformCore.BibleVersion) -> Swift.Void)?",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleVersion) -> Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNameAlias",
+                        "name": "Void",
+                        "printedName": "Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Void",
+                            "printedName": "()"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVersion",
+                        "printedName": "YouVersionPlatformCore.BibleVersion",
+                        "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI13BibleCardViewV9reference10fontFamily0I4Size04showB6Picker02onB6ChangeAC0abC4Core0E9ReferenceV_SS0P10Foundation7CGFloatVSbyAI0eB0VcSgtcfc",
+            "mangledName": "$s20YouVersionPlatformUI13BibleCardViewV9reference10fontFamily0I4Size04showB6Picker02onB6ChangeAC0abC4Core0E9ReferenceV_SS0P8Graphics7CGFloatVSbyAI0eB0VcSgtcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "body",
+            "printedName": "body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI13BibleCardViewV4bodyQrvp",
+            "mangledName": "$s20YouVersionPlatformUI13BibleCardViewV4bodyQrvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI13BibleCardViewV4bodyQrvg",
+                "mangledName": "$s20YouVersionPlatformUI13BibleCardViewV4bodyQrvg",
+                "moduleName": "YouVersionPlatformUI",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Body",
+            "printedName": "Body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI13BibleCardViewV4Bodya",
+            "mangledName": "$s20YouVersionPlatformUI13BibleCardViewV4Bodya",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI13BibleCardViewV",
+        "mangledName": "$s20YouVersionPlatformUI13BibleCardViewV",
+        "moduleName": "YouVersionPlatformUI",
+        "declAttributes": [
+          "Preconcurrency",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "View",
+            "printedName": "View",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Body",
+                "printedName": "Body",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI4ViewP",
+            "mangledName": "$s7SwiftUI4ViewP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleTextView",
+        "printedName": "BibleTextView",
+        "children": [
+          {
+            "kind": "TypeAlias",
+            "name": "VerseTapAction",
+            "printedName": "VerseTapAction",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.BibleReference, Swift.String, [YouVersionPlatformUI.BibleFootnote], Swift.String?) -> Swift.Void",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Void",
+                    "printedName": "Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Void",
+                        "printedName": "()"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Tuple",
+                    "printedName": "(YouVersionPlatformCore.BibleReference, Swift.String, [YouVersionPlatformUI.BibleFootnote], Swift.String?)",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleReference",
+                        "printedName": "YouVersionPlatformCore.BibleReference",
+                        "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Array",
+                        "printedName": "[YouVersionPlatformUI.BibleFootnote]",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "BibleFootnote",
+                            "printedName": "YouVersionPlatformUI.BibleFootnote",
+                            "usr": "s:20YouVersionPlatformUI13BibleFootnoteV"
+                          }
+                        ],
+                        "usr": "s:Sa"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Optional",
+                        "printedName": "Swift.String?",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:Sq"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI13BibleTextViewV14VerseTapActiona",
+            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV14VerseTapActiona",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(_:textOptions:onVerseTap:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextView",
+                "printedName": "YouVersionPlatformUI.BibleTextView",
+                "usr": "s:20YouVersionPlatformUI13BibleTextViewV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.BibleTextOptions?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextOptions",
+                    "printedName": "YouVersionPlatformUI.BibleTextOptions",
+                    "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.BibleTextView.VerseTapAction?",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "VerseTapAction",
+                    "printedName": "YouVersionPlatformUI.BibleTextView.VerseTapAction",
+                    "children": [
+                      {
+                        "kind": "TypeFunc",
+                        "name": "Function",
+                        "printedName": "(YouVersionPlatformCore.BibleReference, Swift.String, [YouVersionPlatformUI.BibleFootnote], Swift.String?) -> Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNameAlias",
+                            "name": "Void",
+                            "printedName": "Swift.Void",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Void",
+                                "printedName": "()"
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Tuple",
+                            "printedName": "(YouVersionPlatformCore.BibleReference, Swift.String, [YouVersionPlatformUI.BibleFootnote], Swift.String?)",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "BibleReference",
+                                "printedName": "YouVersionPlatformCore.BibleReference",
+                                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Array",
+                                "printedName": "[YouVersionPlatformUI.BibleFootnote]",
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "BibleFootnote",
+                                    "printedName": "YouVersionPlatformUI.BibleFootnote",
+                                    "usr": "s:20YouVersionPlatformUI13BibleFootnoteV"
+                                  }
+                                ],
+                                "usr": "s:Sa"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Optional",
+                                "printedName": "Swift.String?",
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "String",
+                                    "printedName": "Swift.String",
+                                    "usr": "s:SS"
+                                  }
+                                ],
+                                "usr": "s:Sq"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI13BibleTextViewV_11textOptions10onVerseTapAC0abC4Core0E9ReferenceV_AA0efI0VSgyAH_SSSayAA0E8FootnoteVGSSSgtcSgtcfc",
+            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV_11textOptions10onVerseTapAC0abC4Core0E9ReferenceV_AA0efI0VSgyAH_SSSayAA0E8FootnoteVGSSSgtcSgtcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(_:textOptions:selectedVerses:onVerseTap:placeholder:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextView",
+                "printedName": "YouVersionPlatformUI.BibleTextView",
+                "usr": "s:20YouVersionPlatformUI13BibleTextViewV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.BibleTextOptions?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextOptions",
+                    "printedName": "YouVersionPlatformUI.BibleTextOptions",
+                    "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Binding",
+                "printedName": "SwiftUI.Binding<Swift.Set<YouVersionPlatformCore.BibleReference>>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Set",
+                    "printedName": "Swift.Set<YouVersionPlatformCore.BibleReference>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleReference",
+                        "printedName": "YouVersionPlatformCore.BibleReference",
+                        "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                      }
+                    ],
+                    "usr": "s:Sh"
+                  }
+                ],
+                "usr": "s:7SwiftUI7BindingV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.BibleTextView.VerseTapAction?",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "VerseTapAction",
+                    "printedName": "YouVersionPlatformUI.BibleTextView.VerseTapAction",
+                    "children": [
+                      {
+                        "kind": "TypeFunc",
+                        "name": "Function",
+                        "printedName": "(YouVersionPlatformCore.BibleReference, Swift.String, [YouVersionPlatformUI.BibleFootnote], Swift.String?) -> Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNameAlias",
+                            "name": "Void",
+                            "printedName": "Swift.Void",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Void",
+                                "printedName": "()"
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Tuple",
+                            "printedName": "(YouVersionPlatformCore.BibleReference, Swift.String, [YouVersionPlatformUI.BibleFootnote], Swift.String?)",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "BibleReference",
+                                "printedName": "YouVersionPlatformCore.BibleReference",
+                                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Array",
+                                "printedName": "[YouVersionPlatformUI.BibleFootnote]",
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "BibleFootnote",
+                                    "printedName": "YouVersionPlatformUI.BibleFootnote",
+                                    "usr": "s:20YouVersionPlatformUI13BibleFootnoteV"
+                                  }
+                                ],
+                                "usr": "s:Sa"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Optional",
+                                "printedName": "Swift.String?",
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "String",
+                                    "printedName": "Swift.String",
+                                    "usr": "s:SS"
+                                  }
+                                ],
+                                "usr": "s:Sq"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "((YouVersionPlatformUI.BibleTextLoadingPhase) -> SwiftUI.AnyView)?",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformUI.BibleTextLoadingPhase) -> SwiftUI.AnyView",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "AnyView",
+                        "printedName": "SwiftUI.AnyView",
+                        "usr": "s:7SwiftUI7AnyViewV"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextLoadingPhase",
+                        "printedName": "YouVersionPlatformUI.BibleTextLoadingPhase",
+                        "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO"
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI13BibleTextViewV_11textOptions14selectedVerses10onVerseTap11placeholderAC0abC4Core0E9ReferenceV_AA0efI0VSg05SwiftD07BindingVyShyAJGGyAJ_SSSayAA0E8FootnoteVGSSSgtcSgAN03AnyG0VAA0eF12LoadingPhaseOcSgtcfc",
+            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV_11textOptions14selectedVerses10onVerseTap11placeholderAC0abC4Core0E9ReferenceV_AA0efI0VSg05SwiftD07BindingVyShyAJGGyAJ_SSSayAA0E8FootnoteVGSSSgtcSgAN03AnyG0VAA0eF12LoadingPhaseOcSgtcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "body",
+            "printedName": "body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI13BibleTextViewV4bodyQrvp",
+            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV4bodyQrvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI13BibleTextViewV4bodyQrvg",
+                "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV4bodyQrvg",
+                "moduleName": "YouVersionPlatformUI",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "viewWithPrefetchedData",
+            "printedName": "viewWithPrefetchedData(reference:fontFamily:fontSize:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "(some SwiftUI.View)?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "hasDefaultArg": true,
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "hasDefaultArg": true,
+                "usr": "s:14CoreFoundation7CGFloatV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI13BibleTextViewV22viewWithPrefetchedData9reference10fontFamily0M4SizeQrSg0abC4Core0E9ReferenceV_SS0P10Foundation7CGFloatVtYaFZ",
+            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV22viewWithPrefetchedData9reference10fontFamily0M4SizeQrSg0abC4Core0E9ReferenceV_SS0P8Graphics7CGFloatVtYaFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "viewFromHtml",
+            "printedName": "viewFromHtml(html:reference:textOptions:onVerseTap:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "(some SwiftUI.View)?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextOptions",
+                "printedName": "YouVersionPlatformUI.BibleTextOptions",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.BibleTextView.VerseTapAction?",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "VerseTapAction",
+                    "printedName": "YouVersionPlatformUI.BibleTextView.VerseTapAction",
+                    "children": [
+                      {
+                        "kind": "TypeFunc",
+                        "name": "Function",
+                        "printedName": "(YouVersionPlatformCore.BibleReference, Swift.String, [YouVersionPlatformUI.BibleFootnote], Swift.String?) -> Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNameAlias",
+                            "name": "Void",
+                            "printedName": "Swift.Void",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Void",
+                                "printedName": "()"
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Tuple",
+                            "printedName": "(YouVersionPlatformCore.BibleReference, Swift.String, [YouVersionPlatformUI.BibleFootnote], Swift.String?)",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "BibleReference",
+                                "printedName": "YouVersionPlatformCore.BibleReference",
+                                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Array",
+                                "printedName": "[YouVersionPlatformUI.BibleFootnote]",
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "BibleFootnote",
+                                    "printedName": "YouVersionPlatformUI.BibleFootnote",
+                                    "usr": "s:20YouVersionPlatformUI13BibleFootnoteV"
+                                  }
+                                ],
+                                "usr": "s:Sa"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Optional",
+                                "printedName": "Swift.String?",
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "String",
+                                    "printedName": "Swift.String",
+                                    "usr": "s:SS"
+                                  }
+                                ],
+                                "usr": "s:Sq"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI13BibleTextViewV12viewFromHtml4html9reference11textOptions10onVerseTapQrSgSS_0abC4Core0E9ReferenceVAA0efN0VyAL_SSSayAA0E8FootnoteVGSSSgtcSgtFZ",
+            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV12viewFromHtml4html9reference11textOptions10onVerseTapQrSgSS_0abC4Core0E9ReferenceVAA0efN0VyAL_SSSayAA0E8FootnoteVGSSSgtcSgtFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Body",
+            "printedName": "Body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI13BibleTextViewV4Bodya",
+            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV4Bodya",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI13BibleTextViewV",
+        "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV",
+        "moduleName": "YouVersionPlatformUI",
+        "declAttributes": [
+          "Preconcurrency",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "View",
+            "printedName": "View",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Body",
+                "printedName": "Body",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI4ViewP",
+            "mangledName": "$s7SwiftUI4ViewP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleTextOptions",
+        "printedName": "BibleTextOptions",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "fontFamily",
+            "printedName": "fontFamily",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV10fontFamilySSvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV10fontFamilySSvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV10fontFamilySSvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV10fontFamilySSvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "fontSize",
+            "printedName": "fontSize",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "usr": "s:14CoreFoundation7CGFloatV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV8fontSize14CoreFoundation7CGFloatVvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV8fontSize12CoreGraphics7CGFloatVvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CGFloat",
+                    "printedName": "CoreGraphics.CGFloat",
+                    "usr": "s:14CoreFoundation7CGFloatV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV8fontSize14CoreFoundation7CGFloatVvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV8fontSize12CoreGraphics7CGFloatVvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "lineSpacing",
+            "printedName": "lineSpacing",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "CoreGraphics.CGFloat?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CGFloat",
+                    "printedName": "CoreGraphics.CGFloat",
+                    "usr": "s:14CoreFoundation7CGFloatV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV11lineSpacing14CoreFoundation7CGFloatVSgvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV11lineSpacing12CoreGraphics7CGFloatVSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "CoreGraphics.CGFloat?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "CGFloat",
+                        "printedName": "CoreGraphics.CGFloat",
+                        "usr": "s:14CoreFoundation7CGFloatV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV11lineSpacing14CoreFoundation7CGFloatVSgvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV11lineSpacing12CoreGraphics7CGFloatVSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "paragraphSpacing",
+            "printedName": "paragraphSpacing",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "CoreGraphics.CGFloat?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CGFloat",
+                    "printedName": "CoreGraphics.CGFloat",
+                    "usr": "s:14CoreFoundation7CGFloatV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV16paragraphSpacing14CoreFoundation7CGFloatVSgvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV16paragraphSpacing12CoreGraphics7CGFloatVSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "CoreGraphics.CGFloat?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "CGFloat",
+                        "printedName": "CoreGraphics.CGFloat",
+                        "usr": "s:14CoreFoundation7CGFloatV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV16paragraphSpacing14CoreFoundation7CGFloatVSgvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV16paragraphSpacing12CoreGraphics7CGFloatVSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "textColor",
+            "printedName": "textColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV9textColor05SwiftD00I0VSgvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV9textColor05SwiftD00I0VSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "SwiftUI.Color?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Color",
+                        "printedName": "SwiftUI.Color",
+                        "usr": "s:7SwiftUI5ColorV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV9textColor05SwiftD00I0VSgvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV9textColor05SwiftD00I0VSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "verseNumColor",
+            "printedName": "verseNumColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "SwiftUI.Color?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Color",
+                        "printedName": "SwiftUI.Color",
+                        "usr": "s:7SwiftUI5ColorV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "wocColor",
+            "printedName": "wocColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "renderHeadlines",
+            "printedName": "renderHeadlines",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV15renderHeadlinesSbvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV15renderHeadlinesSbvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV15renderHeadlinesSbvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV15renderHeadlinesSbvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "renderVerseNumbers",
+            "printedName": "renderVerseNumbers",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV18renderVerseNumbersSbvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV18renderVerseNumbersSbvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV18renderVerseNumbersSbvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV18renderVerseNumbersSbvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "footnoteMode",
+            "printedName": "footnoteMode",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextFootnoteMode",
+                "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV12footnoteModeAA0ef8FootnoteI0Ovp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV12footnoteModeAA0ef8FootnoteI0Ovp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFootnoteMode",
+                    "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                    "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV12footnoteModeAA0ef8FootnoteI0Ovg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV12footnoteModeAA0ef8FootnoteI0Ovg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "footnoteMarker",
+            "printedName": "footnoteMarker",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleAttributedString",
+                    "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                    "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV14footnoteMarkerAA0E16AttributedStringCSgvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV14footnoteMarkerAA0E16AttributedStringCSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "YouVersionPlatformUI.BibleAttributedString?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleAttributedString",
+                        "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                        "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV14footnoteMarkerAA0E16AttributedStringCSgvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV14footnoteMarkerAA0E16AttributedStringCSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "verseSelectionStyle",
+            "printedName": "verseSelectionStyle",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VerseSelectionStyle",
+                "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV19verseSelectionStyleAA05VerseiJ0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV19verseSelectionStyleAA05VerseiJ0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "VerseSelectionStyle",
+                    "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                    "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV19verseSelectionStyleAA05VerseiJ0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV19verseSelectionStyleAA05VerseiJ0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(fontFamily:fontSize:lineSpacing:paragraphSpacing:textColor:verseNumColor:wocColor:renderHeadlines:renderVerseNumbers:footnoteMode:footnoteMarker:verseSelectionStyle:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextOptions",
+                "printedName": "YouVersionPlatformUI.BibleTextOptions",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "hasDefaultArg": true,
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "hasDefaultArg": true,
+                "usr": "s:14CoreFoundation7CGFloatV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "CoreGraphics.CGFloat?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CGFloat",
+                    "printedName": "CoreGraphics.CGFloat",
+                    "usr": "s:14CoreFoundation7CGFloatV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "CoreGraphics.CGFloat?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CGFloat",
+                    "printedName": "CoreGraphics.CGFloat",
+                    "usr": "s:14CoreFoundation7CGFloatV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "hasDefaultArg": true,
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextFootnoteMode",
+                "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                "hasDefaultArg": true,
+                "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleAttributedString",
+                    "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                    "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "VerseSelectionStyle",
+                "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                "hasDefaultArg": true,
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV10fontFamily0H4Size11lineSpacing09paragraphL09textColor08verseNumO003wocO015renderHeadlines0S12VerseNumbers12footnoteMode0W6Marker0P14SelectionStyleACSS_14CoreFoundation7CGFloatVARSgAS05SwiftD00O0VSgAwVS2bAA0ef8FootnoteX0OAA0E16AttributedStringCSgAA0uZ5StyleVtcfc",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV10fontFamily0H4Size11lineSpacing09paragraphL09textColor08verseNumO003wocO015renderHeadlines0S12VerseNumbers12footnoteMode0W6Marker0P14SelectionStyleACSS_12CoreGraphics7CGFloatVARSgAS05SwiftD00O0VSgAwVS2bAA0ef8FootnoteX0OAA0E16AttributedStringCSgAA0uZ5StyleVtcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV",
+        "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV",
+        "moduleName": "YouVersionPlatformUI",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleTextLoadingPhase",
+        "printedName": "BibleTextLoadingPhase",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "inactive",
+            "printedName": "inactive",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextLoadingPhase.Type) -> YouVersionPlatformUI.BibleTextLoadingPhase",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextLoadingPhase",
+                    "printedName": "YouVersionPlatformUI.BibleTextLoadingPhase",
+                    "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextLoadingPhase.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextLoadingPhase",
+                        "printedName": "YouVersionPlatformUI.BibleTextLoadingPhase",
+                        "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO8inactiveyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleTextLoadingPhaseO8inactiveyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "loading",
+            "printedName": "loading",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextLoadingPhase.Type) -> YouVersionPlatformUI.BibleTextLoadingPhase",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextLoadingPhase",
+                    "printedName": "YouVersionPlatformUI.BibleTextLoadingPhase",
+                    "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextLoadingPhase.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextLoadingPhase",
+                        "printedName": "YouVersionPlatformUI.BibleTextLoadingPhase",
+                        "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO7loadingyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleTextLoadingPhaseO7loadingyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "failed",
+            "printedName": "failed",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextLoadingPhase.Type) -> YouVersionPlatformUI.BibleTextLoadingPhase",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextLoadingPhase",
+                    "printedName": "YouVersionPlatformUI.BibleTextLoadingPhase",
+                    "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextLoadingPhase.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextLoadingPhase",
+                        "printedName": "YouVersionPlatformUI.BibleTextLoadingPhase",
+                        "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO6failedyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleTextLoadingPhaseO6failedyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "notPermitted",
+            "printedName": "notPermitted",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextLoadingPhase.Type) -> YouVersionPlatformUI.BibleTextLoadingPhase",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextLoadingPhase",
+                    "printedName": "YouVersionPlatformUI.BibleTextLoadingPhase",
+                    "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextLoadingPhase.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextLoadingPhase",
+                        "printedName": "YouVersionPlatformUI.BibleTextLoadingPhase",
+                        "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO12notPermittedyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleTextLoadingPhaseO12notPermittedyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Function",
+            "name": "__derived_enum_equals",
+            "printedName": "__derived_enum_equals(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextLoadingPhase",
+                "printedName": "YouVersionPlatformUI.BibleTextLoadingPhase",
+                "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextLoadingPhase",
+                "printedName": "YouVersionPlatformUI.BibleTextLoadingPhase",
+                "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO21__derived_enum_equalsySbAC_ACtFZ",
+            "mangledName": "$s20YouVersionPlatformUI21BibleTextLoadingPhaseO21__derived_enum_equalsySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Implements",
+              "Semantics"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hash",
+            "printedName": "hash(into:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Hasher",
+                "printedName": "Swift.Hasher",
+                "paramValueOwnership": "InOut",
+                "usr": "s:s6HasherV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO4hash4intoys6HasherVz_tF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleTextLoadingPhaseO4hash4intoys6HasherVz_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "hashValue",
+            "printedName": "hashValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO9hashValueSivp",
+            "mangledName": "$s20YouVersionPlatformUI21BibleTextLoadingPhaseO9hashValueSivp",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO9hashValueSivg",
+                "mangledName": "$s20YouVersionPlatformUI21BibleTextLoadingPhaseO9hashValueSivg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:20YouVersionPlatformUI21BibleTextLoadingPhaseO",
+        "mangledName": "$s20YouVersionPlatformUI21BibleTextLoadingPhaseO",
+        "moduleName": "YouVersionPlatformUI",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleAttributedString",
+        "printedName": "BibleAttributedString",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleAttributedString",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI21BibleAttributedStringCACycfc",
+            "mangledName": "$s20YouVersionPlatformUI21BibleAttributedStringCACycfc",
+            "moduleName": "YouVersionPlatformUI",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleAttributedString",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI21BibleAttributedStringCyACSScfc",
+            "mangledName": "$s20YouVersionPlatformUI21BibleAttributedStringCyACSScfc",
+            "moduleName": "YouVersionPlatformUI",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "==",
+            "printedName": "==(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleAttributedString",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleAttributedString",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC2eeoiySbAC_ACtFZ",
+            "mangledName": "$s20YouVersionPlatformUI21BibleAttributedStringC2eeoiySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "Final"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hash",
+            "printedName": "hash(into:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Hasher",
+                "printedName": "Swift.Hasher",
+                "paramValueOwnership": "InOut",
+                "usr": "s:s6HasherV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC4hash4intoys6HasherVz_tF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleAttributedStringC4hash4intoys6HasherVz_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "asAttributedString",
+            "printedName": "asAttributedString",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "AttributedString",
+                "printedName": "Foundation.AttributedString",
+                "usr": "s:10Foundation16AttributedStringV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC02asfG010Foundation0fG0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI21BibleAttributedStringC02asfG010Foundation0fG0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "AttributedString",
+                    "printedName": "Foundation.AttributedString",
+                    "usr": "s:10Foundation16AttributedStringV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC02asfG010Foundation0fG0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI21BibleAttributedStringC02asfG010Foundation0fG0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "setFont",
+            "printedName": "setFont(_:from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleAttributedString",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextFontOption",
+                "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextFonts",
+                "printedName": "YouVersionPlatformUI.BibleTextFonts",
+                "usr": "s:20YouVersionPlatformUI14BibleTextFontsV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC7setFont_4fromAcA0e4TextI6OptionO_AA0eK5FontsVtF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleAttributedStringC7setFont_4fromAcA0e4TextI6OptionO_AA0eK5FontsVtF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "DiscardableResult"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "setColor",
+            "printedName": "setColor(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleAttributedString",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC8setColoryAC05SwiftD00I0VF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleAttributedStringC8setColoryAC05SwiftD00I0VF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "DiscardableResult"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "setBaselineOffset",
+            "printedName": "setBaselineOffset(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleAttributedString",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "usr": "s:14CoreFoundation7CGFloatV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC17setBaselineOffsetyAC14CoreFoundation7CGFloatVF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleAttributedStringC17setBaselineOffsetyAC12CoreGraphics7CGFloatVF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "DiscardableResult"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "hashValue",
+            "printedName": "hashValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC9hashValueSivp",
+            "mangledName": "$s20YouVersionPlatformUI21BibleAttributedStringC9hashValueSivp",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true,
+            "declAttributes": [
+              "Final"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC9hashValueSivg",
+                "mangledName": "$s20YouVersionPlatformUI21BibleAttributedStringC9hashValueSivg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC",
+        "mangledName": "$s20YouVersionPlatformUI21BibleAttributedStringC",
+        "moduleName": "YouVersionPlatformUI",
+        "declAttributes": [
+          "Final"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleFootnote",
+        "printedName": "BibleFootnote",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "id",
+            "printedName": "id",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI13BibleFootnoteV2idSSvp",
+            "mangledName": "$s20YouVersionPlatformUI13BibleFootnoteV2idSSvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI13BibleFootnoteV2idSSvg",
+                "mangledName": "$s20YouVersionPlatformUI13BibleFootnoteV2idSSvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "text",
+            "printedName": "text",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleAttributedString",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI13BibleFootnoteV4textAA0E16AttributedStringCvp",
+            "mangledName": "$s20YouVersionPlatformUI13BibleFootnoteV4textAA0E16AttributedStringCvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleAttributedString",
+                    "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                    "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI13BibleFootnoteV4textAA0E16AttributedStringCvg",
+                "mangledName": "$s20YouVersionPlatformUI13BibleFootnoteV4textAA0E16AttributedStringCvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "reference",
+            "printedName": "reference",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI13BibleFootnoteV9reference0abC4Core0E9ReferenceVvp",
+            "mangledName": "$s20YouVersionPlatformUI13BibleFootnoteV9reference0abC4Core0E9ReferenceVvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI13BibleFootnoteV9reference0abC4Core0E9ReferenceVvg",
+                "mangledName": "$s20YouVersionPlatformUI13BibleFootnoteV9reference0abC4Core0E9ReferenceVvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(text:reference:id:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleFootnote",
+                "printedName": "YouVersionPlatformUI.BibleFootnote",
+                "usr": "s:20YouVersionPlatformUI13BibleFootnoteV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleAttributedString",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI13BibleFootnoteV4text9reference2idAcA0E16AttributedStringC_0abC4Core0E9ReferenceVSStcfc",
+            "mangledName": "$s20YouVersionPlatformUI13BibleFootnoteV4text9reference2idAcA0E16AttributedStringC_0abC4Core0E9ReferenceVSStcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "ID",
+            "printedName": "ID",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI13BibleFootnoteV2IDa",
+            "mangledName": "$s20YouVersionPlatformUI13BibleFootnoteV2IDa",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          },
+          {
+            "kind": "Function",
+            "name": "__derived_struct_equals",
+            "printedName": "__derived_struct_equals(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleFootnote",
+                "printedName": "YouVersionPlatformUI.BibleFootnote",
+                "usr": "s:20YouVersionPlatformUI13BibleFootnoteV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleFootnote",
+                "printedName": "YouVersionPlatformUI.BibleFootnote",
+                "usr": "s:20YouVersionPlatformUI13BibleFootnoteV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI13BibleFootnoteV23__derived_struct_equalsySbAC_ACtFZ",
+            "mangledName": "$s20YouVersionPlatformUI13BibleFootnoteV23__derived_struct_equalsySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Implements"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hash",
+            "printedName": "hash(into:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Hasher",
+                "printedName": "Swift.Hasher",
+                "paramValueOwnership": "InOut",
+                "usr": "s:s6HasherV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI13BibleFootnoteV4hash4intoys6HasherVz_tF",
+            "mangledName": "$s20YouVersionPlatformUI13BibleFootnoteV4hash4intoys6HasherVz_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "hashValue",
+            "printedName": "hashValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI13BibleFootnoteV9hashValueSivp",
+            "mangledName": "$s20YouVersionPlatformUI13BibleFootnoteV9hashValueSivp",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI13BibleFootnoteV9hashValueSivg",
+                "mangledName": "$s20YouVersionPlatformUI13BibleFootnoteV9hashValueSivg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI13BibleFootnoteV",
+        "mangledName": "$s20YouVersionPlatformUI13BibleFootnoteV",
+        "moduleName": "YouVersionPlatformUI",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Identifiable",
+            "printedName": "Identifiable",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "ID",
+                "printedName": "ID",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:s12IdentifiableP",
+            "mangledName": "$ss12IdentifiableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleTextBlock",
+        "printedName": "BibleTextBlock",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "id",
+            "printedName": "id",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UUID",
+                "printedName": "Foundation.UUID",
+                "usr": "s:10Foundation4UUIDV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI14BibleTextBlockV2id10Foundation4UUIDVvp",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV2id10Foundation4UUIDVvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UUID",
+                    "printedName": "Foundation.UUID",
+                    "usr": "s:10Foundation4UUIDV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI14BibleTextBlockV2id10Foundation4UUIDVvg",
+                "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV2id10Foundation4UUIDVvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "text",
+            "printedName": "text",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleAttributedString",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI14BibleTextBlockV4textAA0E16AttributedStringCvp",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV4textAA0E16AttributedStringCvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleAttributedString",
+                    "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                    "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI14BibleTextBlockV4textAA0E16AttributedStringCvg",
+                "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV4textAA0E16AttributedStringCvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "chapter",
+            "printedName": "chapter",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI14BibleTextBlockV7chapterSivp",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV7chapterSivp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI14BibleTextBlockV7chapterSivg",
+                "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV7chapterSivg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "rows",
+            "printedName": "rows",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[[YouVersionPlatformUI.BibleAttributedString]]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformUI.BibleAttributedString]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleAttributedString",
+                        "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                        "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI14BibleTextBlockV4rowsSaySayAA0E16AttributedStringCGGvp",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV4rowsSaySayAA0E16AttributedStringCGGvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[[YouVersionPlatformUI.BibleAttributedString]]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Array",
+                        "printedName": "[YouVersionPlatformUI.BibleAttributedString]",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "BibleAttributedString",
+                            "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                            "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+                          }
+                        ],
+                        "usr": "s:Sa"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI14BibleTextBlockV4rowsSaySayAA0E16AttributedStringCGGvg",
+                "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV4rowsSaySayAA0E16AttributedStringCGGvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "firstLineHeadIndent",
+            "printedName": "firstLineHeadIndent",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI14BibleTextBlockV19firstLineHeadIndentSivp",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV19firstLineHeadIndentSivp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI14BibleTextBlockV19firstLineHeadIndentSivg",
+                "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV19firstLineHeadIndentSivg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "headIndent",
+            "printedName": "headIndent",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI14BibleTextBlockV10headIndentSivp",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV10headIndentSivp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI14BibleTextBlockV10headIndentSivg",
+                "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV10headIndentSivg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "marginTop",
+            "printedName": "marginTop",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "usr": "s:14CoreFoundation7CGFloatV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI14BibleTextBlockV9marginTop14CoreFoundation7CGFloatVvp",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV9marginTop12CoreGraphics7CGFloatVvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CGFloat",
+                    "printedName": "CoreGraphics.CGFloat",
+                    "usr": "s:14CoreFoundation7CGFloatV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI14BibleTextBlockV9marginTop14CoreFoundation7CGFloatVvg",
+                "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV9marginTop12CoreGraphics7CGFloatVvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "alignment",
+            "printedName": "alignment",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "TextAlignment",
+                "printedName": "SwiftUI.TextAlignment",
+                "usr": "s:7SwiftUI13TextAlignmentO"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI14BibleTextBlockV9alignment05SwiftD00F9AlignmentOvp",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV9alignment05SwiftD00F9AlignmentOvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "TextAlignment",
+                    "printedName": "SwiftUI.TextAlignment",
+                    "usr": "s:7SwiftUI13TextAlignmentO"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI14BibleTextBlockV9alignment05SwiftD00F9AlignmentOvg",
+                "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV9alignment05SwiftD00F9AlignmentOvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "footnotes",
+            "printedName": "footnotes",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformUI.BibleFootnote]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleFootnote",
+                    "printedName": "YouVersionPlatformUI.BibleFootnote",
+                    "usr": "s:20YouVersionPlatformUI13BibleFootnoteV"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI14BibleTextBlockV9footnotesSayAA0E8FootnoteVGvp",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV9footnotesSayAA0E8FootnoteVGvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformUI.BibleFootnote]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleFootnote",
+                        "printedName": "YouVersionPlatformUI.BibleFootnote",
+                        "usr": "s:20YouVersionPlatformUI13BibleFootnoteV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI14BibleTextBlockV9footnotesSayAA0E8FootnoteVGvg",
+                "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV9footnotesSayAA0E8FootnoteVGvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(text:chapter:firstLineHeadIndent:headIndent:marginTop:alignment:footnotes:rows:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextBlock",
+                "printedName": "YouVersionPlatformUI.BibleTextBlock",
+                "usr": "s:20YouVersionPlatformUI14BibleTextBlockV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleAttributedString",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "usr": "s:14CoreFoundation7CGFloatV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "TextAlignment",
+                "printedName": "SwiftUI.TextAlignment",
+                "usr": "s:7SwiftUI13TextAlignmentO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformUI.BibleFootnote]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleFootnote",
+                    "printedName": "YouVersionPlatformUI.BibleFootnote",
+                    "usr": "s:20YouVersionPlatformUI13BibleFootnoteV"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[[YouVersionPlatformUI.BibleAttributedString]]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformUI.BibleAttributedString]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleAttributedString",
+                        "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                        "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI14BibleTextBlockV4text7chapter19firstLineHeadIndent04headM09marginTop9alignment9footnotes4rowsAcA0E16AttributedStringC_S3i14CoreFoundation7CGFloatV05SwiftD00F9AlignmentOSayAA0E8FootnoteVGSaySayAMGGtcfc",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV4text7chapter19firstLineHeadIndent04headM09marginTop9alignment9footnotes4rowsAcA0E16AttributedStringC_S3i12CoreGraphics7CGFloatV05SwiftD00F9AlignmentOSayAA0E8FootnoteVGSaySayAMGGtcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "ID",
+            "printedName": "ID",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UUID",
+                "printedName": "Foundation.UUID",
+                "usr": "s:10Foundation4UUIDV"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI14BibleTextBlockV2IDa",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV2IDa",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI14BibleTextBlockV",
+        "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV",
+        "moduleName": "YouVersionPlatformUI",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Identifiable",
+            "printedName": "Identifiable",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "ID",
+                "printedName": "ID",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UUID",
+                    "printedName": "Foundation.UUID",
+                    "usr": "s:10Foundation4UUIDV"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:s12IdentifiableP",
+            "mangledName": "$ss12IdentifiableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersionRendering",
+        "printedName": "BibleVersionRendering",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "plainTextOf",
+            "printedName": "plainTextOf(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11plainTextOfySSSg0abC4Core0E9ReferenceVYaKFZ",
+            "mangledName": "$s20YouVersionPlatformUI05BibleB9RenderingO11plainTextOfySSSg0abC4Core0E9ReferenceVYaKFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "textBlocks",
+            "printedName": "textBlocks(from:reference:renderHeadlines:renderVerseNumbers:footnotesMode:footnoteMarker:textColor:verseNumColor:wocColor:fonts:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[YouVersionPlatformUI.BibleTextBlock]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformUI.BibleTextBlock]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextBlock",
+                        "printedName": "YouVersionPlatformUI.BibleTextBlock",
+                        "usr": "s:20YouVersionPlatformUI14BibleTextBlockV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleTextNode?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextNode",
+                    "printedName": "YouVersionPlatformCore.BibleTextNode",
+                    "usr": "s:22YouVersionPlatformCore13BibleTextNodeV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextFootnoteMode",
+                "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                "hasDefaultArg": true,
+                "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleAttributedString",
+                    "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                    "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "hasDefaultArg": true,
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "hasDefaultArg": true,
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "hasDefaultArg": true,
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextFonts",
+                "printedName": "YouVersionPlatformUI.BibleTextFonts",
+                "usr": "s:20YouVersionPlatformUI14BibleTextFontsV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO10textBlocks4from9reference15renderHeadlines0K12VerseNumbers13footnotesMode14footnoteMarker0G5Color08verseNumS003wocS05fontsSayAA0E9TextBlockVGSg0abC4Core0eX4NodeVSg_AS0E9ReferenceVS2bAA0ex8FootnoteP0OAA0E16AttributedStringCSg05SwiftD00S0VA4_A4_AA0eX5FontsVtYaKFZ",
+            "mangledName": "$s20YouVersionPlatformUI05BibleB9RenderingO10textBlocks4from9reference15renderHeadlines0K12VerseNumbers13footnotesMode14footnoteMarker0G5Color08verseNumS003wocS05fontsSayAA0E9TextBlockVGSg0abC4Core0eX4NodeVSg_AS0E9ReferenceVS2bAA0ex8FootnoteP0OAA0E16AttributedStringCSg05SwiftD00S0VA4_A4_AA0eX5FontsVtYaKFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "TypeDecl",
+            "name": "LinkSchemes",
+            "printedName": "LinkSchemes",
+            "children": [
+              {
+                "kind": "Var",
+                "name": "footnote",
+                "printedName": "footnote",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformUI.BibleVersionRendering.LinkSchemes.Type) -> YouVersionPlatformUI.BibleVersionRendering.LinkSchemes",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "LinkSchemes",
+                        "printedName": "YouVersionPlatformUI.BibleVersionRendering.LinkSchemes",
+                        "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformUI.BibleVersionRendering.LinkSchemes.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "LinkSchemes",
+                            "printedName": "YouVersionPlatformUI.BibleVersionRendering.LinkSchemes",
+                            "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO8footnoteyA2EmF",
+                "mangledName": "$s20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO8footnoteyA2EmF",
+                "moduleName": "YouVersionPlatformUI"
+              },
+              {
+                "kind": "Var",
+                "name": "reference",
+                "printedName": "reference",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformUI.BibleVersionRendering.LinkSchemes.Type) -> YouVersionPlatformUI.BibleVersionRendering.LinkSchemes",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "LinkSchemes",
+                        "printedName": "YouVersionPlatformUI.BibleVersionRendering.LinkSchemes",
+                        "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformUI.BibleVersionRendering.LinkSchemes.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "LinkSchemes",
+                            "printedName": "YouVersionPlatformUI.BibleVersionRendering.LinkSchemes",
+                            "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO9referenceyA2EmF",
+                "mangledName": "$s20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO9referenceyA2EmF",
+                "moduleName": "YouVersionPlatformUI"
+              },
+              {
+                "kind": "Constructor",
+                "name": "init",
+                "printedName": "init(rawValue:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "YouVersionPlatformUI.BibleVersionRendering.LinkSchemes?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "LinkSchemes",
+                        "printedName": "YouVersionPlatformUI.BibleVersionRendering.LinkSchemes",
+                        "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Constructor",
+                "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO8rawValueAESgSS_tcfc",
+                "mangledName": "$s20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO8rawValueAESgSS_tcfc",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Inlinable"
+                ],
+                "init_kind": "Designated"
+              },
+              {
+                "kind": "TypeAlias",
+                "name": "RawValue",
+                "printedName": "RawValue",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "TypeAlias",
+                "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO8RawValuea",
+                "mangledName": "$s20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO8RawValuea",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true
+              },
+              {
+                "kind": "Var",
+                "name": "rawValue",
+                "printedName": "rawValue",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO8rawValueSSvp",
+                "mangledName": "$s20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO8rawValueSSvp",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO8rawValueSSvg",
+                    "mangledName": "$s20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO8rawValueSSvg",
+                    "moduleName": "YouVersionPlatformUI",
+                    "implicit": true,
+                    "declAttributes": [
+                      "Inlinable"
+                    ],
+                    "accessorKind": "get"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Enum",
+            "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO",
+            "mangledName": "$s20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO",
+            "moduleName": "YouVersionPlatformUI",
+            "enumRawTypeName": "String",
+            "isEnumExhaustive": true,
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Equatable",
+                "printedName": "Equatable",
+                "usr": "s:SQ",
+                "mangledName": "$sSQ"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Hashable",
+                "printedName": "Hashable",
+                "usr": "s:SH",
+                "mangledName": "$sSH"
+              },
+              {
+                "kind": "Conformance",
+                "name": "RawRepresentable",
+                "printedName": "RawRepresentable",
+                "children": [
+                  {
+                    "kind": "TypeWitness",
+                    "name": "RawValue",
+                    "printedName": "RawValue",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ]
+                  }
+                ],
+                "usr": "s:SY",
+                "mangledName": "$sSY"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO",
+        "mangledName": "$s20YouVersionPlatformUI05BibleB9RenderingO",
+        "moduleName": "YouVersionPlatformUI",
+        "declAttributes": [
+          "Custom"
+        ],
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleTextCategory",
+        "printedName": "BibleTextCategory",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "scripture",
+            "printedName": "scripture",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextCategory.Type) -> YouVersionPlatformUI.BibleTextCategory",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextCategory",
+                    "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                    "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextCategory.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextCategory",
+                        "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                        "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO9scriptureyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI17BibleTextCategoryO9scriptureyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "verseLabel",
+            "printedName": "verseLabel",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextCategory.Type) -> YouVersionPlatformUI.BibleTextCategory",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextCategory",
+                    "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                    "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextCategory.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextCategory",
+                        "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                        "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO10verseLabelyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI17BibleTextCategoryO10verseLabelyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "footnoteMarker",
+            "printedName": "footnoteMarker",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextCategory.Type) -> YouVersionPlatformUI.BibleTextCategory",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextCategory",
+                    "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                    "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextCategory.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextCategory",
+                        "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                        "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO14footnoteMarkeryA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI17BibleTextCategoryO14footnoteMarkeryA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "footnoteImage",
+            "printedName": "footnoteImage",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextCategory.Type) -> YouVersionPlatformUI.BibleTextCategory",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextCategory",
+                    "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                    "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextCategory.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextCategory",
+                        "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                        "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO13footnoteImageyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI17BibleTextCategoryO13footnoteImageyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "footnoteText",
+            "printedName": "footnoteText",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextCategory.Type) -> YouVersionPlatformUI.BibleTextCategory",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextCategory",
+                    "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                    "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextCategory.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextCategory",
+                        "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                        "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO08footnoteF0yA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI17BibleTextCategoryO08footnoteF0yA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "header",
+            "printedName": "header",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextCategory.Type) -> YouVersionPlatformUI.BibleTextCategory",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextCategory",
+                    "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                    "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextCategory.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextCategory",
+                        "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                        "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO6headeryA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI17BibleTextCategoryO6headeryA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Function",
+            "name": "__derived_enum_equals",
+            "printedName": "__derived_enum_equals(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextCategory",
+                "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextCategory",
+                "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO21__derived_enum_equalsySbAC_ACtFZ",
+            "mangledName": "$s20YouVersionPlatformUI17BibleTextCategoryO21__derived_enum_equalsySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Implements",
+              "Semantics"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hash",
+            "printedName": "hash(into:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Hasher",
+                "printedName": "Swift.Hasher",
+                "paramValueOwnership": "InOut",
+                "usr": "s:s6HasherV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO4hash4intoys6HasherVz_tF",
+            "mangledName": "$s20YouVersionPlatformUI17BibleTextCategoryO4hash4intoys6HasherVz_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "hashValue",
+            "printedName": "hashValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO9hashValueSivp",
+            "mangledName": "$s20YouVersionPlatformUI17BibleTextCategoryO9hashValueSivp",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO9hashValueSivg",
+                "mangledName": "$s20YouVersionPlatformUI17BibleTextCategoryO9hashValueSivg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO",
+        "mangledName": "$s20YouVersionPlatformUI17BibleTextCategoryO",
+        "moduleName": "YouVersionPlatformUI",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleReferenceAttribute",
+        "printedName": "BibleReferenceAttribute",
+        "children": [
+          {
+            "kind": "TypeAlias",
+            "name": "Value",
+            "printedName": "Value",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI23BibleReferenceAttributeO5Valuea",
+            "mangledName": "$s20YouVersionPlatformUI23BibleReferenceAttributeO5Valuea",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "name",
+            "printedName": "name",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI23BibleReferenceAttributeO4nameSSvpZ",
+            "mangledName": "$s20YouVersionPlatformUI23BibleReferenceAttributeO4nameSSvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI23BibleReferenceAttributeO4nameSSvgZ",
+                "mangledName": "$s20YouVersionPlatformUI23BibleReferenceAttributeO4nameSSvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:20YouVersionPlatformUI23BibleReferenceAttributeO",
+        "mangledName": "$s20YouVersionPlatformUI23BibleReferenceAttributeO",
+        "moduleName": "YouVersionPlatformUI",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "AttributedStringKey",
+            "printedName": "AttributedStringKey",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Value",
+                "printedName": "Value",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Value",
+                    "printedName": "YouVersionPlatformUI.BibleReferenceAttribute.Value",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleReference",
+                        "printedName": "YouVersionPlatformCore.BibleReference",
+                        "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:10Foundation19AttributedStringKeyP",
+            "mangledName": "$s10Foundation19AttributedStringKeyP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleTextCategoryAttribute",
+        "printedName": "BibleTextCategoryAttribute",
+        "children": [
+          {
+            "kind": "TypeAlias",
+            "name": "Value",
+            "printedName": "Value",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextCategory",
+                "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI26BibleTextCategoryAttributeO5Valuea",
+            "mangledName": "$s20YouVersionPlatformUI26BibleTextCategoryAttributeO5Valuea",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "name",
+            "printedName": "name",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI26BibleTextCategoryAttributeO4nameSSvpZ",
+            "mangledName": "$s20YouVersionPlatformUI26BibleTextCategoryAttributeO4nameSSvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI26BibleTextCategoryAttributeO4nameSSvgZ",
+                "mangledName": "$s20YouVersionPlatformUI26BibleTextCategoryAttributeO4nameSSvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:20YouVersionPlatformUI26BibleTextCategoryAttributeO",
+        "mangledName": "$s20YouVersionPlatformUI26BibleTextCategoryAttributeO",
+        "moduleName": "YouVersionPlatformUI",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "AttributedStringKey",
+            "printedName": "AttributedStringKey",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Value",
+                "printedName": "Value",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Value",
+                    "printedName": "YouVersionPlatformUI.BibleTextCategoryAttribute.Value",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextCategory",
+                        "printedName": "YouVersionPlatformUI.BibleTextCategory",
+                        "usr": "s:20YouVersionPlatformUI17BibleTextCategoryO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:10Foundation19AttributedStringKeyP",
+            "mangledName": "$s10Foundation19AttributedStringKeyP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleTextAttributes",
+        "printedName": "BibleTextAttributes",
+        "children": [
+          {
+            "kind": "TypeAlias",
+            "name": "DecodingConfiguration",
+            "printedName": "DecodingConfiguration",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "AttributeScopeCodableConfiguration",
+                "printedName": "Foundation.AttributeScopeCodableConfiguration",
+                "usr": "s:10Foundation34AttributeScopeCodableConfigurationV"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI19BibleTextAttributesV21DecodingConfigurationa",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextAttributesV21DecodingConfigurationa",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "EncodingConfiguration",
+            "printedName": "EncodingConfiguration",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "AttributeScopeCodableConfiguration",
+                "printedName": "Foundation.AttributeScopeCodableConfiguration",
+                "usr": "s:10Foundation34AttributeScopeCodableConfigurationV"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI19BibleTextAttributesV21EncodingConfigurationa",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextAttributesV21EncodingConfigurationa",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI19BibleTextAttributesV",
+        "mangledName": "$s20YouVersionPlatformUI19BibleTextAttributesV",
+        "moduleName": "YouVersionPlatformUI",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "AttributeScope",
+            "printedName": "AttributeScope",
+            "usr": "s:10Foundation14AttributeScopeP",
+            "mangledName": "$s10Foundation14AttributeScopeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "DecodingConfigurationProviding",
+            "printedName": "DecodingConfigurationProviding",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "DecodingConfiguration",
+                "printedName": "DecodingConfiguration",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "AttributeScopeCodableConfiguration",
+                    "printedName": "Foundation.AttributeScopeCodableConfiguration",
+                    "usr": "s:10Foundation34AttributeScopeCodableConfigurationV"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:10Foundation30DecodingConfigurationProvidingP",
+            "mangledName": "$s10Foundation30DecodingConfigurationProvidingP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "EncodingConfigurationProviding",
+            "printedName": "EncodingConfigurationProviding",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "EncodingConfiguration",
+                "printedName": "EncodingConfiguration",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "AttributeScopeCodableConfiguration",
+                    "printedName": "Foundation.AttributeScopeCodableConfiguration",
+                    "usr": "s:10Foundation34AttributeScopeCodableConfigurationV"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:10Foundation30EncodingConfigurationProvidingP",
+            "mangledName": "$s10Foundation30EncodingConfigurationProvidingP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleTextFootnoteMode",
+        "printedName": "BibleTextFootnoteMode",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "none",
+            "printedName": "none",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFootnoteMode.Type) -> YouVersionPlatformUI.BibleTextFootnoteMode",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFootnoteMode",
+                    "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                    "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFootnoteMode",
+                        "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                        "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO4noneyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleTextFootnoteModeO4noneyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "inline",
+            "printedName": "inline",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFootnoteMode.Type) -> YouVersionPlatformUI.BibleTextFootnoteMode",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFootnoteMode",
+                    "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                    "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFootnoteMode",
+                        "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                        "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO6inlineyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleTextFootnoteModeO6inlineyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "marker",
+            "printedName": "marker",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFootnoteMode.Type) -> YouVersionPlatformUI.BibleTextFootnoteMode",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFootnoteMode",
+                    "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                    "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFootnoteMode",
+                        "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                        "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO6markeryA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleTextFootnoteModeO6markeryA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "letters",
+            "printedName": "letters",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFootnoteMode.Type) -> YouVersionPlatformUI.BibleTextFootnoteMode",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFootnoteMode",
+                    "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                    "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFootnoteMode",
+                        "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                        "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO7lettersyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleTextFootnoteModeO7lettersyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Var",
+            "name": "image",
+            "printedName": "image",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFootnoteMode.Type) -> YouVersionPlatformUI.BibleTextFootnoteMode",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFootnoteMode",
+                    "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                    "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFootnoteMode",
+                        "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                        "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO5imageyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleTextFootnoteModeO5imageyA2CmF",
+            "moduleName": "YouVersionPlatformUI"
+          },
+          {
+            "kind": "Function",
+            "name": "__derived_enum_equals",
+            "printedName": "__derived_enum_equals(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextFootnoteMode",
+                "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextFootnoteMode",
+                "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO21__derived_enum_equalsySbAC_ACtFZ",
+            "mangledName": "$s20YouVersionPlatformUI21BibleTextFootnoteModeO21__derived_enum_equalsySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Implements",
+              "Semantics"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hash",
+            "printedName": "hash(into:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Hasher",
+                "printedName": "Swift.Hasher",
+                "paramValueOwnership": "InOut",
+                "usr": "s:s6HasherV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO4hash4intoys6HasherVz_tF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleTextFootnoteModeO4hash4intoys6HasherVz_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "hashValue",
+            "printedName": "hashValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO9hashValueSivp",
+            "mangledName": "$s20YouVersionPlatformUI21BibleTextFootnoteModeO9hashValueSivp",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO9hashValueSivg",
+                "mangledName": "$s20YouVersionPlatformUI21BibleTextFootnoteModeO9hashValueSivg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO",
+        "mangledName": "$s20YouVersionPlatformUI21BibleTextFootnoteModeO",
+        "moduleName": "YouVersionPlatformUI",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "SignInWithYouVersionButton",
+        "printedName": "SignInWithYouVersionButton",
+        "children": [
+          {
+            "kind": "TypeDecl",
+            "name": "Mode",
+            "printedName": "Mode",
+            "children": [
+              {
+                "kind": "Var",
+                "name": "full",
+                "printedName": "full",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformUI.SignInWithYouVersionButton.Mode.Type) -> YouVersionPlatformUI.SignInWithYouVersionButton.Mode",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Mode",
+                        "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode",
+                        "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Mode",
+                            "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode",
+                            "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO4fullyA2EmF",
+                "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO4fullyA2EmF",
+                "moduleName": "YouVersionPlatformUI"
+              },
+              {
+                "kind": "Var",
+                "name": "compact",
+                "printedName": "compact",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformUI.SignInWithYouVersionButton.Mode.Type) -> YouVersionPlatformUI.SignInWithYouVersionButton.Mode",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Mode",
+                        "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode",
+                        "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Mode",
+                            "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode",
+                            "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO7compactyA2EmF",
+                "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO7compactyA2EmF",
+                "moduleName": "YouVersionPlatformUI"
+              },
+              {
+                "kind": "Var",
+                "name": "iconOnly",
+                "printedName": "iconOnly",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformUI.SignInWithYouVersionButton.Mode.Type) -> YouVersionPlatformUI.SignInWithYouVersionButton.Mode",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Mode",
+                        "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode",
+                        "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Mode",
+                            "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode",
+                            "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8iconOnlyyA2EmF",
+                "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8iconOnlyyA2EmF",
+                "moduleName": "YouVersionPlatformUI"
+              },
+              {
+                "kind": "Constructor",
+                "name": "init",
+                "printedName": "init(rawValue:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Mode",
+                        "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode",
+                        "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Constructor",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8rawValueAESgSS_tcfc",
+                "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8rawValueAESgSS_tcfc",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Inlinable"
+                ],
+                "init_kind": "Designated"
+              },
+              {
+                "kind": "TypeAlias",
+                "name": "AllCases",
+                "printedName": "AllCases",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformUI.SignInWithYouVersionButton.Mode]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Mode",
+                        "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode",
+                        "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "TypeAlias",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8AllCasesa",
+                "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8AllCasesa",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true
+              },
+              {
+                "kind": "TypeAlias",
+                "name": "RawValue",
+                "printedName": "RawValue",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "TypeAlias",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8RawValuea",
+                "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8RawValuea",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true
+              },
+              {
+                "kind": "Var",
+                "name": "allCases",
+                "printedName": "allCases",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformUI.SignInWithYouVersionButton.Mode]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Mode",
+                        "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode",
+                        "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8allCasesSayAEGvpZ",
+                "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8allCasesSayAEGvpZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Nonisolated"
+                ],
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Array",
+                        "printedName": "[YouVersionPlatformUI.SignInWithYouVersionButton.Mode]",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Mode",
+                            "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode",
+                            "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO"
+                          }
+                        ],
+                        "usr": "s:Sa"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8allCasesSayAEGvgZ",
+                    "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8allCasesSayAEGvgZ",
+                    "moduleName": "YouVersionPlatformUI",
+                    "static": true,
+                    "implicit": true,
+                    "accessorKind": "get"
+                  }
+                ]
+              },
+              {
+                "kind": "Var",
+                "name": "rawValue",
+                "printedName": "rawValue",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8rawValueSSvp",
+                "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8rawValueSSvp",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8rawValueSSvg",
+                    "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO8rawValueSSvg",
+                    "moduleName": "YouVersionPlatformUI",
+                    "implicit": true,
+                    "declAttributes": [
+                      "Inlinable"
+                    ],
+                    "accessorKind": "get"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Enum",
+            "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO",
+            "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO",
+            "moduleName": "YouVersionPlatformUI",
+            "enumRawTypeName": "String",
+            "isEnumExhaustive": true,
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "CaseIterable",
+                "printedName": "CaseIterable",
+                "children": [
+                  {
+                    "kind": "TypeWitness",
+                    "name": "AllCases",
+                    "printedName": "AllCases",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Array",
+                        "printedName": "[YouVersionPlatformUI.SignInWithYouVersionButton.Mode]",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Mode",
+                            "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode",
+                            "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO"
+                          }
+                        ],
+                        "usr": "s:Sa"
+                      }
+                    ]
+                  }
+                ],
+                "usr": "s:s12CaseIterableP",
+                "mangledName": "$ss12CaseIterableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Equatable",
+                "printedName": "Equatable",
+                "usr": "s:SQ",
+                "mangledName": "$sSQ"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Hashable",
+                "printedName": "Hashable",
+                "usr": "s:SH",
+                "mangledName": "$sSH"
+              },
+              {
+                "kind": "Conformance",
+                "name": "RawRepresentable",
+                "printedName": "RawRepresentable",
+                "children": [
+                  {
+                    "kind": "TypeWitness",
+                    "name": "RawValue",
+                    "printedName": "RawValue",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ]
+                  }
+                ],
+                "usr": "s:SY",
+                "mangledName": "$sSY"
+              }
+            ]
+          },
+          {
+            "kind": "TypeDecl",
+            "name": "ButtonShape",
+            "printedName": "ButtonShape",
+            "children": [
+              {
+                "kind": "Var",
+                "name": "capsule",
+                "printedName": "capsule",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformUI.SignInWithYouVersionButton.ButtonShape.Type) -> YouVersionPlatformUI.SignInWithYouVersionButton.ButtonShape",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "ButtonShape",
+                        "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.ButtonShape",
+                        "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.ButtonShape.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "ButtonShape",
+                            "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.ButtonShape",
+                            "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO7capsuleyA2EmF",
+                "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO7capsuleyA2EmF",
+                "moduleName": "YouVersionPlatformUI"
+              },
+              {
+                "kind": "Var",
+                "name": "rectangle",
+                "printedName": "rectangle",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformUI.SignInWithYouVersionButton.ButtonShape.Type) -> YouVersionPlatformUI.SignInWithYouVersionButton.ButtonShape",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "ButtonShape",
+                        "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.ButtonShape",
+                        "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.ButtonShape.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "ButtonShape",
+                            "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.ButtonShape",
+                            "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO9rectangleyA2EmF",
+                "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO9rectangleyA2EmF",
+                "moduleName": "YouVersionPlatformUI"
+              },
+              {
+                "kind": "Function",
+                "name": "__derived_enum_equals",
+                "printedName": "__derived_enum_equals(_:_:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ButtonShape",
+                    "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.ButtonShape",
+                    "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ButtonShape",
+                    "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.ButtonShape",
+                    "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO21__derived_enum_equalsySbAE_AEtFZ",
+                "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO21__derived_enum_equalsySbAE_AEtFZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Implements",
+                  "Semantics"
+                ],
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "hash",
+                "printedName": "hash(into:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Hasher",
+                    "printedName": "Swift.Hasher",
+                    "paramValueOwnership": "InOut",
+                    "usr": "s:s6HasherV"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO4hash4intoys6HasherVz_tF",
+                "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO4hash4intoys6HasherVz_tF",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Var",
+                "name": "hashValue",
+                "printedName": "hashValue",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO9hashValueSivp",
+                "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO9hashValueSivp",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO9hashValueSivg",
+                    "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO9hashValueSivg",
+                    "moduleName": "YouVersionPlatformUI",
+                    "implicit": true,
+                    "accessorKind": "get"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Enum",
+            "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO",
+            "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO",
+            "moduleName": "YouVersionPlatformUI",
+            "isEnumExhaustive": true,
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Equatable",
+                "printedName": "Equatable",
+                "usr": "s:SQ",
+                "mangledName": "$sSQ"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Hashable",
+                "printedName": "Hashable",
+                "usr": "s:SH",
+                "mangledName": "$sSH"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(shape:mode:isStroked:onTap:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionButton",
+                "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "ButtonShape",
+                "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.ButtonShape",
+                "hasDefaultArg": true,
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV0H5ShapeO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Mode",
+                "printedName": "YouVersionPlatformUI.SignInWithYouVersionButton.Mode",
+                "hasDefaultArg": true,
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4ModeO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "() -> Swift.Void",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Void",
+                    "printedName": "Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Void",
+                        "printedName": "()"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV5shape4mode9isStroked5onTapA2C0H5ShapeO_AC4ModeOSbyyctcfc",
+            "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV5shape4mode9isStroked5onTapA2C0H5ShapeO_AC4ModeOSbyyctcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "body",
+            "printedName": "body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4bodyQrvp",
+            "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV4bodyQrvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4bodyQrvg",
+                "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV4bodyQrvg",
+                "moduleName": "YouVersionPlatformUI",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Body",
+            "printedName": "Body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV4Bodya",
+            "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV4Bodya",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI010SignInWithaB6ButtonV",
+        "mangledName": "$s20YouVersionPlatformUI010SignInWithaB6ButtonV",
+        "moduleName": "YouVersionPlatformUI",
+        "declAttributes": [
+          "Preconcurrency",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "View",
+            "printedName": "View",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Body",
+                "printedName": "Body",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI4ViewP",
+            "mangledName": "$s7SwiftUI4ViewP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "SignInWithYouVersionView",
+        "printedName": "SignInWithYouVersionView",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(textPrimaryColor:borderPrimaryColor:buttonPrimaryColor:borderSecondaryColor:buttonSecondaryColor:onSignIn:onDismiss:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionView",
+                "printedName": "YouVersionPlatformUI.SignInWithYouVersionView",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB4ViewV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "hasDefaultArg": true,
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "hasDefaultArg": true,
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "hasDefaultArg": true,
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "hasDefaultArg": true,
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "hasDefaultArg": true,
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "() -> Swift.Void",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Void",
+                    "printedName": "Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Void",
+                        "printedName": "()"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ]
+              },
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "() -> Swift.Void",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Void",
+                    "printedName": "Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Void",
+                        "printedName": "()"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI010SignInWithaB4ViewV16textPrimaryColor06borderjK006buttonjK00l9SecondaryK00mnK002oneF00O7DismissAC05SwiftD00K0V_A4Myycyyctcfc",
+            "mangledName": "$s20YouVersionPlatformUI010SignInWithaB4ViewV16textPrimaryColor06borderjK006buttonjK00l9SecondaryK00mnK002oneF00O7DismissAC05SwiftD00K0V_A4Myycyyctcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "body",
+            "printedName": "body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI010SignInWithaB4ViewV4bodyQrvp",
+            "mangledName": "$s20YouVersionPlatformUI010SignInWithaB4ViewV4bodyQrvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI010SignInWithaB4ViewV4bodyQrvg",
+                "mangledName": "$s20YouVersionPlatformUI010SignInWithaB4ViewV4bodyQrvg",
+                "moduleName": "YouVersionPlatformUI",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Body",
+            "printedName": "Body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI010SignInWithaB4ViewV4Bodya",
+            "mangledName": "$s20YouVersionPlatformUI010SignInWithaB4ViewV4Bodya",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI010SignInWithaB4ViewV",
+        "mangledName": "$s20YouVersionPlatformUI010SignInWithaB4ViewV",
+        "moduleName": "YouVersionPlatformUI",
+        "declAttributes": [
+          "Preconcurrency",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "View",
+            "printedName": "View",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Body",
+                "printedName": "Body",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI4ViewP",
+            "mangledName": "$s7SwiftUI4ViewP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VerseSelectionStyle",
+        "printedName": "VerseSelectionStyle",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "color",
+            "printedName": "color",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV5color05SwiftD05ColorVvp",
+            "mangledName": "$s20YouVersionPlatformUI19VerseSelectionStyleV5color05SwiftD05ColorVvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV5color05SwiftD05ColorVvg",
+                "mangledName": "$s20YouVersionPlatformUI19VerseSelectionStyleV5color05SwiftD05ColorVvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "strokeStyle",
+            "printedName": "strokeStyle",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "StrokeStyle",
+                "printedName": "SwiftUI.StrokeStyle",
+                "usr": "s:7SwiftUI11StrokeStyleV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV06strokeG005SwiftD006StrokeG0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI19VerseSelectionStyleV06strokeG005SwiftD006StrokeG0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "StrokeStyle",
+                    "printedName": "SwiftUI.StrokeStyle",
+                    "usr": "s:7SwiftUI11StrokeStyleV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV06strokeG005SwiftD006StrokeG0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI19VerseSelectionStyleV06strokeG005SwiftD006StrokeG0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(color:strokeStyle:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VerseSelectionStyle",
+                "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "hasDefaultArg": true,
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "StrokeStyle",
+                "printedName": "SwiftUI.StrokeStyle",
+                "hasDefaultArg": true,
+                "usr": "s:7SwiftUI11StrokeStyleV"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV5color06strokeG0AC05SwiftD05ColorV_AF06StrokeG0Vtcfc",
+            "mangledName": "$s20YouVersionPlatformUI19VerseSelectionStyleV5color06strokeG0AC05SwiftD05ColorV_AF06StrokeG0Vtcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "solid",
+            "printedName": "solid",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VerseSelectionStyle",
+                "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV5solidACvpZ",
+            "mangledName": "$s20YouVersionPlatformUI19VerseSelectionStyleV5solidACvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "VerseSelectionStyle",
+                    "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                    "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV5solidACvgZ",
+                "mangledName": "$s20YouVersionPlatformUI19VerseSelectionStyleV5solidACvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "dashed",
+            "printedName": "dashed",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VerseSelectionStyle",
+                "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV6dashedACvpZ",
+            "mangledName": "$s20YouVersionPlatformUI19VerseSelectionStyleV6dashedACvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "VerseSelectionStyle",
+                    "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                    "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV6dashedACvgZ",
+                "mangledName": "$s20YouVersionPlatformUI19VerseSelectionStyleV6dashedACvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV",
+        "mangledName": "$s20YouVersionPlatformUI19VerseSelectionStyleV",
+        "moduleName": "YouVersionPlatformUI",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersionPickingButton",
+        "printedName": "BibleVersionPickingButton",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(initialVersionId:onVersionChange:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionPickingButton",
+                "printedName": "YouVersionPlatformUI.BibleVersionPickingButton",
+                "usr": "s:20YouVersionPlatformUI05BibleB13PickingButtonV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "((YouVersionPlatformCore.BibleVersion) -> Swift.Void)?",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleVersion) -> Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNameAlias",
+                        "name": "Void",
+                        "printedName": "Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Void",
+                            "printedName": "()"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVersion",
+                        "printedName": "YouVersionPlatformCore.BibleVersion",
+                        "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI05BibleB13PickingButtonV07initialB2Id02onB6ChangeACSi_y0abC4Core0eB0VcSgtcfc",
+            "mangledName": "$s20YouVersionPlatformUI05BibleB13PickingButtonV07initialB2Id02onB6ChangeACSi_y0abC4Core0eB0VcSgtcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "body",
+            "printedName": "body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI05BibleB13PickingButtonV4bodyQrvp",
+            "mangledName": "$s20YouVersionPlatformUI05BibleB13PickingButtonV4bodyQrvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI05BibleB13PickingButtonV4bodyQrvg",
+                "mangledName": "$s20YouVersionPlatformUI05BibleB13PickingButtonV4bodyQrvg",
+                "moduleName": "YouVersionPlatformUI",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Body",
+            "printedName": "Body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI05BibleB13PickingButtonV4Bodya",
+            "mangledName": "$s20YouVersionPlatformUI05BibleB13PickingButtonV4Bodya",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI05BibleB13PickingButtonV",
+        "mangledName": "$s20YouVersionPlatformUI05BibleB13PickingButtonV",
+        "moduleName": "YouVersionPlatformUI",
+        "declAttributes": [
+          "Preconcurrency",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "View",
+            "printedName": "View",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Body",
+                "printedName": "Body",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI4ViewP",
+            "mangledName": "$s7SwiftUI4ViewP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersionsListView",
+        "printedName": "BibleVersionsListView",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "body",
+            "printedName": "body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI21BibleVersionsListViewV4bodyQrvp",
+            "mangledName": "$s20YouVersionPlatformUI21BibleVersionsListViewV4bodyQrvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI21BibleVersionsListViewV4bodyQrvg",
+                "mangledName": "$s20YouVersionPlatformUI21BibleVersionsListViewV4bodyQrvg",
+                "moduleName": "YouVersionPlatformUI",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Body",
+            "printedName": "Body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI21BibleVersionsListViewV4Bodya",
+            "mangledName": "$s20YouVersionPlatformUI21BibleVersionsListViewV4Bodya",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI21BibleVersionsListViewV",
+        "mangledName": "$s20YouVersionPlatformUI21BibleVersionsListViewV",
+        "moduleName": "YouVersionPlatformUI",
+        "declAttributes": [
+          "Preconcurrency",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "View",
+            "printedName": "View",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Body",
+                "printedName": "Body",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI4ViewP",
+            "mangledName": "$s7SwiftUI4ViewP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersionsMyVersionsView",
+        "printedName": "BibleVersionsMyVersionsView",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "body",
+            "printedName": "body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI015BibleVersionsMyF4ViewV4bodyQrvp",
+            "mangledName": "$s20YouVersionPlatformUI015BibleVersionsMyF4ViewV4bodyQrvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI015BibleVersionsMyF4ViewV4bodyQrvg",
+                "mangledName": "$s20YouVersionPlatformUI015BibleVersionsMyF4ViewV4bodyQrvg",
+                "moduleName": "YouVersionPlatformUI",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Body",
+            "printedName": "Body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI015BibleVersionsMyF4ViewV4Bodya",
+            "mangledName": "$s20YouVersionPlatformUI015BibleVersionsMyF4ViewV4Bodya",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI015BibleVersionsMyF4ViewV",
+        "mangledName": "$s20YouVersionPlatformUI015BibleVersionsMyF4ViewV",
+        "moduleName": "YouVersionPlatformUI",
+        "declAttributes": [
+          "Preconcurrency",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "View",
+            "printedName": "View",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Body",
+                "printedName": "Body",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI4ViewP",
+            "mangledName": "$s7SwiftUI4ViewP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersionsStack",
+        "printedName": "BibleVersionsStack",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionsStack",
+                "printedName": "YouVersionPlatformUI.BibleVersionsStack",
+                "usr": "s:20YouVersionPlatformUI18BibleVersionsStackV"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI18BibleVersionsStackVACycfc",
+            "mangledName": "$s20YouVersionPlatformUI18BibleVersionsStackVACycfc",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "body",
+            "printedName": "body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI18BibleVersionsStackV4bodyQrvp",
+            "mangledName": "$s20YouVersionPlatformUI18BibleVersionsStackV4bodyQrvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI18BibleVersionsStackV4bodyQrvg",
+                "mangledName": "$s20YouVersionPlatformUI18BibleVersionsStackV4bodyQrvg",
+                "moduleName": "YouVersionPlatformUI",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Body",
+            "printedName": "Body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI18BibleVersionsStackV4Bodya",
+            "mangledName": "$s20YouVersionPlatformUI18BibleVersionsStackV4Bodya",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI18BibleVersionsStackV",
+        "mangledName": "$s20YouVersionPlatformUI18BibleVersionsStackV",
+        "moduleName": "YouVersionPlatformUI",
+        "declAttributes": [
+          "Preconcurrency",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "View",
+            "printedName": "View",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Body",
+                "printedName": "Body",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI4ViewP",
+            "mangledName": "$s7SwiftUI4ViewP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersionsViewModel",
+        "printedName": "BibleVersionsViewModel",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "onVersionChange",
+            "printedName": "onVersionChange",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.BibleVersion) -> Swift.Void",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Void",
+                    "printedName": "Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Void",
+                        "printedName": "()"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Changeyy0abC4Core0eB0Vcvp",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Changeyy0abC4Core0eB0Vcvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleVersion) -> Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNameAlias",
+                        "name": "Void",
+                        "printedName": "Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Void",
+                            "printedName": "()"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVersion",
+                        "printedName": "YouVersionPlatformCore.BibleVersion",
+                        "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Changeyy0abC4Core0eB0Vcvg",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Changeyy0abC4Core0eB0Vcvg",
+                "moduleName": "YouVersionPlatformUI",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              },
+              {
+                "kind": "Accessor",
+                "name": "Set",
+                "printedName": "Set()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  },
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleVersion) -> Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNameAlias",
+                        "name": "Void",
+                        "printedName": "Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Void",
+                            "printedName": "()"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVersion",
+                        "printedName": "YouVersionPlatformCore.BibleVersion",
+                        "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Changeyy0abC4Core0eB0Vcvs",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Changeyy0abC4Core0eB0Vcvs",
+                "moduleName": "YouVersionPlatformUI",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "set"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "onSignInRequired",
+            "printedName": "onSignInRequired",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "(() -> Swift.Void)?",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "() -> Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNameAlias",
+                        "name": "Void",
+                        "printedName": "Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Void",
+                            "printedName": "()"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Void",
+                        "printedName": "()"
+                      }
+                    ]
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC16onSignInRequiredyycSgvp",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC16onSignInRequiredyycSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasInitialValue",
+              "Final",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "(() -> Swift.Void)?",
+                    "children": [
+                      {
+                        "kind": "TypeFunc",
+                        "name": "Function",
+                        "printedName": "() -> Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNameAlias",
+                            "name": "Void",
+                            "printedName": "Swift.Void",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Void",
+                                "printedName": "()"
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Void",
+                            "printedName": "()"
+                          }
+                        ]
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC16onSignInRequiredyycSgvg",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC16onSignInRequiredyycSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              },
+              {
+                "kind": "Accessor",
+                "name": "Set",
+                "printedName": "Set()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "(() -> Swift.Void)?",
+                    "children": [
+                      {
+                        "kind": "TypeFunc",
+                        "name": "Function",
+                        "printedName": "() -> Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNameAlias",
+                            "name": "Void",
+                            "printedName": "Swift.Void",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Void",
+                                "printedName": "()"
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Void",
+                            "printedName": "()"
+                          }
+                        ]
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC16onSignInRequiredyycSgvs",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC16onSignInRequiredyycSgvs",
+                "moduleName": "YouVersionPlatformUI",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "set"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "colorTheme",
+            "printedName": "colorTheme",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.ReaderTheme?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ReaderTheme",
+                    "printedName": "YouVersionPlatformUI.ReaderTheme",
+                    "usr": "s:20YouVersionPlatformUI11ReaderThemeV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC10colorThemeAA06ReaderJ0VSgvp",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC10colorThemeAA06ReaderJ0VSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasInitialValue",
+              "Final",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "YouVersionPlatformUI.ReaderTheme?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "ReaderTheme",
+                        "printedName": "YouVersionPlatformUI.ReaderTheme",
+                        "usr": "s:20YouVersionPlatformUI11ReaderThemeV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC10colorThemeAA06ReaderJ0VSgvg",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC10colorThemeAA06ReaderJ0VSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              },
+              {
+                "kind": "Accessor",
+                "name": "Set",
+                "printedName": "Set()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "YouVersionPlatformUI.ReaderTheme?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "ReaderTheme",
+                        "printedName": "YouVersionPlatformUI.ReaderTheme",
+                        "usr": "s:20YouVersionPlatformUI11ReaderThemeV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC10colorThemeAA06ReaderJ0VSgvs",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC10colorThemeAA06ReaderJ0VSgvs",
+                "moduleName": "YouVersionPlatformUI",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "set"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "versionRepository",
+            "printedName": "versionRepository",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionRepositoryProtocol",
+                "printedName": "any YouVersionPlatformCore.BibleVersionRepositoryProtocol",
+                "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC17versionRepository0abC4Core0ebJ8Protocol_pvp",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC17versionRepository0abC4Core0ebJ8Protocol_pvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "HasStorage",
+              "Custom"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersionRepositoryProtocol",
+                    "printedName": "any YouVersionPlatformCore.BibleVersionRepositoryProtocol",
+                    "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC17versionRepository0abC4Core0ebJ8Protocol_pvg",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC17versionRepository0abC4Core0ebJ8Protocol_pvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Final",
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(onVersionChange:versionRepository:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionsViewModel",
+                "printedName": "YouVersionPlatformUI.BibleVersionsViewModel",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC"
+              },
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.BibleVersion) -> Swift.Void",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Void",
+                    "printedName": "Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Void",
+                        "printedName": "()"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ]
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionRepositoryProtocol",
+                "printedName": "any YouVersionPlatformCore.BibleVersionRepositoryProtocol",
+                "hasDefaultArg": true,
+                "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Change17versionRepositoryACy0abC4Core0eB0Vc_AF0ebL8Protocol_ptcfc",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Change17versionRepositoryACy0abC4Core0eB0Vc_AF0ebL8Protocol_ptcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "loadInitialState",
+            "printedName": "loadInitialState(initialVersionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Int?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC16loadInitialState07initialB2IdySiSg_tYaF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC16loadInitialState07initialB2IdySiSg_tYaF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "myVersions",
+            "printedName": "myVersions",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<YouVersionPlatformCore.BibleVersion>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02myF0Shy0abC4Core0eB0VGvp",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02myF0Shy0abC4Core0eB0VGvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasInitialValue",
+              "Final",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Set",
+                    "printedName": "Swift.Set<YouVersionPlatformCore.BibleVersion>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVersion",
+                        "printedName": "YouVersionPlatformCore.BibleVersion",
+                        "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                      }
+                    ],
+                    "usr": "s:Sh"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02myF0Shy0abC4Core0eB0VGvg",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02myF0Shy0abC4Core0eB0VGvg",
+                "moduleName": "YouVersionPlatformUI",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              },
+              {
+                "kind": "Accessor",
+                "name": "Set",
+                "printedName": "Set()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Set",
+                    "printedName": "Swift.Set<YouVersionPlatformCore.BibleVersion>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVersion",
+                        "printedName": "YouVersionPlatformCore.BibleVersion",
+                        "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                      }
+                    ],
+                    "usr": "s:Sh"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02myF0Shy0abC4Core0eB0VGvs",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02myF0Shy0abC4Core0eB0VGvs",
+                "moduleName": "YouVersionPlatformUI",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "set"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "showingVersionsStack",
+            "printedName": "showingVersionsStack",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC07showingF5StackSbvp",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC07showingF5StackSbvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasInitialValue",
+              "Final",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC07showingF5StackSbvg",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC07showingF5StackSbvg",
+                "moduleName": "YouVersionPlatformUI",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              },
+              {
+                "kind": "Accessor",
+                "name": "Set",
+                "printedName": "Set()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC07showingF5StackSbvs",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC07showingF5StackSbvs",
+                "moduleName": "YouVersionPlatformUI",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "set"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "preview",
+            "printedName": "preview",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionsViewModel",
+                "printedName": "YouVersionPlatformUI.BibleVersionsViewModel",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC7previewACvpZ",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC7previewACvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersionsViewModel",
+                    "printedName": "YouVersionPlatformUI.BibleVersionsViewModel",
+                    "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC7previewACvgZ",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC7previewACvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "myVersionItemTapped",
+            "printedName": "myVersionItemTapped(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02myB10ItemTappedyySiF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02myB10ItemTappedyySiF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "myVersionMoreInfoMenuTapped",
+            "printedName": "myVersionMoreInfoMenuTapped(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02myB18MoreInfoMenuTappedyySiF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02myB18MoreInfoMenuTappedyySiF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "finalDownloadButtonTapped",
+            "printedName": "finalDownloadButtonTapped(version:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC25finalDownloadButtonTapped7versiony0abC4Core0eB0V_tF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC25finalDownloadButtonTapped7versiony0abC4Core0eB0V_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "conditionalDownloadButtonTapped",
+            "printedName": "conditionalDownloadButtonTapped(version:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC31conditionalDownloadButtonTapped7versiony0abC4Core0eB0V_tF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC31conditionalDownloadButtonTapped7versiony0abC4Core0eB0V_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "myVersionDownloadMenuTapped",
+            "printedName": "myVersionDownloadMenuTapped(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02myB18DownloadMenuTappedyySiF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02myB18DownloadMenuTappedyySiF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "myVersionRemoveDownloadMenuTapped",
+            "printedName": "myVersionRemoveDownloadMenuTapped(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02myB24RemoveDownloadMenuTappedyySiF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02myB24RemoveDownloadMenuTappedyySiF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "myVersionRemoveVersionMenuTapped",
+            "printedName": "myVersionRemoveVersionMenuTapped(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02myb6RemoveB10MenuTappedyySiF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02myb6RemoveB10MenuTappedyySiF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionDownloadInfoButtonTapped",
+            "printedName": "versionDownloadInfoButtonTapped(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC31versionDownloadInfoButtonTapped3fory0abC4Core0eB0V_tF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC31versionDownloadInfoButtonTapped3fory0abC4Core0eB0V_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionDownloadViewBack",
+            "printedName": "versionDownloadViewBack()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC015versionDownloadG4BackyyF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC015versionDownloadG4BackyyF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionDownloadViewAccepted",
+            "printedName": "versionDownloadViewAccepted(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC015versionDownloadG8Accepted3fory0abC4Core0eB0V_tF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC015versionDownloadG8Accepted3fory0abC4Core0eB0V_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionDownloadViewDismissed",
+            "printedName": "versionDownloadViewDismissed(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC015versionDownloadG9Dismissed3fory0abC4Core0eB0V_tF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC015versionDownloadG9Dismissed3fory0abC4Core0eB0V_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "activeLanguage",
+            "printedName": "activeLanguage",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC14activeLanguageSSvp",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC14activeLanguageSSvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC14activeLanguageSSvg",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC14activeLanguageSSvg",
+                "moduleName": "YouVersionPlatformUI",
+                "declAttributes": [
+                  "Final"
+                ],
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "bibleVersionStatisticsPromo",
+            "printedName": "bibleVersionStatisticsPromo",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC05bibleB15StatisticsPromoSSvp",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC05bibleB15StatisticsPromoSSvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC05bibleB15StatisticsPromoSSvg",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC05bibleB15StatisticsPromoSSvg",
+                "moduleName": "YouVersionPlatformUI",
+                "declAttributes": [
+                  "Final"
+                ],
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "downloadStatus",
+            "printedName": "downloadStatus(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionDownloadStatus",
+                "printedName": "YouVersionPlatformCore.BibleVersionRepository.BibleVersionDownloadStatus",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC0eB14DownloadStatusO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC14downloadStatus3for0abC4Core0eB10RepositoryC0eb8DownloadJ0OSi_tYaF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC14downloadStatus3for0abC4Core0eB10RepositoryC0eb8DownloadJ0OSi_tYaF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "switchToVersion",
+            "printedName": "switchToVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC08switchToB0yySiF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC08switchToB0yySiF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "handleVersionPickerTap",
+            "printedName": "handleVersionPickerTap(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC06handleB9PickerTapyySiF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC06handleB9PickerTapyySiF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "languageTapped",
+            "printedName": "languageTapped()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC14languageTappedyyF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC14languageTappedyyF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "openVersionsStack",
+            "printedName": "openVersionsStack(currentBibleLanguage:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC04openF5Stack07currentE8LanguageySS_tF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC04openF5Stack07currentE8LanguageySS_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC",
+        "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC",
+        "moduleName": "YouVersionPlatformUI",
+        "declAttributes": [
+          "Final",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Observable",
+            "printedName": "Observable",
+            "usr": "s:11Observation10ObservableP",
+            "mangledName": "$s11Observation10ObservableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "ReaderThemeProviding",
+            "printedName": "ReaderThemeProviding",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingP",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "ReaderTheme",
+        "printedName": "ReaderTheme",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "id",
+            "printedName": "id",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI11ReaderThemeV2idSivp",
+            "mangledName": "$s20YouVersionPlatformUI11ReaderThemeV2idSivp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI11ReaderThemeV2idSivg",
+                "mangledName": "$s20YouVersionPlatformUI11ReaderThemeV2idSivg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "foreground",
+            "printedName": "foreground",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI11ReaderThemeV10foreground05SwiftD05ColorVvp",
+            "mangledName": "$s20YouVersionPlatformUI11ReaderThemeV10foreground05SwiftD05ColorVvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI11ReaderThemeV10foreground05SwiftD05ColorVvg",
+                "mangledName": "$s20YouVersionPlatformUI11ReaderThemeV10foreground05SwiftD05ColorVvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "background",
+            "printedName": "background",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI11ReaderThemeV10background05SwiftD05ColorVvp",
+            "mangledName": "$s20YouVersionPlatformUI11ReaderThemeV10background05SwiftD05ColorVvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI11ReaderThemeV10background05SwiftD05ColorVvg",
+                "mangledName": "$s20YouVersionPlatformUI11ReaderThemeV10background05SwiftD05ColorVvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "colorScheme",
+            "printedName": "colorScheme",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "ColorScheme",
+                "printedName": "SwiftUI.ColorScheme",
+                "usr": "s:7SwiftUI11ColorSchemeO"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI11ReaderThemeV11colorScheme05SwiftD005ColorH0Ovp",
+            "mangledName": "$s20YouVersionPlatformUI11ReaderThemeV11colorScheme05SwiftD005ColorH0Ovp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ColorScheme",
+                    "printedName": "SwiftUI.ColorScheme",
+                    "usr": "s:7SwiftUI11ColorSchemeO"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI11ReaderThemeV11colorScheme05SwiftD005ColorH0Ovg",
+                "mangledName": "$s20YouVersionPlatformUI11ReaderThemeV11colorScheme05SwiftD005ColorH0Ovg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "==",
+            "printedName": "==(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "ReaderTheme",
+                "printedName": "YouVersionPlatformUI.ReaderTheme",
+                "usr": "s:20YouVersionPlatformUI11ReaderThemeV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "ReaderTheme",
+                "printedName": "YouVersionPlatformUI.ReaderTheme",
+                "usr": "s:20YouVersionPlatformUI11ReaderThemeV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI11ReaderThemeV2eeoiySbAC_ACtFZ",
+            "mangledName": "$s20YouVersionPlatformUI11ReaderThemeV2eeoiySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "allThemes",
+            "printedName": "allThemes",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformUI.ReaderTheme]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ReaderTheme",
+                    "printedName": "YouVersionPlatformUI.ReaderTheme",
+                    "usr": "s:20YouVersionPlatformUI11ReaderThemeV"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI11ReaderThemeV9allThemesSayACGvpZ",
+            "mangledName": "$s20YouVersionPlatformUI11ReaderThemeV9allThemesSayACGvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformUI.ReaderTheme]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "ReaderTheme",
+                        "printedName": "YouVersionPlatformUI.ReaderTheme",
+                        "usr": "s:20YouVersionPlatformUI11ReaderThemeV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI11ReaderThemeV9allThemesSayACGvgZ",
+                "mangledName": "$s20YouVersionPlatformUI11ReaderThemeV9allThemesSayACGvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "theme",
+            "printedName": "theme(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "ReaderTheme",
+                "printedName": "YouVersionPlatformUI.ReaderTheme",
+                "usr": "s:20YouVersionPlatformUI11ReaderThemeV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Int?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI11ReaderThemeV5theme6withIdACSiSg_tFZ",
+            "mangledName": "$s20YouVersionPlatformUI11ReaderThemeV5theme6withIdACSiSg_tFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "ID",
+            "printedName": "ID",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI11ReaderThemeV2IDa",
+            "mangledName": "$s20YouVersionPlatformUI11ReaderThemeV2IDa",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI11ReaderThemeV",
+        "mangledName": "$s20YouVersionPlatformUI11ReaderThemeV",
+        "moduleName": "YouVersionPlatformUI",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Identifiable",
+            "printedName": "Identifiable",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "ID",
+                "printedName": "ID",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:s12IdentifiableP",
+            "mangledName": "$ss12IdentifiableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "ReaderThemeProviding",
+        "printedName": "ReaderThemeProviding",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "colorTheme",
+            "printedName": "colorTheme",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.ReaderTheme?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ReaderTheme",
+                    "printedName": "YouVersionPlatformUI.ReaderTheme",
+                    "usr": "s:20YouVersionPlatformUI11ReaderThemeV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingP05colorF0AA0eF0VSgvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingP05colorF0AA0eF0VSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "protocolReq": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "YouVersionPlatformUI.ReaderTheme?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "ReaderTheme",
+                        "printedName": "YouVersionPlatformUI.ReaderTheme",
+                        "usr": "s:20YouVersionPlatformUI11ReaderThemeV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingP05colorF0AA0eF0VSgvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingP05colorF0AA0eF0VSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "protocolReq": true,
+                "reqNewWitnessTableEntry": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "colorForScheme",
+            "printedName": "colorForScheme(light:dark:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE14colorForScheme5light4dark05SwiftD05ColorVAI_AItF",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE14colorForScheme5light4dark05SwiftD05ColorVAI_AItF",
+            "moduleName": "YouVersionPlatformUI",
+            "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "readerCanvasPrimaryColor",
+            "printedName": "readerCanvasPrimaryColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerCanvasPrimaryColor05SwiftD00K0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerCanvasPrimaryColor05SwiftD00K0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerCanvasPrimaryColor05SwiftD00K0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerCanvasPrimaryColor05SwiftD00K0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerTextPrimaryColor",
+            "printedName": "readerTextPrimaryColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE22readerTextPrimaryColor05SwiftD00K0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE22readerTextPrimaryColor05SwiftD00K0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE22readerTextPrimaryColor05SwiftD00K0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE22readerTextPrimaryColor05SwiftD00K0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerVerseNumColor",
+            "printedName": "readerVerseNumColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE19readerVerseNumColor05SwiftD00K0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE19readerVerseNumColor05SwiftD00K0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE19readerVerseNumColor05SwiftD00K0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE19readerVerseNumColor05SwiftD00K0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerTextMutedColor",
+            "printedName": "readerTextMutedColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE20readerTextMutedColor05SwiftD00K0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE20readerTextMutedColor05SwiftD00K0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE20readerTextMutedColor05SwiftD00K0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE20readerTextMutedColor05SwiftD00K0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerSurfacePrimaryColor",
+            "printedName": "readerSurfacePrimaryColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE25readerSurfacePrimaryColor05SwiftD00K0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE25readerSurfacePrimaryColor05SwiftD00K0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE25readerSurfacePrimaryColor05SwiftD00K0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE25readerSurfacePrimaryColor05SwiftD00K0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerSurfaceTertiaryColor",
+            "printedName": "readerSurfaceTertiaryColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE26readerSurfaceTertiaryColor05SwiftD00K0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE26readerSurfaceTertiaryColor05SwiftD00K0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE26readerSurfaceTertiaryColor05SwiftD00K0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE26readerSurfaceTertiaryColor05SwiftD00K0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerBorderPrimaryColor",
+            "printedName": "readerBorderPrimaryColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerBorderPrimaryColor05SwiftD00K0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerBorderPrimaryColor05SwiftD00K0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerBorderPrimaryColor05SwiftD00K0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerBorderPrimaryColor05SwiftD00K0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerBorderSecondaryColor",
+            "printedName": "readerBorderSecondaryColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE26readerBorderSecondaryColor05SwiftD00K0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE26readerBorderSecondaryColor05SwiftD00K0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE26readerBorderSecondaryColor05SwiftD00K0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE26readerBorderSecondaryColor05SwiftD00K0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerButtonPrimaryColor",
+            "printedName": "readerButtonPrimaryColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerButtonPrimaryColor05SwiftD00K0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerButtonPrimaryColor05SwiftD00K0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerButtonPrimaryColor05SwiftD00K0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerButtonPrimaryColor05SwiftD00K0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerButtonSecondaryColor",
+            "printedName": "readerButtonSecondaryColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE26readerButtonSecondaryColor05SwiftD00K0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE26readerButtonSecondaryColor05SwiftD00K0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE26readerButtonSecondaryColor05SwiftD00K0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE26readerButtonSecondaryColor05SwiftD00K0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerButtonContrastColor",
+            "printedName": "readerButtonContrastColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE25readerButtonContrastColor05SwiftD00K0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE25readerButtonContrastColor05SwiftD00K0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE25readerButtonContrastColor05SwiftD00K0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE25readerButtonContrastColor05SwiftD00K0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerTextInvertedColor",
+            "printedName": "readerTextInvertedColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE23readerTextInvertedColor05SwiftD00K0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE23readerTextInvertedColor05SwiftD00K0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE23readerTextInvertedColor05SwiftD00K0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE23readerTextInvertedColor05SwiftD00K0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerWhiteColor",
+            "printedName": "readerWhiteColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE16readerWhiteColor05SwiftD00J0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE16readerWhiteColor05SwiftD00J0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE16readerWhiteColor05SwiftD00J0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE16readerWhiteColor05SwiftD00J0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerBlackColor",
+            "printedName": "readerBlackColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE16readerBlackColor05SwiftD00J0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE16readerBlackColor05SwiftD00J0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE16readerBlackColor05SwiftD00J0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE16readerBlackColor05SwiftD00J0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerDropShadowColor",
+            "printedName": "readerDropShadowColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE21readerDropShadowColor05SwiftD00K0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE21readerDropShadowColor05SwiftD00K0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE21readerDropShadowColor05SwiftD00K0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE21readerDropShadowColor05SwiftD00K0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "readerWordsOfChristColor",
+            "printedName": "readerWordsOfChristColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerWordsOfChristColor05SwiftD00L0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerWordsOfChristColor05SwiftD00L0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerWordsOfChristColor05SwiftD00L0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingPAAE24readerWordsOfChristColor05SwiftD00L0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<Self where Self : YouVersionPlatformUI.ReaderThemeProviding>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:20YouVersionPlatformUI20ReaderThemeProvidingP",
+        "mangledName": "$s20YouVersionPlatformUI20ReaderThemeProvidingP",
+        "moduleName": "YouVersionPlatformUI",
+        "declAttributes": [
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VotdView",
+        "printedName": "VotdView",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(bibleVersionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VotdView",
+                "printedName": "YouVersionPlatformUI.VotdView",
+                "usr": "s:20YouVersionPlatformUI8VotdViewV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "hasDefaultArg": true,
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI8VotdViewV05bibleB2IdACSi_tcfc",
+            "mangledName": "$s20YouVersionPlatformUI8VotdViewV05bibleB2IdACSi_tcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "body",
+            "printedName": "body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI8VotdViewV4bodyQrvp",
+            "mangledName": "$s20YouVersionPlatformUI8VotdViewV4bodyQrvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI8VotdViewV4bodyQrvg",
+                "mangledName": "$s20YouVersionPlatformUI8VotdViewV4bodyQrvg",
+                "moduleName": "YouVersionPlatformUI",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Body",
+            "printedName": "Body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI8VotdViewV4Bodya",
+            "mangledName": "$s20YouVersionPlatformUI8VotdViewV4Bodya",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI8VotdViewV",
+        "mangledName": "$s20YouVersionPlatformUI8VotdViewV",
+        "moduleName": "YouVersionPlatformUI",
+        "declAttributes": [
+          "Preconcurrency",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "View",
+            "printedName": "View",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Body",
+                "printedName": "Body",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI4ViewP",
+            "mangledName": "$s7SwiftUI4ViewP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "YouVersionBigButtonStyle",
+        "printedName": "YouVersionBigButtonStyle",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "strokeColor",
+            "printedName": "strokeColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB14BigButtonStyleV11strokeColor05SwiftD00I0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI0aB14BigButtonStyleV11strokeColor05SwiftD00I0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "HasStorage",
+              "Custom"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB14BigButtonStyleV11strokeColor05SwiftD00I0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI0aB14BigButtonStyleV11strokeColor05SwiftD00I0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "backgroundColor",
+            "printedName": "backgroundColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB14BigButtonStyleV15backgroundColor05SwiftD00I0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI0aB14BigButtonStyleV15backgroundColor05SwiftD00I0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "HasStorage",
+              "Custom"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB14BigButtonStyleV15backgroundColor05SwiftD00I0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI0aB14BigButtonStyleV15backgroundColor05SwiftD00I0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "foregroundColor",
+            "printedName": "foregroundColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB14BigButtonStyleV15foregroundColor05SwiftD00I0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI0aB14BigButtonStyleV15foregroundColor05SwiftD00I0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "HasStorage",
+              "Custom"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB14BigButtonStyleV15foregroundColor05SwiftD00I0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI0aB14BigButtonStyleV15foregroundColor05SwiftD00I0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "strokeWidth",
+            "printedName": "strokeWidth",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "usr": "s:14CoreFoundation7CGFloatV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB14BigButtonStyleV11strokeWidth14CoreFoundation7CGFloatVvp",
+            "mangledName": "$s20YouVersionPlatformUI0aB14BigButtonStyleV11strokeWidth12CoreGraphics7CGFloatVvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "HasStorage",
+              "Custom"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CGFloat",
+                    "printedName": "CoreGraphics.CGFloat",
+                    "usr": "s:14CoreFoundation7CGFloatV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB14BigButtonStyleV11strokeWidth14CoreFoundation7CGFloatVvg",
+                "mangledName": "$s20YouVersionPlatformUI0aB14BigButtonStyleV11strokeWidth12CoreGraphics7CGFloatVvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(strokeColor:backgroundColor:foregroundColor:strokeWidth:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "YouVersionBigButtonStyle",
+                "printedName": "YouVersionPlatformUI.YouVersionBigButtonStyle",
+                "usr": "s:20YouVersionPlatformUI0aB14BigButtonStyleV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "hasDefaultArg": true,
+                "usr": "s:14CoreFoundation7CGFloatV"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI0aB14BigButtonStyleV11strokeColor010backgroundI0010foregroundI00H5WidthAC05SwiftD00I0V_A2J14CoreFoundation7CGFloatVtcfc",
+            "mangledName": "$s20YouVersionPlatformUI0aB14BigButtonStyleV11strokeColor010backgroundI0010foregroundI00H5WidthAC05SwiftD00I0V_A2J12CoreGraphics7CGFloatVtcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "makeBody",
+            "printedName": "makeBody(configuration:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              },
+              {
+                "kind": "TypeNameAlias",
+                "name": "Configuration",
+                "printedName": "YouVersionPlatformUI.YouVersionBigButtonStyle.Configuration",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ButtonStyleConfiguration",
+                    "printedName": "SwiftUI.ButtonStyleConfiguration",
+                    "usr": "s:7SwiftUI24ButtonStyleConfigurationV"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI0aB14BigButtonStyleV8makeBody13configurationQr05SwiftD00fG13ConfigurationV_tF",
+            "mangledName": "$s20YouVersionPlatformUI0aB14BigButtonStyleV8makeBody13configurationQr05SwiftD00fG13ConfigurationV_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Body",
+            "printedName": "Body",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI0aB14BigButtonStyleV4Bodya",
+            "mangledName": "$s20YouVersionPlatformUI0aB14BigButtonStyleV4Bodya",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI0aB14BigButtonStyleV",
+        "mangledName": "$s20YouVersionPlatformUI0aB14BigButtonStyleV",
+        "moduleName": "YouVersionPlatformUI",
+        "declAttributes": [
+          "Preconcurrency",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "ButtonStyle",
+            "printedName": "ButtonStyle",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Body",
+                "printedName": "Body",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI11ButtonStyleP",
+            "mangledName": "$s7SwiftUI11ButtonStyleP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "Users",
+        "printedName": "Users",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "signIn",
+            "printedName": "signIn(permissions:contextProvider:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionResult",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<YouVersionPlatformCore.SignInWithYouVersionPermission>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPermission",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                  }
+                ],
+                "usr": "s:Sh"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "ASWebAuthenticationPresentationContextProviding",
+                "printedName": "any AuthenticationServices.ASWebAuthenticationPresentationContextProviding",
+                "usr": "c:objc(pl)ASWebAuthenticationPresentationContextProviding"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO0abC2UIE6signIn11permissions15contextProviderAA04Signi4WithaB6ResultVShyAA0minaB10PermissionOG_So47ASWebAuthenticationPresentationContextProviding_ptYaKFZ",
+            "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO0abC2UIE6signIn11permissions15contextProviderAA04Signi4WithaB6ResultVShyAA0minaB10PermissionOG_So47ASWebAuthenticationPresentationContextProviding_ptYaKFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO",
+        "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO",
+        "moduleName": "YouVersionPlatformCore",
+        "isFromExtension": true,
+        "isExternal": true,
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersion",
+        "printedName": "BibleVersion",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "bookName",
+            "printedName": "bookName(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V0abC2UIE8bookNameySSSgSSF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V0abC2UIE8bookNameySSSgSSF",
+            "moduleName": "YouVersionPlatformUI",
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "shareUrl",
+            "printedName": "shareUrl(reference:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V0abC2UIE8shareUrl9reference10Foundation3URLVSgAA0E9ReferenceV_tF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V0abC2UIE8shareUrl9reference10Foundation3URLVSgAA0E9ReferenceV_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "displayTitle",
+            "printedName": "displayTitle(for:includesVersionAbbreviation:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB0V0abC2UIE12displayTitle3for08includesB12AbbreviationSSAA0E9ReferenceV_SbtF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB0V0abC2UIE12displayTitle3for08includesB12AbbreviationSSAA0E9ReferenceV_SbtF",
+            "moduleName": "YouVersionPlatformUI",
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore05BibleB0V",
+        "mangledName": "$s22YouVersionPlatformCore05BibleB0V",
+        "moduleName": "YouVersionPlatformCore",
+        "isExternal": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "Bundle",
+        "printedName": "Bundle",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "YouVersionUIBundle",
+            "printedName": "YouVersionUIBundle",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bundle",
+                "printedName": "Foundation.Bundle",
+                "usr": "c:objc(cs)NSBundle"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:So8NSBundleC20YouVersionPlatformUIE0bC8UIBundleABvpZ",
+            "mangledName": "$sSo8NSBundleC20YouVersionPlatformUIE0bC8UIBundleABvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "Final"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bundle",
+                    "printedName": "Foundation.Bundle",
+                    "usr": "c:objc(cs)NSBundle"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:So8NSBundleC20YouVersionPlatformUIE0bC8UIBundleABvgZ",
+                "mangledName": "$sSo8NSBundleC20YouVersionPlatformUIE0bC8UIBundleABvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "c:objc(cs)NSBundle",
+        "moduleName": "Foundation",
+        "isOpen": true,
+        "objc_name": "NSBundle",
+        "declAttributes": [
+          "ObjC",
+          "SynthesizedProtocol",
+          "NonSendable",
+          "Sendable",
+          "Dynamic"
+        ],
+        "superclassUsr": "c:objc(cs)NSObject",
+        "isExternal": true,
+        "inheritsConvenienceInitializers": true,
+        "superclassNames": [
+          "ObjectiveC.NSObject"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "NSObjectProtocol",
+            "printedName": "NSObjectProtocol",
+            "usr": "c:objc(pl)NSObject"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CVarArg",
+            "printedName": "CVarArg",
+            "usr": "s:s7CVarArgP",
+            "mangledName": "$ss7CVarArgP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomDebugStringConvertible",
+            "printedName": "CustomDebugStringConvertible",
+            "usr": "s:s28CustomDebugStringConvertibleP",
+            "mangledName": "$ss28CustomDebugStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomStringConvertible",
+            "printedName": "CustomStringConvertible",
+            "usr": "s:s23CustomStringConvertibleP",
+            "mangledName": "$ss23CustomStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "Color",
+        "printedName": "Color",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(hex:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:7SwiftUI5ColorV018YouVersionPlatformB0E3hexACSS_tcfc",
+            "mangledName": "$s7SwiftUI5ColorV018YouVersionPlatformB0E3hexACSS_tcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "isFromExtension": true,
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "hexString",
+            "printedName": "hexString",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:7SwiftUI5ColorV018YouVersionPlatformB0E9hexStringSSSgvp",
+            "mangledName": "$s7SwiftUI5ColorV018YouVersionPlatformB0E9hexStringSSSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:7SwiftUI5ColorV018YouVersionPlatformB0E9hexStringSSSgvg",
+                "mangledName": "$s7SwiftUI5ColorV018YouVersionPlatformB0E9hexStringSSSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:7SwiftUI5ColorV",
+        "mangledName": "$s7SwiftUI5ColorV",
+        "moduleName": "SwiftUICore",
+        "intro_Macosx": "10.15",
+        "intro_iOS": "13.0",
+        "intro_tvOS": "13.0",
+        "intro_watchOS": "6.0",
+        "declAttributes": [
+          "Frozen",
+          "OriginallyDefinedIn",
+          "OriginallyDefinedIn",
+          "OriginallyDefinedIn",
+          "OriginallyDefinedIn",
+          "Available",
+          "Available",
+          "Available",
+          "Available"
+        ],
+        "isExternal": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Transferable",
+            "printedName": "Transferable",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Representation",
+                "printedName": "Representation",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Representation",
+                    "printedName": "SwiftUI.Color.Representation",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "OpaqueTypeArchetype",
+                        "printedName": "some CoreTransferable.TransferRepresentation",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "TransferRepresentation",
+                            "printedName": "CoreTransferable.TransferRepresentation",
+                            "usr": "s:16CoreTransferable22TransferRepresentationP"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:16CoreTransferable0B0P",
+            "mangledName": "$s16CoreTransferable0B0P"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomStringConvertible",
+            "printedName": "CustomStringConvertible",
+            "usr": "s:s23CustomStringConvertibleP",
+            "mangledName": "$ss23CustomStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "ShapeStyle",
+            "printedName": "ShapeStyle",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Resolved",
+                "printedName": "Resolved",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Resolved",
+                    "printedName": "SwiftUI.Color.Resolved",
+                    "usr": "s:7SwiftUI5ColorV8ResolvedV"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI10ShapeStyleP",
+            "mangledName": "$s7SwiftUI10ShapeStyleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "View",
+            "printedName": "View",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Body",
+                "printedName": "Body",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Body",
+                    "printedName": "SwiftUI.Color.Body",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Never",
+                        "printedName": "Swift.Never",
+                        "usr": "s:s5NeverO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI4ViewP",
+            "mangledName": "$s7SwiftUI4ViewP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "String",
+        "printedName": "String",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "localized",
+            "printedName": "localized(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:SS20YouVersionPlatformUIE9localizedyS2SFZ",
+            "mangledName": "$sSS20YouVersionPlatformUIE9localizedyS2SFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:SS",
+        "mangledName": "$sSS",
+        "moduleName": "Swift",
+        "declAttributes": [
+          "EagerMove",
+          "Frozen"
+        ],
+        "isExternal": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Transferable",
+            "printedName": "Transferable",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Representation",
+                "printedName": "Representation",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Representation",
+                    "printedName": "Swift.String.Representation",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "OpaqueTypeArchetype",
+                        "printedName": "some CoreTransferable.TransferRepresentation",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "TransferRepresentation",
+                            "printedName": "CoreTransferable.TransferRepresentation",
+                            "usr": "s:16CoreTransferable22TransferRepresentationP"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:16CoreTransferable0B0P",
+            "mangledName": "$s16CoreTransferable0B0P"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BidirectionalCollection",
+            "printedName": "BidirectionalCollection",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Element",
+                "printedName": "Element",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Element",
+                    "printedName": "Swift.String.Element",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Character",
+                        "printedName": "Swift.Character",
+                        "usr": "s:SJ"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "TypeWitness",
+                "name": "Index",
+                "printedName": "Index",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Index",
+                    "printedName": "Swift.String.Index",
+                    "usr": "s:SS5IndexV"
+                  }
+                ]
+              },
+              {
+                "kind": "TypeWitness",
+                "name": "SubSequence",
+                "printedName": "SubSequence",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "SubSequence",
+                    "printedName": "Swift.String.SubSequence",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Substring",
+                        "printedName": "Swift.Substring",
+                        "usr": "s:Ss"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "TypeWitness",
+                "name": "Indices",
+                "printedName": "Indices",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Indices",
+                    "printedName": "Swift.String.Indices",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "DefaultIndices",
+                        "printedName": "Swift.DefaultIndices<Swift.String>",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:SI"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:SK",
+            "mangledName": "$sSK"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CVarArg",
+            "printedName": "CVarArg",
+            "usr": "s:s7CVarArgP",
+            "mangledName": "$ss7CVarArgP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CodingKeyRepresentable",
+            "printedName": "CodingKeyRepresentable",
+            "usr": "s:s22CodingKeyRepresentableP",
+            "mangledName": "$ss22CodingKeyRepresentableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Collection",
+            "printedName": "Collection",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Element",
+                "printedName": "Element",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Element",
+                    "printedName": "Swift.String.Element",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Character",
+                        "printedName": "Swift.Character",
+                        "usr": "s:SJ"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "TypeWitness",
+                "name": "Index",
+                "printedName": "Index",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Index",
+                    "printedName": "Swift.String.Index",
+                    "usr": "s:SS5IndexV"
+                  }
+                ]
+              },
+              {
+                "kind": "TypeWitness",
+                "name": "Iterator",
+                "printedName": "Iterator",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Iterator",
+                    "printedName": "Swift.String.Iterator",
+                    "usr": "s:SS8IteratorV"
+                  }
+                ]
+              },
+              {
+                "kind": "TypeWitness",
+                "name": "SubSequence",
+                "printedName": "SubSequence",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "SubSequence",
+                    "printedName": "Swift.String.SubSequence",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Substring",
+                        "printedName": "Swift.Substring",
+                        "usr": "s:Ss"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "TypeWitness",
+                "name": "Indices",
+                "printedName": "Indices",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Indices",
+                    "printedName": "Swift.String.Indices",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "DefaultIndices",
+                        "printedName": "Swift.DefaultIndices<Swift.String>",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:SI"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:Sl",
+            "mangledName": "$sSl"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Comparable",
+            "printedName": "Comparable",
+            "usr": "s:SL",
+            "mangledName": "$sSL"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomDebugStringConvertible",
+            "printedName": "CustomDebugStringConvertible",
+            "usr": "s:s28CustomDebugStringConvertibleP",
+            "mangledName": "$ss28CustomDebugStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomReflectable",
+            "printedName": "CustomReflectable",
+            "usr": "s:s17CustomReflectableP",
+            "mangledName": "$ss17CustomReflectableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomStringConvertible",
+            "printedName": "CustomStringConvertible",
+            "usr": "s:s23CustomStringConvertibleP",
+            "mangledName": "$ss23CustomStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "ExpressibleByExtendedGraphemeClusterLiteral",
+            "printedName": "ExpressibleByExtendedGraphemeClusterLiteral",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "ExtendedGraphemeClusterLiteralType",
+                "printedName": "ExtendedGraphemeClusterLiteralType",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "ExtendedGraphemeClusterLiteralType",
+                    "printedName": "Swift.String.ExtendedGraphemeClusterLiteralType",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:s43ExpressibleByExtendedGraphemeClusterLiteralP",
+            "mangledName": "$ss43ExpressibleByExtendedGraphemeClusterLiteralP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "ExpressibleByStringInterpolation",
+            "printedName": "ExpressibleByStringInterpolation",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "StringInterpolation",
+                "printedName": "StringInterpolation",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "StringInterpolation",
+                    "printedName": "Swift.String.StringInterpolation",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "DefaultStringInterpolation",
+                        "printedName": "Swift.DefaultStringInterpolation",
+                        "usr": "s:s26DefaultStringInterpolationV"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:s32ExpressibleByStringInterpolationP",
+            "mangledName": "$ss32ExpressibleByStringInterpolationP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "ExpressibleByStringLiteral",
+            "printedName": "ExpressibleByStringLiteral",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "StringLiteralType",
+                "printedName": "StringLiteralType",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "StringLiteralType",
+                    "printedName": "Swift.String.StringLiteralType",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:s26ExpressibleByStringLiteralP",
+            "mangledName": "$ss26ExpressibleByStringLiteralP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "ExpressibleByUnicodeScalarLiteral",
+            "printedName": "ExpressibleByUnicodeScalarLiteral",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "UnicodeScalarLiteralType",
+                "printedName": "UnicodeScalarLiteralType",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "UnicodeScalarLiteralType",
+                    "printedName": "Swift.String.UnicodeScalarLiteralType",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:s33ExpressibleByUnicodeScalarLiteralP",
+            "mangledName": "$ss33ExpressibleByUnicodeScalarLiteralP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "LosslessStringConvertible",
+            "printedName": "LosslessStringConvertible",
+            "usr": "s:s25LosslessStringConvertibleP",
+            "mangledName": "$ss25LosslessStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "MirrorPath",
+            "printedName": "MirrorPath",
+            "usr": "s:s10MirrorPathP",
+            "mangledName": "$ss10MirrorPathP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "RangeReplaceableCollection",
+            "printedName": "RangeReplaceableCollection",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "SubSequence",
+                "printedName": "SubSequence",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "SubSequence",
+                    "printedName": "Swift.String.SubSequence",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Substring",
+                        "printedName": "Swift.Substring",
+                        "usr": "s:Ss"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:Sm",
+            "mangledName": "$sSm"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sequence",
+            "printedName": "Sequence",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Element",
+                "printedName": "Element",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Element",
+                    "printedName": "Swift.String.Element",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Character",
+                        "printedName": "Swift.Character",
+                        "usr": "s:SJ"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "TypeWitness",
+                "name": "Iterator",
+                "printedName": "Iterator",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Iterator",
+                    "printedName": "Swift.String.Iterator",
+                    "usr": "s:SS8IteratorV"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:ST",
+            "mangledName": "$sST"
+          },
+          {
+            "kind": "Conformance",
+            "name": "StringProtocol",
+            "printedName": "StringProtocol",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "UTF8View",
+                "printedName": "UTF8View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UTF8View",
+                    "printedName": "Swift.String.UTF8View",
+                    "usr": "s:SS8UTF8ViewV"
+                  }
+                ]
+              },
+              {
+                "kind": "TypeWitness",
+                "name": "UTF16View",
+                "printedName": "UTF16View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UTF16View",
+                    "printedName": "Swift.String.UTF16View",
+                    "usr": "s:SS9UTF16ViewV"
+                  }
+                ]
+              },
+              {
+                "kind": "TypeWitness",
+                "name": "UnicodeScalarView",
+                "printedName": "UnicodeScalarView",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnicodeScalarView",
+                    "printedName": "Swift.String.UnicodeScalarView",
+                    "usr": "s:SS17UnicodeScalarViewV"
+                  }
+                ]
+              },
+              {
+                "kind": "TypeWitness",
+                "name": "SubSequence",
+                "printedName": "SubSequence",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "SubSequence",
+                    "printedName": "Swift.String.SubSequence",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Substring",
+                        "printedName": "Swift.Substring",
+                        "usr": "s:Ss"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:Sy",
+            "mangledName": "$sSy"
+          },
+          {
+            "kind": "Conformance",
+            "name": "TextOutputStream",
+            "printedName": "TextOutputStream",
+            "usr": "s:s16TextOutputStreamP",
+            "mangledName": "$ss16TextOutputStreamP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "TextOutputStreamable",
+            "printedName": "TextOutputStreamable",
+            "usr": "s:s20TextOutputStreamableP",
+            "mangledName": "$ss20TextOutputStreamableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "View",
+        "printedName": "View",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "if",
+            "printedName": "if(_:transform:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "OpaqueTypeArchetype",
+                "printedName": "some SwiftUI.View",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "View",
+                    "printedName": "SwiftUI.View",
+                    "usr": "s:7SwiftUI4ViewP"
+                  }
+                ]
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(Self) -> Content",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "GenericTypeParam",
+                    "printedName": "Content"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "GenericTypeParam",
+                    "printedName": "Self"
+                  }
+                ],
+                "typeAttributes": [
+                  "noescape"
+                ]
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:7SwiftUI4ViewP018YouVersionPlatformB0E2if_9transformQrSb_qd__xXEtAaBRd__lF",
+            "mangledName": "$s7SwiftUI4ViewP018YouVersionPlatformB0E2if_9transformQrSb_qd__xXEtAaBRd__lF",
+            "moduleName": "YouVersionPlatformUI",
+            "genericSig": "<Self, Content where Self : SwiftUI.View, Content : SwiftUI.View>",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:7SwiftUI4ViewP",
+        "mangledName": "$s7SwiftUI4ViewP",
+        "moduleName": "SwiftUICore",
+        "genericSig": "<Self.Body : SwiftUI.View>",
+        "intro_Macosx": "10.15",
+        "intro_iOS": "13.0",
+        "intro_tvOS": "13.0",
+        "intro_watchOS": "6.0",
+        "declAttributes": [
+          "Preconcurrency",
+          "TypeEraser",
+          "TypeEraser",
+          "OriginallyDefinedIn",
+          "OriginallyDefinedIn",
+          "OriginallyDefinedIn",
+          "OriginallyDefinedIn",
+          "Available",
+          "Available",
+          "Available",
+          "Available",
+          "Custom"
+        ],
+        "isExternal": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "AttributeDynamicLookup",
+        "printedName": "AttributeDynamicLookup",
+        "children": [
+          {
+            "kind": "Subscript",
+            "name": "subscript",
+            "printedName": "subscript(dynamicMember:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "GenericTypeParam",
+                "printedName": "T"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "KeyPath",
+                "printedName": "Swift.KeyPath<YouVersionPlatformUI.BibleTextAttributes, T>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextAttributes",
+                    "printedName": "YouVersionPlatformUI.BibleTextAttributes",
+                    "usr": "s:20YouVersionPlatformUI19BibleTextAttributesV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "GenericTypeParam",
+                    "printedName": "T"
+                  }
+                ],
+                "usr": "s:s7KeyPathC"
+              }
+            ],
+            "declKind": "Subscript",
+            "usr": "s:10Foundation22AttributeDynamicLookupO20YouVersionPlatformUIE13dynamicMemberxs7KeyPathCyAD19BibleTextAttributesVxG_tcAA016AttributedStringK0Rzluip",
+            "mangledName": "$s10Foundation22AttributeDynamicLookupO20YouVersionPlatformUIE13dynamicMemberxs7KeyPathCyAD19BibleTextAttributesVxG_tcAA016AttributedStringK0Rzluip",
+            "moduleName": "YouVersionPlatformUI",
+            "genericSig": "<T where T : Foundation.AttributedStringKey>",
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "GenericTypeParam",
+                    "printedName": "T"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "KeyPath",
+                    "printedName": "Swift.KeyPath<YouVersionPlatformUI.BibleTextAttributes, T>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextAttributes",
+                        "printedName": "YouVersionPlatformUI.BibleTextAttributes",
+                        "usr": "s:20YouVersionPlatformUI19BibleTextAttributesV"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "GenericTypeParam",
+                        "printedName": "T"
+                      }
+                    ],
+                    "usr": "s:s7KeyPathC"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:10Foundation22AttributeDynamicLookupO20YouVersionPlatformUIE13dynamicMemberxs7KeyPathCyAD19BibleTextAttributesVxG_tcAA016AttributedStringK0Rzluig",
+                "mangledName": "$s10Foundation22AttributeDynamicLookupO20YouVersionPlatformUIE13dynamicMemberxs7KeyPathCyAD19BibleTextAttributesVxG_tcAA016AttributedStringK0Rzluig",
+                "moduleName": "YouVersionPlatformUI",
+                "genericSig": "<T where T : Foundation.AttributedStringKey>",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:10Foundation22AttributeDynamicLookupO",
+        "mangledName": "$s10Foundation22AttributeDynamicLookupO",
+        "moduleName": "Foundation",
+        "intro_Macosx": "12",
+        "intro_iOS": "15",
+        "intro_tvOS": "15",
+        "intro_watchOS": "8",
+        "declAttributes": [
+          "Frozen",
+          "DynamicMemberLookup",
+          "Available",
+          "Available",
+          "Available",
+          "Available"
+        ],
+        "isExternal": true,
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "BitwiseCopyable",
+            "printedName": "BitwiseCopyable",
+            "usr": "s:s15BitwiseCopyableP",
+            "mangledName": "$ss15BitwiseCopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      }
+    ],
+    "json_format_version": 8
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.api-baseline/*.json linguist-generated=true

--- a/.github/workflows/api-stability.yml
+++ b/.github/workflows/api-stability.yml
@@ -1,0 +1,26 @@
+name: API Stability
+
+on: [pull_request]
+
+env:
+  XCODE_VERSION: latest-stable
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check public API for breaking changes
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Display Swift version
+        run: swift --version
+
+      - name: Run API stability check
+        run: scripts/check-api-stability.sh check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,30 @@ Tests are in the top-level Tests dir. The tests of YouVersionPlatformCore must r
 
 - Always run `swift test` and SwiftLint on code changes before finalizing work.
 
+## Public API Stability
+
+Source-breaking changes to the SDK's public interface are blocked by a CI job
+(`.github/workflows/api-stability.yml`) that diffs the PR's API surface against
+committed baselines under `.api-baseline/`. Additive changes pass; renames,
+removals, and signature changes fail until the baseline is intentionally
+updated as part of a major version bump.
+
+To verify locally:
+
+```bash
+scripts/check-api-stability.sh check
+```
+
+When a breaking change is intentional (typically as part of a major version
+bump), update the baselines and commit them in the same PR:
+
+```bash
+scripts/check-api-stability.sh update
+```
+
+The baseline files are JSON dumps from `swift-api-digester` covering
+`YouVersionPlatformCore`, `YouVersionPlatformUI`, and `YouVersionPlatformReader`.
+
 ## SwiftLint
 
 In a Linux container, run SwiftLint with SourceKit configured:

--- a/scripts/check-api-stability.sh
+++ b/scripts/check-api-stability.sh
@@ -20,7 +20,7 @@ fi
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BASELINE_DIR="$REPO_ROOT/.api-baseline"
-TARGET_TRIPLE="arm64-apple-macosx15.0"
+TARGET_TRIPLE="$(uname -m)-apple-macosx15.0"
 MODULES=(YouVersionPlatformCore YouVersionPlatformUI YouVersionPlatformReader)
 
 cd "$REPO_ROOT"

--- a/scripts/check-api-stability.sh
+++ b/scripts/check-api-stability.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# Regenerate or verify the public API baselines used to guard against
+# source-breaking changes in the SDK.
+#
+# Usage:
+#   scripts/check-api-stability.sh update   # overwrite baselines in .api-baseline/
+#   scripts/check-api-stability.sh check    # diff current API against baselines; non-zero exit on breakage
+#
+# If no mode is given, defaults to `check`.
+
+set -euo pipefail
+
+MODE="${1:-check}"
+
+if [[ "$MODE" != "update" && "$MODE" != "check" ]]; then
+  echo "usage: $0 [update|check]" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BASELINE_DIR="$REPO_ROOT/.api-baseline"
+TARGET_TRIPLE="arm64-apple-macosx15.0"
+MODULES=(YouVersionPlatformCore YouVersionPlatformUI YouVersionPlatformReader)
+
+cd "$REPO_ROOT"
+
+echo "Building package for API digest..."
+swift build -c release >/dev/null
+
+BIN_PATH="$(swift build -c release --show-bin-path)"
+MODULES_DIR="$BIN_PATH/Modules"
+
+if [[ ! -d "$MODULES_DIR" ]]; then
+  echo "Expected modules directory not found: $MODULES_DIR" >&2
+  exit 1
+fi
+
+dump_module() {
+  local module="$1"
+  local output="$2"
+  xcrun swift-api-digester \
+    -dump-sdk \
+    -avoid-location \
+    -avoid-tool-args \
+    -module "$module" \
+    -I "$MODULES_DIR" \
+    -target "$TARGET_TRIPLE" \
+    -o "$output"
+}
+
+if [[ "$MODE" == "update" ]]; then
+  mkdir -p "$BASELINE_DIR"
+  for module in "${MODULES[@]}"; do
+    echo "Dumping $module -> .api-baseline/$module.json"
+    dump_module "$module" "$BASELINE_DIR/$module.json"
+  done
+  echo
+  echo "Baselines updated. Review the diff and commit the changes."
+  exit 0
+fi
+
+# check mode
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+FAILED_MODULES=()
+
+for module in "${MODULES[@]}"; do
+  baseline="$BASELINE_DIR/$module.json"
+  current="$WORK_DIR/$module.json"
+  diag="$WORK_DIR/$module.diag"
+
+  if [[ ! -f "$baseline" ]]; then
+    echo "Missing baseline for $module at $baseline" >&2
+    echo "Run: scripts/check-api-stability.sh update" >&2
+    exit 1
+  fi
+
+  echo "Checking $module..."
+  dump_module "$module" "$current"
+
+  xcrun swift-api-digester \
+    -diagnose-sdk \
+    -compiler-style-diags \
+    -input-paths "$baseline" \
+    -input-paths "$current" \
+    >"$diag" 2>&1 || true
+
+  if grep -q "^API breakage:" "$diag"; then
+    FAILED_MODULES+=("$module")
+    echo
+    echo "=== Breaking changes detected in $module ==="
+    grep "^API breakage:" "$diag"
+    echo
+  fi
+done
+
+if (( ${#FAILED_MODULES[@]} > 0 )); then
+  echo "API stability check failed for: ${FAILED_MODULES[*]}" >&2
+  echo
+  echo "If these changes are intentional and tied to a major version bump, run:" >&2
+  echo "  scripts/check-api-stability.sh update" >&2
+  echo "then commit the updated baseline files." >&2
+  exit 1
+fi
+
+echo "API stability check passed."

--- a/scripts/check-api-stability.sh
+++ b/scripts/check-api-stability.sh
@@ -65,6 +65,7 @@ WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 FAILED_MODULES=()
+TOTAL_BREAKAGES=0
 
 for module in "${MODULES[@]}"; do
   baseline="$BASELINE_DIR/$module.json"
@@ -87,22 +88,38 @@ for module in "${MODULES[@]}"; do
     -input-paths "$current" \
     >"$diag" 2>&1 || true
 
-  if grep -q "^API breakage:" "$diag"; then
+  filtered="$WORK_DIR/$module.filtered"
+  python3 "$REPO_ROOT/scripts/filter-api-breakages.py" "$diag" "$current" >"$filtered"
+
+  if [[ -s "$filtered" ]]; then
     FAILED_MODULES+=("$module")
+    count="$(wc -l < "$filtered" | tr -d ' ')"
+    TOTAL_BREAKAGES=$((TOTAL_BREAKAGES + count))
     echo
-    echo "=== Breaking changes detected in $module ==="
-    grep "^API breakage:" "$diag"
+    echo "  $module: $count breaking change(s) detected"
+    sed 's/^API breakage: /    - /' "$filtered"
     echo
   fi
 done
 
 if (( ${#FAILED_MODULES[@]} > 0 )); then
-  echo "API stability check failed for: ${FAILED_MODULES[*]}" >&2
-  echo
-  echo "If these changes are intentional and tied to a major version bump, run:" >&2
-  echo "  scripts/check-api-stability.sh update" >&2
-  echo "then commit the updated baseline files." >&2
+  {
+    echo
+    echo "=============================================================="
+    echo " FAILED: public API stability check"
+    echo "=============================================================="
+    echo "$TOTAL_BREAKAGES breaking change(s) across ${#FAILED_MODULES[@]} module(s): ${FAILED_MODULES[*]}"
+    echo
+    echo "If these changes are intentional and tied to a major version bump,"
+    echo "regenerate the baselines and commit them in the same PR:"
+    echo
+    echo "  scripts/check-api-stability.sh update"
+  } >&2
   exit 1
 fi
 
-echo "API stability check passed."
+echo
+echo "=============================================================="
+echo " PASSED: public API stability check"
+echo "=============================================================="
+echo "No breaking changes detected in: ${MODULES[*]}"

--- a/scripts/filter-api-breakages.py
+++ b/scripts/filter-api-breakages.py
@@ -74,48 +74,66 @@ def selector_labels(signature: str) -> list[str]:
     return [part for part in inside.rstrip(":").split(":") if part]
 
 
+def split_owner(signature: str) -> tuple[str | None, str]:
+    """`Foo.bar(x:)` → ('Foo', 'bar(x:)'); `bar(x:)` → (None, 'bar(x:)').
+
+    Owner is everything before the rightmost `.` in the part preceding `(`.
+    Used to ensure a free function and a method on a type with the same base
+    name are not treated as overloads of each other.
+    """
+    head, _, tail = signature.partition("(")
+    if "." in head:
+        owner, name = head.rsplit(".", 1)
+        return owner, f"{name}({tail}"
+    return None, signature
+
+
 def base_name(signature: str) -> str:
     """`Foo.bar(x:)` → `bar`; `bar(x:)` → `bar`."""
-    head = signature.split("(", 1)[0]
-    return head.rsplit(".", 1)[-1]
+    return split_owner(signature)[1].split("(", 1)[0]
 
 
 CALLABLE_KINDS = frozenset({"Function", "Constructor", "Subscript"})
 
 
-def find_callable(node, printed_name: str):
-    """Depth-first search for a callable declaration (func, init, subscript)
-    with the given printedName."""
+def iter_callables_with_owner(node, owner_stack=None):
+    """Yield (callable_node, owner_string_or_None) for every callable in the
+    dump, where owner is the dot-joined chain of enclosing type names.
+
+    The digester uses `kind: "TypeDecl"` for every declared type (struct,
+    class, enum, etc.); the specific declKind matters for human readability
+    but not for owner-chain construction. Any TypeDecl introduces a scope.
+    """
+    if owner_stack is None:
+        owner_stack = []
     if isinstance(node, dict):
-        if node.get("kind") in CALLABLE_KINDS and node.get("printedName") == printed_name:
-            return node
+        kind = node.get("kind")
+        if kind in CALLABLE_KINDS:
+            owner = ".".join(owner_stack) if owner_stack else None
+            yield node, owner
+        if kind == "TypeDecl":
+            type_name = node.get("printedName") or node.get("name") or ""
+            child_stack = owner_stack + [type_name]
+        else:
+            child_stack = owner_stack
         for value in node.values():
-            hit = find_callable(value, printed_name)
-            if hit is not None:
-                return hit
+            yield from iter_callables_with_owner(value, child_stack)
     elif isinstance(node, list):
         for item in node:
-            hit = find_callable(item, printed_name)
-            if hit is not None:
-                return hit
+            yield from iter_callables_with_owner(item, owner_stack)
+
+
+def find_callable_in_owner(current_dump, owner: str | None, printed_name: str):
+    for callable_node, found_owner in iter_callables_with_owner(current_dump):
+        if found_owner == owner and callable_node.get("printedName") == printed_name:
+            return callable_node
     return None
-
-
-def iter_callables(node):
-    """Yield every callable declaration in the dump."""
-    if isinstance(node, dict):
-        if node.get("kind") in CALLABLE_KINDS:
-            yield node
-        for value in node.values():
-            yield from iter_callables(value)
-    elif isinstance(node, list):
-        for item in node:
-            yield from iter_callables(item)
 
 
 def is_benign_param_addition(old_sig: str, new_sig: str, current_dump) -> bool:
     """True when `old_sig` → `new_sig` is a direct rename diagnostic caused
-    only by appending parameters that all have default values."""
+    only by appending parameters that all have default values to the same
+    declaration (same owner, same base name)."""
     if base_name(old_sig) != base_name(new_sig):
         return False
 
@@ -126,8 +144,12 @@ def is_benign_param_addition(old_sig: str, new_sig: str, current_dump) -> bool:
     if new_labels[: len(old_labels)] != old_labels:
         return False
 
-    new_printed_name = new_sig.split(".", 1)[-1] if "." in new_sig.split("(", 1)[0] else new_sig
-    declaration = find_callable(current_dump, new_printed_name)
+    # The digester is inconsistent about whether the right-hand signature
+    # carries the owner prefix. Use the left-hand owner as truth, and look
+    # the new declaration up in that scope only.
+    old_owner, _ = split_owner(old_sig)
+    _, new_local = split_owner(new_sig)
+    declaration = find_callable_in_owner(current_dump, old_owner, new_local)
     if declaration is None:
         return False
 
@@ -142,12 +164,15 @@ def is_benign_param_addition(old_sig: str, new_sig: str, current_dump) -> bool:
 
 def is_benign_removal(old_sig: str, current_dump) -> bool:
     """True when a 'has been removed' diagnostic is covered by a surviving
-    overload whose signature extends the removed one with only defaulted
-    parameters (so existing call sites still compile)."""
+    overload in the same owner whose signature extends the removed one with
+    only defaulted parameters (so existing call sites still compile)."""
+    old_owner, _ = split_owner(old_sig)
     old_base = base_name(old_sig)
     old_labels = selector_labels(old_sig)
 
-    for candidate in iter_callables(current_dump):
+    for candidate, owner in iter_callables_with_owner(current_dump):
+        if owner != old_owner:
+            continue
         if candidate.get("name") != old_base:
             continue
         candidate_labels = selector_labels(candidate.get("printedName", ""))

--- a/scripts/filter-api-breakages.py
+++ b/scripts/filter-api-breakages.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python3
 """Post-filter swift-api-digester diagnostics.
 
-`swift-api-digester` reports "has been renamed" for any change to a function's
-selector, including the source-compatible case of adding a new parameter that
-has a default value. This script removes those false positives by cross-
-referencing the current API dump: a "rename" is silenced only when all of the
-following hold:
+Silences digester "breakages" that are not real source-incompatible changes:
 
-  1. The base function name is unchanged (real renames are kept).
-  2. The old selector's labels are a prefix of the new selector's labels
-     (no reordering or relabeling of existing parameters).
-  3. Every parameter added to the new signature is marked `hasDefaultArg: true`
-     in the current dump (i.e. existing callers still compile).
+  1. Renames caused by adding a parameter with a default value to an existing
+     function (the digester reports "has been renamed to"). Suppressed only
+     when all of these hold:
+       - The base name is unchanged (real renames are kept).
+       - The old selector's labels are a prefix of the new selector's labels.
+       - Every added parameter has `hasDefaultArg: true` in the current dump.
 
-All other diagnostics, including renames with changed base names, removed
-parameters, parameter relabels, and renames where an added parameter has no
-default, pass through unchanged.
+  2. Removals of a callable when a surviving overload covers the same call
+     sites (the digester reports "has been removed" for constructors and
+     subscripts in cases where functions would have been reported as renamed).
+     Suppressed only when the current dump contains a callable with the same
+     base name whose selector extends the removed one with only defaulted
+     parameters.
+
+  3. Conformance diffs against language-synthesized protocols like `Sendable`,
+     `Copyable`, and `Escapable`. These protocols are inferred by the compiler
+     based on a type's structure, so the set a given toolchain emits for a
+     given type can drift between Swift releases even when the library's
+     declarations are unchanged. Library authors don't declare these
+     conformances explicitly, so diffs against them are toolchain noise rather
+     than API changes.
+
+All other diagnostics pass through unchanged.
 
 Usage:
   filter-api-breakages.py <diagnostic-file> <current-dump.json>
@@ -29,9 +39,27 @@ import sys
 
 
 RENAME_PATTERN = re.compile(
-    r"^API breakage:\s+(?:func|var|let|init|subscript)\s+(.+?)\s+"
-    r"has been renamed to\s+(?:func|var|let|init|subscript)\s+(.+)$"
+    r"^API breakage:\s+\w+\s+(.+?)\s+has been renamed to\s+\w+\s+(.+)$"
 )
+
+REMOVAL_PATTERN = re.compile(
+    r"^API breakage:\s+\w+\s+(.+?)\s+has been removed$"
+)
+
+CONFORMANCE_PATTERN = re.compile(
+    r"^API breakage:\s+.+\s+has (?:added|removed) conformance to\s+(\S+)$"
+)
+
+# Protocols the Swift compiler synthesizes conformance to based on a type's
+# structure rather than explicit declaration. The set a toolchain emits shifts
+# between Swift releases, so diffs against these are not real API changes.
+SYNTHESIZED_PROTOCOLS = frozenset({
+    "Sendable",
+    "SendableMetatype",
+    "Copyable",
+    "Escapable",
+    "BitwiseCopyable",
+})
 
 
 def selector_labels(signature: str) -> list[str]:
@@ -52,24 +80,42 @@ def base_name(signature: str) -> str:
     return head.rsplit(".", 1)[-1]
 
 
-def find_function(node, printed_name: str):
-    """Depth-first search for a Function node with the given printedName."""
+CALLABLE_KINDS = frozenset({"Function", "Constructor", "Subscript"})
+
+
+def find_callable(node, printed_name: str):
+    """Depth-first search for a callable declaration (func, init, subscript)
+    with the given printedName."""
     if isinstance(node, dict):
-        if node.get("kind") == "Function" and node.get("printedName") == printed_name:
+        if node.get("kind") in CALLABLE_KINDS and node.get("printedName") == printed_name:
             return node
         for value in node.values():
-            hit = find_function(value, printed_name)
+            hit = find_callable(value, printed_name)
             if hit is not None:
                 return hit
     elif isinstance(node, list):
         for item in node:
-            hit = find_function(item, printed_name)
+            hit = find_callable(item, printed_name)
             if hit is not None:
                 return hit
     return None
 
 
+def iter_callables(node):
+    """Yield every callable declaration in the dump."""
+    if isinstance(node, dict):
+        if node.get("kind") in CALLABLE_KINDS:
+            yield node
+        for value in node.values():
+            yield from iter_callables(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from iter_callables(item)
+
+
 def is_benign_param_addition(old_sig: str, new_sig: str, current_dump) -> bool:
+    """True when `old_sig` → `new_sig` is a direct rename diagnostic caused
+    only by appending parameters that all have default values."""
     if base_name(old_sig) != base_name(new_sig):
         return False
 
@@ -81,17 +127,41 @@ def is_benign_param_addition(old_sig: str, new_sig: str, current_dump) -> bool:
         return False
 
     new_printed_name = new_sig.split(".", 1)[-1] if "." in new_sig.split("(", 1)[0] else new_sig
-    function = find_function(current_dump, new_printed_name)
-    if function is None:
+    declaration = find_callable(current_dump, new_printed_name)
+    if declaration is None:
         return False
 
-    children = function.get("children", [])
+    children = declaration.get("children", [])
     params = children[1:]
     if len(params) != len(new_labels):
         return False
 
     added_params = params[len(old_labels):]
     return all(p.get("hasDefaultArg") is True for p in added_params)
+
+
+def is_benign_removal(old_sig: str, current_dump) -> bool:
+    """True when a 'has been removed' diagnostic is covered by a surviving
+    overload whose signature extends the removed one with only defaulted
+    parameters (so existing call sites still compile)."""
+    old_base = base_name(old_sig)
+    old_labels = selector_labels(old_sig)
+
+    for candidate in iter_callables(current_dump):
+        if candidate.get("name") != old_base:
+            continue
+        candidate_labels = selector_labels(candidate.get("printedName", ""))
+        if len(candidate_labels) <= len(old_labels):
+            continue
+        if candidate_labels[: len(old_labels)] != old_labels:
+            continue
+        params = candidate.get("children", [])[1:]
+        if len(params) != len(candidate_labels):
+            continue
+        added = params[len(old_labels):]
+        if all(p.get("hasDefaultArg") is True for p in added):
+            return True
+    return False
 
 
 def main() -> int:
@@ -111,8 +181,16 @@ def main() -> int:
     for line in lines:
         if not line.startswith("API breakage:"):
             continue
-        match = RENAME_PATTERN.match(line)
-        if match and is_benign_param_addition(match.group(1), match.group(2), current_dump):
+        rename_match = RENAME_PATTERN.match(line)
+        if rename_match and is_benign_param_addition(
+            rename_match.group(1), rename_match.group(2), current_dump
+        ):
+            continue
+        removal_match = REMOVAL_PATTERN.match(line)
+        if removal_match and is_benign_removal(removal_match.group(1), current_dump):
+            continue
+        conformance_match = CONFORMANCE_PATTERN.match(line)
+        if conformance_match and conformance_match.group(1) in SYNTHESIZED_PROTOCOLS:
             continue
         print(line)
 

--- a/scripts/filter-api-breakages.py
+++ b/scripts/filter-api-breakages.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Post-filter swift-api-digester diagnostics.
+
+`swift-api-digester` reports "has been renamed" for any change to a function's
+selector, including the source-compatible case of adding a new parameter that
+has a default value. This script removes those false positives by cross-
+referencing the current API dump: a "rename" is silenced only when all of the
+following hold:
+
+  1. The base function name is unchanged (real renames are kept).
+  2. The old selector's labels are a prefix of the new selector's labels
+     (no reordering or relabeling of existing parameters).
+  3. Every parameter added to the new signature is marked `hasDefaultArg: true`
+     in the current dump (i.e. existing callers still compile).
+
+All other diagnostics, including renames with changed base names, removed
+parameters, parameter relabels, and renames where an added parameter has no
+default, pass through unchanged.
+
+Usage:
+  filter-api-breakages.py <diagnostic-file> <current-dump.json>
+
+Prints the filtered diagnostic lines to stdout. Exit code 0 always.
+"""
+
+import json
+import re
+import sys
+
+
+RENAME_PATTERN = re.compile(
+    r"^API breakage:\s+(?:func|var|let|init|subscript)\s+(.+?)\s+"
+    r"has been renamed to\s+(?:func|var|let|init|subscript)\s+(.+)$"
+)
+
+
+def selector_labels(signature: str) -> list[str]:
+    """Return the argument labels from `foo(a:b:c:)` → ['a', 'b', 'c']. Empty
+    list for `foo()` or bare `foo`."""
+    match = re.search(r"\((.*)\)$", signature)
+    if not match:
+        return []
+    inside = match.group(1)
+    if not inside:
+        return []
+    return [part for part in inside.rstrip(":").split(":") if part]
+
+
+def base_name(signature: str) -> str:
+    """`Foo.bar(x:)` → `bar`; `bar(x:)` → `bar`."""
+    head = signature.split("(", 1)[0]
+    return head.rsplit(".", 1)[-1]
+
+
+def find_function(node, printed_name: str):
+    """Depth-first search for a Function node with the given printedName."""
+    if isinstance(node, dict):
+        if node.get("kind") == "Function" and node.get("printedName") == printed_name:
+            return node
+        for value in node.values():
+            hit = find_function(value, printed_name)
+            if hit is not None:
+                return hit
+    elif isinstance(node, list):
+        for item in node:
+            hit = find_function(item, printed_name)
+            if hit is not None:
+                return hit
+    return None
+
+
+def is_benign_param_addition(old_sig: str, new_sig: str, current_dump) -> bool:
+    if base_name(old_sig) != base_name(new_sig):
+        return False
+
+    old_labels = selector_labels(old_sig)
+    new_labels = selector_labels(new_sig)
+    if len(new_labels) <= len(old_labels):
+        return False
+    if new_labels[: len(old_labels)] != old_labels:
+        return False
+
+    new_printed_name = new_sig.split(".", 1)[-1] if "." in new_sig.split("(", 1)[0] else new_sig
+    function = find_function(current_dump, new_printed_name)
+    if function is None:
+        return False
+
+    children = function.get("children", [])
+    params = children[1:]
+    if len(params) != len(new_labels):
+        return False
+
+    added_params = params[len(old_labels):]
+    return all(p.get("hasDefaultArg") is True for p in added_params)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(
+            "usage: filter-api-breakages.py <diagnostic-file> <current-dump.json>",
+            file=sys.stderr,
+        )
+        return 2
+
+    diag_path, dump_path = sys.argv[1], sys.argv[2]
+    with open(dump_path) as f:
+        current_dump = json.load(f)
+    with open(diag_path) as f:
+        lines = f.read().splitlines()
+
+    for line in lines:
+        if not line.startswith("API breakage:"):
+            continue
+        match = RENAME_PATTERN.match(line)
+        if match and is_benign_param_addition(match.group(1), match.group(2), current_dump):
+            continue
+        print(line)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- New PR check that guards the SDK's public interface against source-breaking changes.
- `scripts/check-api-stability.sh` uses `swift-api-digester` to dump `YouVersionPlatformCore`, `YouVersionPlatformUI`, and `YouVersionPlatformReader`, then diffs against committed baselines under `.api-baseline/`.
- `.github/workflows/api-stability.yml` runs the script on every PR on `macos-26`. Additive changes pass; renames, removals, and signature changes fail.
- To intentionally ship a breaking change as part of a major version bump, run `scripts/check-api-stability.sh update` and commit the refreshed baselines in the same PR. Documented in `AGENTS.md`.

## Test plan
- [ ] Verify the new `API Stability` job appears on this PR and passes (no API changes in this PR).
- [ ] Optional sanity check: push a throwaway commit that renames a public symbol and confirm the job fails with `API breakage:` output, then drop the commit.
- [ ] Verify existing `Unit Tests` and `SwiftLint` jobs still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a public API stability check to guard the SDK's three modules (`YouVersionPlatformCore`, `YouVersionPlatformUI`, `YouVersionPlatformReader`) against source-breaking changes. It introduces a shell script that dumps the current API surface with `swift-api-digester`, diffs it against committed JSON baselines, and pipes results through a Python post-filter that correctly suppresses false positives from synthesized-protocol conformances, defaulted-parameter additions, and `Constructor`/`Subscript` kinds — all of which are well-handled. The one P2 concern is that `|| true` on the `-diagnose-sdk` invocation could silently pass the check if the digester itself crashes rather than finding breakages.

<h3>Confidence Score: 5/5</h3>

Safe to merge; only P2 hardening feedback, no blocking issues.

All findings are P2 style/hardening suggestions. The core logic — building, dumping, diffing, and filtering API diagnostics — is sound and confirmed against the committed baselines. The `|| true` swallowing tool errors is a defensive-programming gap, not a correctness bug under normal operation.

scripts/check-api-stability.sh — the `-diagnose-sdk` error-handling around line 81.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/check-api-stability.sh | New script that builds, dumps, and diffs public API against baselines; one P2: `|| true` on the `-diagnose-sdk` invocation silently passes on tool errors instead of failing loudly. |
| scripts/filter-api-breakages.py | Well-structured post-filter for digester diagnostics; correctly handles Function, Constructor, and Subscript kinds; `children[1:]` correctly skips the return-type child confirmed against live baseline data. |
| .github/workflows/api-stability.yml | New CI workflow that triggers on every PR on `macos-26`; `latest-stable` Xcode and mutable action tags are intentional consistency choices with the rest of the repo (addressed in prior review threads). |
| AGENTS.md | Adds clear documentation on how to run and update the API stability check; no issues. |
| .gitattributes | Marks baseline JSON files as linguist-generated to reduce PR noise; correct and minimal. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR opened] --> B[api-stability.yml triggered]
    B --> C[checkout + setup Xcode]
    C --> D[check-api-stability.sh check]
    D --> E[swift build -c release]
    E --> F{Modules dir exists?}
    F -- No --> G[exit 1 ❌]
    F -- Yes --> H[For each module]
    H --> I[swift-api-digester dump current API]
    I --> J{Baseline exists?}
    J -- No --> G
    J -- Yes --> K[swift-api-digester diagnose-sdk\nbaseline vs current]
    K --> L[filter-api-breakages.py\nremove false positives]
    L --> M{Filtered output\nnon-empty?}
    M -- Yes --> N[Append to FAILED_MODULES]
    N --> H
    M -- No --> H
    H --> O{All modules\nchecked?}
    O -- No --> H
    O -- Yes --> P{Any FAILED_MODULES?}
    P -- Yes --> Q[Print breakage report\nexit 1 ❌]
    P -- No --> R[PASSED ✅]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fcheck-api-stability.sh%3A81-86%0A**%60%7C%7C%20true%60%20silently%20swallows%20tool%20errors%20in%20diagnose%20phase**%0A%0A%60swift-api-digester%20-diagnose-sdk%60%20exits%20non-zero%20both%20when%20it%20finds%20real%20breakages%20*and*%20when%20it%20encounters%20an%20unrecoverable%20error%20%28e.g.%2C%20the%20two%20JSON%20dumps%20are%20structurally%20incompatible%20after%20an%20Xcode%20upgrade%29.%20The%20%60%7C%7C%20true%60%20is%20necessary%20to%20prevent%20%60set%20-e%60%20from%20exiting%20early%20on%20a%20normal%20%22breakages%20found%22%20run%2C%20but%20it%20also%20discards%20genuine%20failure%20signals.%20If%20the%20tool%20crashes%2C%20%60%24diag%60%20will%20contain%20only%20error%20text%20%28no%20%60API%20breakage%3A%60%20lines%29%2C%20the%20Python%20filter%20outputs%20nothing%2C%20%60%24filtered%60%20is%20empty%2C%20and%20the%20job%20silently%20reports%20%22PASSED%22%20when%20it%20should%20be%20failing%20loudly.%0A%0ACapturing%20the%20exit%20code%20separately%20lets%20you%20distinguish%20tool%20errors%20from%20normal%20breakage%20reports%3A%0A%0A%60%60%60bash%0A%20%20xcrun%20swift-api-digester%20%5C%0A%20%20%20%20-diagnose-sdk%20%5C%0A%20%20%20%20-compiler-style-diags%20%5C%0A%20%20%20%20-input-paths%20%22%24baseline%22%20%5C%0A%20%20%20%20-input-paths%20%22%24current%22%20%5C%0A%20%20%20%20%3E%22%24diag%22%202%3E%261%0A%20%20digester_exit%3D%24%3F%0A%20%20%23%20exit%201%20%3D%20breakages%20found%20%28expected%29%3B%20anything%20else%20is%20a%20tool%20error%0A%20%20if%20%5B%5B%20%24digester_exit%20-ne%200%20%26%26%20%24digester_exit%20-ne%201%20%5D%5D%3B%20then%0A%20%20%20%20echo%20%22swift-api-digester%20failed%20with%20exit%20%24digester_exit%20for%20%24module%22%20%3E%262%0A%20%20%20%20cat%20%22%24diag%22%20%3E%262%0A%20%20%20%20exit%201%0A%20%20fi%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=85&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fcheck-api-stability.sh%3A81-86%0A**%60%7C%7C%20true%60%20silently%20swallows%20tool%20errors%20in%20diagnose%20phase**%0A%0A%60swift-api-digester%20-diagnose-sdk%60%20exits%20non-zero%20both%20when%20it%20finds%20real%20breakages%20*and*%20when%20it%20encounters%20an%20unrecoverable%20error%20%28e.g.%2C%20the%20two%20JSON%20dumps%20are%20structurally%20incompatible%20after%20an%20Xcode%20upgrade%29.%20The%20%60%7C%7C%20true%60%20is%20necessary%20to%20prevent%20%60set%20-e%60%20from%20exiting%20early%20on%20a%20normal%20%22breakages%20found%22%20run%2C%20but%20it%20also%20discards%20genuine%20failure%20signals.%20If%20the%20tool%20crashes%2C%20%60%24diag%60%20will%20contain%20only%20error%20text%20%28no%20%60API%20breakage%3A%60%20lines%29%2C%20the%20Python%20filter%20outputs%20nothing%2C%20%60%24filtered%60%20is%20empty%2C%20and%20the%20job%20silently%20reports%20%22PASSED%22%20when%20it%20should%20be%20failing%20loudly.%0A%0ACapturing%20the%20exit%20code%20separately%20lets%20you%20distinguish%20tool%20errors%20from%20normal%20breakage%20reports%3A%0A%0A%60%60%60bash%0A%20%20xcrun%20swift-api-digester%20%5C%0A%20%20%20%20-diagnose-sdk%20%5C%0A%20%20%20%20-compiler-style-diags%20%5C%0A%20%20%20%20-input-paths%20%22%24baseline%22%20%5C%0A%20%20%20%20-input-paths%20%22%24current%22%20%5C%0A%20%20%20%20%3E%22%24diag%22%202%3E%261%0A%20%20digester_exit%3D%24%3F%0A%20%20%23%20exit%201%20%3D%20breakages%20found%20%28expected%29%3B%20anything%20else%20is%20a%20tool%20error%0A%20%20if%20%5B%5B%20%24digester_exit%20-ne%200%20%26%26%20%24digester_exit%20-ne%201%20%5D%5D%3B%20then%0A%20%20%20%20echo%20%22swift-api-digester%20failed%20with%20exit%20%24digester_exit%20for%20%24module%22%20%3E%262%0A%20%20%20%20cat%20%22%24diag%22%20%3E%262%0A%20%20%20%20exit%201%0A%20%20fi%0A%60%60%60%0A%0A&pr=85&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/check-api-stability.sh
Line: 81-86

Comment:
**`|| true` silently swallows tool errors in diagnose phase**

`swift-api-digester -diagnose-sdk` exits non-zero both when it finds real breakages *and* when it encounters an unrecoverable error (e.g., the two JSON dumps are structurally incompatible after an Xcode upgrade). The `|| true` is necessary to prevent `set -e` from exiting early on a normal "breakages found" run, but it also discards genuine failure signals. If the tool crashes, `$diag` will contain only error text (no `API breakage:` lines), the Python filter outputs nothing, `$filtered` is empty, and the job silently reports "PASSED" when it should be failing loudly.

Capturing the exit code separately lets you distinguish tool errors from normal breakage reports:

```bash
  xcrun swift-api-digester \
    -diagnose-sdk \
    -compiler-style-diags \
    -input-paths "$baseline" \
    -input-paths "$current" \
    >"$diag" 2>&1
  digester_exit=$?
  # exit 1 = breakages found (expected); anything else is a tool error
  if [[ $digester_exit -ne 0 && $digester_exit -ne 1 ]]; then
    echo "swift-api-digester failed with exit $digester_exit for $module" >&2
    cat "$diag" >&2
    exit 1
  fi
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["fix one failing test case of the API sta..."](https://github.com/youversion/platform-sdk-swift/commit/00d73d5f8de03987ce1fd3f3d73123a26e69caf3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29522314)</sub>

<!-- /greptile_comment -->