### PR TITLE
refactor: make BibleChapterRepository and BibleVersionRepository easily mockable, and add tests

### DIFF
--- a/.api-baseline/YouVersionPlatformCore.json
+++ b/.api-baseline/YouVersionPlatformCore.json
@@ -9306,28 +9306,7 @@
             "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC06removeB06withIdySi_tYaF",
             "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryC06removeB06withIdySi_tYaF",
             "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Custom"
-            ],
             "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "TypeAlias",
-            "name": "ObjectWillChangePublisher",
-            "printedName": "ObjectWillChangePublisher",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "ObservableObjectPublisher",
-                "printedName": "Combine.ObservableObjectPublisher",
-                "usr": "s:7Combine25ObservableObjectPublisherC"
-              }
-            ],
-            "declKind": "TypeAlias",
-            "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC25ObjectWillChangePublishera",
-            "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryC25ObjectWillChangePublishera",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true
           },
           {
             "kind": "Var",
@@ -9391,28 +9370,6 @@
         "moduleName": "YouVersionPlatformCore",
         "hasMissingDesignatedInitializers": true,
         "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "ObservableObject",
-            "printedName": "ObservableObject",
-            "children": [
-              {
-                "kind": "TypeWitness",
-                "name": "ObjectWillChangePublisher",
-                "printedName": "ObjectWillChangePublisher",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "ObservableObjectPublisher",
-                    "printedName": "Combine.ObservableObjectPublisher",
-                    "usr": "s:7Combine25ObservableObjectPublisherC"
-                  }
-                ]
-              }
-            ],
-            "usr": "s:7Combine16ObservableObjectP",
-            "mangledName": "$s7Combine16ObservableObjectP"
-          },
           {
             "kind": "Conformance",
             "name": "Copyable",
@@ -17603,13 +17560,6 @@
         "moduleName": "YouVersionPlatformCore",
         "hasMissingDesignatedInitializers": true,
         "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Observable",
-            "printedName": "Observable",
-            "usr": "s:11Observation10ObservableP",
-            "mangledName": "$s11Observation10ObservableP"
-          },
           {
             "kind": "Conformance",
             "name": "Copyable",

--- a/.api-baseline/YouVersionPlatformCore.json
+++ b/.api-baseline/YouVersionPlatformCore.json
@@ -27,13 +27,6 @@
       },
       {
         "kind": "Import",
-        "name": "SwiftUI",
-        "printedName": "SwiftUI",
-        "declKind": "Import",
-        "moduleName": "YouVersionPlatformCore"
-      },
-      {
-        "kind": "Import",
         "name": "_Concurrency",
         "printedName": "_Concurrency",
         "declKind": "Import",
@@ -12438,24 +12431,6 @@
               "Custom"
             ],
             "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "TypeAlias",
-            "name": "ObjectWillChangePublisher",
-            "printedName": "ObjectWillChangePublisher",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "ObservableObjectPublisher",
-                "printedName": "Combine.ObservableObjectPublisher",
-                "usr": "s:7Combine25ObservableObjectPublisherC"
-              }
-            ],
-            "declKind": "TypeAlias",
-            "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC25ObjectWillChangePublishera",
-            "mangledName": "$s22YouVersionPlatformCore24BibleHighlightsViewModelC25ObjectWillChangePublishera",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true
           }
         ],
         "declKind": "Class",
@@ -12466,28 +12441,6 @@
           "Custom"
         ],
         "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "ObservableObject",
-            "printedName": "ObservableObject",
-            "children": [
-              {
-                "kind": "TypeWitness",
-                "name": "ObjectWillChangePublisher",
-                "printedName": "ObjectWillChangePublisher",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "ObservableObjectPublisher",
-                    "printedName": "Combine.ObservableObjectPublisher",
-                    "usr": "s:7Combine25ObservableObjectPublisherC"
-                  }
-                ]
-              }
-            ],
-            "usr": "s:7Combine16ObservableObjectP",
-            "mangledName": "$s7Combine16ObservableObjectP"
-          },
           {
             "kind": "Conformance",
             "name": "Copyable",

--- a/.api-baseline/YouVersionPlatformCore.json
+++ b/.api-baseline/YouVersionPlatformCore.json
@@ -9188,287 +9188,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "ChapterDiskCache",
-        "printedName": "ChapterDiskCache",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(versionId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC06removeB09versionIdySi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC06removeB09versionIdySi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Var",
-            "name": "unownedExecutor",
-            "printedName": "unownedExecutor",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UnownedSerialExecutor",
-                "printedName": "_Concurrency.UnownedSerialExecutor",
-                "usr": "s:Sce"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevp",
-            "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
-            "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
-              "Available",
-              "Final",
-              "Nonisolated",
-              "Semantics"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UnownedSerialExecutor",
-                    "printedName": "_Concurrency.UnownedSerialExecutor",
-                    "usr": "s:Sce"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevg",
-                "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC",
-        "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC",
-        "moduleName": "YouVersionPlatformCore",
-        "hasMissingDesignatedInitializers": true,
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Actor",
-            "printedName": "Actor",
-            "usr": "s:ScA",
-            "mangledName": "$sScA"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "ChapterDownloadCache",
-        "printedName": "ChapterDownloadCache",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "chaptersArePresent",
-            "printedName": "chaptersArePresent(versionId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC18chaptersArePresent9versionIdSbSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC18chaptersArePresent9versionIdSbSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Nonisolated"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(versionId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC06removeB09versionIdySi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC06removeB09versionIdySi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Var",
-            "name": "unownedExecutor",
-            "printedName": "unownedExecutor",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UnownedSerialExecutor",
-                "printedName": "_Concurrency.UnownedSerialExecutor",
-                "usr": "s:Sce"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevp",
-            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
-            "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
-              "Available",
-              "Final",
-              "Nonisolated",
-              "Semantics"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UnownedSerialExecutor",
-                    "printedName": "_Concurrency.UnownedSerialExecutor",
-                    "usr": "s:Sce"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevg",
-                "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC",
-        "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC",
-        "moduleName": "YouVersionPlatformCore",
-        "hasMissingDesignatedInitializers": true,
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Actor",
-            "printedName": "Actor",
-            "usr": "s:ScA",
-            "mangledName": "$sScA"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "BibleChapterRepository",
         "printedName": "BibleChapterRepository",
         "children": [
@@ -9522,6 +9241,24 @@
                 "accessorKind": "get"
               }
             ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleChapterRepository",
+                "printedName": "YouVersionPlatformCore.BibleChapterRepository",
+                "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Convenience"
           },
           {
             "kind": "Function",
@@ -16945,76 +16682,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "BibleVersionAPIClient",
-        "printedName": "BibleVersionAPIClient",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP7version6withIdAA0eB0VSi_tYaKF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP7version6withIdAA0eB0VSi_tYaKF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionAPIClient>",
-            "protocolReq": true,
-            "throwing": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          }
-        ],
-        "declKind": "Protocol",
-        "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP",
-        "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP",
-        "moduleName": "YouVersionPlatformCore",
-        "genericSig": "<Self : Swift.Sendable>",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "BibleVersionRepositoryProtocol",
         "printedName": "BibleVersionRepositoryProtocol",
         "children": [
@@ -17137,6 +16804,63 @@
             "funcSelfKind": "NonMutating"
           },
           {
+            "kind": "Var",
+            "name": "downloadedVersionIds",
+            "printedName": "downloadedVersionIds",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP010downloadedB3IdsSaySiGvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB18RepositoryProtocolP010downloadedB3IdsSaySiGvp",
+            "moduleName": "YouVersionPlatformCore",
+            "protocolReq": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.Int]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP010downloadedB3IdsSaySiGvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB18RepositoryProtocolP010downloadedB3IdsSaySiGvg",
+                "moduleName": "YouVersionPlatformCore",
+                "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionRepositoryProtocol>",
+                "protocolReq": true,
+                "reqNewWitnessTableEntry": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
             "kind": "Function",
             "name": "removeVersion",
             "printedName": "removeVersion(withId:)",
@@ -17235,1146 +16959,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "BibleVersionCaching",
-        "printedName": "BibleVersionCaching",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "YouVersionPlatformCore.BibleVersion?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "BibleVersion",
-                    "printedName": "YouVersionPlatformCore.BibleVersion",
-                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP7version6withIdAA0eB0VSgSi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP7version6withIdAA0eB0VSgSi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
-            "protocolReq": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "addVersion",
-            "printedName": "addVersion(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP03addB0yyAA0eB0VYaF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP03addB0yyAA0eB0VYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
-            "protocolReq": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP06removeB06withIdySi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP06removeB06withIdySi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
-            "protocolReq": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "versionIsPresent",
-            "printedName": "versionIsPresent(for:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP16versionIsPresent3forSbSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP16versionIsPresent3forSbSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
-            "protocolReq": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeUnpermittedVersions",
-            "printedName": "removeUnpermittedVersions(permittedIds:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Set",
-                "printedName": "Swift.Set<Swift.Int>",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sh"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
-            "protocolReq": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          }
-        ],
-        "declKind": "Protocol",
-        "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
-        "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP",
-        "moduleName": "YouVersionPlatformCore",
-        "genericSig": "<Self : Swift.Sendable>",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "VersionClient",
-        "printedName": "VersionClient",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "VersionClient",
-                "printedName": "YouVersionPlatformCore.VersionClient",
-                "usr": "s:22YouVersionPlatformCore0B6ClientC"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore0B6ClientCACycfc",
-            "mangledName": "$s22YouVersionPlatformCore0B6ClientCACycfc",
-            "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B6ClientC7version6withIdAA05BibleB0VSi_tYaKF",
-            "mangledName": "$s22YouVersionPlatformCore0B6ClientC7version6withIdAA05BibleB0VSi_tYaKF",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Final"
-            ],
-            "throwing": true,
-            "funcSelfKind": "NonMutating"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore0B6ClientC",
-        "mangledName": "$s22YouVersionPlatformCore0B6ClientC",
-        "moduleName": "YouVersionPlatformCore",
-        "declAttributes": [
-          "Final"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "BibleVersionAPIClient",
-            "printedName": "BibleVersionAPIClient",
-            "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "VersionMemoryCache",
-        "printedName": "VersionMemoryCache",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "VersionMemoryCache",
-                "printedName": "YouVersionPlatformCore.VersionMemoryCache",
-                "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheCACycfc",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheCACycfc",
-            "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "YouVersionPlatformCore.BibleVersion?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "BibleVersion",
-                    "printedName": "YouVersionPlatformCore.BibleVersion",
-                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "versionIsPresent",
-            "printedName": "versionIsPresent(for:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC16versionIsPresent3forSbSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC16versionIsPresent3forSbSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Nonisolated"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "addVersion",
-            "printedName": "addVersion(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC03addB0yyAA05BibleB0VYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC03addB0yyAA05BibleB0VYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC06removeB06withIdySi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC06removeB06withIdySi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeUnpermittedVersions",
-            "printedName": "removeUnpermittedVersions(permittedIds:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Set",
-                "printedName": "Swift.Set<Swift.Int>",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sh"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Var",
-            "name": "unownedExecutor",
-            "printedName": "unownedExecutor",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UnownedSerialExecutor",
-                "printedName": "_Concurrency.UnownedSerialExecutor",
-                "usr": "s:Sce"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevp",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
-            "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
-              "Available",
-              "Final",
-              "Nonisolated",
-              "Semantics"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UnownedSerialExecutor",
-                    "printedName": "_Concurrency.UnownedSerialExecutor",
-                    "usr": "s:Sce"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevg",
-                "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC",
-        "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC",
-        "moduleName": "YouVersionPlatformCore",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "BibleVersionCaching",
-            "printedName": "BibleVersionCaching",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Actor",
-            "printedName": "Actor",
-            "usr": "s:ScA",
-            "mangledName": "$sScA"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "VersionDiskCache",
-        "printedName": "VersionDiskCache",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "VersionDiskCache",
-                "printedName": "YouVersionPlatformCore.VersionDiskCache",
-                "usr": "s:22YouVersionPlatformCore0B9DiskCacheC"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheCACycfc",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheCACycfc",
-            "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "YouVersionPlatformCore.BibleVersion?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "BibleVersion",
-                    "printedName": "YouVersionPlatformCore.BibleVersion",
-                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC7version6withIdAA05BibleB0VSgSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC7version6withIdAA05BibleB0VSgSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "versionIsPresent",
-            "printedName": "versionIsPresent(for:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC16versionIsPresent3forSbSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC16versionIsPresent3forSbSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Nonisolated"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "addVersion",
-            "printedName": "addVersion(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC03addB0yyAA05BibleB0VYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC03addB0yyAA05BibleB0VYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC06removeB06withIdySi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC06removeB06withIdySi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeUnpermittedVersions",
-            "printedName": "removeUnpermittedVersions(permittedIds:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Set",
-                "printedName": "Swift.Set<Swift.Int>",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sh"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Var",
-            "name": "unownedExecutor",
-            "printedName": "unownedExecutor",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UnownedSerialExecutor",
-                "printedName": "_Concurrency.UnownedSerialExecutor",
-                "usr": "s:Sce"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevp",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
-            "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
-              "Available",
-              "Final",
-              "Nonisolated",
-              "Semantics"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UnownedSerialExecutor",
-                    "printedName": "_Concurrency.UnownedSerialExecutor",
-                    "usr": "s:Sce"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevg",
-                "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore0B9DiskCacheC",
-        "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC",
-        "moduleName": "YouVersionPlatformCore",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "BibleVersionCaching",
-            "printedName": "BibleVersionCaching",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Actor",
-            "printedName": "Actor",
-            "usr": "s:ScA",
-            "mangledName": "$sScA"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "VersionDownloadCache",
-        "printedName": "VersionDownloadCache",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "VersionDownloadCache",
-                "printedName": "YouVersionPlatformCore.VersionDownloadCache",
-                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheCACycfc",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheCACycfc",
-            "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Function",
-            "name": "versionIsPresent",
-            "printedName": "versionIsPresent(for:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC16versionIsPresent3forSbSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC16versionIsPresent3forSbSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Nonisolated"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "YouVersionPlatformCore.BibleVersion?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "BibleVersion",
-                    "printedName": "YouVersionPlatformCore.BibleVersion",
-                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC7version6withIdAA05BibleB0VSgSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC7version6withIdAA05BibleB0VSgSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "addVersion",
-            "printedName": "addVersion(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC03addB0yyAA05BibleB0VYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC03addB0yyAA05BibleB0VYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC06removeB06withIdySi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC06removeB06withIdySi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeUnpermittedVersions",
-            "printedName": "removeUnpermittedVersions(permittedIds:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Set",
-                "printedName": "Swift.Set<Swift.Int>",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sh"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Var",
-            "name": "downloadedVersions",
-            "printedName": "downloadedVersions",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Array",
-                "printedName": "[Swift.Int]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sa"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvpZ",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvpZ",
-            "moduleName": "YouVersionPlatformCore",
-            "static": true,
-            "declAttributes": [
-              "Final"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Array",
-                    "printedName": "[Swift.Int]",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Int",
-                        "printedName": "Swift.Int",
-                        "usr": "s:Si"
-                      }
-                    ],
-                    "usr": "s:Sa"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvgZ",
-                "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvgZ",
-                "moduleName": "YouVersionPlatformCore",
-                "static": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "unownedExecutor",
-            "printedName": "unownedExecutor",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UnownedSerialExecutor",
-                "printedName": "_Concurrency.UnownedSerialExecutor",
-                "usr": "s:Sce"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevp",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
-            "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
-              "Available",
-              "Final",
-              "Nonisolated",
-              "Semantics"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UnownedSerialExecutor",
-                    "printedName": "_Concurrency.UnownedSerialExecutor",
-                    "usr": "s:Sce"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevg",
-                "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC",
-        "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC",
-        "moduleName": "YouVersionPlatformCore",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "BibleVersionCaching",
-            "printedName": "BibleVersionCaching",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Actor",
-            "printedName": "Actor",
-            "usr": "s:ScA",
-            "mangledName": "$sScA"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "BibleVersionRepository",
         "printedName": "BibleVersionRepository",
         "children": [
@@ -18432,48 +17016,20 @@
           {
             "kind": "Constructor",
             "name": "init",
-            "printedName": "init(apiClient:memoryCache:diskCache:downloadCache:)",
+            "printedName": "init()",
             "children": [
               {
                 "kind": "TypeNominal",
                 "name": "BibleVersionRepository",
                 "printedName": "YouVersionPlatformCore.BibleVersionRepository",
                 "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersionAPIClient",
-                "printedName": "any YouVersionPlatformCore.BibleVersionAPIClient",
-                "hasDefaultArg": true,
-                "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersionCaching",
-                "printedName": "any YouVersionPlatformCore.BibleVersionCaching",
-                "hasDefaultArg": true,
-                "usr": "s:22YouVersionPlatformCore05BibleB7CachingP"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersionCaching",
-                "printedName": "any YouVersionPlatformCore.BibleVersionCaching",
-                "hasDefaultArg": true,
-                "usr": "s:22YouVersionPlatformCore05BibleB7CachingP"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersionCaching",
-                "printedName": "any YouVersionPlatformCore.BibleVersionCaching",
-                "hasDefaultArg": true,
-                "usr": "s:22YouVersionPlatformCore05BibleB7CachingP"
               }
             ],
             "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC9apiClient11memoryCache04diskJ008downloadJ0AcA0eB9APIClient_p_AA0eB7Caching_pAaI_pAaI_ptcfc",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC9apiClient11memoryCache04diskJ008downloadJ0AcA0eB9APIClient_p_AA0eB7Caching_pAaI_pAaI_ptcfc",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryCACycfc",
             "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Designated"
+            "init_kind": "Convenience"
           },
           {
             "kind": "Function",
@@ -18876,6 +17432,62 @@
             "funcSelfKind": "NonMutating"
           },
           {
+            "kind": "Var",
+            "name": "downloadedVersionIds",
+            "printedName": "downloadedVersionIds",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.Int]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
             "kind": "Function",
             "name": "removeVersion",
             "printedName": "removeVersion(withId:)",
@@ -18989,6 +17601,7 @@
         "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC",
         "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC",
         "moduleName": "YouVersionPlatformCore",
+        "hasMissingDesignatedInitializers": true,
         "conformances": [
           {
             "kind": "Conformance",

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -1,9 +1,39 @@
 import Foundation
 
-public actor ChapterDiskCache {
+actor ChapterMemoryCache {
+    private var cache: [String: String] = [:]
+
+    init() {}
+
+    func chapterContent(withReference reference: BibleReference) async -> String? {
+        cache[Self.cacheKey(reference: reference)]
+    }
+
+    func addChapterContent(_ content: String, reference: BibleReference) async {
+        cache[Self.cacheKey(reference: reference)] = content
+    }
+
+    func removeVersion(versionId: Int) async {
+        let prefix = "\(versionId)_"
+        let keysToRemove = cache.keys.filter { $0.hasPrefix(prefix) }
+        for key in keysToRemove {
+            cache.removeValue(forKey: key)
+        }
+    }
+
+    private static func cacheKey(reference: BibleReference) -> String {
+        "\(reference.versionId)_\(reference.chapterUSFM ?? "unknown")"
+    }
+}
+
+actor ChapterDiskCache {
     private let storage: BibleContentStorage
 
-    public init(directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()) {
+    init() {
+        self.init(directoryProvider: DefaultBibleContentDirectoryProvider())
+    }
+
+    init(directoryProvider: BibleContentDirectoryProviding) {
         self.storage = BibleContentStorage(storageKind: .cache, directoryProvider: directoryProvider)
     }
 
@@ -21,17 +51,13 @@ public actor ChapterDiskCache {
         let url = storage.url(for: .chapter(versionId: reference.versionId, usfm: chapterUSFM))
         do {
             try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            if let data = content.data(using: .utf8) {
-                try data.write(to: url, options: .atomic)
-            } else {
-                YouVersionPlatformLogger.notice("Failed to convert content to UTF-8 data for \(url)", category: "ChapterCache")
-            }
+            try Data(content.utf8).write(to: url, options: .atomic)
         } catch {
             YouVersionPlatformLogger.notice("ChapterDiskCache failed to write data to \(url): \(error)", category: "ChapterCache")
         }
     }
 
-    public func removeVersion(versionId: Int) async {
+    func removeVersion(versionId: Int) async {
         let cacheURL = storage.url(for: .chaptersDirectory(versionId: versionId))
         do {
             try FileManager.default.removeItem(at: cacheURL)
@@ -46,10 +72,14 @@ public actor ChapterDiskCache {
 
 // TODO: this code is nearly identical to VersionDiskCache, but we can't inherit from an actor. DRY this.
 // (Plus, both of these are nearly identical to the code of VersionDiskCache and VersionDownloadCache!)
-public actor ChapterDownloadCache {
+actor ChapterDownloadCache {
     private let storage: BibleContentStorage
 
-    public init(directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()) {
+    init() {
+        self.init(directoryProvider: DefaultBibleContentDirectoryProvider())
+    }
+
+    init(directoryProvider: BibleContentDirectoryProviding) {
         self.storage = BibleContentStorage(storageKind: .download, directoryProvider: directoryProvider)
     }
 
@@ -60,11 +90,11 @@ public actor ChapterDownloadCache {
         return storage.string(for: .chapter(versionId: reference.versionId, usfm: chapterUSFM))
     }
 
-    nonisolated public func chaptersArePresent(versionId: Int) -> Bool {
+    nonisolated func chaptersArePresent(versionId: Int) -> Bool {
         storage.containsNonEmptyDirectory(.chaptersDirectory(versionId: versionId))
     }
 
-    public func removeVersion(versionId: Int) async {
+    func removeVersion(versionId: Int) async {
         let cacheURL = storage.url(for: .chaptersDirectory(versionId: versionId))
         do {
             try FileManager.default.removeItem(at: cacheURL)
@@ -82,51 +112,49 @@ public actor BibleChapterRepository: ObservableObject {
 
     public static let shared = BibleChapterRepository()
 
-    // TODO: add MRU functionality and a maximum number of entries to this memoryCache.
-    private var memoryCache: [String: String] = [:]
-    private var diskCache = ChapterDiskCache()
-    private var downloadCache = ChapterDownloadCache()
+    private let chapterContentFromAPI: @Sendable (BibleReference) async throws -> String
+    private let memoryCache: ChapterMemoryCache
+    private let diskCache: ChapterDiskCache
+    private let downloadCache: ChapterDownloadCache
 
-    static func cacheKey(reference: BibleReference) -> String {
-        "\(reference.versionId)_\(reference.chapterUSFM ?? "unknown")"
+    public init() {
+        self.init(
+            chapterContentFromAPI: { try await YouVersionAPI.Bible.chapter(reference: $0) },
+            directoryProvider: DefaultBibleContentDirectoryProvider()
+        )
     }
 
-    func removeChaptersFromMemoryCache(withId versionId: Int) {
-        let prefix = "\(versionId)_"
-        let keysToRemove = memoryCache.keys.filter { $0.hasPrefix(prefix) }
-        for key in keysToRemove {
-            memoryCache.removeValue(forKey: key)
-        }
+    init(
+        chapterContentFromAPI: @escaping @Sendable (BibleReference) async throws -> String,
+        directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()
+    ) {
+        self.chapterContentFromAPI = chapterContentFromAPI
+        self.memoryCache = ChapterMemoryCache()
+        self.diskCache = ChapterDiskCache(directoryProvider: directoryProvider)
+        self.downloadCache = ChapterDownloadCache(directoryProvider: directoryProvider)
     }
 
     public func chapter(withReference reference: BibleReference) async throws -> String {
-        let cacheKey = Self.cacheKey(reference: reference)
-
-        if let cachedContent = memoryCache[cacheKey] {
+        if let cachedContent = await memoryCache.chapterContent(withReference: reference) {
             return cachedContent
         }
 
         if let cachedContent = await diskCache.chapterContent(withReference: reference) {
-            memoryCache[cacheKey] = cachedContent
+            await memoryCache.addChapterContent(cachedContent, reference: reference)
             return cachedContent
         }
 
         if let cachedContent = await downloadCache.chapterContent(withReference: reference) {
-            memoryCache[cacheKey] = cachedContent
+            await memoryCache.addChapterContent(cachedContent, reference: reference)
             return cachedContent
         }
 
-        let content = try await YouVersionAPI.Bible.chapter(reference: reference)
+        let content = try await chapterContentFromAPI(reference)
 
-        memoryCache[cacheKey] = content
+        await memoryCache.addChapterContent(content, reference: reference)
         await diskCache.addChapterContent(content, reference: reference)
 
         return content
-    }
-
-    func cachedChapter(withReference reference: BibleReference) throws -> String? {
-        let cacheKey = Self.cacheKey(reference: reference)
-        return memoryCache[cacheKey]
     }
 
     func chaptersArePresent(versionId: Int) -> Bool {
@@ -135,7 +163,7 @@ public actor BibleChapterRepository: ObservableObject {
 
     @MainActor
     public func removeVersion(withId versionId: Int) async {
-        await removeChaptersFromMemoryCache(withId: versionId)
+        await memoryCache.removeVersion(versionId: versionId)
         await diskCache.removeVersion(versionId: versionId)
         await downloadCache.removeVersion(versionId: versionId)
     }

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -13,8 +13,8 @@ actor ChapterMemoryCache {
         cache[Self.cacheKey(reference: reference)] = content
     }
 
-    func removeVersion(versionId: Int) {
-        let prefix = "\(versionId)_"
+    func removeVersion(withId id: Int) {
+        let prefix = "\(id)_"
         let keysToRemove = cache.keys.filter { $0.hasPrefix(prefix) }
         for key in keysToRemove {
             cache.removeValue(forKey: key)
@@ -34,7 +34,7 @@ actor ChapterDiskCache {
     }
 
     init(directoryProvider: BibleContentDirectoryProviding) {
-        self.storage = BibleContentStorage(storageKind: .cache, directoryProvider: directoryProvider)
+        storage = BibleContentStorage(storageKind: .cache, directoryProvider: directoryProvider)
     }
 
     func chapterContent(withReference reference: BibleReference) -> String? {
@@ -58,9 +58,9 @@ actor ChapterDiskCache {
         }
     }
 
-    func removeVersion(versionId: Int) {
+    func removeVersion(withId id: Int) {
         do {
-            try storage.remove(.chaptersDirectory(versionId: versionId))
+            try storage.remove(.chaptersDirectory(versionId: id))
         } catch {
             YouVersionPlatformLogger.notice(
                 "ChapterDiskCache got error while removing: \(error.localizedDescription)",
@@ -78,7 +78,7 @@ actor ChapterDownloadCache {
     }
 
     init(directoryProvider: BibleContentDirectoryProviding) {
-        self.storage = BibleContentStorage(storageKind: .download, directoryProvider: directoryProvider)
+        storage = BibleContentStorage(storageKind: .download, directoryProvider: directoryProvider)
     }
 
     func chapterContent(withReference reference: BibleReference) -> String? {
@@ -92,9 +92,9 @@ actor ChapterDownloadCache {
         storage.containsNonEmptyDirectory(.chaptersDirectory(versionId: versionId))
     }
 
-    func removeVersion(versionId: Int) {
+    func removeVersion(withId id: Int) {
         do {
-            try storage.remove(.chaptersDirectory(versionId: versionId))
+            try storage.remove(.chaptersDirectory(versionId: id))
         } catch {
             YouVersionPlatformLogger.notice(
                 "ChapterDownloadCache got error while removing: \(error.localizedDescription)",
@@ -158,10 +158,10 @@ public actor BibleChapterRepository {
         downloadCache.chaptersArePresent(versionId: versionId)
     }
 
-    public func removeVersion(withId versionId: Int) async {
-        async let memory: Void = memoryCache.removeVersion(versionId: versionId)
-        async let disk: Void = diskCache.removeVersion(versionId: versionId)
-        async let download: Void = downloadCache.removeVersion(versionId: versionId)
+    public func removeVersion(withId id: Int) async {
+        async let memory: Void = memoryCache.removeVersion(withId: id)
+        async let disk: Void = diskCache.removeVersion(withId: id)
+        async let download: Void = downloadCache.removeVersion(withId: id)
         _ = await (memory, disk, download)
     }
 }

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -48,19 +48,19 @@ actor ChapterDiskCache {
         guard let chapterUSFM = reference.chapterUSFM else {
             return
         }
-        let url = storage.url(for: .chapter(versionId: reference.versionId, usfm: chapterUSFM))
         do {
-            try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try Data(content.utf8).write(to: url, options: .atomic)
+            try storage.writeString(content, to: .chapter(versionId: reference.versionId, usfm: chapterUSFM))
         } catch {
-            YouVersionPlatformLogger.notice("ChapterDiskCache failed to write data to \(url): \(error)", category: "ChapterCache")
+            YouVersionPlatformLogger.notice(
+                "ChapterDiskCache failed to write data: \(error.localizedDescription)",
+                category: "ChapterCache"
+            )
         }
     }
 
     func removeVersion(versionId: Int) async {
-        let cacheURL = storage.url(for: .chaptersDirectory(versionId: versionId))
         do {
-            try FileManager.default.removeItem(at: cacheURL)
+            try storage.remove(.chaptersDirectory(versionId: versionId))
         } catch {
             YouVersionPlatformLogger.notice(
                 "ChapterDiskCache got error while removing: \(error.localizedDescription)",
@@ -70,8 +70,6 @@ actor ChapterDiskCache {
     }
 }
 
-// TODO: this code is nearly identical to VersionDiskCache, but we can't inherit from an actor. DRY this.
-// (Plus, both of these are nearly identical to the code of VersionDiskCache and VersionDownloadCache!)
 actor ChapterDownloadCache {
     private let storage: BibleContentStorage
 
@@ -95,9 +93,8 @@ actor ChapterDownloadCache {
     }
 
     func removeVersion(versionId: Int) async {
-        let cacheURL = storage.url(for: .chaptersDirectory(versionId: versionId))
         do {
-            try FileManager.default.removeItem(at: cacheURL)
+            try storage.remove(.chaptersDirectory(versionId: versionId))
         } catch {
             YouVersionPlatformLogger.notice(
                 "ChapterDownloadCache got error while removing: \(error.localizedDescription)",

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -6,39 +6,25 @@ import Foundation
 // import SSZipArchive
 // #endif
 
-func urlForBibleContentDirectory(versionId: Int, kind: FileManager.SearchPathDirectory) -> URL {
-    let cachesDirectory = FileManager.default.urls(for: kind, in: .userDomainMask).first!
-    return cachesDirectory
-        .appending(path: "bible_\(versionId)", directoryHint: .isDirectory)
-}
-
 public actor ChapterDiskCache {
-    static func urlForChaptersDirectory(versionId: Int) -> URL {
-        urlForBibleContentDirectory(versionId: versionId, kind: .cachesDirectory)
-            .appending(path: "Chapters", directoryHint: .isDirectory)
-    }
+    private let storage: BibleContentStorage
 
-    static func urlForCachedChapter(withUSFM usfm: String, versionId: Int) -> URL {
-        urlForChaptersDirectory(versionId: versionId)
-            .appending(path: usfm, directoryHint: .notDirectory)
+    public init(directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()) {
+        self.storage = BibleContentStorage(storageKind: .cache, directoryProvider: directoryProvider)
     }
 
     func chapterContent(withReference reference: BibleReference) -> String? {
         guard let chapterUSFM = reference.chapterUSFM else {
             return nil
         }
-        let url = Self.urlForCachedChapter(withUSFM: chapterUSFM, versionId: reference.versionId)
-        guard let data = try? Data(contentsOf: url) else {
-            return nil
-        }
-        return String(data: data, encoding: .utf8)
+        return storage.string(for: .chapter(versionId: reference.versionId, usfm: chapterUSFM))
     }
 
     func addChapterContent(_ content: String, reference: BibleReference) {
         guard let chapterUSFM = reference.chapterUSFM else {
             return
         }
-        let url = Self.urlForCachedChapter(withUSFM: chapterUSFM, versionId: reference.versionId)
+        let url = storage.url(for: .chapter(versionId: reference.versionId, usfm: chapterUSFM))
         do {
             try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
             if let data = content.data(using: .utf8) {
@@ -52,7 +38,7 @@ public actor ChapterDiskCache {
     }
 
     public func removeVersion(versionId: Int) async {
-        let cacheURL = Self.urlForChaptersDirectory(versionId: versionId)
+        let cacheURL = storage.url(for: .chaptersDirectory(versionId: versionId))
         do {
             try FileManager.default.removeItem(at: cacheURL)
         } catch {
@@ -67,25 +53,17 @@ public actor ChapterDiskCache {
 // TODO: this code is nearly identical to VersionDiskCache, but we can't inherit from an actor. DRY this.
 // (Plus, both of these are nearly identical to the code of VersionDiskCache and VersionDownloadCache!)
 public actor ChapterDownloadCache {
-    static func urlForChaptersDirectory(versionId: Int) -> URL {
-        urlForBibleContentDirectory(versionId: versionId, kind: .applicationSupportDirectory)
-            .appending(path: "Chapters", directoryHint: .isDirectory)
-    }
+    private let storage: BibleContentStorage
 
-    static func urlForCachedChapter(withUSFM usfm: String, versionId: Int) -> URL {
-        urlForChaptersDirectory(versionId: versionId)
-            .appending(path: usfm, directoryHint: .notDirectory)
+    public init(directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()) {
+        self.storage = BibleContentStorage(storageKind: .download, directoryProvider: directoryProvider)
     }
 
     func chapterContent(withReference reference: BibleReference) -> String? {
         guard let chapterUSFM = reference.chapterUSFM else {
             return nil
         }
-        let url = Self.urlForCachedChapter(withUSFM: chapterUSFM, versionId: reference.versionId)
-        guard let data = try? Data(contentsOf: url) else {
-            return nil
-        }
-        return String(data: data, encoding: .utf8)
+        return storage.string(for: .chapter(versionId: reference.versionId, usfm: chapterUSFM))
     }
 
     /* TEMPORARY
@@ -149,15 +127,11 @@ public actor ChapterDownloadCache {
      */
 
     nonisolated public func chaptersArePresent(versionId: Int) -> Bool {
-        let path = Self.urlForChaptersDirectory(versionId: versionId).path()
-        if let contents = FileManager.default.subpaths(atPath: path) {
-            return !contents.isEmpty
-        }
-        return false
+        storage.containsNonEmptyDirectory(.chaptersDirectory(versionId: versionId))
     }
 
     public func removeVersion(versionId: Int) async {
-        let cacheURL = Self.urlForChaptersDirectory(versionId: versionId)
+        let cacheURL = storage.url(for: .chaptersDirectory(versionId: versionId))
         do {
             try FileManager.default.removeItem(at: cacheURL)
         } catch {

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -158,11 +158,10 @@ public actor BibleChapterRepository: ObservableObject {
         downloadCache.chaptersArePresent(versionId: versionId)
     }
 
-    @MainActor
     public func removeVersion(withId versionId: Int) async {
         async let memory: Void = memoryCache.removeVersion(versionId: versionId)
         async let disk: Void = diskCache.removeVersion(versionId: versionId)
         async let download: Void = downloadCache.removeVersion(versionId: versionId)
-      _ = await (memory, disk, download)
+        _ = await (memory, disk, download)
     }
 }

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -26,6 +26,7 @@ actor ChapterMemoryCache {
     }
 }
 
+/// ChapterDiskCache manages a medium-duration cache of Bible chapter data; it's not in-memory therefore will survive the app being terminated.
 actor ChapterDiskCache {
     private let storage: BibleContentStorage
 
@@ -70,6 +71,7 @@ actor ChapterDiskCache {
     }
 }
 
+/// ChapterDownloadCache manages the chapter files of Bible versions which the user chose to download, e.g. for offline usage.
 actor ChapterDownloadCache {
     private let storage: BibleContentStorage
 
@@ -105,27 +107,39 @@ actor ChapterDownloadCache {
 
 }
 
+protocol BibleChapterContentProviding: Sendable {
+    func chapterContent(for reference: BibleReference) async throws -> String
+}
+
+final class BibleChapterContentAPI: BibleChapterContentProviding {
+    init() {}
+
+    func chapterContent(for reference: BibleReference) async throws -> String {
+        try await YouVersionAPI.Bible.chapter(reference: reference)
+    }
+}
+
 public actor BibleChapterRepository {
 
     public static let shared = BibleChapterRepository()
 
-    private let chapterContentFromAPI: @Sendable (BibleReference) async throws -> String
+    private let provider: BibleChapterContentProviding
     private let memoryCache: ChapterMemoryCache
     private let diskCache: ChapterDiskCache
     private let downloadCache: ChapterDownloadCache
 
     public init() {
         self.init(
-            chapterContentFromAPI: { try await YouVersionAPI.Bible.chapter(reference: $0) },
+            provider: BibleChapterContentAPI(),
             directoryProvider: DefaultBibleContentDirectoryProvider()
         )
     }
 
     init(
-        chapterContentFromAPI: @escaping @Sendable (BibleReference) async throws -> String,
+        provider: BibleChapterContentProviding,
         directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()
     ) {
-        self.chapterContentFromAPI = chapterContentFromAPI
+        self.provider = provider
         self.memoryCache = ChapterMemoryCache()
         self.diskCache = ChapterDiskCache(directoryProvider: directoryProvider)
         self.downloadCache = ChapterDownloadCache(directoryProvider: directoryProvider)
@@ -146,7 +160,7 @@ public actor BibleChapterRepository {
             return cachedContent
         }
 
-        let content = try await chapterContentFromAPI(reference)
+        let content = try await provider.chapterContent(for: reference)
 
         await memoryCache.addChapterContent(content, reference: reference)
         await diskCache.addChapterContent(content, reference: reference)

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -1,10 +1,4 @@
 import Foundation
-//import ZipArchive // TEMPORARY
-// #if canImport(ZipArchive)
-// import ZipArchive
-// #elseif canImport(SSZipArchive)
-// import SSZipArchive
-// #endif
 
 public actor ChapterDiskCache {
     private let storage: BibleContentStorage
@@ -65,66 +59,6 @@ public actor ChapterDownloadCache {
         }
         return storage.string(for: .chapter(versionId: reference.versionId, usfm: chapterUSFM))
     }
-
-    /* TEMPORARY
-    func addChapterContent(_ content: String, reference: BibleReference) {
-        guard let chapterUSFM = reference.chapterUSFM else {
-            return
-        }
-        let url = Self.urlForCachedChapter(withUSFM: chapterUSFM, versionId: reference.versionId)
-        do {
-            try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            if let data = content.data(using: .utf8) {
-                try data.write(to: url, options: .atomic)
-            } else {
-                print("WARNING: Failed to convert content to UTF-8 data for \(url)")
-            }
-        } catch {
-            print("WARNING: ChapterDownloadCache failed to write data to \(url): \(error)")
-        }
-    }
-
-    /// Downloads and installs a complete version bundle
-    func downloadVersionBundle(versionId: Int, build: Int, accessToken: String) async throws {
-        guard let appKey = YouVersionPlatformConfiguration.appKey else {
-            fatalError("YouVersionPlatformConfiguration.appKey must be set.")
-        }
-
-        let host = YouVersionPlatformConfiguration.apiHost
-        let url = URL(string: "https://\(host)/bible/bundle?version=\(versionId)&build=\(build)")!
-        var request = URLRequest(url: url)
-        request.setValue(appKey, forHTTPHeaderField: "x-yvp-app-key")
-        request.setValue(YouVersionPlatformConfiguration.installId, forHTTPHeaderField: "x-yvp-installation-id")
-        request.setValue(accessToken, forHTTPHeaderField: "x-yv-lat")
-
-        let (localURL, response) = try await URLSession.shared.download(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            print("downloadVersionBundle: unexpected response type")
-            throw YouVersionAPIError.invalidResponse
-        }
-
-        if httpResponse.statusCode == 401 {
-            print("downloadVersionBundle: 401 Unauthorized (possibly a bad appKey, or the user has not granted permission)")
-            throw YouVersionAPIError.notPermitted
-        }
-
-        guard httpResponse.statusCode == 200 else {
-            print("error \(httpResponse.statusCode) while downloading a version")
-            throw YouVersionAPIError.cannotDownload
-        }
-
-        var cacheURL = Self.urlForChaptersDirectory(versionId: versionId)
-        try FileManager.default.createDirectory(at: cacheURL, withIntermediateDirectories: true)
-
-        SSZipArchive.unzipFile(atPath: localURL.path(), toDestination: cacheURL.path(percentEncoded: false))
-
-        // exclude it from iCloud backup
-        var values = URLResourceValues()
-        values.isExcludedFromBackup = true
-        try? cacheURL.setResourceValues(values)
-    }
-     */
 
     nonisolated public func chaptersArePresent(versionId: Int) -> Bool {
         storage.containsNonEmptyDirectory(.chaptersDirectory(versionId: versionId))
@@ -194,28 +128,6 @@ public actor BibleChapterRepository: ObservableObject {
         let cacheKey = Self.cacheKey(reference: reference)
         return memoryCache[cacheKey]
     }
-
-    /* TEMPORARY
-    public func download(version: BibleVersion) async throws {
-        guard let accessToken = YouVersionPlatformConfiguration.accessToken else {
-            throw YouVersionAPIError.notPermitted
-        }
-        guard let build = version.offline?.build?.max else {
-            print("no build info")
-            throw YouVersionAPIError.cannotDownload
-        }
-        do {
-            try await downloadCache.downloadVersionBundle(
-                versionId: version.id,
-                build: build,
-                accessToken: accessToken
-            )
-        } catch {
-            print("download failed: \(error)")
-            throw error
-        }
-        await diskCache.removeVersion(versionId: version.id)  // no need to keep 2 copies
-    }*/
 
     func chaptersArePresent(versionId: Int) -> Bool {
         downloadCache.chaptersArePresent(versionId: versionId)

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -105,7 +105,7 @@ actor ChapterDownloadCache {
 
 }
 
-public actor BibleChapterRepository: ObservableObject {
+public actor BibleChapterRepository {
 
     public static let shared = BibleChapterRepository()
 

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -5,15 +5,15 @@ actor ChapterMemoryCache {
 
     init() {}
 
-    func chapterContent(withReference reference: BibleReference) async -> String? {
+    func chapterContent(withReference reference: BibleReference) -> String? {
         cache[Self.cacheKey(reference: reference)]
     }
 
-    func addChapterContent(_ content: String, reference: BibleReference) async {
+    func addChapterContent(_ content: String, reference: BibleReference) {
         cache[Self.cacheKey(reference: reference)] = content
     }
 
-    func removeVersion(versionId: Int) async {
+    func removeVersion(versionId: Int) {
         let prefix = "\(versionId)_"
         let keysToRemove = cache.keys.filter { $0.hasPrefix(prefix) }
         for key in keysToRemove {
@@ -58,7 +58,7 @@ actor ChapterDiskCache {
         }
     }
 
-    func removeVersion(versionId: Int) async {
+    func removeVersion(versionId: Int) {
         do {
             try storage.remove(.chaptersDirectory(versionId: versionId))
         } catch {
@@ -92,7 +92,7 @@ actor ChapterDownloadCache {
         storage.containsNonEmptyDirectory(.chaptersDirectory(versionId: versionId))
     }
 
-    func removeVersion(versionId: Int) async {
+    func removeVersion(versionId: Int) {
         do {
             try storage.remove(.chaptersDirectory(versionId: versionId))
         } catch {

--- a/Sources/YouVersionPlatformCore/Bible/BibleContentStorage.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleContentStorage.swift
@@ -1,18 +1,16 @@
 import Foundation
 
-public enum BibleContentStorageKind: Sendable {
+enum BibleContentStorageKind: Sendable {
     case cache
     case download
 }
 
-public protocol BibleContentDirectoryProviding: Sendable {
+protocol BibleContentDirectoryProviding: Sendable {
     func rootURL(for storageKind: BibleContentStorageKind) -> URL
 }
 
-public struct DefaultBibleContentDirectoryProvider: BibleContentDirectoryProviding {
-    public init() {}
-
-    public func rootURL(for storageKind: BibleContentStorageKind) -> URL {
+struct DefaultBibleContentDirectoryProvider: BibleContentDirectoryProviding {
+    func rootURL(for storageKind: BibleContentStorageKind) -> URL {
         let searchPathDirectory: FileManager.SearchPathDirectory = switch storageKind {
         case .cache:
             .cachesDirectory
@@ -44,7 +42,30 @@ struct BibleContentStorage: Sendable {
     }
 
     var versionDirectoryIds: [Int] {
-        scanForVersionsIn(dir: directoryProvider.rootURL(for: storageKind))
+        let dir = directoryProvider.rootURL(for: storageKind)
+        let urls = (try? FileManager.default.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+
+        var ids: [Int] = []
+        let prefix = "bible_"
+
+        for url in urls {
+            if let values = try? url.resourceValues(forKeys: [.isDirectoryKey]),
+               values.isDirectory == true {
+                let name = url.lastPathComponent
+                if name.hasPrefix(prefix) {
+                    let suffix = String(name.dropFirst(prefix.count))
+                    let isAllDigits = suffix.unicodeScalars.allSatisfy { CharacterSet.decimalDigits.contains($0) }
+                    if isAllDigits, suffix.count < 7, let id = Int(suffix) {
+                        ids.append(id)
+                    }
+                }
+            }
+        }
+        return ids
     }
 
     func url(for resource: BibleContentStorageResource) -> URL {
@@ -93,30 +114,4 @@ struct BibleContentStorage: Sendable {
         }
         return !contents.isEmpty
     }
-}
-
-func scanForVersionsIn(dir: URL) -> [Int] {
-    let urls = (try? FileManager.default.contentsOfDirectory(
-        at: dir,
-        includingPropertiesForKeys: [.isDirectoryKey],
-        options: [.skipsHiddenFiles]
-    )) ?? []
-
-    var ids: [Int] = []
-    let prefix = "bible_"
-
-    for url in urls {
-        if let values = try? url.resourceValues(forKeys: [.isDirectoryKey]),
-           values.isDirectory == true {
-            let name = url.lastPathComponent
-            if name.hasPrefix(prefix) {
-                let suffix = String(name.dropFirst(prefix.count))
-                let isAllDigits = suffix.unicodeScalars.allSatisfy { CharacterSet.decimalDigits.contains($0) }
-                if isAllDigits, suffix.count < 7, let id = Int(suffix) {
-                    ids.append(id)
-                }
-            }
-        }
-    }
-    return ids
 }

--- a/Sources/YouVersionPlatformCore/Bible/BibleContentStorage.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleContentStorage.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+public enum BibleContentStorageKind: Sendable {
+    case cache
+    case download
+}
+
+public protocol BibleContentDirectoryProviding: Sendable {
+    func rootURL(for storageKind: BibleContentStorageKind) -> URL
+}
+
+public struct DefaultBibleContentDirectoryProvider: BibleContentDirectoryProviding {
+    public init() {}
+
+    public func rootURL(for storageKind: BibleContentStorageKind) -> URL {
+        let searchPathDirectory: FileManager.SearchPathDirectory = switch storageKind {
+        case .cache:
+            .cachesDirectory
+        case .download:
+            .applicationSupportDirectory
+        }
+
+        return FileManager.default.urls(for: searchPathDirectory, in: .userDomainMask).first!
+    }
+}
+
+enum BibleContentStorageResource: Sendable {
+    case versionDirectory(versionId: Int)
+    case versionMetadata(versionId: Int)
+    case chaptersDirectory(versionId: Int)
+    case chapter(versionId: Int, usfm: String)
+}
+
+struct BibleContentStorage: Sendable {
+    private let storageKind: BibleContentStorageKind
+    private let directoryProvider: BibleContentDirectoryProviding
+
+    init(
+        storageKind: BibleContentStorageKind,
+        directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()
+    ) {
+        self.storageKind = storageKind
+        self.directoryProvider = directoryProvider
+    }
+
+    var versionDirectoryIds: [Int] {
+        scanForVersionsIn(dir: directoryProvider.rootURL(for: storageKind))
+    }
+
+    func url(for resource: BibleContentStorageResource) -> URL {
+        switch resource {
+        case let .versionDirectory(versionId):
+            directoryProvider.rootURL(for: storageKind)
+                .appending(path: "bible_\(versionId)", directoryHint: .isDirectory)
+        case let .versionMetadata(versionId):
+            url(for: .versionDirectory(versionId: versionId))
+                .appending(path: "BibleVersionMetadata_v1", directoryHint: .notDirectory)
+        case let .chaptersDirectory(versionId):
+            url(for: .versionDirectory(versionId: versionId))
+                .appending(path: "Chapters", directoryHint: .isDirectory)
+        case let .chapter(versionId, usfm):
+            url(for: .chaptersDirectory(versionId: versionId))
+                .appending(path: usfm, directoryHint: .notDirectory)
+        }
+    }
+
+    func data(for resource: BibleContentStorageResource) -> Data? {
+        try? Data(contentsOf: url(for: resource))
+    }
+
+    func string(for resource: BibleContentStorageResource) -> String? {
+        guard let data = data(for: resource) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    func decoded<T: Decodable>(_ type: T.Type, for resource: BibleContentStorageResource) -> T? {
+        guard let data = data(for: resource) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(type, from: data)
+    }
+
+    func contains(_ resource: BibleContentStorageResource) -> Bool {
+        FileManager.default.fileExists(atPath: url(for: resource).path)
+    }
+
+    func containsNonEmptyDirectory(_ resource: BibleContentStorageResource) -> Bool {
+        let path = url(for: resource).path()
+        guard let contents = FileManager.default.subpaths(atPath: path) else {
+            return false
+        }
+        return !contents.isEmpty
+    }
+}
+
+func scanForVersionsIn(dir: URL) -> [Int] {
+    let urls = (try? FileManager.default.contentsOfDirectory(
+        at: dir,
+        includingPropertiesForKeys: [.isDirectoryKey],
+        options: [.skipsHiddenFiles]
+    )) ?? []
+
+    var ids: [Int] = []
+    let prefix = "bible_"
+
+    for url in urls {
+        if let values = try? url.resourceValues(forKeys: [.isDirectoryKey]),
+           values.isDirectory == true {
+            let name = url.lastPathComponent
+            if name.hasPrefix(prefix) {
+                let suffix = String(name.dropFirst(prefix.count))
+                let isAllDigits = suffix.unicodeScalars.allSatisfy { CharacterSet.decimalDigits.contains($0) }
+                if isAllDigits, suffix.count < 7, let id = Int(suffix) {
+                    ids.append(id)
+                }
+            }
+        }
+    }
+    return ids
+}

--- a/Sources/YouVersionPlatformCore/Bible/BibleContentStorage.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleContentStorage.swift
@@ -103,6 +103,34 @@ struct BibleContentStorage: Sendable {
         return try? JSONDecoder().decode(type, from: data)
     }
 
+    func write(_ data: Data, to resource: BibleContentStorageResource, isExcludedFromBackup: Bool = false) throws {
+        var directoryURL = url(for: resource).deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true
+        )
+
+        if isExcludedFromBackup {
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            try? directoryURL.setResourceValues(values)
+        }
+
+        try data.write(to: url(for: resource), options: .atomic)
+    }
+
+    func writeString(_ string: String, to resource: BibleContentStorageResource) throws {
+        try write(Data(string.utf8), to: resource)
+    }
+
+    func writeEncoded<T: Encodable>(
+        _ value: T,
+        to resource: BibleContentStorageResource,
+        isExcludedFromBackup: Bool = false
+    ) throws {
+        try write(JSONEncoder().encode(value), to: resource, isExcludedFromBackup: isExcludedFromBackup)
+    }
+
     func contains(_ resource: BibleContentStorageResource) -> Bool {
         FileManager.default.fileExists(atPath: url(for: resource).path)
     }
@@ -113,5 +141,9 @@ struct BibleContentStorage: Sendable {
             return false
         }
         return !contents.isEmpty
+    }
+
+    func remove(_ resource: BibleContentStorageResource) throws {
+        try FileManager.default.removeItem(at: url(for: resource))
     }
 }

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
@@ -1,14 +1,9 @@
 import Foundation
-#if canImport(SwiftUI)
-import SwiftUI
-#else
-public protocol ObservableObject {}
-#endif
 
 // MARK: - Bible Highlights View Model
 
 @MainActor
-public class BibleHighlightsViewModel: ObservableObject {
+public class BibleHighlightsViewModel {
 
     public static let shared = BibleHighlightsViewModel()
 

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -5,10 +5,6 @@ import Observation
 public protocol Observable {}
 #endif
 
-public protocol BibleVersionAPIClient: Sendable {
-    func version(withId id: Int) async throws -> BibleVersion
-}
-
 /// Abstraction over Bible version lookup and download operations.
 public protocol BibleVersionRepositoryProtocol: Sendable {
     /// Returns a cached version when one is already available locally.
@@ -23,6 +19,9 @@ public protocol BibleVersionRepositoryProtocol: Sendable {
     /// Returns the current download status for a version.
     func downloadStatus(for id: Int) -> BibleVersionRepository.BibleVersionDownloadStatus
 
+    /// Returns the IDs for versions currently downloaded for offline use.
+    var downloadedVersionIds: [Int] { get }
+
     /// Removes a version from every local cache.
     func removeVersion(withId versionId: Int) async
 
@@ -30,68 +29,48 @@ public protocol BibleVersionRepositoryProtocol: Sendable {
     func removeUnpermittedVersions(permittedIds: Set<Int>) async
 }
 
-public protocol BibleVersionCaching: Sendable {
-    func version(withId id: Int) async -> BibleVersion?
-    func addVersion(_ version: BibleVersion) async
-    func removeVersion(withId versionId: Int) async
-    func versionIsPresent(for id: Int) -> Bool
-    func removeUnpermittedVersions(permittedIds: Set<Int>) async
-}
-
-public final class VersionClient: BibleVersionAPIClient {
-    public init() {}
-
-    public func version(withId id: Int) async throws -> BibleVersion {
-        try await YouVersionAPI.Bible.version(versionId: id)
-    }
-}
-
-public actor VersionMemoryCache: BibleVersionCaching {
-    public init() {}
+actor VersionMemoryCache {
+    init() {}
 
     private var cache: [Int: BibleVersion] = [:]
 
-    public func version(withId id: Int) async -> BibleVersion? {
+    func version(withId id: Int) async -> BibleVersion? {
         cache[id]
     }
 
-    nonisolated public func versionIsPresent(for id: Int) -> Bool {
-        false
-    }
-
-    public func addVersion(_ version: BibleVersion) async {
+    func addVersion(_ version: BibleVersion) async {
         cache[version.id] = version
     }
 
-    public func removeVersion(withId versionId: Int) async {
+    func removeVersion(withId versionId: Int) async {
         cache.removeValue(forKey: versionId)
     }
 
-    public func removeUnpermittedVersions(permittedIds: Set<Int>) async {
-        let ids = cache.keys
-        let idsToRemove = ids.filter { !permittedIds.contains($0) }
-        for idToRemove in idsToRemove {
-            cache.removeValue(forKey: idToRemove)
-        }
+    func removeUnpermittedVersions(permittedIds: Set<Int>) async {
+        cache = cache.filter { permittedIds.contains($0.key) }
     }
 }
 
-public actor VersionDiskCache: BibleVersionCaching {
+actor VersionDiskCache {
     private let storage: BibleContentStorage
 
-    public init(directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()) {
+    init() {
+        self.init(directoryProvider: DefaultBibleContentDirectoryProvider())
+    }
+
+    init(directoryProvider: BibleContentDirectoryProviding) {
         self.storage = BibleContentStorage(storageKind: .cache, directoryProvider: directoryProvider)
     }
 
-    public func version(withId id: Int) -> BibleVersion? {
+    func version(withId id: Int) -> BibleVersion? {
         storage.decoded(BibleVersion.self, for: .versionMetadata(versionId: id))
     }
 
-    nonisolated public func versionIsPresent(for id: Int) -> Bool {
-        false
+    nonisolated func versionIsPresent(for id: Int) -> Bool {
+        storage.contains(.versionMetadata(versionId: id))
     }
 
-    public func addVersion(_ version: BibleVersion) async {
+    func addVersion(_ version: BibleVersion) async {
         let url = storage.url(for: .versionMetadata(versionId: version.id))
         try? FileManager.default.createDirectory(
             at: url.deletingLastPathComponent(),
@@ -102,7 +81,7 @@ public actor VersionDiskCache: BibleVersionCaching {
         }
     }
 
-    public func removeVersion(withId versionId: Int) async {
+    func removeVersion(withId versionId: Int) async {
         let url = storage.url(for: .versionDirectory(versionId: versionId))
         do {
             try FileManager.default.removeItem(at: url)
@@ -114,13 +93,7 @@ public actor VersionDiskCache: BibleVersionCaching {
         }
     }
 
-    static func cachedVersions(
-        directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()
-    ) async -> [Int] {
-        BibleContentStorage(storageKind: .cache, directoryProvider: directoryProvider).versionDirectoryIds
-    }
-
-    public func removeUnpermittedVersions(permittedIds: Set<Int>) async {
+    func removeUnpermittedVersions(permittedIds: Set<Int>) async {
         let cached = storage.versionDirectoryIds
         for id in cached where !permittedIds.contains(id) {
             YouVersionPlatformLogger.notice(
@@ -134,22 +107,26 @@ public actor VersionDiskCache: BibleVersionCaching {
 
 // TODO: this code is nearly identical to VersionDiskCache, but we can't inherit from an actor. DRY this.
 // (Plus, both of these are nearly identical to the code of ChapterDownloadCache and ChapterDiskCache!)
-public actor VersionDownloadCache: BibleVersionCaching {
+actor VersionDownloadCache {
     private let storage: BibleContentStorage
 
-    public init(directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()) {
+    init() {
+        self.init(directoryProvider: DefaultBibleContentDirectoryProvider())
+    }
+
+    init(directoryProvider: BibleContentDirectoryProviding) {
         self.storage = BibleContentStorage(storageKind: .download, directoryProvider: directoryProvider)
     }
 
-    nonisolated public func versionIsPresent(for id: Int) -> Bool {
+    nonisolated func versionIsPresent(for id: Int) -> Bool {
         storage.contains(.versionMetadata(versionId: id))
     }
 
-    public func version(withId id: Int) -> BibleVersion? {
+    func version(withId id: Int) -> BibleVersion? {
         storage.decoded(BibleVersion.self, for: .versionMetadata(versionId: id))
     }
 
-    public func addVersion(_ version: BibleVersion) async {
+    func addVersion(_ version: BibleVersion) async {
         var directoryURL = storage.url(for: .versionDirectory(versionId: version.id))
         let metadataUrl = storage.url(for: .versionMetadata(versionId: version.id))
 
@@ -168,11 +145,7 @@ public actor VersionDownloadCache: BibleVersionCaching {
         }
     }
 
-    public func removeVersion(withId id: Int) {
-        removeDownloadedVersionDirectory(id: id)
-    }
-
-    private func removeDownloadedVersionDirectory(id: Int) {
+    func removeVersion(withId id: Int) {
         let url = storage.url(for: .versionDirectory(versionId: id))
         do {
             try FileManager.default.removeItem(at: url)
@@ -184,7 +157,7 @@ public actor VersionDownloadCache: BibleVersionCaching {
         }
     }
 
-    public func removeUnpermittedVersions(permittedIds: Set<Int>) {
+    func removeUnpermittedVersions(permittedIds: Set<Int>) {
         let downloads = storage.versionDirectoryIds
         for downloadedId in downloads where !permittedIds.contains(downloadedId) {
             YouVersionPlatformLogger.notice(
@@ -195,11 +168,7 @@ public actor VersionDownloadCache: BibleVersionCaching {
         }
     }
 
-    public static var downloadedVersions: [Int] {
-        downloadedVersions(directoryProvider: DefaultBibleContentDirectoryProvider())
-    }
-
-    static func downloadedVersions(directoryProvider: BibleContentDirectoryProviding) -> [Int] {
+    static func downloadedVersionIds(directoryProvider: BibleContentDirectoryProviding) -> [Int] {
         BibleContentStorage(storageKind: .download, directoryProvider: directoryProvider).versionDirectoryIds
     }
 
@@ -209,23 +178,30 @@ public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol 
 
     public static let shared = BibleVersionRepository()
 
-    private let apiClient: BibleVersionAPIClient
-    private let memoryCache: BibleVersionCaching
-    private let diskCache: BibleVersionCaching
-    private let downloadCache: BibleVersionCaching
+    private let versionFromAPI: @Sendable (Int) async throws -> BibleVersion
+    private let directoryProvider: BibleContentDirectoryProviding
+    private let memoryCache: VersionMemoryCache
+    private let diskCache: VersionDiskCache
+    private let downloadCache: VersionDownloadCache
 
     private var inFlightTasks: [Int: Task<BibleVersion, Error>] = [:]
 
-    public init(
-        apiClient: BibleVersionAPIClient = VersionClient(),
-        memoryCache: BibleVersionCaching = VersionMemoryCache(),
-        diskCache: BibleVersionCaching = VersionDiskCache(),
-        downloadCache: BibleVersionCaching = VersionDownloadCache()
+    public init() {
+        self.init(
+            versionFromAPI: { try await YouVersionAPI.Bible.version(versionId: $0) },
+            directoryProvider: DefaultBibleContentDirectoryProvider()
+        )
+    }
+
+    init(
+        versionFromAPI: @escaping @Sendable (Int) async throws -> BibleVersion,
+        directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()
     ) {
-        self.apiClient = apiClient
-        self.memoryCache = memoryCache
-        self.diskCache = diskCache
-        self.downloadCache = downloadCache
+        self.versionFromAPI = versionFromAPI
+        self.directoryProvider = directoryProvider
+        self.memoryCache = VersionMemoryCache()
+        self.diskCache = VersionDiskCache(directoryProvider: directoryProvider)
+        self.downloadCache = VersionDownloadCache(directoryProvider: directoryProvider)
     }
 
     public func versionIfCached(_ id: Int) async throws -> BibleVersion? {
@@ -261,8 +237,8 @@ public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol 
         }
 
         // Otherwise, create a new fetch task
-        let task = Task { [apiClient, diskCache] in
-            let version = try await apiClient.version(withId: id)
+        let task = Task { [versionFromAPI, diskCache] in
+            let version = try await versionFromAPI(id)
             await diskCache.addVersion(version)
             return version
         }
@@ -275,7 +251,6 @@ public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol 
 
         let version = try await task.value
         await memoryCache.addVersion(version)
-        await diskCache.addVersion(version)
         return version
     }
 
@@ -305,6 +280,11 @@ public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol 
         }
         // TODO: look at the BibleVersion to see if it's downloadable or not.
         return .notDownloadable
+    }
+
+    /// Returns the IDs for versions currently downloaded for offline use.
+    nonisolated public var downloadedVersionIds: [Int] {
+        VersionDownloadCache.downloadedVersionIds(directoryProvider: directoryProvider)
     }
 
     public func removeVersion(withId versionId: Int) async {

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -163,11 +163,23 @@ actor VersionDownloadCache {
 
 }
 
+protocol BibleVersionProviding: Sendable {
+    func version(withId id: Int) async throws -> BibleVersion
+}
+
+final class BibleVersionAPI: BibleVersionProviding {
+    init() {}
+
+    func version(withId id: Int) async throws -> BibleVersion {
+        try await YouVersionAPI.Bible.version(versionId: id)
+    }
+}
+
 public actor BibleVersionRepository: BibleVersionRepositoryProtocol {
 
     public static let shared = BibleVersionRepository()
 
-    private let versionFromAPI: @Sendable (Int) async throws -> BibleVersion
+    private let provider: BibleVersionProviding
     private let directoryProvider: BibleContentDirectoryProviding
     private let memoryCache: VersionMemoryCache
     private let diskCache: VersionDiskCache
@@ -177,16 +189,16 @@ public actor BibleVersionRepository: BibleVersionRepositoryProtocol {
 
     public init() {
         self.init(
-            versionFromAPI: { try await YouVersionAPI.Bible.version(versionId: $0) },
+            provider: BibleVersionAPI(),
             directoryProvider: DefaultBibleContentDirectoryProvider()
         )
     }
 
     init(
-        versionFromAPI: @escaping @Sendable (Int) async throws -> BibleVersion,
+        provider: BibleVersionProviding,
         directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()
     ) {
-        self.versionFromAPI = versionFromAPI
+        self.provider = provider
         self.directoryProvider = directoryProvider
         self.memoryCache = VersionMemoryCache()
         self.diskCache = VersionDiskCache(directoryProvider: directoryProvider)
@@ -226,8 +238,8 @@ public actor BibleVersionRepository: BibleVersionRepositoryProtocol {
         }
 
         // Otherwise, create a new fetch task
-        let task = Task { [versionFromAPI, diskCache] in
-            let version = try await versionFromAPI(id)
+        let task = Task { [provider, memoryCache, diskCache] in
+            let version = try await provider.version(withId: id)
             async let memory: Void = memoryCache.addVersion(version)
             async let disk: Void = diskCache.addVersion(version)
             _ = await (memory, disk)

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -46,6 +46,7 @@ actor VersionMemoryCache {
     }
 }
 
+/// VersionDiskCache manages a medium-duration cache of Bible version metadata; it's not in-memory therefore will survive the app being terminated.
 actor VersionDiskCache {
     private let storage: BibleContentStorage
 
@@ -99,6 +100,7 @@ actor VersionDiskCache {
     }
 }
 
+/// VersionDownloadCache manages the Bible versions which the user chose to download, e.g. for offline usage.
 actor VersionDownloadCache {
     private let storage: BibleContentStorage
 
@@ -226,7 +228,9 @@ public actor BibleVersionRepository: BibleVersionRepositoryProtocol {
         // Otherwise, create a new fetch task
         let task = Task { [versionFromAPI, diskCache] in
             let version = try await versionFromAPI(id)
-            await diskCache.addVersion(version)
+            async let memory: Void = memoryCache.addVersion(version)
+            async let disk: Void = diskCache.addVersion(version)
+            _ = await (memory, disk)
             return version
         }
 

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -71,20 +71,19 @@ actor VersionDiskCache {
     }
 
     func addVersion(_ version: BibleVersion) async {
-        let url = storage.url(for: .versionMetadata(versionId: version.id))
-        try? FileManager.default.createDirectory(
-            at: url.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-        if let data = try? JSONEncoder().encode(version) {
-            try? data.write(to: url, options: .atomic)
+        do {
+            try storage.writeEncoded(version, to: .versionMetadata(versionId: version.id))
+        } catch {
+            YouVersionPlatformLogger.notice(
+                "VersionDiskCache failed to write metadata for \(version.id): \(error.localizedDescription)",
+                category: "VersionCache"
+            )
         }
     }
 
     func removeVersion(withId versionId: Int) async {
-        let url = storage.url(for: .versionDirectory(versionId: versionId))
         do {
-            try FileManager.default.removeItem(at: url)
+            try storage.remove(.versionDirectory(versionId: versionId))
         } catch {
             YouVersionPlatformLogger.notice(
                 "VersionDiskCache got error while removing: \(error.localizedDescription)",
@@ -105,8 +104,6 @@ actor VersionDiskCache {
     }
 }
 
-// TODO: this code is nearly identical to VersionDiskCache, but we can't inherit from an actor. DRY this.
-// (Plus, both of these are nearly identical to the code of ChapterDownloadCache and ChapterDiskCache!)
 actor VersionDownloadCache {
     private let storage: BibleContentStorage
 
@@ -127,28 +124,23 @@ actor VersionDownloadCache {
     }
 
     func addVersion(_ version: BibleVersion) async {
-        var directoryURL = storage.url(for: .versionDirectory(versionId: version.id))
-        let metadataUrl = storage.url(for: .versionMetadata(versionId: version.id))
-
-        try? FileManager.default.createDirectory(
-            at: directoryURL,
-            withIntermediateDirectories: true
-        )
-        // exclude it from iCloud backup
-        var values = URLResourceValues()
-        values.isExcludedFromBackup = true
-        try? directoryURL.setResourceValues(values)
-
-        // save the metadata file inside there
-        if let data = try? JSONEncoder().encode(version) {
-            try? data.write(to: metadataUrl, options: .atomic)
+        do {
+            try storage.writeEncoded(
+                version,
+                to: .versionMetadata(versionId: version.id),
+                isExcludedFromBackup: true
+            )
+        } catch {
+            YouVersionPlatformLogger.notice(
+                "VersionDownloadCache failed to write metadata for \(version.id): \(error.localizedDescription)",
+                category: "VersionCache"
+            )
         }
     }
 
     func removeVersion(withId id: Int) {
-        let url = storage.url(for: .versionDirectory(versionId: id))
         do {
-            try FileManager.default.removeItem(at: url)
+            try storage.remove(.versionDirectory(versionId: id))
         } catch {
             YouVersionPlatformLogger.notice(
                 "VersionDownloadCache got error while removing: \(error.localizedDescription)",

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -1,9 +1,4 @@
 import Foundation
-#if canImport(Observation)
-import Observation
-#else
-public protocol Observable {}
-#endif
 
 /// Abstraction over Bible version lookup and download operations.
 public protocol BibleVersionRepositoryProtocol: Sendable {
@@ -166,7 +161,7 @@ actor VersionDownloadCache {
 
 }
 
-public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol {
+public actor BibleVersionRepository: BibleVersionRepositoryProtocol {
 
     public static let shared = BibleVersionRepository()
 

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -46,32 +46,6 @@ public final class VersionClient: BibleVersionAPIClient {
     }
 }
 
-func scanForVersionsIn(dir: URL) -> [Int] {
-    let urls = (try? FileManager.default.contentsOfDirectory(
-        at: dir,
-        includingPropertiesForKeys: [.isDirectoryKey],
-        options: [.skipsHiddenFiles]
-    )) ?? []
-
-    var ids: [Int] = []
-    let prefix = "bible_"
-
-    for url in urls {
-        if let values = try? url.resourceValues(forKeys: [.isDirectoryKey]),
-            values.isDirectory == true {
-            let name = url.lastPathComponent
-            if name.hasPrefix(prefix) {
-                let suffix = String(name.dropFirst(prefix.count))
-                let isAllDigits = suffix.unicodeScalars.allSatisfy { CharacterSet.decimalDigits.contains($0) }
-                if isAllDigits, suffix.count < 7, let id = Int(suffix) {
-                    ids.append(id)
-                }
-            }
-        }
-    }
-    return ids
-}
-
 public actor VersionMemoryCache: BibleVersionCaching {
     public init() {}
 
@@ -103,19 +77,14 @@ public actor VersionMemoryCache: BibleVersionCaching {
 }
 
 public actor VersionDiskCache: BibleVersionCaching {
-    public init() {}
+    private let storage: BibleContentStorage
 
-    static func urlForCachedVersionMetadata(_ versionId: Int) -> URL {
-        urlForBibleContentDirectory(versionId: versionId, kind: .cachesDirectory)
-            .appending(path: "BibleVersionMetadata_v1", directoryHint: .notDirectory)
+    public init(directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()) {
+        self.storage = BibleContentStorage(storageKind: .cache, directoryProvider: directoryProvider)
     }
 
     public func version(withId id: Int) -> BibleVersion? {
-        let url = Self.urlForCachedVersionMetadata(id)
-        guard let data = try? Data(contentsOf: url) else {
-            return nil
-        }
-        return try? JSONDecoder().decode(BibleVersion.self, from: data)
+        storage.decoded(BibleVersion.self, for: .versionMetadata(versionId: id))
     }
 
     nonisolated public func versionIsPresent(for id: Int) -> Bool {
@@ -123,7 +92,7 @@ public actor VersionDiskCache: BibleVersionCaching {
     }
 
     public func addVersion(_ version: BibleVersion) async {
-        let url = Self.urlForCachedVersionMetadata(version.id)
+        let url = storage.url(for: .versionMetadata(versionId: version.id))
         try? FileManager.default.createDirectory(
             at: url.deletingLastPathComponent(),
             withIntermediateDirectories: true
@@ -134,7 +103,7 @@ public actor VersionDiskCache: BibleVersionCaching {
     }
 
     public func removeVersion(withId versionId: Int) async {
-        let url = urlForBibleContentDirectory(versionId: versionId, kind: .cachesDirectory)
+        let url = storage.url(for: .versionDirectory(versionId: versionId))
         do {
             try FileManager.default.removeItem(at: url)
         } catch {
@@ -145,15 +114,14 @@ public actor VersionDiskCache: BibleVersionCaching {
         }
     }
 
-    static func cachedVersions() async -> [Int] {
-        guard let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
-            return []
-        }
-        return scanForVersionsIn(dir: dir)
+    static func cachedVersions(
+        directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()
+    ) async -> [Int] {
+        BibleContentStorage(storageKind: .cache, directoryProvider: directoryProvider).versionDirectoryIds
     }
 
     public func removeUnpermittedVersions(permittedIds: Set<Int>) async {
-        let cached: [Int] = Array(await Self.cachedVersions().compactMap(\.self) )
+        let cached = storage.versionDirectoryIds
         for id in cached where !permittedIds.contains(id) {
             YouVersionPlatformLogger.notice(
                 "Removing cached Bible version \(id) because it is no longer permitted",
@@ -167,30 +135,23 @@ public actor VersionDiskCache: BibleVersionCaching {
 // TODO: this code is nearly identical to VersionDiskCache, but we can't inherit from an actor. DRY this.
 // (Plus, both of these are nearly identical to the code of ChapterDownloadCache and ChapterDiskCache!)
 public actor VersionDownloadCache: BibleVersionCaching {
-    public init() {}
+    private let storage: BibleContentStorage
 
-    static func urlForDownloadedVersion(_ versionId: Int) -> URL {
-        urlForBibleContentDirectory(versionId: versionId, kind: .applicationSupportDirectory)
-            .appending(path: "BibleVersionMetadata_v1", directoryHint: .notDirectory)
+    public init(directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()) {
+        self.storage = BibleContentStorage(storageKind: .download, directoryProvider: directoryProvider)
     }
 
     nonisolated public func versionIsPresent(for id: Int) -> Bool {
-        let url = Self.urlForDownloadedVersion(id)
-        let ret = FileManager.default.fileExists(atPath: url.path)
-        return ret
+        storage.contains(.versionMetadata(versionId: id))
     }
 
     public func version(withId id: Int) -> BibleVersion? {
-        let url = Self.urlForDownloadedVersion(id)
-        guard let data = try? Data(contentsOf: url) else {
-            return nil
-        }
-        return try? JSONDecoder().decode(BibleVersion.self, from: data)
+        storage.decoded(BibleVersion.self, for: .versionMetadata(versionId: id))
     }
 
     public func addVersion(_ version: BibleVersion) async {
-        var directoryURL = urlForBibleContentDirectory(versionId: version.id, kind: .applicationSupportDirectory)
-        let metadataUrl = Self.urlForDownloadedVersion(version.id)
+        var directoryURL = storage.url(for: .versionDirectory(versionId: version.id))
+        let metadataUrl = storage.url(for: .versionMetadata(versionId: version.id))
 
         try? FileManager.default.createDirectory(
             at: directoryURL,
@@ -212,7 +173,7 @@ public actor VersionDownloadCache: BibleVersionCaching {
     }
 
     private func removeDownloadedVersionDirectory(id: Int) {
-        let url = urlForBibleContentDirectory(versionId: id, kind: .applicationSupportDirectory)
+        let url = storage.url(for: .versionDirectory(versionId: id))
         do {
             try FileManager.default.removeItem(at: url)
         } catch {
@@ -224,7 +185,7 @@ public actor VersionDownloadCache: BibleVersionCaching {
     }
 
     public func removeUnpermittedVersions(permittedIds: Set<Int>) {
-        let downloads = Self.downloadedVersions
+        let downloads = storage.versionDirectoryIds
         for downloadedId in downloads where !permittedIds.contains(downloadedId) {
             YouVersionPlatformLogger.notice(
                 "Removing downloaded Bible version \(downloadedId) because it is no longer permitted",
@@ -235,10 +196,11 @@ public actor VersionDownloadCache: BibleVersionCaching {
     }
 
     public static var downloadedVersions: [Int] {
-        guard let downloadsDirectory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            return []
-        }
-        return scanForVersionsIn(dir: downloadsDirectory)
+        downloadedVersions(directoryProvider: DefaultBibleContentDirectoryProvider())
+    }
+
+    static func downloadedVersions(directoryProvider: BibleContentDirectoryProviding) -> [Int] {
+        BibleContentStorage(storageKind: .download, directoryProvider: directoryProvider).versionDirectoryIds
     }
 
 }

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -18,7 +18,7 @@ public protocol BibleVersionRepositoryProtocol: Sendable {
     var downloadedVersionIds: [Int] { get }
 
     /// Removes a version from every local cache.
-    func removeVersion(withId versionId: Int) async
+    func removeVersion(withId id: Int) async
 
     /// Removes every locally stored version that is no longer permitted.
     func removeUnpermittedVersions(permittedIds: Set<Int>) async
@@ -37,8 +37,8 @@ actor VersionMemoryCache {
         cache[version.id] = version
     }
 
-    func removeVersion(withId versionId: Int) async {
-        cache.removeValue(forKey: versionId)
+    func removeVersion(withId id: Int) async {
+        cache.removeValue(forKey: id)
     }
 
     func removeUnpermittedVersions(permittedIds: Set<Int>) async {
@@ -76,9 +76,9 @@ actor VersionDiskCache {
         }
     }
 
-    func removeVersion(withId versionId: Int) async {
+    func removeVersion(withId id: Int) async {
         do {
-            try storage.remove(.versionDirectory(versionId: versionId))
+            try storage.remove(.versionDirectory(versionId: id))
         } catch {
             YouVersionPlatformLogger.notice(
                 "VersionDiskCache got error while removing: \(error.localizedDescription)",
@@ -274,10 +274,10 @@ public actor BibleVersionRepository: BibleVersionRepositoryProtocol {
         VersionDownloadCache.downloadedVersionIds(directoryProvider: directoryProvider)
     }
 
-    public func removeVersion(withId versionId: Int) async {
-        async let memory: Void = memoryCache.removeVersion(withId: versionId)
-        async let disk: Void = diskCache.removeVersion(withId: versionId)
-        async let download: Void = downloadCache.removeVersion(withId: versionId)
+    public func removeVersion(withId id: Int) async {
+        async let memory: Void = memoryCache.removeVersion(withId: id)
+        async let disk: Void = diskCache.removeVersion(withId: id)
+        async let download: Void = downloadCache.removeVersion(withId: id)
         _ = await (memory, disk, download)
     }
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -45,7 +45,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
                 self.showBookIntro = UserDefaults.standard.bool(forKey: userDefaultsKeyForBibleDisplayIntro)
             } else {
                 // no specified or saved version, so, pick a downloaded one, else a safe default.
-                let downloads = VersionDownloadCache.downloadedVersions
+                let downloads = BibleVersionRepository.shared.downloadedVersionIds
                 let versionId = reference?.versionId ?? downloads.first ?? 3034
                 self.reference = BibleReference(versionId: versionId, bookUSFM: "JHN", chapter: 1)
                 self.showBookIntro = false

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -72,7 +72,7 @@ public final class BibleVersionsViewModel {
         }
         
         // downloaded versions must also be in MyVersions, otherwise they couldn't be deleted.
-        let downloads = VersionDownloadCache.downloadedVersions
+        let downloads = versionRepository.downloadedVersionIds
         for id in downloads {
             if self.myVersions.contains(where: { $0.id == id }) {
                 continue
@@ -119,7 +119,7 @@ public final class BibleVersionsViewModel {
     }
     
     private func findAnyAcceptableVersion(savedIds: Set<Int>) async -> Int? {
-        let downloads = VersionDownloadCache.downloadedVersions
+        let downloads = versionRepository.downloadedVersionIds
         if !downloads.isEmpty {
             return downloads.first!
         }

--- a/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
@@ -2,9 +2,9 @@ import Foundation
 import Testing
 @testable import YouVersionPlatformCore
 
-// MARK: - API Recorder
+// MARK: - API Request Counter
 
-final class BibleChapterAPIRecorder: @unchecked Sendable {
+final class BibleChapterAPIRequestCounter: @unchecked Sendable {
     private(set) var requestedReferences: [BibleReference] = []
     var result: String
     var error: Error?
@@ -32,21 +32,21 @@ struct BibleChapterRepositoryTests {
 
     @discardableResult
     private func makeRepository(
-        apiRecorder: BibleChapterAPIRecorder? = nil
+        apiCounter: BibleChapterAPIRequestCounter? = nil
     ) throws -> (
         repository: BibleChapterRepository,
-        apiRecorder: BibleChapterAPIRecorder,
+        apiCounter: BibleChapterAPIRequestCounter,
         storage: RepositoryTemporaryStorage
     ) {
-        let apiRecorder = apiRecorder ?? BibleChapterAPIRecorder(result: "<div>server</div>")
+        let apiCounter = apiCounter ?? BibleChapterAPIRequestCounter(result: "<div>server</div>")
         let storage = try RepositoryTemporaryStorage()
 
         return (
             BibleChapterRepository(
-                chapterContentFromAPI: apiRecorder.chapterContent(withReference:),
+                chapterContentFromAPI: apiCounter.chapterContent(withReference:),
                 directoryProvider: storage.provider
             ),
-            apiRecorder,
+            apiCounter,
             storage
         )
     }
@@ -59,7 +59,7 @@ struct BibleChapterRepositoryTests {
         await diskCache.addChapterContent("<div>disk</div>", reference: reference)
 
         let content = try await repository.chapter(withReference: reference)
-        await diskCache.removeVersion(versionId: reference.versionId)
+        await diskCache.removeVersion(withId: reference.versionId)
         let memoryContent = try await repository.chapter(withReference: reference)
 
         #expect(content == "<div>disk</div>")
@@ -104,7 +104,7 @@ struct BibleChapterRepositoryTests {
         let diskCache = ChapterDiskCache(directoryProvider: storage.provider)
 
         let first = try await repository.chapter(withReference: reference)
-        await diskCache.removeVersion(versionId: reference.versionId)
+        await diskCache.removeVersion(withId: reference.versionId)
         let second = try await repository.chapter(withReference: reference)
 
         #expect(first == "<div>server</div>")
@@ -114,8 +114,8 @@ struct BibleChapterRepositoryTests {
 
     @Test
     func chapterPropagatesAPIErrorAndDoesNotCache() async throws {
-        let api = BibleChapterAPIRecorder(result: "<div>server</div>", error: TestChapterError.network)
-        let (repository, _, storage) = try makeRepository(apiRecorder: api)
+        let api = BibleChapterAPIRequestCounter(result: "<div>server</div>", error: TestChapterError.network)
+        let (repository, _, storage) = try makeRepository(apiCounter: api)
         defer { storage.remove() }
         let diskCache = ChapterDiskCache(directoryProvider: storage.provider)
 

--- a/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import Testing
+@testable import YouVersionPlatformCore
+
+// MARK: - API Recorder
+
+final class BibleChapterAPIRecorder: @unchecked Sendable {
+    private(set) var requestedReferences: [BibleReference] = []
+    var result: String
+    var error: Error?
+
+    init(result: String, error: Error? = nil) {
+        self.result = result
+        self.error = error
+    }
+
+    func chapterContent(withReference reference: BibleReference) async throws -> String {
+        requestedReferences.append(reference)
+        if let error {
+            throw error
+        }
+        return result
+    }
+
+    var callCount: Int { requestedReferences.count }
+}
+
+// MARK: - Tests
+
+struct BibleChapterRepositoryTests {
+    private let reference = BibleReference(versionId: 206, bookUSFM: "GEN", chapter: 1)
+
+    @discardableResult
+    private func makeRepository(
+        apiRecorder: BibleChapterAPIRecorder? = nil
+    ) throws -> (
+        repository: BibleChapterRepository,
+        apiRecorder: BibleChapterAPIRecorder,
+        storage: RepositoryTemporaryStorage
+    ) {
+        let apiRecorder = apiRecorder ?? BibleChapterAPIRecorder(result: "<div>server</div>")
+        let storage = try RepositoryTemporaryStorage()
+
+        return (
+            BibleChapterRepository(
+                chapterContentFromAPI: apiRecorder.chapterContent(withReference:),
+                directoryProvider: storage.provider
+            ),
+            apiRecorder,
+            storage
+        )
+    }
+
+    @Test
+    func chapterReturnsDiskContentAndWarmsMemory() async throws {
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let diskCache = ChapterDiskCache(directoryProvider: storage.provider)
+        await diskCache.addChapterContent("<div>disk</div>", reference: reference)
+
+        let content = try await repository.chapter(withReference: reference)
+        await diskCache.removeVersion(versionId: reference.versionId)
+        let memoryContent = try await repository.chapter(withReference: reference)
+
+        #expect(content == "<div>disk</div>")
+        #expect(memoryContent == "<div>disk</div>")
+        #expect(api.callCount == 0)
+    }
+
+    @Test
+    func chapterReturnsDownloadContentAndWarmsMemory() async throws {
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        try writeDownloadedChapterContent("<div>download</div>", reference: reference, storage: storage)
+
+        let content = try await repository.chapter(withReference: reference)
+        try FileManager.default.removeItem(at: chapterURL(storageKind: .download, reference: reference, storage: storage))
+        let memoryContent = try await repository.chapter(withReference: reference)
+
+        #expect(content == "<div>download</div>")
+        #expect(memoryContent == "<div>download</div>")
+        #expect(api.callCount == 0)
+    }
+
+    @Test
+    func chapterLoadsFromAPIWhenNotCachedAndStoresOnDisk() async throws {
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let diskCache = ChapterDiskCache(directoryProvider: storage.provider)
+
+        let content = try await repository.chapter(withReference: reference)
+        let diskContent = await diskCache.chapterContent(withReference: reference)
+
+        #expect(content == "<div>server</div>")
+        #expect(api.callCount == 1)
+        #expect(api.requestedReferences == [reference])
+        #expect(diskContent == "<div>server</div>")
+    }
+
+    @Test
+    func chapterUsesMemoryCacheOnSubsequentCalls() async throws {
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let diskCache = ChapterDiskCache(directoryProvider: storage.provider)
+
+        let first = try await repository.chapter(withReference: reference)
+        await diskCache.removeVersion(versionId: reference.versionId)
+        let second = try await repository.chapter(withReference: reference)
+
+        #expect(first == "<div>server</div>")
+        #expect(second == "<div>server</div>")
+        #expect(api.callCount == 1)
+    }
+
+    @Test
+    func chapterPropagatesAPIErrorAndDoesNotCache() async throws {
+        let api = BibleChapterAPIRecorder(result: "<div>server</div>", error: TestChapterError.network)
+        let (repository, _, storage) = try makeRepository(apiRecorder: api)
+        defer { storage.remove() }
+        let diskCache = ChapterDiskCache(directoryProvider: storage.provider)
+
+        await #expect(throws: TestChapterError.network) {
+            _ = try await repository.chapter(withReference: reference)
+        }
+
+        #expect(api.callCount == 1)
+        #expect(await diskCache.chapterContent(withReference: reference) == nil)
+    }
+
+    @Test
+    func chaptersArePresentReflectsDownloadedChapters() async throws {
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        try writeDownloadedChapterContent("<div>download</div>", reference: reference, storage: storage)
+
+        let arePresent = await repository.chaptersArePresent(versionId: reference.versionId)
+
+        #expect(arePresent)
+        #expect(api.callCount == 0)
+    }
+
+    @Test
+    func removeVersionClearsAllCaches() async throws {
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let diskCache = ChapterDiskCache(directoryProvider: storage.provider)
+
+        await diskCache.addChapterContent("<div>disk</div>", reference: reference)
+        try writeDownloadedChapterContent("<div>download</div>", reference: reference, storage: storage)
+
+        let diskContent = try await repository.chapter(withReference: reference)
+        #expect(diskContent == "<div>disk</div>")
+
+        await repository.removeVersion(withId: reference.versionId)
+
+        #expect(await diskCache.chapterContent(withReference: reference) == nil)
+        #expect(FileManager.default.fileExists(atPath: chapterURL(storageKind: .download, reference: reference, storage: storage).path) == false)
+
+        let apiContent = try await repository.chapter(withReference: reference)
+        #expect(apiContent == "<div>server</div>")
+        #expect(api.callCount == 1)
+    }
+
+    private func writeDownloadedChapterContent(
+        _ content: String,
+        reference: BibleReference,
+        storage: RepositoryTemporaryStorage
+    ) throws {
+        try storage.write(content, to: chapterURL(storageKind: .download, reference: reference, storage: storage))
+    }
+
+    private func chapterURL(
+        storageKind: BibleContentStorageKind,
+        reference: BibleReference,
+        storage: RepositoryTemporaryStorage
+    ) -> URL {
+        let chapterUSFM = reference.chapterUSFM ?? "unknown"
+        return BibleContentStorage(storageKind: storageKind, directoryProvider: storage.provider)
+            .url(for: .chapter(versionId: reference.versionId, usfm: chapterUSFM))
+    }
+}
+
+private enum TestChapterError: Error {
+    case network
+}

--- a/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
@@ -131,11 +131,12 @@ struct BibleChapterRepositoryTests {
     func chaptersArePresentReflectsDownloadedChapters() async throws {
         let (repository, api, storage) = try makeRepository()
         defer { storage.remove() }
+
+        #expect(await repository.chaptersArePresent(versionId: reference.versionId) == false)
+
         try writeDownloadedChapterContent("<div>download</div>", reference: reference, storage: storage)
 
-        let arePresent = await repository.chaptersArePresent(versionId: reference.versionId)
-
-        #expect(arePresent)
+        #expect(await repository.chaptersArePresent(versionId: reference.versionId))
         #expect(api.callCount == 0)
     }
 

--- a/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 // MARK: - API Request Counter
 
-final class BibleChapterAPIRequestCounter: @unchecked Sendable {
+final class BibleChapterAPIRequestCounter: BibleChapterContentProviding, @unchecked Sendable {
     private(set) var requestedReferences: [BibleReference] = []
     var result: String
     var error: Error?
@@ -14,7 +14,7 @@ final class BibleChapterAPIRequestCounter: @unchecked Sendable {
         self.error = error
     }
 
-    func chapterContent(withReference reference: BibleReference) async throws -> String {
+    func chapterContent(for reference: BibleReference) async throws -> String {
         requestedReferences.append(reference)
         if let error {
             throw error
@@ -43,7 +43,7 @@ struct BibleChapterRepositoryTests {
 
         return (
             BibleChapterRepository(
-                chapterContentFromAPI: apiCounter.chapterContent(withReference:),
+                provider: apiCounter,
                 directoryProvider: storage.provider
             ),
             apiCounter,

--- a/Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift
@@ -221,7 +221,7 @@ private struct TemporaryStorage {
     let rootURL: URL
     let cacheRootURL: URL
     let downloadRootURL: URL
-    let provider: TemporaryBibleContentDirectoryProvider
+    let provider: TestBibleContentDirectoryProvider
 
     init() throws {
         let rootURL = FileManager.default.temporaryDirectory
@@ -235,7 +235,7 @@ private struct TemporaryStorage {
         self.rootURL = rootURL
         self.cacheRootURL = cacheRootURL
         self.downloadRootURL = downloadRootURL
-        self.provider = TemporaryBibleContentDirectoryProvider(
+        self.provider = TestBibleContentDirectoryProvider(
             cacheRootURL: cacheRootURL,
             downloadRootURL: downloadRootURL
         )
@@ -269,19 +269,5 @@ private struct TemporaryStorage {
             withIntermediateDirectories: true
         )
         try data.write(to: url)
-    }
-}
-
-private struct TemporaryBibleContentDirectoryProvider: BibleContentDirectoryProviding {
-    let cacheRootURL: URL
-    let downloadRootURL: URL
-
-    func rootURL(for storageKind: BibleContentStorageKind) -> URL {
-        switch storageKind {
-        case .cache:
-            cacheRootURL
-        case .download:
-            downloadRootURL
-        }
     }
 }

--- a/Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift
@@ -1,0 +1,237 @@
+import Foundation
+import Testing
+@testable import YouVersionPlatformCore
+
+struct BibleContentStorageTests {
+
+    @Test
+    func urlBuildsExpectedCacheAndDownloadPaths() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+
+        let cacheStorage = BibleContentStorage(storageKind: .cache, directoryProvider: temporaryStorage.provider)
+        let downloadStorage = BibleContentStorage(storageKind: .download, directoryProvider: temporaryStorage.provider)
+
+        #expect(
+            cacheStorage.url(for: .versionDirectory(versionId: 206)) ==
+                temporaryStorage.cacheRootURL.appending(path: "bible_206", directoryHint: .isDirectory)
+        )
+        #expect(
+            cacheStorage.url(for: .versionMetadata(versionId: 206)) ==
+                temporaryStorage.cacheRootURL
+                .appending(path: "bible_206", directoryHint: .isDirectory)
+                .appending(path: "BibleVersionMetadata_v1", directoryHint: .notDirectory)
+        )
+        #expect(
+            downloadStorage.url(for: .chapter(versionId: 206, usfm: "GEN.1")) ==
+                temporaryStorage.downloadRootURL
+                .appending(path: "bible_206", directoryHint: .isDirectory)
+                .appending(path: "Chapters", directoryHint: .isDirectory)
+                .appending(path: "GEN.1", directoryHint: .notDirectory)
+        )
+    }
+
+    @Test
+    func versionDirectoryIdsReturnsValidBibleDirectoriesOnly() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+
+        try temporaryStorage.createCacheDirectory(named: "bible_1")
+        try temporaryStorage.createCacheDirectory(named: "bible_206")
+        try temporaryStorage.createCacheDirectory(named: "bible_123456")
+        try temporaryStorage.createCacheDirectory(named: "bible_1234567")
+        try temporaryStorage.createCacheDirectory(named: "bible_abc")
+        try temporaryStorage.createCacheDirectory(named: "not_bible_7")
+        try temporaryStorage.writeCacheFile(named: "bible_999", data: Data())
+
+        let storage = BibleContentStorage(storageKind: .cache, directoryProvider: temporaryStorage.provider)
+
+        #expect(Set(storage.versionDirectoryIds) == Set([1, 206, 123456]))
+    }
+
+    @Test
+    func versionDirectoryIdsKeepsCacheAndDownloadRootsSeparate() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+
+        try temporaryStorage.createCacheDirectory(named: "bible_1")
+        try temporaryStorage.createDownloadDirectory(named: "bible_2")
+
+        let cacheStorage = BibleContentStorage(storageKind: .cache, directoryProvider: temporaryStorage.provider)
+        let downloadStorage = BibleContentStorage(storageKind: .download, directoryProvider: temporaryStorage.provider)
+
+        #expect(cacheStorage.versionDirectoryIds == [1])
+        #expect(downloadStorage.versionDirectoryIds == [2])
+    }
+
+    @Test
+    func dataAndDecodedReadStoredVersionMetadata() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+
+        let storage = BibleContentStorage(storageKind: .cache, directoryProvider: temporaryStorage.provider)
+        let fixtureData = try Self.fixtureData()
+        try temporaryStorage.write(fixtureData, to: storage.url(for: .versionMetadata(versionId: 206)))
+
+        let data = storage.data(for: .versionMetadata(versionId: 206))
+        let version = storage.decoded(BibleVersion.self, for: .versionMetadata(versionId: 206))
+
+        #expect(data == fixtureData)
+        #expect(version?.id == 206)
+        #expect(version?.localizedTitle == "World English Bible, American English Edition, without Strong's Numbers")
+    }
+
+    @Test
+    func decodedReturnsNilForMissingOrInvalidData() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+
+        let storage = BibleContentStorage(storageKind: .cache, directoryProvider: temporaryStorage.provider)
+        try temporaryStorage.write(Data("not json".utf8), to: storage.url(for: .versionMetadata(versionId: 999)))
+
+        let missing = storage.decoded(BibleVersion.self, for: .versionMetadata(versionId: 206))
+        let invalid = storage.decoded(BibleVersion.self, for: .versionMetadata(versionId: 999))
+
+        #expect(missing == nil)
+        #expect(invalid == nil)
+    }
+
+    @Test
+    func stringReadsUtf8ChapterContent() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+
+        let storage = BibleContentStorage(storageKind: .download, directoryProvider: temporaryStorage.provider)
+        try temporaryStorage.write(
+            Data("<div>In the beginning</div>".utf8),
+            to: storage.url(for: .chapter(versionId: 206, usfm: "GEN.1"))
+        )
+
+        let content = storage.string(for: .chapter(versionId: 206, usfm: "GEN.1"))
+
+        #expect(content == "<div>In the beginning</div>")
+    }
+
+    @Test
+    func stringReturnsNilForMissingOrInvalidUtf8Data() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+
+        let storage = BibleContentStorage(storageKind: .download, directoryProvider: temporaryStorage.provider)
+        try temporaryStorage.write(Data([0xFF, 0xFE]), to: storage.url(for: .chapter(versionId: 206, usfm: "GEN.1")))
+
+        let missing = storage.string(for: .chapter(versionId: 206, usfm: "EXO.1"))
+        let invalid = storage.string(for: .chapter(versionId: 206, usfm: "GEN.1"))
+
+        #expect(missing == nil)
+        #expect(invalid == nil)
+    }
+
+    @Test
+    func containsChecksPresenceWithoutDecoding() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+
+        let storage = BibleContentStorage(storageKind: .cache, directoryProvider: temporaryStorage.provider)
+        try temporaryStorage.write(Data("not json".utf8), to: storage.url(for: .versionMetadata(versionId: 206)))
+
+        #expect(storage.contains(.versionMetadata(versionId: 206)))
+        #expect(storage.contains(.versionMetadata(versionId: 999)) == false)
+    }
+
+    @Test
+    func containsNonEmptyDirectoryChecksDirectoryContents() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+
+        let storage = BibleContentStorage(storageKind: .download, directoryProvider: temporaryStorage.provider)
+        try FileManager.default.createDirectory(
+            at: storage.url(for: .chaptersDirectory(versionId: 206)),
+            withIntermediateDirectories: true
+        )
+
+        #expect(storage.containsNonEmptyDirectory(.chaptersDirectory(versionId: 206)) == false)
+        #expect(storage.containsNonEmptyDirectory(.chaptersDirectory(versionId: 999)) == false)
+
+        try temporaryStorage.write(
+            Data("<div>content</div>".utf8),
+            to: storage.url(for: .chapter(versionId: 206, usfm: "GEN.1"))
+        )
+
+        #expect(storage.containsNonEmptyDirectory(.chaptersDirectory(versionId: 206)))
+    }
+
+    private static func fixtureData() throws -> Data {
+        let url = try #require(Bundle.module.url(forResource: "bible_206", withExtension: "json"))
+        return try Data(contentsOf: url)
+    }
+}
+
+private struct TemporaryStorage {
+    let rootURL: URL
+    let cacheRootURL: URL
+    let downloadRootURL: URL
+    let provider: TemporaryBibleContentDirectoryProvider
+
+    init() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appending(path: "BibleContentStorageTests-\(UUID().uuidString)", directoryHint: .isDirectory)
+        let cacheRootURL = rootURL.appending(path: "cache", directoryHint: .isDirectory)
+        let downloadRootURL = rootURL.appending(path: "download", directoryHint: .isDirectory)
+
+        try FileManager.default.createDirectory(at: cacheRootURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: downloadRootURL, withIntermediateDirectories: true)
+
+        self.rootURL = rootURL
+        self.cacheRootURL = cacheRootURL
+        self.downloadRootURL = downloadRootURL
+        self.provider = TemporaryBibleContentDirectoryProvider(
+            cacheRootURL: cacheRootURL,
+            downloadRootURL: downloadRootURL
+        )
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: rootURL)
+    }
+
+    func createCacheDirectory(named name: String) throws {
+        try FileManager.default.createDirectory(
+            at: cacheRootURL.appending(path: name, directoryHint: .isDirectory),
+            withIntermediateDirectories: true
+        )
+    }
+
+    func createDownloadDirectory(named name: String) throws {
+        try FileManager.default.createDirectory(
+            at: downloadRootURL.appending(path: name, directoryHint: .isDirectory),
+            withIntermediateDirectories: true
+        )
+    }
+
+    func writeCacheFile(named name: String, data: Data) throws {
+        try write(data, to: cacheRootURL.appending(path: name, directoryHint: .notDirectory))
+    }
+
+    func write(_ data: Data, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: url)
+    }
+}
+
+private struct TemporaryBibleContentDirectoryProvider: BibleContentDirectoryProviding {
+    let cacheRootURL: URL
+    let downloadRootURL: URL
+
+    func rootURL(for storageKind: BibleContentStorageKind) -> URL {
+        switch storageKind {
+        case .cache:
+            cacheRootURL
+        case .download:
+            downloadRootURL
+        }
+    }
+}

--- a/Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift
@@ -65,6 +65,17 @@ struct BibleContentStorageTests {
     }
 
     @Test
+    func versionDirectoryIdsReturnsEmptyWhenRootIsMissing() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+
+        try FileManager.default.removeItem(at: temporaryStorage.cacheRootURL)
+        let storage = BibleContentStorage(storageKind: .cache, directoryProvider: temporaryStorage.provider)
+
+        #expect(storage.versionDirectoryIds.isEmpty)
+    }
+
+    @Test
     func dataAndDecodedReadStoredVersionMetadata() throws {
         let temporaryStorage = try TemporaryStorage()
         defer { temporaryStorage.remove() }
@@ -159,6 +170,45 @@ struct BibleContentStorageTests {
         )
 
         #expect(storage.containsNonEmptyDirectory(.chaptersDirectory(versionId: 206)))
+    }
+
+    @Test
+    func writeEncodedCreatesVersionMetadata() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+
+        let storage = BibleContentStorage(storageKind: .cache, directoryProvider: temporaryStorage.provider)
+        let fixture = try JSONDecoder().decode(BibleVersion.self, from: Self.fixtureData())
+
+        try storage.writeEncoded(fixture, to: .versionMetadata(versionId: fixture.id))
+
+        #expect(storage.decoded(BibleVersion.self, for: .versionMetadata(versionId: fixture.id))?.id == fixture.id)
+    }
+
+    @Test
+    func writeStringCreatesChapterContent() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+
+        let storage = BibleContentStorage(storageKind: .cache, directoryProvider: temporaryStorage.provider)
+
+        try storage.writeString("chapter content", to: .chapter(versionId: 206, usfm: "GEN.1"))
+
+        #expect(storage.string(for: .chapter(versionId: 206, usfm: "GEN.1")) == "chapter content")
+    }
+
+    @Test
+    func removeDeletesResourceDirectory() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+
+        let storage = BibleContentStorage(storageKind: .download, directoryProvider: temporaryStorage.provider)
+        try storage.writeString("chapter content", to: .chapter(versionId: 206, usfm: "GEN.1"))
+
+        try storage.remove(.versionDirectory(versionId: 206))
+
+        #expect(storage.contains(.chapter(versionId: 206, usfm: "GEN.1")) == false)
+        #expect(storage.contains(.versionDirectory(versionId: 206)) == false)
     }
 
     private static func fixtureData() throws -> Data {

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
@@ -202,11 +202,12 @@ struct BibleVersionRepositoryTests {
         let (repository, api, storage) = try makeRepository()
         defer { storage.remove() }
         let downloadCache = VersionDownloadCache(directoryProvider: storage.provider)
+
+        #expect(await repository.versionIsPresent(for: Self.fixture.id) == false)
+
         await downloadCache.addVersion(Self.fixture)
 
-        let isPresent = await repository.versionIsPresent(for: Self.fixture.id)
-
-        #expect(isPresent)
+        #expect(await repository.versionIsPresent(for: Self.fixture.id))
         #expect(api.callCount == 0)
     }
 
@@ -215,6 +216,9 @@ struct BibleVersionRepositoryTests {
         let (repository, api, storage) = try makeRepository()
         defer { storage.remove() }
         let downloadCache = VersionDownloadCache(directoryProvider: storage.provider)
+
+        #expect(repository.downloadStatus(for: Self.fixture.id) == .notDownloadable)
+
         await downloadCache.addVersion(Self.fixture)
 
         let status = repository.downloadStatus(for: Self.fixture.id)
@@ -230,6 +234,9 @@ struct BibleVersionRepositoryTests {
         let (repository, api, storage) = try makeRepository()
         defer { storage.remove() }
         let downloadCache = VersionDownloadCache(directoryProvider: storage.provider)
+
+        #expect(repository.downloadedVersionIds == [])
+
         await downloadCache.addVersion(Self.fixture)
 
         #expect(repository.downloadedVersionIds == [Self.fixture.id])

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
@@ -2,9 +2,9 @@ import Foundation
 import Testing
 @testable import YouVersionPlatformCore
 
-// MARK: - Mocks
+// MARK: - API Recorder
 
-final class MockBibleVersionAPIClient: BibleVersionAPIClient, @unchecked Sendable {
+final class BibleVersionAPIRecorder: @unchecked Sendable {
     private(set) var requestedIds: [Int] = []
     var result: BibleVersion
     var error: Error?
@@ -25,52 +25,6 @@ final class MockBibleVersionAPIClient: BibleVersionAPIClient, @unchecked Sendabl
     var callCount: Int { requestedIds.count }
 }
 
-final class MockBibleVersionCache: BibleVersionCaching, @unchecked Sendable {
-    private var storage: [Int: BibleVersion] = [:]
-    private(set) var versionCallCount = 0
-    private(set) var addCallCount = 0
-    private(set) var removeCallCount = 0
-    private(set) var removeUnpermittedCallCount = 0
-    private(set) var versionIsPresentCallCount = 0
-
-    func version(withId id: Int) async -> BibleVersion? {
-        versionCallCount += 1
-        return storage[id]
-    }
-
-    func addVersion(_ version: BibleVersion) async {
-        addCallCount += 1
-        storage[version.id] = version
-    }
-
-    func removeVersion(withId versionId: Int) async {
-        removeCallCount += 1
-        storage.removeValue(forKey: versionId)
-    }
-
-    func versionIsPresent(for id: Int) -> Bool {
-        versionIsPresentCallCount += 1
-        return storage[id] != nil
-    }
-
-    func removeUnpermittedVersions(permittedIds: Set<Int>) async {
-        removeUnpermittedCallCount += 1
-        storage = storage.filter { permittedIds.contains($0.key) }
-    }
-
-    func prime(with version: BibleVersion) {
-        storage[version.id] = version
-    }
-
-    func contains(_ id: Int) -> Bool {
-        storage[id] != nil
-    }
-
-    func storedVersion(withId id: Int) -> BibleVersion? {
-        storage[id]
-    }
-}
-
 // MARK: - Tests
 
 struct BibleVersionRepositoryTests {
@@ -89,33 +43,22 @@ struct BibleVersionRepositoryTests {
 
     @discardableResult
     private func makeRepository(
-        apiClient: MockBibleVersionAPIClient? = nil,
-        memoryCache: MockBibleVersionCache? = nil,
-        diskCache: MockBibleVersionCache? = nil,
-        downloadCache: MockBibleVersionCache? = nil
-    ) -> (
+        apiRecorder: BibleVersionAPIRecorder? = nil
+    ) throws -> (
         repository: BibleVersionRepository,
-        apiClient: MockBibleVersionAPIClient,
-        memoryCache: MockBibleVersionCache,
-        diskCache: MockBibleVersionCache,
-        downloadCache: MockBibleVersionCache
+        apiRecorder: BibleVersionAPIRecorder,
+        storage: RepositoryTemporaryStorage
     ) {
-        let apiClient = apiClient ?? MockBibleVersionAPIClient(result: Self.fixture)
-        let memoryCache = memoryCache ?? MockBibleVersionCache()
-        let diskCache = diskCache ?? MockBibleVersionCache()
-        let downloadCache = downloadCache ?? MockBibleVersionCache()
+        let apiRecorder = apiRecorder ?? BibleVersionAPIRecorder(result: Self.fixture)
+        let storage = try RepositoryTemporaryStorage()
 
         return (
             BibleVersionRepository(
-                apiClient: apiClient,
-                memoryCache: memoryCache,
-                diskCache: diskCache,
-                downloadCache: downloadCache
+                versionFromAPI: apiRecorder.version(withId:),
+                directoryProvider: storage.provider
             ),
-            apiClient,
-            memoryCache,
-            diskCache,
-            downloadCache
+            apiRecorder,
+            storage
         )
     }
 
@@ -123,126 +66,139 @@ struct BibleVersionRepositoryTests {
 
     @Test
     func versionIfCachedReturnsDiskVersionAndWarmsMemory() async throws {
-        let (repository, api, memory, disk, _) = makeRepository()
-        disk.prime(with: Self.fixture)
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let diskCache = VersionDiskCache(directoryProvider: storage.provider)
+        await diskCache.addVersion(Self.fixture)
 
         let cached = try await repository.versionIfCached(Self.fixture.id)
+        await diskCache.removeVersion(withId: Self.fixture.id)
+        let memoryCached = try await repository.versionIfCached(Self.fixture.id)
 
         #expect(cached?.id == Self.fixture.id)
-        #expect(cached?.localizedTitle == Self.fixture.localizedTitle)
+        #expect(memoryCached?.id == Self.fixture.id)
+        #expect(memoryCached?.localizedTitle == Self.fixture.localizedTitle)
         #expect(api.callCount == 0)
-        #expect(memory.contains(Self.fixture.id))
-        #expect(memory.addCallCount == 1)
-        #expect(disk.versionCallCount == 1)
     }
 
     // MARK: version(withId:)
 
     @Test
-    func versionLoadsFromAPIWhenNotCachedAndStoresInCaches() async throws {
-        let (repository, api, memory, disk, _) = makeRepository()
+    func versionLoadsFromAPIWhenNotCachedAndStoresOnDisk() async throws {
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let diskCache = VersionDiskCache(directoryProvider: storage.provider)
 
         let version = try await repository.version(withId: Self.fixture.id)
+        let diskVersion = await diskCache.version(withId: Self.fixture.id)
 
         #expect(version.id == Self.fixture.id)
         #expect(version.languageTag == Self.fixture.languageTag)
-        #expect(version.title == Self.fixture.title)
         #expect(api.callCount == 1)
-        #expect(memory.contains(Self.fixture.id))
-        #expect(memory.addCallCount == 1)
-        #expect(disk.contains(Self.fixture.id))
-        #expect(disk.addCallCount >= 1)
-        #expect(disk.storedVersion(withId: Self.fixture.id)?.copyright == Self.fixture.copyright)
+        #expect(api.requestedIds == [Self.fixture.id])
+        #expect(diskVersion?.id == Self.fixture.id)
+        #expect(diskVersion?.copyright == Self.fixture.copyright)
     }
 
     @Test
     func versionUsesMemoryCacheOnSubsequentCalls() async throws {
-        let (repository, api, memory, _, _) = makeRepository()
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let diskCache = VersionDiskCache(directoryProvider: storage.provider)
 
         let first = try await repository.version(withId: Self.fixture.id)
+        await diskCache.removeVersion(withId: Self.fixture.id)
         let second = try await repository.version(withId: Self.fixture.id)
 
         #expect(first.id == Self.fixture.id)
-        #expect(first.localizedAbbreviation == Self.fixture.localizedAbbreviation)
         #expect(second.id == Self.fixture.id)
         #expect(second.readerFooter == Self.fixture.readerFooter)
         #expect(api.callCount == 1)
-        #expect(memory.versionCallCount >= 2)
     }
 
     @Test
     func versionRefetchesAfterCachesAreCleared() async throws {
-        let (repository, api, memory, disk, _) = makeRepository()
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let diskCache = VersionDiskCache(directoryProvider: storage.provider)
 
         let initial = try await repository.version(withId: Self.fixture.id)
         #expect(initial.copyright == Self.fixture.copyright)
         #expect(api.callCount == 1)
 
         await repository.removeVersion(withId: Self.fixture.id)
-
-        #expect(memory.contains(Self.fixture.id) == false)
-        #expect(disk.contains(Self.fixture.id) == false)
-        #expect(disk.storedVersion(withId: Self.fixture.id) == nil)
+        #expect(await diskCache.version(withId: Self.fixture.id) == nil)
 
         let refetched = try await repository.version(withId: Self.fixture.id)
 
         #expect(refetched.readerFooterUrl == Self.fixture.readerFooterUrl)
         #expect(api.callCount == 2)
-        #expect(memory.contains(Self.fixture.id))
-        #expect(disk.contains(Self.fixture.id))
-        #expect(disk.storedVersion(withId: Self.fixture.id)?.title == Self.fixture.title)
+        #expect(await diskCache.version(withId: Self.fixture.id)?.title == Self.fixture.title)
     }
 
     // MARK: downloadVersion
 
     @Test
     func downloadVersionDoesNotFetchWhenAlreadyDownloaded() async throws {
-        let (repository, api, _, disk, download) = makeRepository()
-        download.prime(with: Self.fixture)
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let downloadCache = VersionDownloadCache(directoryProvider: storage.provider)
+        await downloadCache.addVersion(Self.fixture)
 
         try await repository.downloadVersion(withId: Self.fixture.id)
 
         #expect(api.callCount == 0)
-        #expect(download.addCallCount == 0)
-        #expect(disk.removeCallCount == 0)
-
-        let stored = download.storedVersion(withId: Self.fixture.id)
-        #expect(stored?.abbreviation == Self.fixture.abbreviation)
+        #expect(await downloadCache.version(withId: Self.fixture.id)?.abbreviation == Self.fixture.abbreviation)
     }
 
     @Test
     func downloadVersionFetchesWhenNotDownloaded() async throws {
-        let (repository, api, _, disk, download) = makeRepository()
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let diskCache = VersionDiskCache(directoryProvider: storage.provider)
+        let downloadCache = VersionDownloadCache(directoryProvider: storage.provider)
 
         try await repository.downloadVersion(withId: Self.fixture.id)
 
         #expect(api.callCount == 1)
-        #expect(download.contains(Self.fixture.id))
-        #expect(download.addCallCount == 1)
-        #expect(disk.removeCallCount == 1)
-
-        let stored = download.storedVersion(withId: Self.fixture.id)
-        #expect(stored?.promotionalContent == Self.fixture.promotionalContent)
+        #expect(await downloadCache.version(withId: Self.fixture.id)?.promotionalContent == Self.fixture.promotionalContent)
+        #expect(await diskCache.version(withId: Self.fixture.id) == nil)
     }
 
     // MARK: Other methods
 
     @Test
-    func versionIsPresentDelegatesToDownloadCache() async throws {
-        let (repository, api, _, _, download) = makeRepository()
-        download.prime(with: Self.fixture)
+    func diskCacheVersionIsPresentReflectsStoredMetadata() async throws {
+        let storage = try RepositoryTemporaryStorage()
+        defer { storage.remove() }
+        let diskCache = VersionDiskCache(directoryProvider: storage.provider)
+
+        #expect(diskCache.versionIsPresent(for: Self.fixture.id) == false)
+
+        await diskCache.addVersion(Self.fixture)
+
+        #expect(diskCache.versionIsPresent(for: Self.fixture.id))
+    }
+
+    @Test
+    func versionIsPresentReflectsDownloadCache() async throws {
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let downloadCache = VersionDownloadCache(directoryProvider: storage.provider)
+        await downloadCache.addVersion(Self.fixture)
 
         let isPresent = await repository.versionIsPresent(for: Self.fixture.id)
 
         #expect(isPresent)
-        #expect(download.versionIsPresentCallCount == 1)
         #expect(api.callCount == 0)
     }
 
     @Test
     func downloadStatusReflectsDownloadCache() async throws {
-        let (repository, api, _, _, download) = makeRepository()
-        download.prime(with: Self.fixture)
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let downloadCache = VersionDownloadCache(directoryProvider: storage.provider)
+        await downloadCache.addVersion(Self.fixture)
 
         let status = repository.downloadStatus(for: Self.fixture.id)
         let otherStatus = repository.downloadStatus(for: 999)
@@ -253,27 +209,51 @@ struct BibleVersionRepositoryTests {
     }
 
     @Test
-    func removeVersionClearsAllCaches() async throws {
-        let (repository, _, memory, disk, download) = makeRepository()
-        memory.prime(with: Self.fixture)
-        disk.prime(with: Self.fixture)
-        download.prime(with: Self.fixture)
+    func downloadedVersionIdsReflectDownloadCache() async throws {
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let downloadCache = VersionDownloadCache(directoryProvider: storage.provider)
+        await downloadCache.addVersion(Self.fixture)
 
-        await repository.removeVersion(withId: Self.fixture.id)
-
-        #expect(memory.removeCallCount == 1)
-        #expect(disk.removeCallCount == 1)
-        #expect(download.removeCallCount == 1)
+        #expect(repository.downloadedVersionIds == [Self.fixture.id])
+        #expect(api.callCount == 0)
     }
 
     @Test
-    func removeUnpermittedVersionsForwardsToCaches() async throws {
-        let (repository, _, memory, disk, download) = makeRepository()
+    func removeVersionClearsAllCaches() async throws {
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let diskCache = VersionDiskCache(directoryProvider: storage.provider)
+        let downloadCache = VersionDownloadCache(directoryProvider: storage.provider)
+
+        _ = try await repository.version(withId: Self.fixture.id)
+        await downloadCache.addVersion(Self.fixture)
+
+        await repository.removeVersion(withId: Self.fixture.id)
+
+        #expect(await diskCache.version(withId: Self.fixture.id) == nil)
+        #expect(await downloadCache.version(withId: Self.fixture.id) == nil)
+
+        _ = try await repository.version(withId: Self.fixture.id)
+        #expect(api.callCount == 2)
+    }
+
+    @Test
+    func removeUnpermittedVersionsRemovesStoredVersionsAndMemoryCache() async throws {
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let diskCache = VersionDiskCache(directoryProvider: storage.provider)
+        let downloadCache = VersionDownloadCache(directoryProvider: storage.provider)
+
+        _ = try await repository.version(withId: Self.fixture.id)
+        await downloadCache.addVersion(Self.fixture)
 
         await repository.removeUnpermittedVersions(permittedIds: [])
 
-        #expect(memory.removeUnpermittedCallCount == 1)
-        #expect(disk.removeUnpermittedCallCount == 1)
-        #expect(download.removeUnpermittedCallCount == 1)
+        #expect(await diskCache.version(withId: Self.fixture.id) == nil)
+        #expect(await downloadCache.version(withId: Self.fixture.id) == nil)
+
+        _ = try await repository.version(withId: Self.fixture.id)
+        #expect(api.callCount == 2)
     }
 }

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
@@ -81,6 +81,23 @@ struct BibleVersionRepositoryTests {
         #expect(api.callCount == 0)
     }
 
+    @Test
+    func versionIfCachedReturnsDownloadVersionAndWarmsMemory() async throws {
+        let (repository, api, storage) = try makeRepository()
+        defer { storage.remove() }
+        let downloadCache = VersionDownloadCache(directoryProvider: storage.provider)
+        await downloadCache.addVersion(Self.fixture)
+
+        let cached = try await repository.versionIfCached(Self.fixture.id)
+        await downloadCache.removeVersion(withId: Self.fixture.id)
+        let memoryCached = try await repository.versionIfCached(Self.fixture.id)
+
+        #expect(cached?.id == Self.fixture.id)
+        #expect(memoryCached?.id == Self.fixture.id)
+        #expect(memoryCached?.abbreviation == Self.fixture.abbreviation)
+        #expect(api.callCount == 0)
+    }
+
     // MARK: version(withId:)
 
     @Test

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
@@ -2,9 +2,9 @@ import Foundation
 import Testing
 @testable import YouVersionPlatformCore
 
-// MARK: - API Recorder
+// MARK: - API Request Counter
 
-final class BibleVersionAPIRecorder: @unchecked Sendable {
+final class BibleVersionAPIRequestCounter: BibleVersionProviding, @unchecked Sendable {
     private(set) var requestedIds: [Int] = []
     var result: BibleVersion
     var error: Error?
@@ -43,21 +43,21 @@ struct BibleVersionRepositoryTests {
 
     @discardableResult
     private func makeRepository(
-        apiRecorder: BibleVersionAPIRecorder? = nil
+        apiRequestCounter: BibleVersionAPIRequestCounter? = nil
     ) throws -> (
         repository: BibleVersionRepository,
-        apiRecorder: BibleVersionAPIRecorder,
+        apiRequestCounter: BibleVersionAPIRequestCounter,
         storage: RepositoryTemporaryStorage
     ) {
-        let apiRecorder = apiRecorder ?? BibleVersionAPIRecorder(result: Self.fixture)
+        let apiRequestCounter = apiRequestCounter ?? BibleVersionAPIRequestCounter(result: Self.fixture)
         let storage = try RepositoryTemporaryStorage()
 
         return (
             BibleVersionRepository(
-                versionFromAPI: apiRecorder.version(withId:),
+                provider: apiRequestCounter,
                 directoryProvider: storage.provider
             ),
-            apiRecorder,
+            apiRequestCounter,
             storage
         )
     }

--- a/Tests/YouVersionPlatformCoreTests/RepositoryStorageTestHelpers.swift
+++ b/Tests/YouVersionPlatformCoreTests/RepositoryStorageTestHelpers.swift
@@ -5,7 +5,7 @@ struct RepositoryTemporaryStorage {
     let rootURL: URL
     let cacheRootURL: URL
     let downloadRootURL: URL
-    let provider: RepositoryBibleContentDirectoryProvider
+    let provider: TestBibleContentDirectoryProvider
 
     init() throws {
         let rootURL = FileManager.default.temporaryDirectory
@@ -19,7 +19,7 @@ struct RepositoryTemporaryStorage {
         self.rootURL = rootURL
         self.cacheRootURL = cacheRootURL
         self.downloadRootURL = downloadRootURL
-        self.provider = RepositoryBibleContentDirectoryProvider(
+        self.provider = TestBibleContentDirectoryProvider(
             cacheRootURL: cacheRootURL,
             downloadRootURL: downloadRootURL
         )
@@ -42,7 +42,7 @@ struct RepositoryTemporaryStorage {
     }
 }
 
-struct RepositoryBibleContentDirectoryProvider: BibleContentDirectoryProviding {
+struct TestBibleContentDirectoryProvider: BibleContentDirectoryProviding {
     let cacheRootURL: URL
     let downloadRootURL: URL
 

--- a/Tests/YouVersionPlatformCoreTests/RepositoryStorageTestHelpers.swift
+++ b/Tests/YouVersionPlatformCoreTests/RepositoryStorageTestHelpers.swift
@@ -1,0 +1,57 @@
+import Foundation
+@testable import YouVersionPlatformCore
+
+struct RepositoryTemporaryStorage {
+    let rootURL: URL
+    let cacheRootURL: URL
+    let downloadRootURL: URL
+    let provider: RepositoryBibleContentDirectoryProvider
+
+    init() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appending(path: "BibleRepositoryTests-\(UUID().uuidString)", directoryHint: .isDirectory)
+        let cacheRootURL = rootURL.appending(path: "cache", directoryHint: .isDirectory)
+        let downloadRootURL = rootURL.appending(path: "download", directoryHint: .isDirectory)
+
+        try FileManager.default.createDirectory(at: cacheRootURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: downloadRootURL, withIntermediateDirectories: true)
+
+        self.rootURL = rootURL
+        self.cacheRootURL = cacheRootURL
+        self.downloadRootURL = downloadRootURL
+        self.provider = RepositoryBibleContentDirectoryProvider(
+            cacheRootURL: cacheRootURL,
+            downloadRootURL: downloadRootURL
+        )
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: rootURL)
+    }
+
+    func write(_ data: Data, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: url)
+    }
+
+    func write(_ content: String, to url: URL) throws {
+        try write(Data(content.utf8), to: url)
+    }
+}
+
+struct RepositoryBibleContentDirectoryProvider: BibleContentDirectoryProviding {
+    let cacheRootURL: URL
+    let downloadRootURL: URL
+
+    func rootURL(for storageKind: BibleContentStorageKind) -> URL {
+        switch storageKind {
+        case .cache:
+            cacheRootURL
+        case .download:
+            downloadRootURL
+        }
+    }
+}

--- a/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
@@ -58,7 +58,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
         downloadedVersionIdsForListing
     }
 
-    func removeVersion(withId versionId: Int) async {
+    func removeVersion(withId id: Int) async {
     }
 
     func removeUnpermittedVersions(permittedIds: Set<Int>) async {

--- a/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
@@ -8,6 +8,11 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
     var cachedVersionById: [Int: BibleVersion] = [:]
     var thrownError: Error?
     var downloadedIds: [Int] = []
+    private let downloadedVersionIdsForListing: [Int]
+
+    init(downloadedVersionIds: [Int] = []) {
+        self.downloadedVersionIdsForListing = downloadedVersionIds
+    }
 
     func setVersion(_ version: BibleVersion) {
         versionById[version.id] = version
@@ -47,6 +52,10 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
 
     nonisolated func downloadStatus(for id: Int) -> BibleVersionRepository.BibleVersionDownloadStatus {
         .notDownloadable
+    }
+
+    nonisolated var downloadedVersionIds: [Int] {
+        downloadedVersionIdsForListing
     }
 
     func removeVersion(withId versionId: Int) async {

--- a/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
@@ -182,7 +182,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
     }
 
     private func waitFor(
-        timeoutNanoseconds: UInt64 = 1_000_000_000,
+        timeoutNanoseconds: UInt64 = 5_000_000_000,
         condition: @escaping @MainActor () -> Bool
     ) async {
         let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
@@ -193,6 +193,9 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             await Task.yield()
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
+        // One final check: Task.sleep can oversleep on a loaded machine, so the condition
+        // may have been satisfied during the last sleep even though the deadline has passed.
+        if condition() { return }
         Issue.record("Timed out waiting for condition")
     }
 }


### PR DESCRIPTION
## Description

refactor!: make BibleChapterRepository and BibleVersionRepository easily mockable, and add tests.

  BREAKING CHANGE: BibleVersionAPIClient, BibleVersionCaching, and VersionClient have
  been removed from the public API. BibleVersionRepositoryProtocol now requires
  downloadedVersionIds. Callers that implemented this protocol or depended on those
  types must update accordingly.

These classes were never intended to be public, and were not documented, and are unlikely to have been used by anyone, but regardless this must be classified as a breaking change.

Specifically:
- class ChapterDiskCache has been removed
- class ChapterDownloadCache has been removed
- class VersionClient has been removed
- class VersionDiskCache has been removed
- class VersionDownloadCache has been removed
- class VersionMemoryCache has been removed
- class BibleChapterRepository has removed conformance to ObservableObject (but this was never functional)
- class BibleVersionRepository has removed conformance to Observable (but this was never functional)
- constructor BibleVersionRepository.init(apiClient:memoryCache:diskCache:downloadCache:) has been removed
- protocol BibleVersionAPIClient has been removed
- protocol BibleVersionCaching has been removed
- var BibleVersionRepositoryProtocol.downloadedVersionIds has been added as a protocol requirement


## Type of Change

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [ ] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [x] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [x] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] All commit messages follow [conventional commits](https://www.conventionalcommits.org/) format

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors `BibleChapterRepository` and `BibleVersionRepository` to improve testability by internalizing previously-public cache types (`ChapterDiskCache`, `VersionDiskCache`, etc.) and replacing them with injectable protocol seams (`BibleChapterContentProviding`, `BibleVersionProviding`, `BibleContentDirectoryProviding`). The new `downloadedVersionIds` requirement on `BibleVersionRepositoryProtocol` enables full mock implementations, as demonstrated by the `MockBibleVersionRepository` used in the new `BibleVersionsViewModelTests`. Test coverage is comprehensive, exercising memory, disk, and download cache layers with isolated temporary directories.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style suggestions with no correctness impact.

Only one P2 finding (redundant memory-cache write that is harmless). The refactoring is well-structured, the injectable seams are clean, and the new tests cover the critical caching paths thoroughly.

No files require special attention beyond the acknowledged `chaptersArePresent` visibility noted in a prior review.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift | Refactored to remove public cache types and add `downloadedVersionIds` to the protocol; minor redundant memory-cache write in `version(withId:)`. |
| Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift | Cleaned up to remove ObservableObject conformance and internal cache types; `chaptersArePresent` remains internal (flagged in prior review). |
| Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift | Thorough white-box tests covering all caching layers, error propagation, download flow, and `downloadedVersionIds`. |
| Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift | Good coverage of memory, disk, and download cache paths; error propagation and removal are tested. |
| Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift | New ViewModel tests using a properly implemented `MockBibleVersionRepository` actor; `waitFor` helper handles async UI state correctly. |
| Tests/YouVersionPlatformCoreTests/RepositoryStorageTestHelpers.swift | New shared test helper isolating file-system operations per test run with unique temp directories. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant BibleVersionRepository
    participant VersionMemoryCache
    participant VersionDiskCache
    participant VersionDownloadCache
    participant BibleVersionProviding

    Caller->>BibleVersionRepository: version(withId:)
    BibleVersionRepository->>VersionMemoryCache: version(withId:)
    alt memory hit
        VersionMemoryCache-->>BibleVersionRepository: BibleVersion
        BibleVersionRepository-->>Caller: BibleVersion
    else memory miss
        BibleVersionRepository->>VersionDiskCache: version(withId:)
        alt disk hit
            VersionDiskCache-->>BibleVersionRepository: BibleVersion
            BibleVersionRepository->>VersionMemoryCache: addVersion(_:)
            BibleVersionRepository-->>Caller: BibleVersion
        else disk miss
            BibleVersionRepository->>VersionDownloadCache: version(withId:)
            alt download hit
                VersionDownloadCache-->>BibleVersionRepository: BibleVersion
                BibleVersionRepository->>VersionMemoryCache: addVersion(_:)
                BibleVersionRepository-->>Caller: BibleVersion
            else all misses
                BibleVersionRepository->>BibleVersionProviding: version(withId:)
                BibleVersionProviding-->>BibleVersionRepository: BibleVersion
                BibleVersionRepository->>VersionMemoryCache: addVersion(_:)
                BibleVersionRepository->>VersionDiskCache: addVersion(_:)
                BibleVersionRepository-->>Caller: BibleVersion
            end
        end
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift`, line 1357-1369 ([link](https://github.com/youversion/platform-sdk-swift/blob/d4945999ef6b9be9c31deaa8fbc7102fab09a7e1/Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift#L1357-L1369)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Duplicated test directory-provider implementation**

   `TemporaryBibleContentDirectoryProvider` (defined here as `private`) and `RepositoryBibleContentDirectoryProvider` (in `RepositoryStorageTestHelpers.swift`) have identical bodies. Both sit in the same test target (`YouVersionPlatformCoreTests`), so one of them could be promoted to `internal` in the shared helpers file and reused here, reducing the risk of the two drifting apart if a new `BibleContentStorageKind` case is ever added.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift
   Line: 1357-1369

   Comment:
   **Duplicated test directory-provider implementation**

   `TemporaryBibleContentDirectoryProvider` (defined here as `private`) and `RepositoryBibleContentDirectoryProvider` (in `RepositoryStorageTestHelpers.swift`) have identical bodies. Both sit in the same test target (`YouVersionPlatformCoreTests`), so one of them could be promoted to `internal` in the shared helpers file and reused here, reducing the risk of the two drifting apart if a new `BibleContentStorageKind` case is ever added.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Tests%2FYouVersionPlatformCoreTests%2FBibleContentStorageTests.swift%0ALine%3A%201357-1369%0A%0AComment%3A%0A**Duplicated%20test%20directory-provider%20implementation**%0A%0A%60TemporaryBibleContentDirectoryProvider%60%20%28defined%20here%20as%20%60private%60%29%20and%20%60RepositoryBibleContentDirectoryProvider%60%20%28in%20%60RepositoryStorageTestHelpers.swift%60%29%20have%20identical%20bodies.%20Both%20sit%20in%20the%20same%20test%20target%20%28%60YouVersionPlatformCoreTests%60%29%2C%20so%20one%20of%20them%20could%20be%20promoted%20to%20%60internal%60%20in%20the%20shared%20helpers%20file%20and%20reused%20here%2C%20reducing%20the%20risk%20of%20the%20two%20drifting%20apart%20if%20a%20new%20%60BibleContentStorageKind%60%20case%20is%20ever%20added.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=87&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Tests%2FYouVersionPlatformCoreTests%2FBibleContentStorageTests.swift%0ALine%3A%201357-1369%0A%0AComment%3A%0A**Duplicated%20test%20directory-provider%20implementation**%0A%0A%60TemporaryBibleContentDirectoryProvider%60%20%28defined%20here%20as%20%60private%60%29%20and%20%60RepositoryBibleContentDirectoryProvider%60%20%28in%20%60RepositoryStorageTestHelpers.swift%60%29%20have%20identical%20bodies.%20Both%20sit%20in%20the%20same%20test%20target%20%28%60YouVersionPlatformCoreTests%60%29%2C%20so%20one%20of%20them%20could%20be%20promoted%20to%20%60internal%60%20in%20the%20shared%20helpers%20file%20and%20reused%20here%2C%20reducing%20the%20risk%20of%20the%20two%20drifting%20apart%20if%20a%20new%20%60BibleContentStorageKind%60%20case%20is%20ever%20added.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=87&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

2. `Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift`, line 316-318 ([link](https://github.com/youversion/platform-sdk-swift/blob/b3a11cf15f2a9224976ca5c8b630ce5a0b1e21be/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift#L316-L318)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`chaptersArePresent` silently dropped from public API**

   `chaptersArePresent(versionId:)` was `nonisolated public` before this PR and is now implicitly `internal`. Since `BibleChapterRepository` is a public actor in a distributable SDK, any downstream caller of this method will get a "value of type 'BibleChapterRepository' has no member 'chaptersArePresent'" build error after updating. If the intent is to keep it accessible, restoring `public` (and, optionally, `nonisolated`) would avoid the breaking change.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
   Line: 316-318

   Comment:
   **`chaptersArePresent` silently dropped from public API**

   `chaptersArePresent(versionId:)` was `nonisolated public` before this PR and is now implicitly `internal`. Since `BibleChapterRepository` is a public actor in a distributable SDK, any downstream caller of this method will get a "value of type 'BibleChapterRepository' has no member 'chaptersArePresent'" build error after updating. If the intent is to keep it accessible, restoring `public` (and, optionally, `nonisolated`) would avoid the breaking change.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformCore%2FBible%2FBibleChapterRepository.swift%0ALine%3A%20316-318%0A%0AComment%3A%0A**%60chaptersArePresent%60%20silently%20dropped%20from%20public%20API**%0A%0A%60chaptersArePresent%28versionId%3A%29%60%20was%20%60nonisolated%20public%60%20before%20this%20PR%20and%20is%20now%20implicitly%20%60internal%60.%20Since%20%60BibleChapterRepository%60%20is%20a%20public%20actor%20in%20a%20distributable%20SDK%2C%20any%20downstream%20caller%20of%20this%20method%20will%20get%20a%20%22value%20of%20type%20'BibleChapterRepository'%20has%20no%20member%20'chaptersArePresent'%22%20build%20error%20after%20updating.%20If%20the%20intent%20is%20to%20keep%20it%20accessible%2C%20restoring%20%60public%60%20%28and%2C%20optionally%2C%20%60nonisolated%60%29%20would%20avoid%20the%20breaking%20change.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=87&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformCore%2FBible%2FBibleChapterRepository.swift%0ALine%3A%20316-318%0A%0AComment%3A%0A**%60chaptersArePresent%60%20silently%20dropped%20from%20public%20API**%0A%0A%60chaptersArePresent%28versionId%3A%29%60%20was%20%60nonisolated%20public%60%20before%20this%20PR%20and%20is%20now%20implicitly%20%60internal%60.%20Since%20%60BibleChapterRepository%60%20is%20a%20public%20actor%20in%20a%20distributable%20SDK%2C%20any%20downstream%20caller%20of%20this%20method%20will%20get%20a%20%22value%20of%20type%20'BibleChapterRepository'%20has%20no%20member%20'chaptersArePresent'%22%20build%20error%20after%20updating.%20If%20the%20intent%20is%20to%20keep%20it%20accessible%2C%20restoring%20%60public%60%20%28and%2C%20optionally%2C%20%60nonisolated%60%29%20would%20avoid%20the%20breaking%20change.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=87&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformCore%2FBible%2FBibleVersionRepository.swift%3A241-256%0A**Redundant%20%60memoryCache.addVersion%60%20after%20task%20completion**%0A%0AThe%20%60Task%60%20closure%20already%20calls%20%60memoryCache.addVersion%28version%29%60%20internally%20%28line%20243%29%2C%20so%20the%20second%20call%20on%20line%20256%20is%20a%20duplicate%20write%20for%20every%20successful%20API%20fetch.%20The%20version%20ends%20up%20written%20to%20the%20memory%20cache%20twice%20%E2%80%94%20once%20from%20inside%20the%20task%2C%20and%20once%20from%20the%20caller%20after%20%60task.value%60%20resolves.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20version%20%3D%20try%20await%20task.value%0A%20%20%20%20%20%20%20%20return%20version%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=87&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformCore%2FBible%2FBibleVersionRepository.swift%3A241-256%0A**Redundant%20%60memoryCache.addVersion%60%20after%20task%20completion**%0A%0AThe%20%60Task%60%20closure%20already%20calls%20%60memoryCache.addVersion%28version%29%60%20internally%20%28line%20243%29%2C%20so%20the%20second%20call%20on%20line%20256%20is%20a%20duplicate%20write%20for%20every%20successful%20API%20fetch.%20The%20version%20ends%20up%20written%20to%20the%20memory%20cache%20twice%20%E2%80%94%20once%20from%20inside%20the%20task%2C%20and%20once%20from%20the%20caller%20after%20%60task.value%60%20resolves.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20version%20%3D%20try%20await%20task.value%0A%20%20%20%20%20%20%20%20return%20version%0A%60%60%60%0A%0A&pr=87&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
Line: 241-256

Comment:
**Redundant `memoryCache.addVersion` after task completion**

The `Task` closure already calls `memoryCache.addVersion(version)` internally (line 243), so the second call on line 256 is a duplicate write for every successful API fetch. The version ends up written to the memory cache twice — once from inside the task, and once from the caller after `task.value` resolves.

```suggestion
        let version = try await task.value
        return version
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (13): Last reviewed commit: ["test: use more standard injection mechan..."](https://github.com/youversion/platform-sdk-swift/commit/de3ad77826dba35e764b0fc4a2e9664c17686479) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30035530)</sub>

<!-- /greptile_comment -->