### PR TITLE
chore: extract Swift conventions into skills and configure Greptile

### DIFF
--- a/.claude/skills/audit-swift-ui/SKILL.md
+++ b/.claude/skills/audit-swift-ui/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: audit-swift-ui
+description: Audit SwiftUI code for compliance with this project's view-specific conventions (Dynamic Type, @State privacy, view naming). Use when writing new SwiftUI views, reviewing a PR that touches SwiftUI, or checking whether existing SwiftUI code follows project rules.
+---
+
+# Auditing SwiftUI code
+
+These rules are specific to SwiftUI views. For general Swift conventions, load the `audit-swift` skill. For naming guidance, load `naming`.
+
+- Mark `@State` properties `private`.
+- Do not use the suffix "Widget" for SwiftUI view names, as it conflicts with iOS home screen widgets (WidgetKit); use a more descriptive name instead.
+- Use Dynamic Type text styles (`.body`, `.callout`, `.footnote`, etc.) instead of `.font(.system(size:))` so fonts adapt to the user's preferred text size.
+- When using `Font.custom`, always include the `relativeTo:` parameter (e.g., `Font.custom("MyFont", size: 16, relativeTo: .callout)`) so custom fonts scale with Dynamic Type.

--- a/.claude/skills/audit-swift/SKILL.md
+++ b/.claude/skills/audit-swift/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: audit-swift
+description: Audit Swift code for compliance with this project's style and conventions (access control, async/await, code organization, idioms, formatting). Use when writing new Swift code, reviewing a PR for style, or checking whether existing Swift code follows project rules.
+---
+
+# Auditing Swift code
+
+Apply these rules when writing or reviewing Swift code in this project. They apply across all targets — `YouVersionPlatformCore`, `YouVersionPlatformUI`, and `YouVersionPlatformReader` — and to the example apps.
+
+For naming guidance (types, functions, parameters, properties, cases), load the `naming` skill. For SwiftUI-specific rules, load `audit-swift-ui`.
+
+## Style and idioms
+
+- Prefer idiomatic, industry standard Swift style. Follow https://www.swift.org/documentation/api-design-guidelines/.
+- Don't make whitespace-only changes.
+- Prefer async-await to completion block-based API design.
+- Prefer Swift Concurrency over Combine.
+- Prefer `@Observable` to `ObservableObject`.
+- ALWAYS mark ViewModel types as `@MainActor`.
+- NEVER use locks (NSLock, etc.); prefer actors for isolation.
+- When awaiting multiple independent async calls, run them concurrently with `async let` (or a task group) rather than serially with back-to-back `await`s.
+- Don't build a new array with a `for` loop and `append`. Use `map`, `filter`, `compactMap`, `flatMap`, or `reduce` instead.
+- Use local functions instead of inline closure blocks (`let x: () -> T = { ... }`).
+- Don't unwrap optional closures with `if let` — use `closure?()`.
+- If a function immediately `guard`s an Optional argument, make the argument non-Optional. The unwrap belongs at the call site, where the precondition stays explicit.
+- When using `guard`, the `return`/`continue` belongs on a new line.
+- Don't use `guard` in an overridden method to return early.
+- Don't use a comma between logical expressions when `&&` will suffice.
+- Use `Notification.Name("name")` not `Notification.Name(rawValue:)`, and `Notification.Name` not `NSNotification.Name`.
+
+## Access control and mutability
+
+- Make access controls on properties and functions as strict as they can be (`private`, `fileprivate`, `private(set)`, etc).
+- Don't specify `internal` — it's the default.
+- Prefer to make entity properties immutable (`let` over `var`).
+- Classes should be marked `final` if they have no subclasses.
+- Prefer structs over classes.
+- For computed values with no arguments, prefer `var` over `func`.
+
+## Initializers
+
+- NEVER create objects starting with `.init(...)`.
+- Don't override methods or initializers only to call `super`.
+- Do not add a `deinit` solely to remove `NotificationCenter` observers — it's unnecessary.
+
+## Code organization within a type
+
+- Properties should be listed before all functions.
+- Stored properties should be declared before all initializers.
+- Derived properties and functions should be declared after all initializers.
+- Sort imports alphabetically.
+
+## Comments and dead code
+
+- Don't add inline comments inside functions, but don't delete existing inline comments.
+- Do add DocC comments to new, non-private functions, but not on SwiftUI initializers and body.
+- No author attribution comment blocks (`// Created by`).
+- Don't leave unused code.
+- Do not leave commented-out code in place.
+
+## Formatting
+
+- Do not prepend `self.` when it is unnecessary.
+- `else`/`catch` on the same line as the closing brace (`} else {`, `} catch {`).
+- No blank lines at the top of `var`/`func`/`init` blocks.
+- Always have one blank line between functions.
+- Let the compiler infer types when possible.
+- Use `""` over `String()` for empty strings.
+- Use `private(set)` not `private (set)`.
+- Use `private static` not `static private`.
+
+## Naming summary
+
+Detailed naming guidance lives in the `naming` skill — load it for anything name-related. The project-specific essentials:
+
+- Avoid abbreviations; prefer clarity over brevity.
+- Public-facing types should generally include "YouVersion" in their name (e.g. `YouVersionBigButtonStyle`, `SignInWithYouVersionView`) to disambiguate from client-local types.
+- Class, struct, enum entity names should always be in PascalCase. Property and function names should always be in camelCase.
+- Async functions with return values should have names that are noun phrases describing the return value rather than verb phrases and should never begin with "get", "load", "fetch", or "request".
+- For Booleans, ensure that they start with a helping verb like "is", "should". "shows" and "showing" are also acceptable prefixes.
+- Non-boolean entities should end with a word that indicates their data type (e.g. `shadowColor` rather than `colorShadow` for a Color).
+
+## Localization
+
+- Use existing localized strings if possible; prompt the user before adding new strings.
+
+## Testing
+
+- Use Swift Testing for unit tests, not XCTest.
+
+## Platform support
+
+- Code MUST support iOS 17 but can branch using `if #available(iOS ##.#, *)` checks.

--- a/.claude/skills/naming/SKILL.md
+++ b/.claude/skills/naming/SKILL.md
@@ -1,0 +1,349 @@
+---
+name: naming
+description: Name Swift entities (types, protocols, functions, parameters, properties, local variables, cases) following Apple's Swift API Design Guidelines and this project's conventions. Use when introducing or renaming any identifier in Swift code, reviewing a PR for naming, or deciding between candidate names.
+---
+
+# Naming Entities in Swift
+
+The goal of a name is **clarity at the point of use**. A name succeeds when a reader who has never seen the call site can predict what it does, what type it is, and how it fits with the code around it. A name fails when it forces the reader to pause and think *"why is this one different?"* or *"what does that abbreviation stand for?"*
+
+Apply these rules any time you introduce or rename a type, protocol, function, method, parameter, property, local variable, enum case, or generic parameter.
+
+---
+
+## 1. Hard rules
+
+These are non-negotiable on this project.
+
+### No abbreviations
+
+Abbreviations force the reader to decode. Write the full word.
+
+```swift
+// No
+let usr: User
+let btnTitle: String
+let createdDt: Date
+let msgCount: Int
+func calc(...) -> Int
+class NoteMgr { ... }
+
+// Yes
+let user: User
+let buttonTitle: String
+let createdDate: Date
+let messageCount: Int
+func calculate(...) -> Int
+class NotesManager { ... }
+```
+
+Narrow exceptions:
+- **Deeply precedented domain terms** that everyone in that field would recognize: `sin`, `cos`, `url`, `id`, `json`, `html`. If a reasonable web search on the abbreviation alone would confirm the meaning, it is fine.
+- **Established acronyms** already in the platform: `URL`, `UUID`, `HTTP`, `JSON`.
+
+Acronyms follow the Swift case convention: uniformly upper-cased when capitalized (`URL`, `UTF8`), uniformly lower-cased otherwise (`urlString`, `jsonDecoder`). Never `Url` or `urlDecoderUrl`.
+
+### No restating context
+
+Inside a type, a property name should not repeat the enclosing type's name. The context is already obvious.
+
+```swift
+// No
+struct BibleVersion {
+    let versionTitle: String
+    let bibleVersionAbbreviation: String
+    let versionID: Int
+}
+
+// Yes
+struct BibleVersion {
+    let title: String
+    let abbreviation: String
+    let id: Int
+}
+```
+
+Same for function parameters — do not restate the function's subject in each label:
+
+```swift
+// No
+func updateVersion(versionTitle: String, versionAbbreviation: String) { ... }
+
+// Yes
+func updateVersion(title: String, abbreviation: String) { ... }
+```
+
+### Prefer product-focused names over technical names
+
+When a shorter, more product-focused name conveys nearly all the meaning, use it. Multi-word internal-implementation names are a smell.
+
+```swift
+// No — technical, implementation-leaking, long
+class NoteObjectStateSyncMachine { ... }
+class UserDataRepositoryCoordinator { ... }
+class PlanReadingProgressStateHandler { ... }
+
+// Yes — what the thing is, in product terms
+class NotesManager { ... }
+class UserRepository { ... }
+class PlanProgress { ... }
+```
+
+Ask *"what does this do for the product?"* and name from that vocabulary. Save specificity for the handful of cases where the role really is the distinguishing thing.
+
+### A name must imply its type
+
+A reader should be able to guess the type from the name without jumping to the declaration. Be consistent with the shape already used in nearby code.
+
+| Type             | Suffix / shape                                  | Examples                                 |
+| ---------------- | ----------------------------------------------- | ---------------------------------------- |
+| `Date`           | `...Date`                                       | `createdDate`, `expirationDate`          |
+| `TimeInterval`   | `...Duration`, `...Interval`, `...Seconds`      | `animationDuration`, `timeoutSeconds`    |
+| `URL`            | `...URL`                                        | `avatarURL`, `shareURL`                  |
+| `String` (URL)   | `...URLString`                                  | `avatarURLString`                        |
+| `Bool`           | `is...`, `has...`, `can...`, `should...`        | `isHidden`, `hasUnread`, `canDismiss`    |
+| Count            | `...Count`                                      | `messageCount`, `unreadCount`            |
+| Array            | pluralize                                       | `friends`, `savedMoments`                |
+| Dictionary       | `...By...` or descriptive pair                  | `usersByID`                              |
+| Identifier       | `...ID` (when not the primary `id` of the type) | `userID`, `planID`                       |
+| Closure          | verb phrase describing what it does             | `onTap`, `onLoad`, `didSelect`           |
+
+Do not invent a new shape when a nearby one exists. If surrounding code uses `createdDate`, do not introduce `createdOn` or `createdAt` or `createdDt` — match the established pattern. **Never make the reader think "why is this similar-looking thing different from the other cases?"**
+
+### Consistency with nearby code wins
+
+Before naming a new thing, read the file and the module around it. If there is an existing convention — suffix, verb, parameter label order, collection naming — follow it. A technically better name that breaks a local pattern is worse than the local pattern.
+
+---
+
+## 2. Choosing the base name
+
+### Name by role, not by type
+
+Use the *role* the value plays in the code, not its class name.
+
+```swift
+// No
+let string: String
+let view: UIView
+let array: [YVNPerson]
+
+// Yes
+let greeting: String
+let avatarView: UIView
+let suggestedFriends: [YVNPerson]
+```
+
+### Include just enough — no more, no less
+
+> Every word in a name should convey salient information at the use site.
+
+Two failure modes:
+
+1. **Too few words** → ambiguous. `remove(x)` could mean "remove the first equal element" or "remove at index x". `remove(at: x)` makes it clear.
+2. **Too many words** → noise. If `view.backgroundColor` already tells you it is a color, don't write `view.backgroundColorColor` or `view.backgroundColorValue`.
+
+### Compensate for weak type information
+
+When a parameter's type is `Any`, `NSObject`, `String`, `Int`, a closure, or similar, add a noun that describes its role:
+
+```swift
+// No — "add what?"
+func add(_ observer: Any)
+
+// Yes
+func addObserver(_ observer: Any)
+```
+
+---
+
+## 3. Functions and methods
+
+### Functions that return a value are noun phrases, not verb phrases
+
+If a function's job is to **produce and hand back a value**, its name describes that value. Think of the call site as reading "the … of x", not "do something to x".
+
+This applies to every kind of value-returning function — synchronous, async, throwing, static, free functions, computed helpers. Not just async. Not just API methods.
+
+Never start a value-returning function with `get`, `load`, `fetch`, `request`, `build`, `compute`, `calculate`, `retrieve`, or `find`. Reserve `make` exclusively for factory methods per Apple's guidelines.
+
+```swift
+// No — verb phrases for something that just returns a value
+func getUser(id: String) async throws -> User
+func fetchSuggestedFriends() async throws -> [Person]
+func loadPlans() async throws -> [Plan]
+func calculateTotalPrice() -> Decimal
+func buildAttributedTitle() -> NSAttributedString
+func findMatchingVerse(in chapter: Chapter) -> Verse?
+
+// Yes — noun phrases that describe the returned value
+func user(withID id: String) async throws -> User
+func suggestedFriends() async throws -> [Person]
+func plans() async throws -> [Plan]
+func totalPrice() -> Decimal
+func attributedTitle() -> NSAttributedString
+func matchingVerse(in chapter: Chapter) -> Verse?
+```
+
+Read the call site out loud: `let verse = matchingVerse(in: chapter)` reads as "let verse equal the matching verse in chapter" — natural. `let verse = findMatchingVerse(in: chapter)` reads as an instruction, not an expression.
+
+Exceptions (narrow):
+- **Booleans** read as assertions, so they start with `is` / `has` / `can` / `should` — these are verbs but they *are* the noun-phrase form for booleans. `isEmpty`, `hasUnread`, `canDismiss`.
+- **Factory methods** start with `make` per Apple's guidelines: `makeIterator()`.
+- **Mutating/nonmutating pairs** — the `-ed`/`-ing` form of a verb (`sorted()`, `reversed()`, `strippingNewlines()`) returns a value and keeps the verb root; that is the intended form for the non-mutating sibling of a verb-rooted mutating operation.
+
+### Functions with side effects are imperative verb phrases
+
+```swift
+func dismissSuggestion(...)        // does a thing
+func reload()                      // does a thing
+func sort()                        // mutates in place
+```
+
+In UIKit code on this project, function names are verb phrases: `setUp` not `setup`.
+
+### What if a function both returns a value *and* has side effects?
+
+Prefer splitting it — one side-effecting method and one accessor — so each name tells the truth. If you can't split it, name it for the dominant purpose. If the caller primarily wants the returned value, name it as a noun phrase. If the caller primarily wants the side effect and the return value is incidental (like `@discardableResult` status codes or inserted elements), name it as an imperative verb phrase.
+
+### Mutating / non-mutating pairs
+
+- **Verb-rooted:** imperative mutates, `-ed`/`-ing` returns a new value.
+  `x.sort()` ↔ `x.sorted()`, `x.reverse()` ↔ `x.reversed()`.
+- **Noun-rooted:** the noun form returns a new value, `form-` prefix mutates.
+  `a.union(b)` ↔ `a.formUnion(b)`.
+
+### Boolean methods and properties read as assertions
+
+```swift
+x.isEmpty
+line1.intersects(line2)
+user.hasUnreadMessages
+```
+
+### Factory methods start with `make`
+
+```swift
+func makeIterator() -> Iterator
+```
+
+### Computed vars vs functions
+
+A zero-argument, side-effect-free accessor is a `var`, not a `func`:
+
+```swift
+// No
+func displayName() -> String { ... }
+
+// Yes
+var displayName: String { ... }
+```
+
+---
+
+## 4. Argument labels
+
+The goal is for the call site to read like a grammatical English phrase.
+
+### First-argument labels
+
+- **Initializers and factory methods:** the first argument label does *not* form part of a phrase starting with the base name. Write `Color(red: 32, green: 64, blue: 128)`, not `Color(havingRGBValuesRed: 32, ...)`.
+- **Value-preserving conversions:** first label is `_`. `Int64(someUInt32)`.
+- **Narrowing conversions:** use a descriptive label. `Int(truncating: x)`, `Int(saturating: y)`.
+- **Prepositional phrase at first argument:** label begins with the preposition. `x.removeBoxes(havingLength: 12)`.
+- **Arguments that join the base name grammatically:** omit the first label and fold the word into the name. `view.addSubview(y)`, not `view.add(subview: y)`.
+- **When the first argument does not form a grammatical phrase with the base name:** label it.
+
+### Omit labels only when the arguments are truly indistinguishable
+
+```swift
+min(a, b)              // order doesn't carry meaning
+zip(xs, ys)            // symmetric
+```
+
+Anything else takes a label.
+
+### Defaulted arguments are always labeled
+
+A caller may or may not pass them, so the label anchors the meaning when they do.
+
+### Parameters with defaults go at the end of the list
+
+---
+
+## 5. Types and protocols
+
+### Types, properties, variables, constants — noun phrases
+
+```swift
+struct BibleVersion { ... }
+let title: String
+var createdDate: Date
+```
+
+Types and protocols use `UpperCamelCase`; everything else is `lowerCamelCase`.
+
+### Protocols
+
+- A protocol that describes **what something is**: a noun. `Collection`, `Sequence`, `Identifiable`, `Plan`.
+- A protocol that describes a **capability**: suffix with `-able`, `-ible`, or `-ing`. `Equatable`, `Hashable`, `ProgressReporting`, `AsyncRequestSending`.
+
+Avoid the `I`-prefix, `...Protocol` suffix, or other Obj-C / C# holdovers. Only append `Protocol` when you genuinely need to disambiguate from an associated type of the same name.
+
+### Enum cases
+
+Enum cases are `lowerCamelCase` noun phrases. The enum name already supplies context — don't restate it.
+
+```swift
+// No
+enum Tab {
+    case bibleTab, plansTab, momentsTab
+}
+
+// Yes
+enum Tab {
+    case bible, plans, moments
+}
+```
+
+---
+
+## 6. Parameters that never appear at the call site
+
+Parameter *names* (as opposed to labels) do not appear at call sites, but they do appear in documentation and in the function body. Pick ones that read well there.
+
+```swift
+// No — reads badly in docs and body
+func remove(_ a: Element) -> Element?
+
+// Yes
+func remove(_ member: Element) -> Element?
+```
+
+The same applies to closure parameters and tuple members — give them names where they appear in the API so documentation and call-site autocomplete are expressive.
+
+---
+
+## 7. Use established terminology
+
+- Prefer the common word when it serves equally well; reserve technical terms for when they carry meaning ordinary words cannot.
+- When you *do* reach for a technical term, use it in its accepted sense. Don't call something a `Monad` if it isn't one.
+- Favor platform precedent. `Array`, not `List`. `Dictionary`, not `Map`. `Set`, not `HashSet`.
+
+---
+
+## 8. A short checklist when you name something
+
+Run through this in order. Stop at the first problem and fix it.
+
+1. **Any abbreviations?** Spell them out.
+2. **Would a reader know the type from the name?** If not, adjust the shape (`...Date`, `is...`, `...URL`, etc.).
+3. **Does the name restate the containing type or function subject?** Drop the redundancy.
+4. **Is the name implementation-leaking or needlessly technical?** Try a product-focused alternative.
+5. **Does it match the pattern of nearby similar things?** If not, either match them or have a strong reason not to.
+6. **At the call site, does the full line read like a grammatical phrase?** Read it out loud. If it is awkward, the label is wrong.
+7. **Does the function return a value?** Then its name is a noun phrase — no `get`/`load`/`fetch`/`request`/`calculate`/`compute`/`retrieve`/`build`/`find`. **Does it only cause a side effect?** Imperative verb. Confirm the shape matches.
+8. **Boolean?** Starts with `is` / `has` / `can` / `should`, reads as an assertion.
+9. **Can you shorten the name without losing clarity?** Do it. `NotesManager` beats `NoteObjectStateSyncMachine`.
+
+If you are hesitating between two names, read both at the call site — not at the declaration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,66 +102,14 @@ Use for large tasks or risky changes (SDK updates, major API adoption):
 - Never commit a real `appKey` to the remote. In `Examples/SampleApp/SampleApp.swift`, keep the tracked placeholder `<#Your App Key#>` and leave your real key as an unstaged local change.
 - Use GitHub to create pull requests (PRs).
 - PR titles should always be the same as the first line of the commit message.
-- Prefer idiomatic, industry standard Swift style. Follow https://www.swift.org/documentation/api-design-guidelines/.
-- Don't make whitespace-only changes.
-- Prefer async-await to completion block-based API design.
-- Async functions with return values should have names that are noun phrases describing the return value rather than verb phrases and should never begin with "get", "load", "fetch", or "request".
-- Don't add inline comments inside functions, but don't delete existing inline comments.
-- Do add DocC comments to new, non-private functions, but not on SwiftUI initializers and body.
-- Make access controls on properties and functions as strict as they can be (private, fileprivate, private(set), etc).
-- Prefer to make entity properties immutable (let over var).
-- Avoid abbreviations; prefer clarity over brevity.
-- For Booleans, ensure that they start with a helping verb like "is", "should". "shows" and "showing" are also acceptable prefixes.
-- Non-boolean entities should end with a word that indicates their data type (ex. "shadowColor" rather than "colorShadow" for a Color).
-- Do not prepend "self." when it is unnecessary.
-- Properties should be listed before all functions.
-- Classes should be marked final if they have no subclasses.
-- Prefer structs over classes.
-- Don't leave unused code.
-- Do not leave commented out code in place.
-- Public-facing types should generally include "YouVersion" in their name (e.g. `YouVersionBigButtonStyle`, `SignInWithYouVersionView`) to disambiguate from client-local types.
-- Class, struct, enum entity names should always be in PascalCase.
-- Property and function names should always be in camelCase.
-- Prefer Swift Concurrency over Combine.
-- Prefer `@Observable` to `ObservableObject`.
-- ALWAYS mark ViewModel types as `@MainActor`.
-- NEVER use locks (NSLock, etc.); prefer actors for isolation.
-- For computed values with no arguments, prefer `var` over `func`.
-- Don't specify `internal` — it's the default.
-- No author attribution comment blocks (`// Created by`).
-- Sort imports alphabetically.
-- `else`/`catch` on the same line as the closing brace (`} else {`, `} catch {`).
-- No blank lines at the top of `var`/`func`/`init` blocks.
-- Always have one blank line between functions.
-- Let the compiler infer types when possible.
-- Use `""` over `String()` for empty strings.
-- Use `private(set)` not `private (set)`.
-- Use `private static` not `static private`.
-- Don't use a comma between logical expressions when `&&` will suffice.
-- Don't override methods or initializers only to call `super`.
-- Do not add a `deinit` solely to remove `NotificationCenter` observers — it's unnecessary.
-- When using `guard`, the `return`/`continue` belongs on a new line.
-- Don't use `guard` in an overridden method to return early.
-- Use existing localized strings if possible; prompt the user before adding new strings.
-- Use Swift Testing for unit tests, not XCTest.
-- NEVER create objects starting with `.init(...)`.
-- Code MUST support iOS 17 but can branch using `if #available(iOS ##.#, *)` checks.
-- Stored properties should be declared before all initializers.
-- Derived properties and functions should be declared after all initializers.
-- Use `Notification.Name("name")` not `Notification.Name(rawValue:)`, and `Notification.Name` not `NSNotification.Name`.
-- Use local functions instead of inline closure blocks (`let x: () -> T = { ... }`).
-- Don't unwrap optional closures with `if let` — use `closure?()`.
-- Don't leave commented-out code in place.
-- If a function immediately `guard`s an Optional argument, make the argument non-Optional. The unwrap belongs at the call site, where the precondition stays explicit.
-- Don't build a new array with a `for` loop and `append`. Use `map`, `filter`, `compactMap`, `flatMap`, or `reduce` instead.
-- When awaiting multiple independent async calls, run them concurrently with `async let` (or a task group) rather than serially with back-to-back `await`s.
 
-### SwiftUI-Specific Rules
+## Code style references
 
-- Mark `@State` properties `private`.
-- Do not use the suffix "Widget" for SwiftUI view names, as it conflicts with iOS home screen widgets (WidgetKit); use a more descriptive name instead.
-- Use Dynamic Type text styles (`.body`, `.callout`, `.footnote`, etc.) instead of `.font(.system(size:))` so fonts adapt to the user's preferred text size.
-- When using `Font.custom`, always include the `relativeTo:` parameter (e.g., `Font.custom("MyFont", size: 16, relativeTo: .callout)`) so custom fonts scale with Dynamic Type.
+When writing or reviewing code in this repo, load the relevant skill:
+
+- **`audit-swift`** (`.claude/skills/audit-swift/SKILL.md`) — project Swift conventions: access control, async/await, code organization, idioms, formatting.
+- **`audit-swift-ui`** (`.claude/skills/audit-swift-ui/SKILL.md`) — SwiftUI-specific rules: Dynamic Type, `@State` privacy, view naming.
+- **`naming`** (`.claude/skills/naming/SKILL.md`) — naming Swift entities (types, protocols, functions, parameters, properties, cases).
 
 ## Localization
 

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,25 @@
+{
+  "customContext": {
+    "files": [
+      {
+        "scope": ["**/*.swift"],
+        "path": ".claude/skills/audit-swift/SKILL.md",
+        "description": "Project Swift conventions: access control, async/await, code organization, idioms, formatting."
+      },
+      {
+        "scope": [
+          "Sources/YouVersionPlatformUI/**/*.swift",
+          "Sources/YouVersionPlatformReader/**/*.swift",
+          "Examples/**/*.swift"
+        ],
+        "path": ".claude/skills/audit-swift-ui/SKILL.md",
+        "description": "SwiftUI-specific rules: Dynamic Type, @State privacy, view naming."
+      },
+      {
+        "scope": ["**/*.swift"],
+        "path": ".claude/skills/naming/SKILL.md",
+        "description": "Naming Swift entities (types, protocols, functions, parameters, properties, cases) per Apple guidelines and project conventions."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Move the Swift and SwiftUI tip lists out of `AGENTS.md` into three skill files under `.claude/skills/`: `audit-swift`, `audit-swift-ui`, and `naming` (the latter was already drafted on this branch).
- `AGENTS.md` keeps the workflow-only tips (appKey handling, PR titles, GitHub usage) and now points at the skills as references instead of inlining them.
- Add `greptile.json` with `customContext.files` entries so Greptile reliably loads the skill files into every PR review, scoped by glob (SwiftUI rules limited to `YouVersionPlatformUI`, `YouVersionPlatformReader`, and `Examples/` since `YouVersionPlatformCore` must run on Linux).

## Why this shape
- **Claude Code** auto-discovers `.claude/skills/<name>/SKILL.md` via the Skill tool — frontmatter `description` controls when each skill triggers.
- **OpenAI Codex** auto-loads `AGENTS.md`, which now references the same files; Codex can read them on demand.
- **Greptile** auto-absorbs `AGENTS.md` and additionally loads the explicit file references from `greptile.json` for reliability.

One source of truth, three tools.

## Test plan
- [ ] Confirm `AGENTS.md` still renders cleanly on GitHub and the workflow tips remain.
- [ ] Open a Swift PR against this branch and verify Greptile's review references the project conventions.
- [ ] In Claude Code, confirm the three skills appear in the available skills list and trigger on Swift edits.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the Swift and SwiftUI coding conventions previously inlined in `AGENTS.md` into three dedicated skill files under `.claude/skills/` and wires them into Greptile via a new `greptile.json`. The restructuring is complete — every rule from the removed sections of `AGENTS.md` is present in the appropriate skill file — creating a single source of truth consumed by Claude Code, Codex, and Greptile alike.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely documentation and tooling configuration, no production code changed.

All changes are documentation reorganization and config files. Every rule from AGENTS.md was successfully migrated to a skill file with no omissions or contradictions detected. No runtime or logic risk.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .claude/skills/audit-swift/SKILL.md | New skill file migrating all general Swift conventions from AGENTS.md; content is complete and well-organized into clear sections. |
| .claude/skills/audit-swift-ui/SKILL.md | New skill file extracting the four SwiftUI-specific rules from AGENTS.md; content is accurate and references companion skills correctly. |
| .claude/skills/naming/SKILL.md | New naming-conventions skill; comprehensive Swift naming guide covering types, protocols, functions, parameters, and cases per Apple guidelines and project rules. |
| AGENTS.md | Workflow-only tips retained; inline Swift/SwiftUI rules removed and replaced with a 'Code style references' section pointing to the three new skill files. |
| greptile.json | New Greptile config wiring skill files to glob scopes; SwiftUI scope correctly excludes YouVersionPlatformCore (Linux-only target) as noted in the PR description. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Sources["Single Source of Truth"]
        AS[".claude/skills/audit-swift/SKILL.md"]
        AU[".claude/skills/audit-swift-ui/SKILL.md"]
        NM[".claude/skills/naming/SKILL.md"]
    end

    subgraph Config["Config / Entry Points"]
        AG["AGENTS.md\n(workflow tips + references)"]
        GJ["greptile.json\n(customContext.files + scopes)"]
    end

    subgraph Consumers["AI Tool Consumers"]
        CC["Claude Code\n(Skill tool auto-discovery)"]
        OC["OpenAI Codex\n(reads AGENTS.md on demand)"]
        GR["Greptile\n(absorbs AGENTS.md + greptile.json)"]
    end

    AG -->|references| AS
    AG -->|references| AU
    AG -->|references| NM

    GJ -->|scope: **/*.swift| AS
    GJ -->|scope: UI + Reader + Examples| AU
    GJ -->|scope: **/*.swift| NM

    CC -->|auto-discovers .claude/skills/| AS
    CC -->|auto-discovers .claude/skills/| AU
    CC -->|auto-discovers .claude/skills/| NM

    OC -->|reads| AG
    GR -->|reads| AG
    GR -->|loads via| GJ
```

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into bm/swift-conven..."](https://github.com/youversion/platform-sdk-swift/commit/03964bce568b7947e4297840bd4faa0913c54f55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30061673)</sub>

<!-- /greptile_comment -->