### PR TITLE
refactor: enforce Swift style and clean up dead code

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,14 +2,14 @@ custom_rules:
 
   font_style_syntax: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "" # rule name. optional.
     regex: "(L|l)abel\\.font = StyleGuide\\.FontStyle\\.[^\n]*\\.font" # matching pattern 
     message: "Use label.apply(fontStyle:)" # violation message. optional.
 
   func_set_up: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "" # rule name. optional.
     regex: "func (setup)" # matching pattern 
     capture_group: 1
@@ -17,14 +17,14 @@ custom_rules:
 
   func_name_space: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Function Name Space" # rule name. optional.
     regex: "func [^\\(\\s=<>]+\\s+\\(.*\\)" # matching pattern
     message: "Remove space after function name before parentheses" # violation message. optional.
 
   uicontrol_state_usage: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "UIControl.State() Usage" # rule name. optional.
     regex: "(UIControl.State\\(\\))" # matching pattern 
     capture_group: 1
@@ -32,7 +32,7 @@ custom_rules:
 
   indexpath_casting: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "IndexPath Casting" # rule name. optional.
     regex: "(indexPath as NSIndexPath)" # matching pattern 
     capture_group: 1
@@ -40,7 +40,7 @@ custom_rules:
 
   nullable_singleton: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Nullable Singleton" # rule name. optional.
     regex: "\\.shared\\(\\)(\\?)" # matching pattern 
     capture_group: 1
@@ -48,7 +48,7 @@ custom_rules:
 
   internal_default: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Internal Default" # rule name. optional.
     regex: "(internal )" # matching pattern 
     capture_group: 1
@@ -56,7 +56,7 @@ custom_rules:
 
   commonly_misspelled_words: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Commonly Misspelled Words" # rule name. optional.
     regex: "([aA]naltyics|[pP]redicitive|[sS]eperator|[bB]oarder)" # matching pattern 
     capture_group: 1
@@ -64,7 +64,7 @@ custom_rules:
 
   view_lifecycle_order_1: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 1" # rule name. optional.
     regex: "(viewWillAppear)\\([\\s\\S]*viewDidLoad\\(" # matching pattern 
     capture_group: 1
@@ -72,7 +72,7 @@ custom_rules:
 
   view_lifecycle_order_2: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 2" # rule name. optional.
     regex: "(viewDidAppear)\\([\\s\\S]*viewWillAppear\\(" # matching pattern 
     capture_group: 1
@@ -80,7 +80,7 @@ custom_rules:
 
   view_lifecycle_order_3: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 3" # rule name. optional.
     regex: "(viewWillDisappear)\\([\\s\\S]*viewWillAppear\\(" # matching pattern 
     capture_group: 1
@@ -88,7 +88,7 @@ custom_rules:
 
   view_lifecycle_order_4: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 4" # rule name. optional.
     regex: "(viewDidDisappear)\\([\\s\\S]*viewWillDisappear\\(" # matching pattern 
     capture_group: 1
@@ -96,7 +96,7 @@ custom_rules:
 
   view_lifecycle_order_5: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 5" # rule name. optional.
     regex: "(viewDidDisappear)\\([\\s\\S]*viewDidAppear\\(" # matching pattern 
     capture_group: 1
@@ -104,7 +104,7 @@ custom_rules:
 
   view_lifecycle_order_6: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 6" # rule name. optional.
     regex: "(viewDidAppear)\\([\\s\\S]*viewDidLoad\\(" # matching pattern 
     capture_group: 1
@@ -112,7 +112,7 @@ custom_rules:
 
   view_lifecycle_order_7: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 7" # rule name. optional.
     regex: "(viewDidLoad)\\([\\s\\S]* loadView\\(" # matching pattern 
     capture_group: 1
@@ -120,7 +120,7 @@ custom_rules:
 
   view_lifecycle_order_8: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 8" # rule name. optional.
     regex: "(viewDidLoad)\\([\\s\\S]* init\\(" # matching pattern 
     capture_group: 1
@@ -128,7 +128,7 @@ custom_rules:
 
   view_lifecycle_order_9: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 9" # rule name. optional.
     regex: "(viewWillDisappear)\\([\\s\\S]* viewDidAppear\\(" # matching pattern 
     capture_group: 1
@@ -136,7 +136,7 @@ custom_rules:
 
   view_lifecycle_order_10: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 10" # rule name. optional.
     regex: "(viewDidLayoutSubviews)\\([\\s\\S]* viewWillLayoutSubviews\\(" # matching pattern 
     capture_group: 1
@@ -144,7 +144,7 @@ custom_rules:
 
   view_lifecycle_order_11: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 11" # rule name. optional.
     regex: "(func loadView)\\([\\s\\S]* init\\(" # matching pattern 
     capture_group: 1
@@ -152,7 +152,7 @@ custom_rules:
 
   view_lifecycle_order_12: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 12" # rule name. optional.
     regex: "(viewIsAppearing)\\([\\s\\S]* viewDidLoad\\(" # matching pattern 
     capture_group: 1
@@ -160,7 +160,7 @@ custom_rules:
 
   view_lifecycle_order_13: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 13" # rule name. optional.
     regex: "(viewIsAppearing)\\([\\s\\S]* viewWillAppear\\(" # matching pattern 
     capture_group: 1
@@ -168,7 +168,7 @@ custom_rules:
 
   view_lifecycle_order_14: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 14" # rule name. optional.
     regex: "(viewDidAppear)\\([\\s\\S]* viewIsAppearing\\(" # matching pattern 
     capture_group: 1
@@ -176,7 +176,7 @@ custom_rules:
 
   view_lifecycle_order_15: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 15" # rule name. optional.
     regex: "(viewWillDisappear)\\([\\s\\S]* viewIsAppearing\\(" # matching pattern 
     capture_group: 1
@@ -184,7 +184,7 @@ custom_rules:
 
   view_lifecycle_order_16: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "View Lifecycle Override Order 16" # rule name. optional.
     regex: "(viewDidDisappear)\\([\\s\\S]* viewIsAppearing\\(" # matching pattern 
     capture_group: 1
@@ -192,7 +192,7 @@ custom_rules:
 
   old_constraints_api: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Adding Constraints the Old Way" # rule name. optional.
     regex: "addConstraint[s]{0,1}" # matching pattern 
     match_kinds:
@@ -201,7 +201,7 @@ custom_rules:
 
   init_abuse: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Init Abuse" # rule name. optional.
     regex: "(\\b[A-Z_]\\w*\\b|\\s)(\\.init)\\(" # matching pattern 
     match_kinds:
@@ -211,21 +211,21 @@ custom_rules:
 
   confusing_logic: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Confusing Logic" # rule name. optional.
     regex: "\\?\\? 0 > 0" # matching pattern
     message: "There has to be a better way" # violation message. optional.
 
   extraneous_logic: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Extraneous Logic" # rule name. optional.
     regex: "(\\? true : false|\\? false : true)" # matching pattern
     message: "Use the condition itself" # violation message. optional.
 
   visual_format: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Visual Format Constraints" # rule name. optional.
     regex: "withVisualFormat" # matching pattern
     match_kinds:
@@ -234,7 +234,7 @@ custom_rules:
 
   touch_up_inside: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "TouchUpInside -> PrimaryActionTriggered" # rule name. optional.
     regex: "for: .touchUpInside" # matching pattern
     match_kinds:
@@ -244,7 +244,7 @@ custom_rules:
 
   no_system_font: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "No Direct System Font Use" # rule name. optional.
     regex: "UIFont.(systemFont|boldSystemFont)" # matching pattern
     match_kinds:
@@ -254,7 +254,7 @@ custom_rules:
 
   back_bar_button_item: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Back Bar Button Item" # rule name. optional.
     regex: "backBarButtonItem =" # matching pattern
     match_kinds:
@@ -264,7 +264,7 @@ custom_rules:
 
   system_bar_button_items: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "System Bar Button Item" # rule name. optional.
     regex: "barButtonSystemItem:" # matching pattern
     match_kinds:
@@ -274,7 +274,7 @@ custom_rules:
 
   var_over_func: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Var Over Func" # rule name. optional.
     regex: "[A-Za-z0-9]+\\(\\) ->" # matching pattern
     match_kinds:
@@ -284,7 +284,7 @@ custom_rules:
 
   private_set_syntax: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Private Set Syntax" # rule name. optional.
     regex: "private \\(set\\)" # matching pattern
     match_kinds:
@@ -294,7 +294,7 @@ custom_rules:
 
   author_attribution: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Author Attribution" # rule name. optional.
     regex: "\\/\\/  Created by" # matching pattern
     match_kinds:
@@ -304,7 +304,7 @@ custom_rules:
 
   private_static_syntax: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Private Static Syntax" # rule name. optional.
     regex: "static private" # matching pattern
     match_kinds:
@@ -315,7 +315,7 @@ custom_rules:
 
   notification_name_raw_value: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Notification.Name Raw Value" # rule name. optional.
     regex: "Notification.Name\\((rawValue:)" # matching pattern
     capture_group: 1
@@ -324,7 +324,7 @@ custom_rules:
 
   notification_name_over_nsnotification_name: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Notification > NSNotification" # rule name. optional.
     regex: "(NS)Notification.Name" # matching pattern
     capture_group: 1
@@ -333,7 +333,7 @@ custom_rules:
 
   var_func_blank_line: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Blank Line In Top Of Var/Func" # rule name. optional.
     regex: "(var |func |init\\()[^\\n]*\\{\\n\\s*(\\n)" # matching pattern
     capture_group: 2
@@ -342,7 +342,7 @@ custom_rules:
 
   remove_synchronize: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Synchronize Function is Unnecessary" # rule name. optional.
     regex: "(UserDefaults.standard.synchronize)" # matching pattern
     capture_group: 1
@@ -350,7 +350,7 @@ custom_rules:
 
   image_tinting: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Tinting Image Directly" # rule name. optional.
     regex: "(View\\??\\.image|\\.setImage\\()[^\\n]+?(\\.withTintColor)\\(([^\\n]+|\\))"
     capture_group: 2
@@ -359,7 +359,7 @@ custom_rules:
 
   unnecessary_type_specification: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Unnecessary Type Specification" # rule name. optional.
     regex: "(var|let) \\S+: (Bool|Int|String) = (?!\\{)"
     capture_group: 2
@@ -368,7 +368,7 @@ custom_rules:
 
   else_on_newline: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Else On Newline" # rule name. optional.
     regex: "\\}\\n\\s*(else)" # matching pattern
     capture_group: 1
@@ -377,7 +377,7 @@ custom_rules:
 
   catch_on_newline: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Catch On Newline" # rule name. optional.
     regex: "\\}\\n\\s*(catch) " # matching pattern
     capture_group: 1
@@ -386,7 +386,7 @@ custom_rules:
 
   aspect_ratio_constraint_1: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Aspect Ratio Constraint" # rule name. optional.
     regex: "(\\S+)\\.widthAnchor\\.constraint\\(equalTo: \\1\\.heightAnchor" # matching pattern
     message: "Use UIView.aspectRatioConstraint(withMultiplier:)" # violation message. optional.
@@ -394,7 +394,7 @@ custom_rules:
 
   aspect_ratio_constraint_2: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Aspect Ratio Constraint" # rule name. optional.
     regex: "(\\S+)\\.heightAnchor\\.constraint\\(equalTo: \\1\\.widthAnchor" # matching pattern
     message: "Use UIView.aspectRatioConstraint(withMultiplier:)" # violation message. optional.
@@ -402,7 +402,7 @@ custom_rules:
 
   string_initializer: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Empty String Initializer" # rule name. optional.
     regex: " String\\(\\)" # matching pattern
     message: "Use an empty String literal" # violation message. optional.
@@ -410,7 +410,7 @@ custom_rules:
 
   is_kind_check: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Is Kind Check" # rule name. optional.
     regex: "\\.isKind\\(of:" # matching pattern
     message: "Use 'object is Type'" # violation message. optional.
@@ -418,7 +418,7 @@ custom_rules:
 
   legacy_transformation: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Legacy Transformation" # rule name. optional.
     regex: "(transformedSet|transformedArray)" # matching pattern
     capture_group: 1
@@ -427,7 +427,7 @@ custom_rules:
 
   inline_block: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Inline Block" # rule name. optional.
     regex: "(var|let) \\S+:[^\\n]*->[^\\n]* = \\{" # matching pattern
     message: "Use a local function" # violation message. optional.
@@ -435,7 +435,7 @@ custom_rules:
 
   value_for_key_path: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Value For Key Path" # rule name. optional.
     regex: "(value\\(forKeyPath:)" # matching pattern
     capture_group: 1
@@ -444,7 +444,7 @@ custom_rules:
 
   async_api_design: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Async API Design" # rule name. optional.
     regex: "func (get|request|fetch|load)[^\\n]+? async (throws )?-> [^\\n]+?\\{" # matching pattern
     capture_group: 1
@@ -453,7 +453,7 @@ custom_rules:
 
   attributed_string_keys: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Attributed String Keys" # rule name. optional.
     regex: "(addAttribute\\(NSAttributedString.Key|addAttributes\\(\\[NSAttributedString.Key)" # matching pattern
     capture_group: 1
@@ -462,7 +462,7 @@ custom_rules:
 
   legacy_nsindexpath: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Legacy NSIndexPath" # rule name. optional.
     regex: "(NSIndexPath)" # matching pattern
     capture_group: 1
@@ -471,7 +471,7 @@ custom_rules:
 
   redundant_argument_name: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Redundant Argument Name" # rule name. optional.
     regex: "func [a-zA-Z]+?([a-z]+)\\(([A-Za-z]\\1):" # matching pattern
     capture_group: 2
@@ -480,7 +480,7 @@ custom_rules:
 
   optional_closure_check: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Optional Closure Check" # rule name. optional.
     regex: "if let ([a-zA-Z]+)[\\s]*? \\{\\s+(\\1)\\(\\)" # matching pattern
     capture_group: 2
@@ -489,7 +489,7 @@ custom_rules:
 
   legacy_model_class: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Legacy Model Class" # rule name. optional.
     regex: "(SRBAutomappingModelObject)" # matching pattern
     capture_group: 1
@@ -498,7 +498,7 @@ custom_rules:
 
   common_debug_statements: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Common Debug Statements" # rule name. optional.
     regex: "(Task.sleep|!!!)" # matching pattern
     capture_group: 1
@@ -507,7 +507,7 @@ custom_rules:
 
   swiftui_localization: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "SwiftUI Localization" # rule name. optional.
     regex: "\\W(Text|TextField|SecureField|Button|Label|Toggle|Picker|Menu|confirmationDialog|navigationTitle|navigationBarTitle|alert)\\((NSLocalizedString)" # matching pattern
     capture_group: 2
@@ -516,7 +516,7 @@ custom_rules:
 
   ambiguous_dateformatter: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Ambiguous DateFormatter" # rule name. optional.
     regex: " (DateFormatter\\(\\))" # matching pattern
     capture_group: 1
@@ -525,23 +525,23 @@ custom_rules:
   
   swiftui_fullscreencover: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "SwiftUI sheet view modifier" # rule name. optional.
     regex: "\\.fullScreenCover\\(" # matching pattern
     message: "Please use the yvFullScreenCover view modifier" # violation message. optional.
     severity: error # violation severity. optional.
 
-  no_import_red: # rule identifier
+  snake_case_property: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
-    name: "No Direct RED Import" # rule name. optional.
-    regex: "^\\s*import\\s+RED\\s*$" # matching pattern - matches "import RED" but not "import class RED.iOSDate"
-    message: "Don't import the entire RED module. Use specific imports like 'import class RED.iOSDate' instead." # violation message. optional.
+    name: "Snake Case Property" # rule name. optional.
+    regex: "\\b(let|var)\\s+([a-z][a-z0-9]*_[a-zA-Z0-9_]+)" # matching pattern
+    capture_group: 2
+    message: "Use camelCase for property names. Map to snake_case JSON keys via CodingKeys." # violation message. optional.
     severity: error # violation severity. optional.
 
   reduce_motion_guard: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    excluded: ".*Tests?\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Reduce Motion Guard" # rule name. optional.
     regex: "(withAnimation\\s*\\(\\s*\\.|\\.animation\\s*\\(\\s*\\.|\\.transition\\s*\\(\\s*\\.|Transaction\\s*\\(\\s*animation:\\s*\\.)" # matching pattern - a literal animation (dot-prefixed) passed directly to the call is a hint it's unguarded; guarded forms pass a ternary or derived property.
     capture_group: 1
@@ -603,7 +603,6 @@ opt_in_rules: # some rules are only opt-in
 # included: # paths to include during linting. `--path` is ignored if present.
 #   - Source
 excluded: # paths to ignore during linting. Takes precedence over `included`.
-  - Tests
   - Package.swift
   - Sources/Utilities/ThreadSafeDictionary.swift
   - '**/derived_data'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ Use for large tasks or risky changes (SDK updates, major API adoption):
 5. Run `swiftlint` to ensure code style compliance
 
 ## Important Tips
+- Never commit a real `appKey` to the remote. In `Examples/SampleApp/SampleApp.swift`, keep the tracked placeholder `<#Your App Key#>` and leave your real key as an unstaged local change.
 - Use GitHub to create pull requests (PRs).
 - PR titles should always be the same as the first line of the commit message.
 - Prefer idiomatic, industry standard Swift style. Follow https://www.swift.org/documentation/api-design-guidelines/.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,9 @@ Use for large tasks or risky changes (SDK updates, major API adoption):
 - Use local functions instead of inline closure blocks (`let x: () -> T = { ... }`).
 - Don't unwrap optional closures with `if let` — use `closure?()`.
 - Don't leave commented-out code in place.
+- If a function immediately `guard`s an Optional argument, make the argument non-Optional. The unwrap belongs at the call site, where the precondition stays explicit.
+- Don't build a new array with a `for` loop and `append`. Use `map`, `filter`, `compactMap`, `flatMap`, or `reduce` instead.
+- When awaiting multiple independent async calls, run them concurrently with `async let` (or a task group) rather than serially with back-to-back `await`s.
 
 ### SwiftUI-Specific Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ Use for large tasks or risky changes (SDK updates, major API adoption):
 - Prefer idiomatic, industry standard Swift style. Follow https://www.swift.org/documentation/api-design-guidelines/.
 - Don't make whitespace-only changes.
 - Prefer async-await to completion block-based API design.
-- Async functions with return values should have names that are noun phrases describing the return value rather than verb phrases and should never begin with "get", "load", or "request".
+- Async functions with return values should have names that are noun phrases describing the return value rather than verb phrases and should never begin with "get", "load", "fetch", or "request".
 - Don't add inline comments inside functions, but don't delete existing inline comments.
 - Do add DocC comments to new, non-private functions, but not on SwiftUI initializers and body.
 - Make access controls on properties and functions as strict as they can be (private, fileprivate, private(set), etc).
@@ -121,6 +121,43 @@ Use for large tasks or risky changes (SDK updates, major API adoption):
 - Public-facing types should generally include "YouVersion" in their name (e.g. `YouVersionBigButtonStyle`, `SignInWithYouVersionView`) to disambiguate from client-local types.
 - Class, struct, enum entity names should always be in PascalCase.
 - Property and function names should always be in camelCase.
+- Prefer Swift Concurrency over Combine.
+- Prefer `@Observable` to `ObservableObject`.
+- ALWAYS mark ViewModel types as `@MainActor`.
+- NEVER use locks (NSLock, etc.); prefer actors for isolation.
+- For computed values with no arguments, prefer `var` over `func`.
+- Don't specify `internal` — it's the default.
+- No author attribution comment blocks (`// Created by`).
+- Sort imports alphabetically.
+- `else`/`catch` on the same line as the closing brace (`} else {`, `} catch {`).
+- No blank lines at the top of `var`/`func`/`init` blocks.
+- Always have one blank line between functions.
+- Let the compiler infer types when possible.
+- Use `""` over `String()` for empty strings.
+- Use `private(set)` not `private (set)`.
+- Use `private static` not `static private`.
+- Don't use a comma between logical expressions when `&&` will suffice.
+- Don't override methods or initializers only to call `super`.
+- Do not add a `deinit` solely to remove `NotificationCenter` observers — it's unnecessary.
+- When using `guard`, the `return`/`continue` belongs on a new line.
+- Don't use `guard` in an overridden method to return early.
+- Use existing localized strings if possible; prompt the user before adding new strings.
+- Use Swift Testing for unit tests, not XCTest.
+- NEVER create objects starting with `.init(...)`.
+- Code MUST support iOS 17 but can branch using `if #available(iOS ##.#, *)` checks.
+- Stored properties should be declared before all initializers.
+- Derived properties and functions should be declared after all initializers.
+- Use `Notification.Name("name")` not `Notification.Name(rawValue:)`, and `Notification.Name` not `NSNotification.Name`.
+- Use local functions instead of inline closure blocks (`let x: () -> T = { ... }`).
+- Don't unwrap optional closures with `if let` — use `closure?()`.
+- Don't leave commented-out code in place.
+
+### SwiftUI-Specific Rules
+
+- Mark `@State` properties `private`.
+- Do not use the suffix "Widget" for SwiftUI view names, as it conflicts with iOS home screen widgets (WidgetKit); use a more descriptive name instead.
+- Use Dynamic Type text styles (`.body`, `.callout`, `.footnote`, etc.) instead of `.font(.system(size:))` so fonts adapt to the user's preferred text size.
+- When using `Font.custom`, always include the `relativeTo:` parameter (e.g., `Font.custom("MyFont", size: 16, relativeTo: .callout)`) so custom fonts scale with Dynamic Type.
 
 ## Localization
 

--- a/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
@@ -29,7 +29,7 @@ public extension YouVersionAPI.Bible {
             organizationId: metadata.organizationId,
             bookCodes: metadata.bookCodes,
             books: index.books,
-            textDirection: index.text_direction,
+            textDirection: index.textDirection,
         )
     }
 
@@ -156,7 +156,12 @@ public extension YouVersionAPI.Bible {
     // MARK: - utility structs
 
     private struct BibleVersionIndex: Codable {
-        let text_direction: String?
+        let textDirection: String?
         let books: [BibleBook]?
+
+        enum CodingKeys: String, CodingKey {
+            case textDirection = "text_direction"
+            case books
+        }
     }
 }

--- a/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
@@ -109,7 +109,7 @@ public extension YouVersionAPI.Bible {
             throw URLError(.badURL)
         }
 
-        let request = YouVersionAPI.buildRequest(url: url, accessToken: accessToken, session: session)
+        let request = YouVersionAPI.makeRequest(url: url, accessToken: accessToken, session: session)
         let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {

--- a/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
@@ -49,11 +49,10 @@ public extension YouVersionAPI.Bible {
     ///   - `YouVersionAPIError.cannotDownload` if the server returns an error response.
     ///   - `YouVersionAPIError.invalidResponse` if the server response is not valid.
     static func basicVersion(versionId: Int, accessToken: String?, session: URLSession = .shared) async throws -> BibleVersion {
-        let data = try await YouVersionAPI.commonFetch(
-            url: URLBuilder.versionURL(versionId: versionId),
-            accessToken: accessToken,
-            session: session
-        )
+        guard let url = URLBuilder.versionURL(versionId: versionId) else {
+            throw URLError(.badURL)
+        }
+        let data = try await YouVersionAPI.data(at: url, accessToken: accessToken, session: session)
         let responseObject = try JSONDecoder().decode(BibleVersion.self, from: data)
         return responseObject
     }
@@ -63,11 +62,10 @@ public extension YouVersionAPI.Bible {
             let data: [BibleBook]
         }
 
-        let data = try await YouVersionAPI.commonFetch(
-            url: URLBuilder.versionBooksURL(versionId: versionId),
-            accessToken: accessToken,
-            session: session
-        )
+        guard let url = URLBuilder.versionBooksURL(versionId: versionId) else {
+            throw URLError(.badURL)
+        }
+        let data = try await YouVersionAPI.data(at: url, accessToken: accessToken, session: session)
         let response = try JSONDecoder().decode(BibleVersionBooksResponse.self, from: data)
         return response.data
     }
@@ -77,11 +75,10 @@ public extension YouVersionAPI.Bible {
             let data: [BibleChapter]
         }
 
-        let data = try await YouVersionAPI.commonFetch(
-            url: URLBuilder.versionBookChaptersURL(versionId: versionId, book: book),
-            accessToken: accessToken,
-            session: session
-        )
+        guard let url = URLBuilder.versionBookChaptersURL(versionId: versionId, book: book) else {
+            throw URLError(.badURL)
+        }
+        let data = try await YouVersionAPI.data(at: url, accessToken: accessToken, session: session)
         let response = try JSONDecoder().decode(BibleVersionChaptersResponse.self, from: data)
         return response.data
     }
@@ -91,11 +88,10 @@ public extension YouVersionAPI.Bible {
             let data: [BibleChapter]
         }
 
-        let data = try await YouVersionAPI.commonFetch(
-            url: URLBuilder.versionIndexURL(versionId: versionId),
-            accessToken: accessToken,
-            session: session
-        )
+        guard let url = URLBuilder.versionIndexURL(versionId: versionId) else {
+            throw URLError(.badURL)
+        }
+        let data = try await YouVersionAPI.data(at: url, accessToken: accessToken, session: session)
         let response = try JSONDecoder().decode(BibleVersionIndex.self, from: data)
         return response
     }
@@ -109,7 +105,7 @@ public extension YouVersionAPI.Bible {
             throw URLError(.badURL)
         }
 
-        let request = YouVersionAPI.makeRequest(url: url, accessToken: accessToken, session: session)
+        let request = YouVersionAPI.urlRequest(with: url, accessToken: accessToken, session: session)
         let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -138,12 +134,12 @@ public extension YouVersionAPI.Bible {
     
     /// Fetches the html content of the "intro" (introductory material) for a book from the server.
     static func introMaterial(versionId: Int, passageId: String, accessToken providedToken: String? = nil, session: URLSession = .shared) async throws -> String {
+        guard let url = URLBuilder.passageIntroURL(versionId: versionId, passageId: passageId) else {
+            throw URLError(.badURL)
+        }
+        
         let accessToken = providedToken ?? YouVersionPlatformConfiguration.accessToken
-        let data = try await YouVersionAPI.commonFetch(
-            url: URLBuilder.passageIntroURL(versionId: versionId, passageId: passageId),
-            accessToken: accessToken,
-            session: session
-        )
+        let data = try await YouVersionAPI.data(at: url, accessToken: accessToken, session: session)
         let object = try JSONSerialization.jsonObject(with: data, options: [])
         guard let json = object as? [String: Any],
               let content = json["content"] as? String else {

--- a/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift
@@ -55,7 +55,7 @@ public extension YouVersionAPI.Bible {
             } else {
                 let responseObject = try JSONDecoder().decode(BibleVersionsResponse.self, from: data)
                 allResults.append(contentsOf: responseObject.data)
-                pageToken = responseObject.next_page_token
+                pageToken = responseObject.nextPageToken
                 if responseObject.data.isEmpty {
                     pageToken = nil
                 }
@@ -90,7 +90,11 @@ public extension YouVersionAPI.Bible {
 
     private struct BibleVersionsResponse: Decodable {
         let data: [BibleVersion]
-        let next_page_token: String?
-        let total_size: Int?
+        let nextPageToken: String?
+
+        enum CodingKeys: String, CodingKey {
+            case data
+            case nextPageToken = "next_page_token"
+        }
     }
 }

--- a/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift
@@ -32,7 +32,7 @@ public extension YouVersionAPI.Bible {
                 throw URLError(.badURL)
             }
 
-            let request = YouVersionAPI.buildRequest(url: url, accessToken: accessToken, session: session)
+            let request = YouVersionAPI.makeRequest(url: url, accessToken: accessToken, session: session)
             let (data, response) = try await session.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift
@@ -32,7 +32,7 @@ public extension YouVersionAPI.Bible {
                 throw URLError(.badURL)
             }
 
-            let request = YouVersionAPI.makeRequest(url: url, accessToken: accessToken, session: session)
+            let request = YouVersionAPI.urlRequest(with: url, accessToken: accessToken, session: session)
             let (data, response) = try await session.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
@@ -78,12 +78,11 @@ public extension YouVersionAPI.Bible {
         let accessToken = providedToken ?? YouVersionPlatformConfiguration.accessToken
         let range = languageTag == nil ? [] : [languageTag!]
 
-        let data = try await YouVersionAPI.commonFetch(
-            // pageSize: nil means fetch them all. Permitted since we're only getting two fields.
-            url: URLBuilder.versionsURL(languageRanges: range, fields: ["id", "language_tag"], pageSize: nil),
-            accessToken: accessToken,
-            session: session
-        )
+        // pageSize: nil means fetch them all. Permitted since we're only getting two fields.
+        guard let url = URLBuilder.versionsURL(languageRanges: range, fields: ["id", "language_tag"], pageSize: nil) else {
+            throw URLError(.badURL)
+        }
+        let data = try await YouVersionAPI.data(at: url, accessToken: accessToken, session: session)
         let responseObject = try JSONDecoder().decode(BibleVersionsResponse.self, from: data)
         return responseObject.data.map({ BibleVersionMinimalInfo(id: $0.id, languageTag: $0.languageTag) })
     }

--- a/Sources/YouVersionPlatformCore/APIs/Bible/Highlights.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/Highlights.swift
@@ -40,7 +40,7 @@ public extension YouVersionAPI {
                 color: color.lowercased()
             )
 
-            var request = YouVersionAPI.buildRequest(url: url, accessToken: accessToken, session: session)
+            var request = YouVersionAPI.makeRequest(url: url, accessToken: accessToken, session: session)
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = try JSONEncoder().encode(requestBody)
@@ -83,7 +83,7 @@ public extension YouVersionAPI {
                 throw URLError(.badURL)
             }
 
-            let request = YouVersionAPI.buildRequest(
+            let request = YouVersionAPI.makeRequest(
                 url: url,
                 accessToken: accessToken,
                 session: session,
@@ -150,7 +150,7 @@ public extension YouVersionAPI {
                 color: color.lowercased()
             )
 
-            var request = YouVersionAPI.buildRequest(url: url, accessToken: accessToken, session: session)
+            var request = YouVersionAPI.makeRequest(url: url, accessToken: accessToken, session: session)
             request.httpMethod = "PUT"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = try JSONEncoder().encode(requestBody)
@@ -189,7 +189,7 @@ public extension YouVersionAPI {
             guard let url = URLBuilder.highlightsDeleteURL(bibleId: bibleId, passageId: passageId) else {
                 throw URLError(.badURL)
             }
-            var request = YouVersionAPI.buildRequest(url: url, accessToken: accessToken, session: session)
+            var request = YouVersionAPI.makeRequest(url: url, accessToken: accessToken, session: session)
             request.httpMethod = "DELETE"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 

--- a/Sources/YouVersionPlatformCore/APIs/Bible/Highlights.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/Highlights.swift
@@ -40,7 +40,7 @@ public extension YouVersionAPI {
                 color: color.lowercased()
             )
 
-            var request = YouVersionAPI.makeRequest(url: url, accessToken: accessToken, session: session)
+            var request = YouVersionAPI.urlRequest(with: url, accessToken: accessToken, session: session)
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = try JSONEncoder().encode(requestBody)
@@ -83,8 +83,8 @@ public extension YouVersionAPI {
                 throw URLError(.badURL)
             }
 
-            let request = YouVersionAPI.makeRequest(
-                url: url,
+            let request = YouVersionAPI.urlRequest(
+                with: url,
                 accessToken: accessToken,
                 session: session,
                 cachePolicy: .reloadIgnoringLocalCacheData
@@ -150,7 +150,7 @@ public extension YouVersionAPI {
                 color: color.lowercased()
             )
 
-            var request = YouVersionAPI.makeRequest(url: url, accessToken: accessToken, session: session)
+            var request = YouVersionAPI.urlRequest(with: url, accessToken: accessToken, session: session)
             request.httpMethod = "PUT"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = try JSONEncoder().encode(requestBody)
@@ -189,7 +189,7 @@ public extension YouVersionAPI {
             guard let url = URLBuilder.highlightsDeleteURL(bibleId: bibleId, passageId: passageId) else {
                 throw URLError(.badURL)
             }
-            var request = YouVersionAPI.makeRequest(url: url, accessToken: accessToken, session: session)
+            var request = YouVersionAPI.urlRequest(with: url, accessToken: accessToken, session: session)
             request.httpMethod = "DELETE"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 

--- a/Sources/YouVersionPlatformCore/APIs/Languages/Languages.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Languages/Languages.swift
@@ -99,7 +99,7 @@ public extension YouVersionAPI {
 
                 let responseObject = try JSONDecoder().decode(LanguagesResponse.self, from: data)
                 allResults.append(contentsOf: responseObject.data)
-                pageToken = responseObject.next_page_token
+                pageToken = responseObject.nextPageToken
             } while pageToken != nil
 
             return allResults
@@ -107,8 +107,14 @@ public extension YouVersionAPI {
 
         private struct LanguagesResponse: Decodable {
             let data: [LanguageOverview]
-            let next_page_token: String?
-            let total_size: Int?
+            let nextPageToken: String?
+            let totalSize: Int?
+
+            enum CodingKeys: String, CodingKey {
+                case data
+                case nextPageToken = "next_page_token"
+                case totalSize = "total_size"
+            }
         }
     }
 }

--- a/Sources/YouVersionPlatformCore/APIs/Languages/Languages.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Languages/Languages.swift
@@ -79,7 +79,7 @@ public extension YouVersionAPI {
                     throw URLError(.badURL)
                 }
 
-                let request = YouVersionAPI.buildRequest(url: url, accessToken: accessToken, session: session)
+                let request = YouVersionAPI.makeRequest(url: url, accessToken: accessToken, session: session)
                 let (data, response) = try await session.data(for: request)
 
                 guard let httpResponse = response as? HTTPURLResponse else {

--- a/Sources/YouVersionPlatformCore/APIs/Languages/Languages.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Languages/Languages.swift
@@ -79,7 +79,7 @@ public extension YouVersionAPI {
                     throw URLError(.badURL)
                 }
 
-                let request = YouVersionAPI.makeRequest(url: url, accessToken: accessToken, session: session)
+                let request = YouVersionAPI.urlRequest(with: url, accessToken: accessToken, session: session)
                 let (data, response) = try await session.data(for: request)
 
                 guard let httpResponse = response as? HTTPURLResponse else {

--- a/Sources/YouVersionPlatformCore/APIs/Organizations/Organizations.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Organizations/Organizations.swift
@@ -50,7 +50,7 @@ public extension YouVersionAPI {
             guard let url = URLBuilder.organizationsURL(id: id) else {
                 throw URLError(.badURL)
             }
-            let data = try await YouVersionAPI.commonFetch(url: url, accessToken: nil, session: session)
+            let data = try await YouVersionAPI.data(at: url, accessToken: nil, session: session)
             guard let decodedResponse = try? JSONDecoder().decode(Organization.self, from: data) else {
                 throw URLError(.badServerResponse)
             }

--- a/Sources/YouVersionPlatformCore/APIs/Users/Users.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Users/Users.swift
@@ -192,7 +192,7 @@ public extension YouVersionAPI {
                 "refresh_token": refreshToken
             ])
 
-            var request = YouVersionAPI.makeRequest(url: url, accessToken: nil, session: session)
+            var request = YouVersionAPI.urlRequest(with: url, accessToken: nil, session: session)
             request.httpMethod = "POST"
             request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
             request.httpBody = bodyData

--- a/Sources/YouVersionPlatformCore/APIs/Users/Users.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Users/Users.swift
@@ -192,7 +192,7 @@ public extension YouVersionAPI {
                 "refresh_token": refreshToken
             ])
 
-            var request = YouVersionAPI.buildRequest(url: url, accessToken: nil, session: session)
+            var request = YouVersionAPI.makeRequest(url: url, accessToken: nil, session: session)
             request.httpMethod = "POST"
             request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
             request.httpBody = bodyData

--- a/Sources/YouVersionPlatformCore/APIs/VOTD/VOTD.swift
+++ b/Sources/YouVersionPlatformCore/APIs/VOTD/VOTD.swift
@@ -18,8 +18,11 @@ public extension YouVersionAPI {
         ///   - `URLError.badURL` if the URL could not be constructed.
         ///   - `URLError.badServerResponse` if the server response could not be decoded.
         public static func verseOfTheDay(dayOfYear: Int, accessToken providedToken: String? = nil, session: URLSession = .shared) async throws -> YouVersionVerseOfTheDay {
-            let data = try await YouVersionAPI.commonFetch(
-                url: URLBuilder.votdURL(dayOfYear: dayOfYear),
+            guard let url = URLBuilder.votdURL(dayOfYear: dayOfYear) else {
+                throw URLError(.badURL)
+            }
+            let data = try await YouVersionAPI.data(
+                at: url,
                 accessToken: providedToken ?? YouVersionPlatformConfiguration.accessToken,
                 session: session
             )

--- a/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
@@ -36,12 +36,8 @@ public enum YouVersionAPI {
         return true
     }
 
-    static func commonFetch(url: URL?, accessToken: String?, session: URLSession) async throws -> Data {
-        guard let url else {
-            throw URLError(.badURL)
-        }
-
-        let request = makeRequest(url: url, accessToken: accessToken, session: session)
+    static func data(at url: URL, accessToken: String?, session: URLSession) async throws -> Data {
+        let request = urlRequest(with: url, accessToken: accessToken, session: session)
         let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -61,8 +57,8 @@ public enum YouVersionAPI {
         return data
     }
 
-    static func makeRequest(
-        url: URL,
+    static func urlRequest(
+        with url: URL,
         accessToken: String?,
         session: URLSession,
         cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy

--- a/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
@@ -41,7 +41,7 @@ public enum YouVersionAPI {
             throw URLError(.badURL)
         }
 
-        let request = buildRequest(url: url, accessToken: accessToken, session: session)
+        let request = makeRequest(url: url, accessToken: accessToken, session: session)
         let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -61,7 +61,7 @@ public enum YouVersionAPI {
         return data
     }
 
-    static func buildRequest(
+    static func makeRequest(
         url: URL,
         accessToken: String?,
         session: URLSession,

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -249,8 +249,9 @@ public actor BibleChapterRepository: ObservableObject {
 
     @MainActor
     public func removeVersion(withId versionId: Int) async {
-        await removeChaptersFromMemoryCache(withId: versionId)
-        await diskCache.removeVersion(versionId: versionId)
-        await downloadCache.removeVersion(versionId: versionId)
+        async let memory: Void = removeChaptersFromMemoryCache(withId: versionId)
+        async let disk: Void = diskCache.removeVersion(versionId: versionId)
+        async let download: Void = downloadCache.removeVersion(versionId: versionId)
+        _ = await (memory, disk, download)
     }
 }

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -224,8 +224,7 @@ public actor VersionDownloadCache: BibleVersionCaching {
     }
 
     public func removeUnpermittedVersions(permittedIds: Set<Int>) {
-        let downloads = Self.downloadedVersions
-        for downloadedId in downloads where !permittedIds.contains(downloadedId) {
+        for downloadedId in Self.downloadedVersions where !permittedIds.contains(downloadedId) {
             YouVersionPlatformLogger.notice(
                 "Removing downloaded Bible version \(downloadedId) because it is no longer permitted",
                 category: "VersionCache"
@@ -299,9 +298,11 @@ public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol 
         }
 
         // Otherwise, create a new fetch task
-        let task = Task { [apiClient, diskCache] in
+        let task = Task { [apiClient, diskCache, memoryCache] in
             let version = try await apiClient.version(withId: id)
-            await diskCache.addVersion(version)
+            async let memory: Void = memoryCache.addVersion(version)
+            async let disk: Void = diskCache.addVersion(version)
+            _ = await (memory, disk)
             return version
         }
 
@@ -311,10 +312,7 @@ public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol 
             inFlightTasks[id] = nil
         }
 
-        let version = try await task.value
-        await memoryCache.addVersion(version)
-        await diskCache.addVersion(version)
-        return version
+        return try await task.value
     }
 
     public func versionIsPresent(for id: Int) -> Bool {
@@ -346,14 +344,16 @@ public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol 
     }
 
     public func removeVersion(withId versionId: Int) async {
-        await memoryCache.removeVersion(withId: versionId)
-        await diskCache.removeVersion(withId: versionId)
-        await downloadCache.removeVersion(withId: versionId)
+        async let memory: Void = memoryCache.removeVersion(withId: versionId)
+        async let disk: Void = diskCache.removeVersion(withId: versionId)
+        async let download: Void = downloadCache.removeVersion(withId: versionId)
+        _ = await (memory, disk, download)
     }
 
     public func removeUnpermittedVersions(permittedIds: Set<Int>) async {
-        await memoryCache.removeUnpermittedVersions(permittedIds: permittedIds)
-        await diskCache.removeUnpermittedVersions(permittedIds: permittedIds)
-        await downloadCache.removeUnpermittedVersions(permittedIds: permittedIds)
+        async let memory: Void = memoryCache.removeUnpermittedVersions(permittedIds: permittedIds)
+        async let disk: Void = diskCache.removeUnpermittedVersions(permittedIds: permittedIds)
+        async let download: Void = downloadCache.removeUnpermittedVersions(permittedIds: permittedIds)
+        _ = await (memory, disk, download)
     }
 }

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -10,11 +10,10 @@ public struct BibleReaderView: View {
 #endif
 
     @Environment(\.openURL) private var openURL
-    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    let fontSettingsDetent = PresentationDetent.height(360)
-    let fontListDetent = PresentationDetent.height(480)
+    private let fontSettingsDetent = PresentationDetent.height(360)
+    private let fontListDetent = PresentationDetent.height(480)
     @State private var selectedDetent: PresentationDetent
     @State private var detents: Set<PresentationDetent>
 
@@ -283,7 +282,7 @@ public struct BibleReaderView: View {
     }
 
 #if !os(tvOS)
-    class ContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
+    final class ContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
         func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
 #if canImport(UIKit)
             guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
@@ -300,7 +299,7 @@ public struct BibleReaderView: View {
 #endif
 
     /// Helper to detect scroll offset in ScrollView
-    struct ScrollOffsetPreferenceKey: PreferenceKey {
+    private struct ScrollOffsetPreferenceKey: PreferenceKey {
         typealias Value = CGFloat
         static var defaultValue: Value { .zero }
         static func reduce(value: inout Value, nextValue: () -> Value) {

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -262,7 +262,7 @@ public struct BibleReaderView: View {
                 }
                 .frame(height: 0)
             }
-            .coordinateSpace(name: "scrollView")
+            .coordinateSpace(.named("scrollView"))
             .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
                 Task { @MainActor in
                     viewModel.handleScroll(offset: value)

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift
@@ -112,12 +112,12 @@ public struct BibleReaderBookAndChapterPickerView: View {
                 }
                 .buttonStyle(PlainButtonStyle())
             }
-            ForEach(chapters.indices, id: \.self) { idx in
+            ForEach(Array(chapters.enumerated()), id: \.offset) { idx, label in
                 Button(action: {
                     isPresented = false
                     onSelectionChange?(versionId, bookCode, idx + 1, nil)
                 }) {
-                    chapterListButton(label: chapters[idx])
+                    chapterListButton(label: label)
                 }
                 .buttonStyle(PlainButtonStyle())
             }

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift
@@ -47,22 +47,20 @@ struct BibleReaderDrawer: View {
     }
 
     private var highlightColorButtons: some View {
-        HStack {
-            ForEach(highlightColors, id: \.self) { color in
-                if viewModel.isColorPresentOnAnySelectedVerses(color) {
-                    Button(action: { viewModel.removeVerseColor(color) }) {
-                        coloredCircle(with: color)
-                            .overlay(
-                                Image(systemName: "xmark")
-                            )
-                    }
+        let colorsToRemove = highlightColors.filter(viewModel.isColorPresentOnAnySelectedVerses)
+        let colorsToAdd = highlightColors.filter { !viewModel.isColorPresentOnAllSelectedVerses($0) }
+        return HStack {
+            ForEach(colorsToRemove, id: \.self) { color in
+                Button(action: { viewModel.removeVerseColor(color) }) {
+                    coloredCircle(with: color)
+                        .overlay(
+                            Image(systemName: "xmark")
+                        )
                 }
             }
-            ForEach(highlightColors, id: \.self) { color in
-                if !viewModel.isColorPresentOnAllSelectedVerses(color) {
-                    Button(action: { viewModel.addVerseColor(color) }) {
-                        coloredCircle(with: color)
-                    }
+            ForEach(colorsToAdd, id: \.self) { color in
+                Button(action: { viewModel.addVerseColor(color) }) {
+                    coloredCircle(with: color)
                 }
             }
         }

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift
@@ -31,7 +31,6 @@ struct BibleReaderDrawer: View {
                 .padding(.horizontal, 24)
             }
             .padding(.bottom, 32)
-            //swipeUpLabel  // uncomment this once we support swipe, and have something to show!
         }
         .foregroundStyle(viewModel.readerTextMutedColor)
         .background(viewModel.readerCanvasPrimaryColor)
@@ -107,14 +106,6 @@ struct BibleReaderDrawer: View {
         drawerButton(imageName: "square.on.square", text: .localized("verseActions.copy")) {
             viewModel.handleVerseActionCopy()
         }
-    }
-
-    var swipeUpLabel: some View {
-        HStack {
-            Image(systemName: "chevron.up")
-            Text(String.localized("verseActions.swipeUpLabel"))
-        }
-        .font(YouVersionFonts.fontCaptionsL)
     }
 }
 

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
@@ -4,7 +4,9 @@ import YouVersionPlatformUI
 
 public struct BibleReaderHeaderView: View {
     @Environment(BibleReaderViewModel.self) private var viewModel
+#if canImport(UIKit)
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+#endif
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let showChrome: Bool

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift
@@ -140,7 +140,7 @@ struct BibleReaderFontSettingsView: View {
             Button {
                 viewModel.selectNextLineSpacing()
             } label: {
-                let currentSpacing = viewModel.textOptions.lineSpacing ?? CGFloat(ReaderFonts.lineSpacingOptions.first!)
+                let currentSpacing = viewModel.textOptions.lineSpacing ?? ReaderFonts.lineSpacingOptions.first ?? 6
                 VStack(
                     alignment: .leading,
                     spacing: currentSpacing / 3

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -28,6 +28,41 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     let onVerseTap: ((BibleReference) -> Void)?
     let verseSelectionStyle: VerseSelectionStyle
 
+    // MARK: - UI state of the Reader itself
+    var showChrome = true
+    var lastScrollOffset: CGFloat = 0
+    var scrollToTop = false
+    var isChangingChapter = false
+    var showingSignInSheet = false
+    var showingFontSettings = false
+    var showingFontList = false
+    var showingFootnotes = false
+    var showingIntroFootnoteSheet = false
+    var showingVerseActionsDrawer = false
+    var isReduceMotionEnabled = false
+    var selectedVerses: Set<BibleReference> = []
+    var showingBookPicker = false
+    private var showingChapterPicker = false
+    var headerExpandedBookCode: String?
+    var footnotesToDisplay: [BibleFootnote] = []
+    let readerMaxWidth = CGFloat(700)  // of the reader and the verse action drawer, maybe others
+
+    // MARK: - Font settings
+
+    private var fontFamily: String? = ReaderFonts.defaultFontFamily
+    private var fontSize: CGFloat? = ReaderFonts.defaultFontSize
+    private var lineSpacing = ReaderFonts.defaultLineSpacing
+
+    // MARK: - Colors
+
+    private(set) var colorTheme: ReaderTheme? = ReaderTheme.theme()
+
+    // MARK: - Sign In & Out
+
+    var startSignInFlow = false
+    private(set) var isSignedIn = false
+    var showSignOutConfirmation = false
+
     init(
         reference: BibleReference? = nil,
         highlightsViewModel: BibleHighlightsViewModel? = nil,
@@ -76,15 +111,37 @@ final class BibleReaderViewModel: ReaderThemeProviding {
             }
         }
     }
-    
+
+    var verseActionsDrawerAnimation: Animation {
+        isReduceMotionEnabled ? .easeInOut(duration: 0.2) : .smooth(duration: 0.3)
+    }
+
+    var textOptions: BibleTextOptions {
+        ReaderFonts.installFontsIfNeeded()
+        let ourFontSize = fontSize ?? 18
+        return BibleTextOptions(
+            fontFamily: fontFamily ?? "Georgia",
+            fontSize: ourFontSize,
+            // TODO: maybe have one of these spacings be a delta added to the other:
+            lineSpacing: lineSpacing,
+            paragraphSpacing: lineSpacing,
+            textColor: readerTextPrimaryColor,
+            verseNumColor: readerVerseNumColor,
+            wocColor: readerWordsOfChristColor,
+            footnoteMode: .image,
+            footnoteMarker: nil,
+            verseSelectionStyle: verseSelectionStyle
+        )
+    }
+
     func onVersionChange(version: BibleVersion) {
         self.version = version
-        self.reference = BibleReference(versionId: version.id, bookUSFM: reference.bookUSFM, chapter: reference.chapter)
+        reference = BibleReference(versionId: version.id, bookUSFM: reference.bookUSFM, chapter: reference.chapter)
         Task {
             await onHeaderSelectionChange(reference, showIntro: false)
         }
     }
-    
+
     func onSignInRequired() {
         startSignInFlow = true
     }
@@ -111,67 +168,6 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         if let data = try? JSONEncoder().encode(settings) {
             UserDefaults.standard.set(data, forKey: userDefaultsKeyForReaderSettings)
         }
-    }
-
-    private class ReaderSettings: Codable {
-        let fontFamily: String?
-        let fontSize: CGFloat?
-        let lineSpacing: CGFloat?
-        let colorTheme: Int?
-        init(fontFamily: String?, fontSize: CGFloat?, lineSpacing: CGFloat?, colorTheme: Int?) {
-            self.fontFamily = fontFamily
-            self.fontSize = fontSize
-            self.lineSpacing = lineSpacing
-            self.colorTheme = colorTheme
-        }
-    }
-
-    // MARK: - UI state of the Reader itself
-    var showChrome = true
-    var lastScrollOffset: CGFloat = 0
-    var scrollToTop = false
-    var isChangingChapter = false
-    var showingSignInSheet = false
-    var showingFontSettings = false
-    var showingFontList = false
-    var showingFootnotes = false
-    var showingIntroFootnoteSheet = false
-    var showingVerseActionsDrawer = false
-    var isReduceMotionEnabled = false
-    var verseActionsDrawerAnimation: Animation {
-        isReduceMotionEnabled ? .easeInOut(duration: 0.2) : .smooth(duration: 0.3)
-    }
-    var selectedVerses: Set<BibleReference> = []
-
-    var showingBookPicker = false
-    private var showingChapterPicker = false
-    var headerExpandedBookCode: String?
-    var footnotesToDisplay: [BibleFootnote] = []
-
-    let readerMaxWidth = CGFloat(700)  // of the reader and the verse action drawer, maybe others
-
-    // MARK: - Font settings
-
-    private var fontFamily: String? = ReaderFonts.defaultFontFamily
-    private var fontSize: CGFloat? = ReaderFonts.defaultFontSize
-    private var lineSpacing = ReaderFonts.defaultLineSpacing
-
-    var textOptions: BibleTextOptions {
-        ReaderFonts.installFontsIfNeeded()
-        let ourFontSize = fontSize ?? 18
-        return BibleTextOptions(
-            fontFamily: fontFamily ?? "Georgia",
-            fontSize: ourFontSize,
-            // TODO: maybe have one of these spacings be a delta added to the other:
-            lineSpacing: lineSpacing,
-            paragraphSpacing: lineSpacing,
-            textColor: readerTextPrimaryColor,
-            verseNumColor: readerVerseNumColor,
-            wocColor: readerWordsOfChristColor,
-            footnoteMode: .image,
-            footnoteMarker: nil,
-            verseSelectionStyle: verseSelectionStyle
-        )
     }
 
     func openFontSettings() {
@@ -205,21 +201,11 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         saveUserSettingsToStorage()
     }
 
-    // MARK: Colors
-
-    var colorTheme: ReaderTheme? = ReaderTheme.theme()
-
     func setColorTheme(_ theme: ReaderTheme) {
         colorTheme = theme
         versionsViewModel.colorTheme = theme
         saveUserSettingsToStorage()
     }
-
-    // MARK: - Sign In & Out
-
-    var startSignInFlow = false
-    private(set) var isSignedIn = false
-    var showSignOutConfirmation = false
 
     func updateSignInState() {
         Task {
@@ -245,5 +231,12 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         YouVersionAPI.Users.signOut()
         highlightsViewModel.reset()
         isSignedIn = false
+    }
+
+    private struct ReaderSettings: Codable {
+        let fontFamily: String?
+        let fontSize: CGFloat?
+        let lineSpacing: CGFloat?
+        let colorTheme: Int?
     }
 }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -80,8 +80,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
                 self.showBookIntro = UserDefaults.standard.bool(forKey: userDefaultsKeyForBibleDisplayIntro)
             } else {
                 // no specified or saved version, so, pick a downloaded one, else a safe default.
-                let downloads = VersionDownloadCache.downloadedVersions
-                let versionId = reference?.versionId ?? downloads.first ?? 3034
+                let versionId = reference?.versionId ?? VersionDownloadCache.downloadedVersions.first ?? 3034
                 self.reference = BibleReference(versionId: versionId, bookUSFM: "JHN", chapter: 1)
                 self.showBookIntro = false
             }
@@ -152,7 +151,11 @@ final class BibleReaderViewModel: ReaderThemeProviding {
             // missing or corrupted settings; use the defaults.
             return
         }
-        fontFamily = ReaderFonts.isPermittedFont(savedValue.fontFamily) ? savedValue.fontFamily : ReaderFonts.defaultFontFamily
+        fontFamily = if let savedFamily = savedValue.fontFamily, ReaderFonts.isPermittedFont(savedFamily) {
+            savedFamily
+        } else {
+            ReaderFonts.defaultFontFamily
+        }
         fontSize = savedValue.fontSize ?? ReaderFonts.defaultFontSize
         lineSpacing = savedValue.lineSpacing ?? ReaderFonts.defaultLineSpacing
         colorTheme = ReaderTheme.theme(withId: savedValue.colorTheme)

--- a/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
@@ -86,8 +86,8 @@ public enum ReaderFonts {
 
     // MARK: - Font Sizes and Spacing
 
-    static let availableSizes = [9, 12, 15, 18, 21, 24, 27]
-    static let lineSpacingOptions = [6, 12, 18]
+    static let availableSizes: [CGFloat] = [9, 12, 15, 18, 21, 24, 27]
+    static let lineSpacingOptions: [CGFloat] = [6, 12, 18]
 
     // MARK: - Default Values
 
@@ -98,20 +98,16 @@ public enum ReaderFonts {
     // MARK: - Utility Functions
 
     static func nextSmallerSize(currentSize: CGFloat) -> CGFloat? {
-        let currentSizeInt = Int(currentSize)
-        return availableSizes.filter({ $0 < currentSizeInt }).max().map(CGFloat.init)
+        availableSizes.filter { $0 < currentSize }.max()
     }
 
     static func nextLargerSize(currentSize: CGFloat) -> CGFloat? {
-        let currentSizeInt = Int(currentSize)
-        return availableSizes.filter({ $0 > currentSizeInt }).min().map(CGFloat.init)
+        availableSizes.filter { $0 > currentSize }.min()
     }
 
     static func nextLineSpacing(currentSpacing: CGFloat) -> CGFloat {
-        if let nextBigger = lineSpacingOptions.filter({ CGFloat($0) > currentSpacing }).min() {
-            CGFloat(nextBigger)
-        } else {
-            CGFloat(lineSpacingOptions.min()!)
-        }
+        lineSpacingOptions.filter { $0 > currentSpacing }.min()
+            ?? lineSpacingOptions.min()
+            ?? 6
     }
 }

--- a/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
@@ -77,11 +77,8 @@ public enum ReaderFonts {
         "Trebuchet MS"
     ]
 
-    static func isPermittedFont(_ family: String?) -> Bool {
-        guard let family else {
-            return false
-        }
-        return suggestedFamilies.contains(family) || otherFamilies.contains(family)
+    static func isPermittedFont(_ family: String) -> Bool {
+        suggestedFamilies.contains(family) || otherFamilies.contains(family)
     }
 
     // MARK: - Font Sizes and Spacing

--- a/Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift
+++ b/Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift
@@ -39,16 +39,14 @@ public struct BibleTextFonts {
         verseNumBaselineOffset = baseSize * 0.3
         let boldFamilyName: String
         let italicFamilyName: String
-        //let boldItalicFamilyName: String
+        
         if familyName.hasSuffix("-Regular") {
             let base = familyName.split(separator: "-").dropLast().joined(separator: "-")
             boldFamilyName = base + "-Bold"
             italicFamilyName = base + "-Italic"
-            //boldItalicFamilyName = base + "-BoldItalic"
         } else {
             boldFamilyName = familyName
             italicFamilyName = familyName
-            //boldItalicFamilyName = familyName
         }
 
         let larger = Font.custom(familyName, fixedSize: baseSize * 1.1)

--- a/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
@@ -31,7 +31,7 @@ public struct BibleCardView: View {
     }
     
     private func update(version: BibleVersion) {
-        let updatedReference = referenceForVersionId(version.id)
+        let updatedReference = reference(forVersionId: version.id)
         self.version = version
         reference = updatedReference
         isReferenceUnavailable = !updatedReference.existsIn(version: version)
@@ -134,7 +134,7 @@ public struct BibleCardView: View {
             .frame(width: 106, height: 24)
     }
 
-    private func referenceForVersionId(_ versionId: Int) -> BibleReference {
+    private func reference(forVersionId versionId: Int) -> BibleReference {
         if let verseStart = reference.verseStart {
             let verseEnd = reference.verseEnd ?? verseStart
             if verseStart == verseEnd {

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
@@ -100,11 +100,14 @@ extension BibleTextView {
             let reference: BibleReference? = run.1 // as? BibleReference
             let range = run.2
             var t = AttributedString(string[range])
-            if category == .scripture || category == .verseLabel {
-                t.backgroundColor = highlightFor(reference: reference)
-                // better, we could have our TextRenderer add the color to some portions
+            var isUnderlined = false
+            if let reference {
+                if category == .scripture || category == .verseLabel {
+                    t.backgroundColor = highlightFor(reference: reference)
+                    // better, we could have our TextRenderer add the color to some portions
+                }
+                isUnderlined = isSelected(reference) && category == .scripture
             }
-            let isUnderlined = isSelected(reference) && category == .scripture
             // swiftlint:disable:next shorthand_operator
             textCombo = textCombo + Text(t).customAttribute(RenderHowAttribute(underlined: isUnderlined, footnoteImage: category == .footnoteImage))
         }
@@ -165,10 +168,7 @@ extension BibleTextView {
         .padding()
     }
 
-    private func isSelected(_ reference: BibleReference?) -> Bool {
-        guard let reference else {
-            return false
-        }
+    private func isSelected(_ reference: BibleReference) -> Bool {
         for verse in selectedVerses {
             if verse.chapter == reference.chapter && verse.verseStart == reference.verseStart {
                 return true
@@ -177,10 +177,7 @@ extension BibleTextView {
         return false
     }
 
-    private func highlightFor(reference: BibleReference?) -> Color {
-        guard let reference else {
-            return .clear
-        }
+    private func highlightFor(reference: BibleReference) -> Color {
         for highlight in ourHighlights {
             if highlight.reference.chapter == reference.chapter && highlight.reference.verseStart == reference.verseStart {
                 return Color(hex: highlight.color)

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
@@ -177,18 +177,6 @@ extension BibleTextView {
         return false
     }
 
-    private func highlightFor(reference: BibleReference?) -> Color {
-        guard let reference else {
-            return .clear
-        }
-        for highlight in ourHighlights {
-            if highlight.reference.chapter == reference.chapter && highlight.reference.verseStart == reference.verseStart {
-                return Color(hex: highlight.color)
-            }
-        }
-        return .clear
-    }
-
     // so that the Grid has a Hashable, Identifiable list to work with
     private struct TableCellDoubleString: Hashable, Identifiable {
         let id = UUID()  // for Identifiable

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
@@ -88,7 +88,7 @@ extension BibleTextView {
         var footnoteImage = false
     }
 
-    private func textViewFor(double: BibleAttributedString, firstLineHeadIndent: Int, blockId: UUID, textOptions: BibleTextOptions) -> some View {
+    private func textView(for double: BibleAttributedString, firstLineHeadIndent: Int, blockId: UUID, textOptions: BibleTextOptions) -> some View {
         let string = double.asAttributedString
         // Copy the category from AttributedString-world into Text-world.
         // textCombo is a Text object built up from multiple Text objects,
@@ -124,8 +124,8 @@ extension BibleTextView {
     }
 
     private func emitTextBlock(_ block: BibleTextBlock, textOptions: BibleTextOptions, ignoreMarginTop: Bool) -> some View {
-        textViewFor(
-            double: block.text,
+        textView(
+            for: block.text,
             firstLineHeadIndent: block.firstLineHeadIndent,
             blockId: block.id,
             textOptions: textOptions
@@ -150,8 +150,8 @@ extension BibleTextView {
             ForEach(theRows, id: \.self) { row in
                 GridRow {
                     ForEach(row.doubles, id: \.self) { cell in
-                        textViewFor(
-                            double: cell.double,
+                        textView(
+                            for: cell.double,
                             firstLineHeadIndent: 0,
                             blockId: cell.id,
                             textOptions: textOptions
@@ -175,6 +175,18 @@ extension BibleTextView {
             }
         }
         return false
+    }
+
+    private func highlightFor(reference: BibleReference?) -> Color {
+        guard let reference else {
+            return .clear
+        }
+        for highlight in ourHighlights {
+            if highlight.reference.chapter == reference.chapter && highlight.reference.verseStart == reference.verseStart {
+                return Color(hex: highlight.color)
+            }
+        }
+        return .clear
     }
 
     // so that the Grid has a Hashable, Identifiable list to work with

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
@@ -13,7 +13,8 @@ public struct BibleTextView: View {
     @State private var isVersionRightToLeft = false
     @State private var blocks: [BibleTextBlock]
     @State private var loadingPhase: BibleTextLoadingPhase?
-    @State private var ourHighlights: [BibleHighlight] = []
+    // swiftlint:disable:next private_swiftui_state
+    @State var ourHighlights: [BibleHighlight] = []
     @Binding var selectedVerses: Set<BibleReference>
     @Environment(\.layoutDirection) private var systemLayoutDirection
 
@@ -94,18 +95,6 @@ public struct BibleTextView: View {
         .onChange(of: BibleHighlightsCache.shared.cachedHighlights) { _, _ in
             ourHighlights = BibleHighlightsCache.shared.highlights(overlapping: reference)
         }
-    }
-
-    func highlightFor(reference: BibleReference?) -> Color {
-        guard let reference else {
-            return .clear
-        }
-        for highlight in ourHighlights {
-            if highlight.reference.chapter == reference.chapter && highlight.reference.verseStart == reference.verseStart {
-                return Color(hex: highlight.color)
-            }
-        }
-        return .clear
     }
 
     private func footnotesFor(reference: BibleReference) -> [BibleFootnote] {

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
@@ -13,8 +13,7 @@ public struct BibleTextView: View {
     @State private var isVersionRightToLeft = false
     @State private var blocks: [BibleTextBlock]
     @State private var loadingPhase: BibleTextLoadingPhase?
-    // swiftlint:disable:next private_swiftui_state
-    @State var ourHighlights: [BibleHighlight] = []
+    @State private var ourHighlights: [BibleHighlight] = []
     @Binding var selectedVerses: Set<BibleReference>
     @Environment(\.layoutDirection) private var systemLayoutDirection
 
@@ -85,7 +84,7 @@ public struct BibleTextView: View {
         .task(id: "\(reference)\(textOptions.fontSize)\(textOptions.fontFamily)\(textOptions.textColor ?? .clear)") {
             await loadBlocks()
         }
-        .coordinateSpace(name: "BibleTextView")
+        .coordinateSpace(.named("BibleTextView"))
         .task(id: reference) {
             BibleHighlightsViewModel.shared.ensureHighlightsForChapterLoaded(reference)
         }
@@ -95,6 +94,18 @@ public struct BibleTextView: View {
         .onChange(of: BibleHighlightsCache.shared.cachedHighlights) { _, _ in
             ourHighlights = BibleHighlightsCache.shared.highlights(overlapping: reference)
         }
+    }
+
+    func highlightFor(reference: BibleReference?) -> Color {
+        guard let reference else {
+            return .clear
+        }
+        for highlight in ourHighlights {
+            if highlight.reference.chapter == reference.chapter && highlight.reference.verseStart == reference.verseStart {
+                return Color(hex: highlight.color)
+            }
+        }
+        return .clear
     }
 
     private func footnotesFor(reference: BibleReference) -> [BibleFootnote] {

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
@@ -98,13 +98,7 @@ public struct BibleTextView: View {
     }
 
     private func footnotesFor(reference: BibleReference) -> [BibleFootnote] {
-        var footnotes: [BibleFootnote] = []
-        for block in blocks {
-            for footnote in block.footnotes where footnote.reference == reference {
-                footnotes.append(footnote)
-            }
-        }
-        return footnotes
+        blocks.flatMap(\.footnotes).filter { $0.reference == reference }
     }
 
     private func parseReference(url: URL) -> BibleReference? {

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleTextBlock.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleTextBlock.swift
@@ -8,8 +8,6 @@ public struct BibleTextBlock: Identifiable {
     public let rows: [[BibleAttributedString]]  // If it's a table, these are present instead of "text".
     public let firstLineHeadIndent: Int  // The indentation of the first line of the paragraph. Always >= 0.
     public let headIndent: Int  // The indentation of the paragraph’s lines other than the first. Always >= 0.
-    //let tailIndent: Int  // If positive, this value is the distance from the leading margin (for example,
-    //the left margin in left-to-right text). If 0 or negative, it’s the distance from the trailing margin.
     public let marginTop: CGFloat
     public let alignment: TextAlignment
     public let footnotes: [BibleFootnote]

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift
@@ -624,10 +624,6 @@ public struct BibleTextAttributes: AttributeScope {
     let bibleTextCategory: BibleTextCategoryAttribute
 }
 
-//extension AttributeScopes {
-//    var bibleTextAttributes: BibleTextAttributes.Type { BibleTextAttributes.self }
-//}
-
 // This extension allows our code to say "myString.bibleReference = ..."
 public extension AttributeDynamicLookup {
     subscript<T: AttributedStringKey>(

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift
@@ -12,7 +12,7 @@ public struct BibleVersionPickingButton: View {
         onVersionChange: ((BibleVersion) -> Void)? = nil
     ) {
         self.initialVersionId = initialVersionId
-        self.versionsViewModel = BibleVersionsViewModel { _ in }
+        self._versionsViewModel = State(wrappedValue: BibleVersionsViewModel { _ in })
         self.onVersionChange = onVersionChange
     }
 

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsLanguagesView.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsLanguagesView.swift
@@ -25,7 +25,7 @@ struct BibleVersionsLanguagesView: View {
                     TextField(String.localized("generic.search"), text: $searchText)
                         .textFieldStyle(.plain)
                         .focused($searchFieldIsFocused)
-                        .disableAutocorrection(true)
+                        .autocorrectionDisabled(true)
                         #if os(iOS)
                         .textInputAutocapitalization(.never)
                         #endif

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsMyVersionsListItem.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsMyVersionsListItem.swift
@@ -56,12 +56,7 @@ struct BibleVersionsMyVersionsListItem: View, AbbreviationSplitting {
             }
 
             Spacer()
-            // TEMPORARY
-//            if viewModel.versionRepository.downloadStatus(for: item.id) != .downloaded {
-//                Image(systemName: "cloud")
-//                    .foregroundStyle(viewModel.readerTextMutedColor)
-//                    .padding(.trailing, 8)
-//            }
+
             ellipsisMenuButton
         }
         .contentShape(Rectangle())

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+MyVersions.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+MyVersions.swift
@@ -49,8 +49,6 @@ extension BibleVersionsViewModel {
     public func myVersionRemoveDownloadMenuTapped(_ versionId: Int) {
         Task {
             await versionRepository.removeVersion(withId: versionId)
-            // no need to do the following, as versionRepository handles it:
-            //try await BibleChapterRepository.shared.removeVersion(version: version)
         }
     }
 
@@ -92,8 +90,6 @@ extension BibleVersionsViewModel {
             let versionName = version.localizedTitle ?? version.title ?? .localized("myVersions.defaultVersionName")
             do {
                 try await versionRepository.downloadVersion(withId: version.id)
-                // TEMPORARY removal
-                //try await BibleChapterRepository.shared.download(version: version)
                 showGenericAlert = true
                 textForGenericAlertTitle = .localized("myVersions.downloadCompleteTitle")
                 textForGenericAlertBody = String(format: .localized("myVersions.downloadCompleteBodyFormat"), versionName)

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import YouVersionPlatformCore
 
 extension BibleVersionsViewModel {
-
     public var activeLanguage: String {
         chosenLanguage ?? currentBibleVersionLanguage ?? "en"
     }
@@ -24,12 +23,6 @@ extension BibleVersionsViewModel {
         if versionRepository.downloadStatus(for: id) == .downloaded {
             return .downloaded
         }
-        // TEMPORARY
-//        if let overview = permittedVersions.first(where: { $0.id == id }) {
-//            if overview.downloadable == true {
-//                return .downloadable
-//            }
-//        }
         return .notDownloadable
     }
 
@@ -88,7 +81,7 @@ extension BibleVersionsViewModel {
     }
 
     public func languageTapped() {
-        if permittedVersionsList == nil || permittedVersionsList!.isEmpty {
+        if permittedVersionsList?.isEmpty ?? true {
             showGenericAlert = true
             textForGenericAlertTitle = .localized("generic.error")
             textForGenericAlertBody = .localized("reader.availableLanguagesErrorBody")
@@ -127,5 +120,4 @@ extension BibleVersionsViewModel {
         textForGenericAlertTitle = .localized("generic.error")
         textForGenericAlertBody = .localized("reader.versionAccessErrorBody")
     }
-
 }

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -41,11 +41,12 @@ public final class BibleVersionsViewModel {
         hasLoadedInitialState = true
 
         // Grab the saved data first, because initializing myVersions clears the saved data.
-        let savedIds = UserDefaults.standard.array(forKey: userDefaultsKeyForMyVersions) as? [Int] ?? []
+        let savedIds = Set(UserDefaults.standard.array(forKey: userDefaultsKeyForMyVersions) as? [Int] ?? [])
 
-        await loadVersion(versionId: initialVersionId, savedIds: savedIds)
-        await restoreMyVersions(savedIds: savedIds)
-        await loadSuggestedLanguages()
+        async let version: Void = loadVersion(versionId: initialVersionId, savedIds: savedIds)
+        async let restored: Void = restoreMyVersions(savedIds: savedIds)
+        async let suggested: Void = loadSuggestedLanguages()
+        _ = await (version, restored, suggested)
         await removeUnpermittedVersions(initialVersionId: initialVersionId)
     }
     
@@ -60,11 +61,11 @@ public final class BibleVersionsViewModel {
             myVersions.remove(version)
         }
         if let initialVersionId, !permittedIds.contains(initialVersionId) {
-            await selectFallbackVersion(savedIds: Array(myVersions.map(\.id)))
+            await selectFallbackVersion(savedIds: Set(myVersions.map(\.id)))
         }
     }
     
-    private func restoreMyVersions(savedIds: [Int]) async {
+    private func restoreMyVersions(savedIds: Set<Int>) async {
         for id in savedIds {
             if let version = try? await versionRepository.versionIfCached(id) {
                 myVersions.insert(version)
@@ -72,18 +73,14 @@ public final class BibleVersionsViewModel {
         }
 
         // downloaded versions must also be in MyVersions, otherwise they couldn't be deleted.
-        let downloads = VersionDownloadCache.downloadedVersions
-        for id in downloads {
-            if myVersions.contains(where: { $0.id == id }) {
-                continue
-            }
+        for id in VersionDownloadCache.downloadedVersions where !myVersions.contains(where: { $0.id == id }) {
             if let version = try? await versionRepository.versionIfCached(id) {
                 myVersions.insert(version)
             }
         }
     }
     
-    private func loadVersion(versionId: Int?, savedIds: [Int]) async {
+    private func loadVersion(versionId: Int?, savedIds: Set<Int>) async {
         // Resolve the desired version if possible; otherwise fall back once at the end
         var loadedVersion: BibleVersion?
 
@@ -105,8 +102,8 @@ public final class BibleVersionsViewModel {
         }
     }
     
-    private func selectFallbackVersion(savedIds: [Int]) async {
-        guard let nextBestVersion = await fallbackVersion(from: Set(savedIds)),
+    private func selectFallbackVersion(savedIds: Set<Int>) async {
+        guard let nextBestVersion = await fallbackVersion(savedIds: savedIds),
               let version = try? await versionRepository.version(withId: nextBestVersion)
         else {
             // bring up the UI, let the user choose.
@@ -118,10 +115,21 @@ public final class BibleVersionsViewModel {
         myVersions.insert(version)
     }
     
-    private func fallbackVersion(from savedIds: Set<Int>) async -> Int? {
-        let downloads = VersionDownloadCache.downloadedVersions
-        if !downloads.isEmpty {
-            return downloads.first!
+    /// Picks a Bible version to fall back to when no specific version is selected,
+    /// trying these sources in priority order:
+    /// 1. The first version the user has already downloaded.
+    /// 2. The first of the user's saved versions that is currently permitted.
+    /// 3. The first available English version.
+    /// 4. Any available version.
+    ///
+    /// - Parameter savedIds: IDs of versions the user has previously saved
+    ///   (used as a preference at priority step 2).
+    /// - Returns: A fallback version ID, or `nil` if no version is available
+    ///   (typically because the device is offline).
+    private func fallbackVersion(savedIds: Set<Int>) async -> Int? {
+        let downloadedVersionIds = VersionDownloadCache.downloadedVersions
+        if let downloadedVersionId = downloadedVersionIds.first {
+            return downloadedVersionId
         }
         
         if let versions = try? await YouVersionAPI.Bible.versions() {

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -106,7 +106,7 @@ public final class BibleVersionsViewModel {
     }
     
     private func selectFallbackVersion(savedIds: [Int]) async {
-        guard let nextBestVersion = await findAnyAcceptableVersion(savedIds: Set(savedIds)),
+        guard let nextBestVersion = await anyAcceptableVersion(savedIds: Set(savedIds)),
               let version = try? await versionRepository.version(withId: nextBestVersion)
         else {
             // bring up the UI, let the user choose.
@@ -118,7 +118,7 @@ public final class BibleVersionsViewModel {
         myVersions.insert(version)
     }
     
-    private func findAnyAcceptableVersion(savedIds: Set<Int>) async -> Int? {
+    private func anyAcceptableVersion(savedIds: Set<Int>) async -> Int? {
         let downloads = VersionDownloadCache.downloadedVersions
         if !downloads.isEmpty {
             return downloads.first!

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -106,7 +106,7 @@ public final class BibleVersionsViewModel {
     }
     
     private func selectFallbackVersion(savedIds: [Int]) async {
-        guard let nextBestVersion = await anyAcceptableVersion(savedIds: Set(savedIds)),
+        guard let nextBestVersion = await fallbackVersion(from: Set(savedIds)),
               let version = try? await versionRepository.version(withId: nextBestVersion)
         else {
             // bring up the UI, let the user choose.
@@ -118,7 +118,7 @@ public final class BibleVersionsViewModel {
         myVersions.insert(version)
     }
     
-    private func anyAcceptableVersion(savedIds: Set<Int>) async -> Int? {
+    private func fallbackVersion(from savedIds: Set<Int>) async -> Int? {
         let downloads = VersionDownloadCache.downloadedVersions
         if !downloads.isEmpty {
             return downloads.first!

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -56,29 +56,29 @@ public final class BibleVersionsViewModel {
         let permittedIds = Set(permittedVersions.map(\.id))
         await versionRepository.removeUnpermittedVersions(permittedIds: permittedIds)
         
-        for version in self.myVersions where !permittedIds.contains(version.id) {
-            self.myVersions.remove(version)
+        for version in myVersions where !permittedIds.contains(version.id) {
+            myVersions.remove(version)
         }
         if let initialVersionId, !permittedIds.contains(initialVersionId) {
-            await selectFallbackVersion(savedIds: Array(self.myVersions.map(\.id)))
+            await selectFallbackVersion(savedIds: Array(myVersions.map(\.id)))
         }
     }
     
     private func restoreMyVersions(savedIds: [Int]) async {
         for id in savedIds {
             if let version = try? await versionRepository.versionIfCached(id) {
-                self.myVersions.insert(version)
+                myVersions.insert(version)
             }
         }
-        
+
         // downloaded versions must also be in MyVersions, otherwise they couldn't be deleted.
         let downloads = VersionDownloadCache.downloadedVersions
         for id in downloads {
-            if self.myVersions.contains(where: { $0.id == id }) {
+            if myVersions.contains(where: { $0.id == id }) {
                 continue
             }
             if let version = try? await versionRepository.versionIfCached(id) {
-                self.myVersions.insert(version)
+                myVersions.insert(version)
             }
         }
     }
@@ -98,7 +98,7 @@ public final class BibleVersionsViewModel {
         }
 
         if let version = loadedVersion {
-            self.myVersions.insert(version)
+            myVersions.insert(version)
             onVersionChange(version)
         } else {
             await selectFallbackVersion(savedIds: savedIds)
@@ -114,8 +114,8 @@ public final class BibleVersionsViewModel {
             return
         }
         onVersionChange(version)
-        
-        self.myVersions.insert(version)
+
+        myVersions.insert(version)
     }
     
     private func findAnyAcceptableVersion(savedIds: Set<Int>) async -> Int? {
@@ -152,7 +152,7 @@ public final class BibleVersionsViewModel {
     var versionsInLanguage: [String: [BibleVersion]] = [:]
     
     /// Holds minimal information about all Bible versions available to this app, in all languages.
-    var permittedVersionsList: [YouVersionAPI.Bible.BibleVersionMinimalInfo]?
+    private(set) var permittedVersionsList: [YouVersionAPI.Bible.BibleVersionMinimalInfo]?
     
     /// Returns minimal information about all Bible versions available to this app, in all languages.
     /// On error or when offline, returns nil
@@ -232,7 +232,7 @@ public final class BibleVersionsViewModel {
     
     // MARK: - Languages picking
     
-    var suggestedLanguagesList: [LanguageOverview]
+    private(set) var suggestedLanguagesList: [LanguageOverview]
     var chosenLanguage: String?
     var languageNames: [String: String] = [:]
     
@@ -253,10 +253,10 @@ public final class BibleVersionsViewModel {
     
     /// Returns languages likely to be ones the user will want. Doesn't return any for which we have no Bible versions.
     var suggestedLanguages: [String] {
-        guard !self.suggestedLanguagesList.isEmpty else {
+        guard !suggestedLanguagesList.isEmpty else {
             return ["en", "es"]
         }
-        let codes = extractLanguageCodes(languages: self.suggestedLanguagesList)
+        let codes = extractLanguageCodes(languages: suggestedLanguagesList)
         guard let versionsInfo = permittedVersionsList else {
             return codes
         }

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,0 +1,3 @@
+only_rules:
+  - custom_rules
+  - snake_case_property

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,2 +1,3 @@
 only_rules:
   - custom_rules
+  - snake_case_property

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,3 +1,2 @@
 only_rules:
   - custom_rules
-  - snake_case_property

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests.swift
@@ -76,26 +76,26 @@ func testCompare_SameBookDifferentChapters() {
 
 @Test
 func testCompare_SameChapterDifferentVerses() {
-    let gen1_1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
-    let gen1_2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 2)
-    
-    #expect(gen1_1 < gen1_2)
-    #expect(gen1_2 > gen1_1)
+    let gen1Verse1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+    let gen1Verse2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 2)
+
+    #expect(gen1Verse1 < gen1Verse2)
+    #expect(gen1Verse2 > gen1Verse1)
 }
 
 @Test
 func testCompare_Ranges() {
-    let gen1_1to3 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
-    let gen1_2to4 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 2, verseEnd: 4)
-    
+    let gen1Verses1to3 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
+    let gen1Verses2to4 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 2, verseEnd: 4)
+
     // Compare based on starting verse first
-    #expect(gen1_1to3 < gen1_2to4)
-    
+    #expect(gen1Verses1to3 < gen1Verses2to4)
+
     // Same starting verse, compare end verse
-    let gen1_1to3_2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
-    let gen1_1to4 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 4)
-    
-    #expect(gen1_1to3_2 < gen1_1to4)    // 1-3 < 1-4
+    let gen1Verses1to3Again = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
+    let gen1Verses1to4 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 4)
+
+    #expect(gen1Verses1to3Again < gen1Verses1to4)    // 1-3 < 1-4
 }
 
 @Test

--- a/Tests/YouVersionPlatformCoreTests/HighlightsAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/HighlightsAPITests.swift
@@ -46,7 +46,17 @@ extension URLRequest {
         let (session, token) = HTTPMocking.makeSession()
         defer { HTTPMocking.clear(token: token) }
 
-        struct Body: Decodable { let bible_id: Int; let passage_id: String; let color: String }
+        struct Body: Decodable {
+            let bibleId: Int
+            let passageId: String
+            let color: String
+
+            enum CodingKeys: String, CodingKey {
+                case bibleId = "bible_id"
+                case passageId = "passage_id"
+                case color
+            }
+        }
         var captured: URLRequest?
         var capturedJSONBody: Any?
 
@@ -72,8 +82,8 @@ extension URLRequest {
         let jsonBody = try #require(capturedJSONBody)
         let jsonData = try JSONSerialization.data(withJSONObject: jsonBody)
         let decoded = try JSONDecoder().decode(Body.self, from: jsonData)
-        #expect(decoded.bible_id == 1)
-        #expect(decoded.passage_id == "GEN.1.1")
+        #expect(decoded.bibleId == 1)
+        #expect(decoded.passageId == "GEN.1.1")
         #expect(decoded.color == "ff00ff")
         #expect(result)
     }

--- a/Tests/YouVersionPlatformCoreTests/LanguagesAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/LanguagesAPITests.swift
@@ -41,7 +41,7 @@ import Testing
             )
         ]
 
-        let responseData = try JSONEncoder().encode(LanguagesResponse(data: expectedLanguages, next_page_token: nil, total_size: nil))
+        let responseData = try JSONEncoder().encode(LanguagesResponse(data: expectedLanguages, nextPageToken: nil, totalSize: nil))
         var capturedRequest: URLRequest?
 
         HTTPMocking.setHandler(token: token) { request in
@@ -84,7 +84,7 @@ import Testing
             )
         ]
 
-        let responseData = try JSONEncoder().encode(LanguagesResponse(data: expectedLanguages, next_page_token: nil, total_size: nil))
+        let responseData = try JSONEncoder().encode(LanguagesResponse(data: expectedLanguages, nextPageToken: nil, totalSize: nil))
         var capturedRequest: URLRequest?
 
         HTTPMocking.setHandler(token: token) { request in
@@ -168,7 +168,7 @@ import Testing
         let (session, token) = HTTPMocking.makeSession()
         defer { HTTPMocking.clear(token: token) }
 
-        let emptyResponse = LanguagesResponse(data: [], next_page_token: nil, total_size: nil)
+        let emptyResponse = LanguagesResponse(data: [], nextPageToken: nil, totalSize: nil)
         let responseData = try JSONEncoder().encode(emptyResponse)
 
         HTTPMocking.setHandler(token: token) { request in
@@ -183,7 +183,13 @@ import Testing
     // Helper struct for encoding test responses
     private struct LanguagesResponse: Encodable {
         let data: [LanguageOverview]
-        let next_page_token: String?
-        let total_size: Int?
+        let nextPageToken: String?
+        let totalSize: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case data
+            case nextPageToken = "next_page_token"
+            case totalSize = "total_size"
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Reapplies the Swift style enforcement and dead-code cleanup that was originally landed in #82 and then reverted in 3dc2fd2.
- Adds a follow-up commit with additional Swift / SwiftUI cleanups on top.

## Test plan
- [ ] CI: SwiftLint passes
- [ ] CI: Unit tests pass
- [ ] CI: API Stability check passes (no public API changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR re-applies (and extends) the Swift style enforcement and dead-code cleanup from #82. It renames internal helper functions (`commonFetch` → `data(at:)`, `buildRequest` → `urlRequest(with:)`), promotes sequential `await` chains to concurrent `async let` groups, fixes a double-write to `diskCache` in `BibleVersionRepository`, migrates snake_case stored-property names to camelCase + CodingKeys, removes commented-out dead code, and updates the SwiftLint config to cover the `Tests/` directory with the new `snake_case_property` rule.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are style/cleanup with one genuine bug fix (double disk-cache write); no P0 or P1 issues found.

Thorough review of all 35 changed files found no logic errors or regressions. The concurrent async let changes are correct given @MainActor and actor isolation. The snake_case → CodingKeys migrations are mechanically correct and test-verified. The double-write fix in BibleVersionRepository is a genuine improvement.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift | Fixes a real double-write bug (disk cache was written twice), adds memoryCache to the task capture list, and parallelises all three remove/removeUnpermitted cache operations correctly. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift | loadInitialState now runs three independent async operations concurrently via async let; safe because the class is @MainActor, which serialises all state mutations through the main actor. |
| Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift | commonFetch renamed to data(at:) (now takes a non-optional URL) and buildRequest renamed to urlRequest(with:); all callers updated with guard-let at their own sites. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Stored properties moved before init per style guide, ReaderSettings changed from class to struct, colorTheme tightened to private(set), fontFamily conditional rewritten as a Swift if-expression. |
| .swiftlint.yml | All excluded patterns updated from .*Test\.swift to .*Tests?\.swift; no_import_red replaced by snake_case_property; Tests/ removed from top-level excluded so the Tests/.swiftlint.yml override can control test linting. |
| Tests/.swiftlint.yml | New file; enables only custom_rules + snake_case_property for the test target, as confirmed necessary by the team's empirical testing. |
| Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift | highlightFor and isSelected tightened to non-optional BibleReference; nil guard moved to the call site; no semantic regression. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift | Corrects @State initialisation to use self._versionsViewModel = State(wrappedValue:), which is the proper SwiftUI pattern inside a custom init. |
| Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift | availableSizes and lineSpacingOptions typed as [CGFloat], eliminating Int→CGFloat casts; nextSmallerSize/nextLargerSize/nextLineSpacing simplified; no behaviour change. |
| AGENTS.md | Adds detailed Swift style rules (concurrency, SwiftUI, naming, access control) and a reminder to never commit real app keys. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["version(withId:)"] --> B{Cached?}
    B -- yes --> C[Return cached version]
    B -- no --> D{In-flight task?}
    D -- yes --> E[Await existing task]
    D -- no --> F[Create new Task]
    F --> G["apiClient.version(withId:)"]
    G --> H["async let: memoryCache.addVersion"]
    G --> I["async let: diskCache.addVersion"]
    H & I --> J["await (memory, disk)"]
    J --> K[Return version]
    E --> K
    K --> L[Clear inFlightTasks entry via defer]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.swiftlint.yml`, line 562-563 ([link](https://github.com/youversion/platform-sdk-swift/blob/a2c0fc01ef97785fd3097dcfe3f26fedd9e785a0/.swiftlint.yml#L562-L563)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`snake_case_property` is missing the `excluded` pattern present on every other custom rule**

   Every other custom rule in this file carries `excluded: ".*Tests?\\.swift"`, but the newly added `snake_case_property` rule does not. At the same time, the same PR removes `Tests` from the top-level `excluded:` list, so SwiftLint now lints the `Tests/` directory with `only_rules: [custom_rules]` (via `Tests/.swiftlint.yml`).

   Any test file that still contains a `let`/`var` snake_case declaration not touched by this PR will now trigger an error-severity lint failure and break the SwiftLint CI check.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .swiftlint.yml
   Line: 562-563

   Comment:
   **`snake_case_property` is missing the `excluded` pattern present on every other custom rule**

   Every other custom rule in this file carries `excluded: ".*Tests?\\.swift"`, but the newly added `snake_case_property` rule does not. At the same time, the same PR removes `Tests` from the top-level `excluded:` list, so SwiftLint now lints the `Tests/` directory with `only_rules: [custom_rules]` (via `Tests/.swiftlint.yml`).

   Any test file that still contains a `let`/`var` snake_case declaration not touched by this PR will now trigger an error-severity lint failure and break the SwiftLint CI check.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.swiftlint.yml%0ALine%3A%20562-563%0A%0AComment%3A%0A**%60snake_case_property%60%20is%20missing%20the%20%60excluded%60%20pattern%20present%20on%20every%20other%20custom%20rule**%0A%0AEvery%20other%20custom%20rule%20in%20this%20file%20carries%20%60excluded%3A%20%22.*Tests%3F%5C%5C.swift%22%60%2C%20but%20the%20newly%20added%20%60snake_case_property%60%20rule%20does%20not.%20At%20the%20same%20time%2C%20the%20same%20PR%20removes%20%60Tests%60%20from%20the%20top-level%20%60excluded%3A%60%20list%2C%20so%20SwiftLint%20now%20lints%20the%20%60Tests%2F%60%20directory%20with%20%60only_rules%3A%20%5Bcustom_rules%5D%60%20%28via%20%60Tests%2F.swiftlint.yml%60%29.%0A%0AAny%20test%20file%20that%20still%20contains%20a%20%60let%60%2F%60var%60%20snake_case%20declaration%20not%20touched%20by%20this%20PR%20will%20now%20trigger%20an%20error-severity%20lint%20failure%20and%20break%20the%20SwiftLint%20CI%20check.%0A%0A%60%60%60suggestion%0A%20%20snake_case_property%3A%20%23%20rule%20identifier%0A%20%20%20%20included%3A%20%22.*%5C%5C.swift%22%20%23%20regex%20that%20defines%20paths%20to%20include%20during%20linting.%20optional.%0A%20%20%20%20excluded%3A%20%22.*Tests%3F%5C%5C.swift%22%20%23%20regex%20that%20defines%20paths%20to%20exclude%20during%20linting.%20optional%0A%20%20%20%20name%3A%20%22Snake%20Case%20Property%22%20%23%20rule%20name.%20optional.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=86&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.swiftlint.yml%0ALine%3A%20562-563%0A%0AComment%3A%0A**%60snake_case_property%60%20is%20missing%20the%20%60excluded%60%20pattern%20present%20on%20every%20other%20custom%20rule**%0A%0AEvery%20other%20custom%20rule%20in%20this%20file%20carries%20%60excluded%3A%20%22.*Tests%3F%5C%5C.swift%22%60%2C%20but%20the%20newly%20added%20%60snake_case_property%60%20rule%20does%20not.%20At%20the%20same%20time%2C%20the%20same%20PR%20removes%20%60Tests%60%20from%20the%20top-level%20%60excluded%3A%60%20list%2C%20so%20SwiftLint%20now%20lints%20the%20%60Tests%2F%60%20directory%20with%20%60only_rules%3A%20%5Bcustom_rules%5D%60%20%28via%20%60Tests%2F.swiftlint.yml%60%29.%0A%0AAny%20test%20file%20that%20still%20contains%20a%20%60let%60%2F%60var%60%20snake_case%20declaration%20not%20touched%20by%20this%20PR%20will%20now%20trigger%20an%20error-severity%20lint%20failure%20and%20break%20the%20SwiftLint%20CI%20check.%0A%0A%60%60%60suggestion%0A%20%20snake_case_property%3A%20%23%20rule%20identifier%0A%20%20%20%20included%3A%20%22.*%5C%5C.swift%22%20%23%20regex%20that%20defines%20paths%20to%20include%20during%20linting.%20optional.%0A%20%20%20%20excluded%3A%20%22.*Tests%3F%5C%5C.swift%22%20%23%20regex%20that%20defines%20paths%20to%20exclude%20during%20linting.%20optional%0A%20%20%20%20name%3A%20%22Snake%20Case%20Property%22%20%23%20rule%20name.%20optional.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=86&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["refactor: enforce new naming/structure g..."](https://github.com/youversion/platform-sdk-swift/commit/5fa542f32c92ec819056e3446e816c32ab81ed2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29863585)</sub>

<!-- /greptile_comment -->