### PR TITLE
Restore deprecated public API surface to match main baseline

### DIFF
--- a/.api-baseline/YouVersionPlatformCore.json
+++ b/.api-baseline/YouVersionPlatformCore.json
@@ -27,6 +27,13 @@
       },
       {
         "kind": "Import",
+        "name": "SwiftUI",
+        "printedName": "SwiftUI",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformCore"
+      },
+      {
+        "kind": "Import",
         "name": "_Concurrency",
         "printedName": "_Concurrency",
         "declKind": "Import",
@@ -9181,6 +9188,287 @@
       },
       {
         "kind": "TypeDecl",
+        "name": "ChapterDiskCache",
+        "printedName": "ChapterDiskCache",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC06removeB09versionIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC06removeB09versionIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC",
+        "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "hasMissingDesignatedInitializers": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "ChapterDownloadCache",
+        "printedName": "ChapterDownloadCache",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "chaptersArePresent",
+            "printedName": "chaptersArePresent(versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC18chaptersArePresent9versionIdSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC18chaptersArePresent9versionIdSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC06removeB09versionIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC06removeB09versionIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC",
+        "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "hasMissingDesignatedInitializers": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
         "name": "BibleChapterRepository",
         "printedName": "BibleChapterRepository",
         "children": [
@@ -9236,24 +9524,6 @@
             ]
           },
           {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "BibleChapterRepository",
-                "printedName": "YouVersionPlatformCore.BibleChapterRepository",
-                "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryCACycfc",
-            "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryCACycfc",
-            "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Convenience"
-          },
-          {
             "kind": "Function",
             "name": "chapter",
             "printedName": "chapter(withReference:)",
@@ -9299,7 +9569,28 @@
             "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC06removeB06withIdySi_tYaF",
             "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryC06removeB06withIdySi_tYaF",
             "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
             "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "ObjectWillChangePublisher",
+            "printedName": "ObjectWillChangePublisher",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "ObservableObjectPublisher",
+                "printedName": "Combine.ObservableObjectPublisher",
+                "usr": "s:7Combine25ObservableObjectPublisherC"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC25ObjectWillChangePublishera",
+            "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryC25ObjectWillChangePublishera",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true
           },
           {
             "kind": "Var",
@@ -9363,6 +9654,28 @@
         "moduleName": "YouVersionPlatformCore",
         "hasMissingDesignatedInitializers": true,
         "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "ObservableObject",
+            "printedName": "ObservableObject",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "ObjectWillChangePublisher",
+                "printedName": "ObjectWillChangePublisher",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ObservableObjectPublisher",
+                    "printedName": "Combine.ObservableObjectPublisher",
+                    "usr": "s:7Combine25ObservableObjectPublisherC"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7Combine16ObservableObjectP",
+            "mangledName": "$s7Combine16ObservableObjectP"
+          },
           {
             "kind": "Conformance",
             "name": "Copyable",
@@ -12431,6 +12744,24 @@
               "Custom"
             ],
             "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "ObjectWillChangePublisher",
+            "printedName": "ObjectWillChangePublisher",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "ObservableObjectPublisher",
+                "printedName": "Combine.ObservableObjectPublisher",
+                "usr": "s:7Combine25ObservableObjectPublisherC"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC25ObjectWillChangePublishera",
+            "mangledName": "$s22YouVersionPlatformCore24BibleHighlightsViewModelC25ObjectWillChangePublishera",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true
           }
         ],
         "declKind": "Class",
@@ -12441,6 +12772,28 @@
           "Custom"
         ],
         "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "ObservableObject",
+            "printedName": "ObservableObject",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "ObjectWillChangePublisher",
+                "printedName": "ObjectWillChangePublisher",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ObservableObjectPublisher",
+                    "printedName": "Combine.ObservableObjectPublisher",
+                    "usr": "s:7Combine25ObservableObjectPublisherC"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7Combine16ObservableObjectP",
+            "mangledName": "$s7Combine16ObservableObjectP"
+          },
           {
             "kind": "Conformance",
             "name": "Copyable",
@@ -16592,6 +16945,76 @@
       },
       {
         "kind": "TypeDecl",
+        "name": "BibleVersionAPIClient",
+        "printedName": "BibleVersionAPIClient",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP7version6withIdAA0eB0VSi_tYaKF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP7version6withIdAA0eB0VSi_tYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionAPIClient>",
+            "protocolReq": true,
+            "throwing": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP",
+        "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP",
+        "moduleName": "YouVersionPlatformCore",
+        "genericSig": "<Self : Swift.Sendable>",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
         "name": "BibleVersionRepositoryProtocol",
         "printedName": "BibleVersionRepositoryProtocol",
         "children": [
@@ -16714,63 +17137,6 @@
             "funcSelfKind": "NonMutating"
           },
           {
-            "kind": "Var",
-            "name": "downloadedVersionIds",
-            "printedName": "downloadedVersionIds",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Array",
-                "printedName": "[Swift.Int]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sa"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP010downloadedB3IdsSaySiGvp",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB18RepositoryProtocolP010downloadedB3IdsSaySiGvp",
-            "moduleName": "YouVersionPlatformCore",
-            "protocolReq": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Array",
-                    "printedName": "[Swift.Int]",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Int",
-                        "printedName": "Swift.Int",
-                        "usr": "s:Si"
-                      }
-                    ],
-                    "usr": "s:Sa"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP010downloadedB3IdsSaySiGvg",
-                "mangledName": "$s22YouVersionPlatformCore05BibleB18RepositoryProtocolP010downloadedB3IdsSaySiGvg",
-                "moduleName": "YouVersionPlatformCore",
-                "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionRepositoryProtocol>",
-                "protocolReq": true,
-                "reqNewWitnessTableEntry": true,
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
             "kind": "Function",
             "name": "removeVersion",
             "printedName": "removeVersion(withId:)",
@@ -16869,6 +17235,1146 @@
       },
       {
         "kind": "TypeDecl",
+        "name": "BibleVersionCaching",
+        "printedName": "BibleVersionCaching",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP7version6withIdAA0eB0VSgSi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP7version6withIdAA0eB0VSgSi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP03addB0yyAA0eB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP03addB0yyAA0eB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+        "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP",
+        "moduleName": "YouVersionPlatformCore",
+        "genericSig": "<Self : Swift.Sendable>",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionClient",
+        "printedName": "VersionClient",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionClient",
+                "printedName": "YouVersionPlatformCore.VersionClient",
+                "usr": "s:22YouVersionPlatformCore0B6ClientC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B6ClientCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B6ClientCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B6ClientC7version6withIdAA05BibleB0VSi_tYaKF",
+            "mangledName": "$s22YouVersionPlatformCore0B6ClientC7version6withIdAA05BibleB0VSi_tYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final"
+            ],
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B6ClientC",
+        "mangledName": "$s22YouVersionPlatformCore0B6ClientC",
+        "moduleName": "YouVersionPlatformCore",
+        "declAttributes": [
+          "Final"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionAPIClient",
+            "printedName": "BibleVersionAPIClient",
+            "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionMemoryCache",
+        "printedName": "VersionMemoryCache",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionMemoryCache",
+                "printedName": "YouVersionPlatformCore.VersionMemoryCache",
+                "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC03addB0yyAA05BibleB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC03addB0yyAA05BibleB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC",
+        "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionCaching",
+            "printedName": "BibleVersionCaching",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionDiskCache",
+        "printedName": "VersionDiskCache",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionDiskCache",
+                "printedName": "YouVersionPlatformCore.VersionDiskCache",
+                "usr": "s:22YouVersionPlatformCore0B9DiskCacheC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC7version6withIdAA05BibleB0VSgSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC7version6withIdAA05BibleB0VSgSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC03addB0yyAA05BibleB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC03addB0yyAA05BibleB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B9DiskCacheC",
+        "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionCaching",
+            "printedName": "BibleVersionCaching",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionDownloadCache",
+        "printedName": "VersionDownloadCache",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionDownloadCache",
+                "printedName": "YouVersionPlatformCore.VersionDownloadCache",
+                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC7version6withIdAA05BibleB0VSgSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC7version6withIdAA05BibleB0VSgSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC03addB0yyAA05BibleB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC03addB0yyAA05BibleB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC06removeB06withIdySi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC06removeB06withIdySi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "downloadedVersions",
+            "printedName": "downloadedVersions",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "Final"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.Int]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC",
+        "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionCaching",
+            "printedName": "BibleVersionCaching",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
         "name": "BibleVersionRepository",
         "printedName": "BibleVersionRepository",
         "children": [
@@ -16926,20 +18432,48 @@
           {
             "kind": "Constructor",
             "name": "init",
-            "printedName": "init()",
+            "printedName": "init(apiClient:memoryCache:diskCache:downloadCache:)",
             "children": [
               {
                 "kind": "TypeNominal",
                 "name": "BibleVersionRepository",
                 "printedName": "YouVersionPlatformCore.BibleVersionRepository",
                 "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionAPIClient",
+                "printedName": "any YouVersionPlatformCore.BibleVersionAPIClient",
+                "hasDefaultArg": true,
+                "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionCaching",
+                "printedName": "any YouVersionPlatformCore.BibleVersionCaching",
+                "hasDefaultArg": true,
+                "usr": "s:22YouVersionPlatformCore05BibleB7CachingP"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionCaching",
+                "printedName": "any YouVersionPlatformCore.BibleVersionCaching",
+                "hasDefaultArg": true,
+                "usr": "s:22YouVersionPlatformCore05BibleB7CachingP"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionCaching",
+                "printedName": "any YouVersionPlatformCore.BibleVersionCaching",
+                "hasDefaultArg": true,
+                "usr": "s:22YouVersionPlatformCore05BibleB7CachingP"
               }
             ],
             "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryCACycfc",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryCACycfc",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC9apiClient11memoryCache04diskJ008downloadJ0AcA0eB9APIClient_p_AA0eB7Caching_pAaI_pAaI_ptcfc",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC9apiClient11memoryCache04diskJ008downloadJ0AcA0eB9APIClient_p_AA0eB7Caching_pAaI_pAaI_ptcfc",
             "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Convenience"
+            "init_kind": "Designated"
           },
           {
             "kind": "Function",
@@ -17342,62 +18876,6 @@
             "funcSelfKind": "NonMutating"
           },
           {
-            "kind": "Var",
-            "name": "downloadedVersionIds",
-            "printedName": "downloadedVersionIds",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Array",
-                "printedName": "[Swift.Int]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sa"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvp",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvp",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Nonisolated"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Array",
-                    "printedName": "[Swift.Int]",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Int",
-                        "printedName": "Swift.Int",
-                        "usr": "s:Si"
-                      }
-                    ],
-                    "usr": "s:Sa"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvg",
-                "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvg",
-                "moduleName": "YouVersionPlatformCore",
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
             "kind": "Function",
             "name": "removeVersion",
             "printedName": "removeVersion(withId:)",
@@ -17511,8 +18989,14 @@
         "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC",
         "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC",
         "moduleName": "YouVersionPlatformCore",
-        "hasMissingDesignatedInitializers": true,
         "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Observable",
+            "printedName": "Observable",
+            "usr": "s:11Observation10ObservableP",
+            "mangledName": "$s11Observation10ObservableP"
+          },
           {
             "kind": "Conformance",
             "name": "Copyable",

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
 
 actor ChapterMemoryCache {
     private var cache: [String: String] = [:]
@@ -27,10 +30,11 @@ actor ChapterMemoryCache {
 }
 
 /// ChapterDiskCache manages a medium-duration cache of Bible chapter data; it's not in-memory therefore will survive the app being terminated.
-actor ChapterDiskCache {
+@available(*, deprecated, message: "Internal SDK type. This class will be removed in a future major version.")
+public actor ChapterDiskCache {
     private let storage: BibleContentStorage
 
-    init() {
+    public init() {
         self.init(directoryProvider: DefaultBibleContentDirectoryProvider())
     }
 
@@ -69,13 +73,19 @@ actor ChapterDiskCache {
             )
         }
     }
+
+    @available(*, deprecated, message: "Use BibleChapterRepository.removeVersion(withId:) instead.")
+    public func removeVersion(versionId: Int) async {
+        removeVersion(withId: versionId)
+    }
 }
 
 /// ChapterDownloadCache manages the chapter files of Bible versions which the user chose to download, e.g. for offline usage.
-actor ChapterDownloadCache {
+@available(*, deprecated, message: "Internal SDK type. This class will be removed in a future major version.")
+public actor ChapterDownloadCache {
     private let storage: BibleContentStorage
 
-    init() {
+    public init() {
         self.init(directoryProvider: DefaultBibleContentDirectoryProvider())
     }
 
@@ -90,7 +100,7 @@ actor ChapterDownloadCache {
         return storage.string(for: .chapter(versionId: reference.versionId, usfm: chapterUSFM))
     }
 
-    nonisolated func chaptersArePresent(versionId: Int) -> Bool {
+    nonisolated public func chaptersArePresent(versionId: Int) -> Bool {
         storage.containsNonEmptyDirectory(.chaptersDirectory(versionId: versionId))
     }
 
@@ -105,6 +115,10 @@ actor ChapterDownloadCache {
         }
     }
 
+    @available(*, deprecated, message: "Use BibleChapterRepository.removeVersion(withId:) instead.")
+    public func removeVersion(versionId: Int) async {
+        removeVersion(withId: versionId)
+    }
 }
 
 protocol BibleChapterContentProviding: Sendable {
@@ -119,7 +133,7 @@ final class BibleChapterContentAPI: BibleChapterContentProviding {
     }
 }
 
-public actor BibleChapterRepository {
+public actor BibleChapterRepository: ObservableObject {
 
     public static let shared = BibleChapterRepository()
 

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
@@ -1,9 +1,14 @@
 import Foundation
+#if canImport(SwiftUI)
+import SwiftUI
+#else
+public protocol ObservableObject {}
+#endif
 
 // MARK: - Bible Highlights View Model
 
 @MainActor
-public class BibleHighlightsViewModel {
+public class BibleHighlightsViewModel: ObservableObject {
 
     public static let shared = BibleHighlightsViewModel()
 

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if canImport(Observation)
+import Observation
+#else
+public protocol Observable {}
+#endif
 
 /// Abstraction over Bible version lookup and download operations.
 public protocol BibleVersionRepositoryProtocol: Sendable {
@@ -14,9 +19,6 @@ public protocol BibleVersionRepositoryProtocol: Sendable {
     /// Returns the current download status for a version.
     func downloadStatus(for id: Int) -> BibleVersionRepository.BibleVersionDownloadStatus
 
-    /// Returns the IDs for versions currently downloaded for offline use.
-    var downloadedVersionIds: [Int] { get }
-
     /// Removes a version from every local cache.
     func removeVersion(withId id: Int) async
 
@@ -24,33 +26,39 @@ public protocol BibleVersionRepositoryProtocol: Sendable {
     func removeUnpermittedVersions(permittedIds: Set<Int>) async
 }
 
-actor VersionMemoryCache {
-    init() {}
+@available(*, deprecated, message: "Internal SDK type. This class will be removed in a future major version.")
+public actor VersionMemoryCache: BibleVersionCaching {
+    public init() {}
 
     private var cache: [Int: BibleVersion] = [:]
 
-    func version(withId id: Int) async -> BibleVersion? {
+    public func version(withId id: Int) async -> BibleVersion? {
         cache[id]
     }
 
-    func addVersion(_ version: BibleVersion) async {
+    nonisolated public func versionIsPresent(for id: Int) -> Bool {
+        false
+    }
+
+    public func addVersion(_ version: BibleVersion) async {
         cache[version.id] = version
     }
 
-    func removeVersion(withId id: Int) async {
+    public func removeVersion(withId id: Int) async {
         cache.removeValue(forKey: id)
     }
 
-    func removeUnpermittedVersions(permittedIds: Set<Int>) async {
+    public func removeUnpermittedVersions(permittedIds: Set<Int>) async {
         cache = cache.filter { permittedIds.contains($0.key) }
     }
 }
 
 /// VersionDiskCache manages a medium-duration cache of Bible version metadata; it's not in-memory therefore will survive the app being terminated.
-actor VersionDiskCache {
+@available(*, deprecated, message: "Internal SDK type. This class will be removed in a future major version.")
+public actor VersionDiskCache: BibleVersionCaching {
     private let storage: BibleContentStorage
 
-    init() {
+    public init() {
         self.init(directoryProvider: DefaultBibleContentDirectoryProvider())
     }
 
@@ -58,15 +66,15 @@ actor VersionDiskCache {
         self.storage = BibleContentStorage(storageKind: .cache, directoryProvider: directoryProvider)
     }
 
-    func version(withId id: Int) -> BibleVersion? {
+    public func version(withId id: Int) async -> BibleVersion? {
         storage.decoded(BibleVersion.self, for: .versionMetadata(versionId: id))
     }
 
-    nonisolated func versionIsPresent(for id: Int) -> Bool {
+    nonisolated public func versionIsPresent(for id: Int) -> Bool {
         storage.contains(.versionMetadata(versionId: id))
     }
 
-    func addVersion(_ version: BibleVersion) async {
+    public func addVersion(_ version: BibleVersion) async {
         do {
             try storage.writeEncoded(version, to: .versionMetadata(versionId: version.id))
         } catch {
@@ -77,7 +85,7 @@ actor VersionDiskCache {
         }
     }
 
-    func removeVersion(withId id: Int) async {
+    public func removeVersion(withId id: Int) async {
         do {
             try storage.remove(.versionDirectory(versionId: id))
         } catch {
@@ -88,7 +96,7 @@ actor VersionDiskCache {
         }
     }
 
-    func removeUnpermittedVersions(permittedIds: Set<Int>) async {
+    public func removeUnpermittedVersions(permittedIds: Set<Int>) async {
         let cached = storage.versionDirectoryIds
         for id in cached where !permittedIds.contains(id) {
             YouVersionPlatformLogger.notice(
@@ -101,10 +109,11 @@ actor VersionDiskCache {
 }
 
 /// VersionDownloadCache manages the Bible versions which the user chose to download, e.g. for offline usage.
-actor VersionDownloadCache {
+@available(*, deprecated, message: "Internal SDK type. This class will be removed in a future major version.")
+public actor VersionDownloadCache: BibleVersionCaching {
     private let storage: BibleContentStorage
 
-    init() {
+    public init() {
         self.init(directoryProvider: DefaultBibleContentDirectoryProvider())
     }
 
@@ -112,15 +121,15 @@ actor VersionDownloadCache {
         self.storage = BibleContentStorage(storageKind: .download, directoryProvider: directoryProvider)
     }
 
-    nonisolated func versionIsPresent(for id: Int) -> Bool {
+    nonisolated public func versionIsPresent(for id: Int) -> Bool {
         storage.contains(.versionMetadata(versionId: id))
     }
 
-    func version(withId id: Int) -> BibleVersion? {
+    public func version(withId id: Int) async -> BibleVersion? {
         storage.decoded(BibleVersion.self, for: .versionMetadata(versionId: id))
     }
 
-    func addVersion(_ version: BibleVersion) async {
+    public func addVersion(_ version: BibleVersion) async {
         do {
             try storage.writeEncoded(
                 version,
@@ -135,7 +144,7 @@ actor VersionDownloadCache {
         }
     }
 
-    func removeVersion(withId id: Int) {
+    public func removeVersion(withId id: Int) {
         do {
             try storage.remove(.versionDirectory(versionId: id))
         } catch {
@@ -146,7 +155,7 @@ actor VersionDownloadCache {
         }
     }
 
-    func removeUnpermittedVersions(permittedIds: Set<Int>) {
+    public func removeUnpermittedVersions(permittedIds: Set<Int>) {
         let downloads = storage.versionDirectoryIds
         for downloadedId in downloads where !permittedIds.contains(downloadedId) {
             YouVersionPlatformLogger.notice(
@@ -161,6 +170,10 @@ actor VersionDownloadCache {
         BibleContentStorage(storageKind: .download, directoryProvider: directoryProvider).versionDirectoryIds
     }
 
+    /// Returns the IDs of Bible versions that have been downloaded for offline use, scanning the default app-support directory.
+    public static var downloadedVersions: [Int] {
+        downloadedVersionIds(directoryProvider: DefaultBibleContentDirectoryProvider())
+    }
 }
 
 protocol BibleVersionProviding: Sendable {
@@ -175,7 +188,7 @@ final class BibleVersionAPI: BibleVersionProviding {
     }
 }
 
-public actor BibleVersionRepository: BibleVersionRepositoryProtocol {
+public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol {
 
     public static let shared = BibleVersionRepository()
 
@@ -203,6 +216,19 @@ public actor BibleVersionRepository: BibleVersionRepositoryProtocol {
         self.memoryCache = VersionMemoryCache()
         self.diskCache = VersionDiskCache(directoryProvider: directoryProvider)
         self.downloadCache = VersionDownloadCache(directoryProvider: directoryProvider)
+    }
+
+    @available(*, deprecated, message: "The apiClient/memoryCache/diskCache/downloadCache parameters are no longer honored. Use init() instead; this initializer will be removed in a future major version.")
+    public init(
+        apiClient: BibleVersionAPIClient = VersionClient(),
+        memoryCache: BibleVersionCaching = VersionMemoryCache(),
+        diskCache: BibleVersionCaching = VersionDiskCache(),
+        downloadCache: BibleVersionCaching = VersionDownloadCache()
+    ) {
+        self.init(
+            provider: BibleVersionAPI(),
+            directoryProvider: DefaultBibleContentDirectoryProvider()
+        )
     }
 
     public func versionIfCached(_ id: Int) async throws -> BibleVersion? {

--- a/Sources/YouVersionPlatformCore/Bible/DeprecatedBibleAPI.swift
+++ b/Sources/YouVersionPlatformCore/Bible/DeprecatedBibleAPI.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+// MARK: - Deprecated public surface
+//
+// The types and members in this file existed in earlier releases as part of
+// the public SDK surface but are no longer used internally. They are kept
+// here only so existing call sites continue to compile and link. New code
+// should not reference any of them — they will be removed at the next
+// major version bump.
+
+@available(*, deprecated, message: "Internal SDK type. This protocol will be removed in a future major version.")
+public protocol BibleVersionAPIClient: Sendable {
+    func version(withId id: Int) async throws -> BibleVersion
+}
+
+@available(*, deprecated, message: "Internal SDK type. This protocol will be removed in a future major version.")
+public protocol BibleVersionCaching: Sendable {
+    func version(withId id: Int) async -> BibleVersion?
+    func addVersion(_ version: BibleVersion) async
+    func removeVersion(withId versionId: Int) async
+    func versionIsPresent(for id: Int) -> Bool
+    func removeUnpermittedVersions(permittedIds: Set<Int>) async
+}
+
+@available(*, deprecated, message: "Internal SDK type. This class will be removed in a future major version.")
+public final class VersionClient: BibleVersionAPIClient {
+    public init() {}
+
+    public func version(withId id: Int) async throws -> BibleVersion {
+        try await YouVersionAPI.Bible.version(versionId: id)
+    }
+}

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -73,7 +73,7 @@ public final class BibleVersionsViewModel {
         }
 
         // downloaded versions must also be in MyVersions, otherwise they couldn't be deleted.
-        for id in versionRepository.downloadedVersionIds where !myVersions.contains(where: { $0.id == id }) {
+        for id in VersionDownloadCache.downloadedVersions where !myVersions.contains(where: { $0.id == id }) {
             if let version = try? await versionRepository.versionIfCached(id) {
                 myVersions.insert(version)
             }
@@ -127,7 +127,7 @@ public final class BibleVersionsViewModel {
     /// - Returns: A fallback version ID, or `nil` if no version is available
     ///   (typically because the device is offline).
     private func fallbackVersion(savedIds: Set<Int>) async -> Int? {
-        let downloadedVersionIds = versionRepository.downloadedVersionIds
+        let downloadedVersionIds = VersionDownloadCache.downloadedVersions
         if let downloadedVersionId = downloadedVersionIds.first {
             return downloadedVersionId
         }

--- a/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
@@ -8,11 +8,8 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
     var cachedVersionById: [Int: BibleVersion] = [:]
     var thrownError: Error?
     var downloadedIds: [Int] = []
-    private let downloadedVersionIdsForListing: [Int]
 
-    init(downloadedVersionIds: [Int] = []) {
-        self.downloadedVersionIdsForListing = downloadedVersionIds
-    }
+    init() {}
 
     func setVersion(_ version: BibleVersion) {
         versionById[version.id] = version
@@ -52,10 +49,6 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
 
     nonisolated func downloadStatus(for id: Int) -> BibleVersionRepository.BibleVersionDownloadStatus {
         .notDownloadable
-    }
-
-    nonisolated var downloadedVersionIds: [Int] {
-        downloadedVersionIdsForListing
     }
 
     func removeVersion(withId id: Int) async {


### PR DESCRIPTION
## Summary

- Reverts `.api-baseline/YouVersionPlatformCore.json` to `main`'s state, holding the public SDK surface at the level shipped from `main` rather than from #87 on `feature/release5`.
- Restores the symbols #87 removed as `@available(*, deprecated)` forwarders so existing call sites continue to compile and link without a major version bump.
- Drops the new `downloadedVersionIds` requirement from `BibleVersionRepositoryProtocol` (the digester flagged the addition as a breaking protocol requirement); `BibleVersionsViewModel` now reads `VersionDownloadCache.downloadedVersions` directly, matching `main`.

## Restored as deprecated

- `public protocol BibleVersionAPIClient`
- `public protocol BibleVersionCaching`
- `public final class VersionClient`
- `public actor VersionMemoryCache` (with `BibleVersionCaching` conformance)
- `public actor VersionDiskCache` (with `BibleVersionCaching` conformance)
- `public actor VersionDownloadCache` (with `BibleVersionCaching` conformance and `static var downloadedVersions`)
- `public actor ChapterDiskCache` (with public `removeVersion(versionId:)`)
- `public actor ChapterDownloadCache` (with public `chaptersArePresent(versionId:)` and `removeVersion(versionId:)`)
- `public BibleVersionRepository.init(apiClient:memoryCache:diskCache:downloadCache:)`
- `Observable` conformance on `BibleVersionRepository`
- `ObservableObject` conformance on `BibleChapterRepository` and `BibleHighlightsViewModel` (which restores the implicit `ObjectWillChangePublisher` typealias)

The internal implementation introduced in #87 is unchanged; the deprecated public types and methods are thin wrappers/markers that the new internal code keeps using.

## Test plan

- [x] `scripts/check-api-stability.sh check` — passes (no breaking changes vs `main` baseline).
- [x] `swift build` — clean (deprecation warnings only on internal callers, no errors).
- [x] `swift test` — 260 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the public SDK surface from `main` onto `feature/release5` by re-introducing deprecated forwarder types and conformances removed in #87, ensuring existing call sites continue to compile without a major version bump. The API baseline is reverted to `main`'s state, and `BibleVersionsViewModel` reads `VersionDownloadCache.downloadedVersions` directly (matching `main`) after the `downloadedVersionIds` requirement was dropped from `BibleVersionRepositoryProtocol` to avoid a breaking protocol change. The approach is pragmatic and well-documented; both P2 findings below are intentional trade-offs acknowledged in the PR description.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all findings are P2 style/design notes that match the documented intent of the PR.

Only P2 findings; no runtime errors or data-correctness issues. The two observations (silent parameter discard on the deprecated init and the VersionDownloadCache bypass in BibleVersionsViewModel) are both deliberate and documented design decisions matching main's behavior.

BibleVersionRepository.swift (deprecated init discards parameters) and BibleVersionsViewModel.swift (direct VersionDownloadCache.downloadedVersions coupling)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/Bible/DeprecatedBibleAPI.swift | New file restoring deprecated public surface; thin wrappers with clear deprecation messages. All cache actors are well-structured. |
| Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift | Restored deprecated init silently discards all passed parameters (documented); remainder of the actor logic is sound. |
| Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift | Re-adds ObservableObject conformance and deprecated public removeVersion(versionId:) forwarders on ChapterDiskCache and ChapterDownloadCache; logic is correct. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift | Reads VersionDownloadCache.downloadedVersions directly in two places, bypassing the injected repository abstraction and limiting testability. |
| Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift | Solid test coverage for the injected-repository path; the downloaded-versions branch in restoreMyVersions is not covered (relies on real file system). |
| .api-baseline/YouVersionPlatformCore.json | Baseline reverted to main state; confirms all restored symbols are present and no breaking changes vs main. |

</details>



<h3>Class Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class BibleVersionRepositoryProtocol {
        <<protocol>>
        +versionIfCached(id) BibleVersion?
        +version(withId id) BibleVersion
        +downloadVersion(withId id)
        +downloadStatus(for id) BibleVersionDownloadStatus
        +removeVersion(withId id)
        +removeUnpermittedVersions(permittedIds)
    }

    class BibleVersionRepository {
        <<actor, Observable>>
        +shared BibleVersionRepository
        +downloadedVersionIds [Int]
        +init()
        +init(apiClient:memoryCache:diskCache:downloadCache:) deprecated
    }

    class BibleVersionCaching {
        <<protocol, deprecated>>
        +version(withId id) BibleVersion?
        +addVersion(_)
        +removeVersion(withId id)
        +versionIsPresent(for id) Bool
        +removeUnpermittedVersions(permittedIds)
    }

    class VersionDownloadCache {
        <<actor, deprecated>>
        +init()
        +downloadedVersions$ [Int]
    }

    class BibleVersionsViewModel {
        <<Observable, MainActor>>
        +versionRepository BibleVersionRepositoryProtocol
        +loadInitialState()
        -restoreMyVersions()
    }

    BibleVersionRepository ..|> BibleVersionRepositoryProtocol
    VersionDownloadCache ..|> BibleVersionCaching
    BibleVersionRepository --> VersionDownloadCache : private
    BibleVersionsViewModel --> BibleVersionRepositoryProtocol : injected
    BibleVersionsViewModel ..> VersionDownloadCache : direct (deprecated)
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift`, line 76-80 ([link](https://github.com/youversion/platform-sdk-swift/blob/0101fa5fc3adf4589899ec6cd6010220d5d68bff/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift#L76-L80)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Bypasses injected repository for downloaded IDs**

   `VersionDownloadCache.downloadedVersions` is called directly instead of going through `versionRepository`, so the `MockBibleVersionRepository` in tests can never inject fake downloaded-version IDs for this code path. In production the static property always scans the real file system. This is intentional per the PR description (matching `main`), but it's worth noting that if a future test needs to verify the "downloaded version added to My Versions" branch, there is no seam to do it without stubbing the file system or adding `downloadedVersionIds` back to the protocol.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
   Line: 76-80

   Comment:
   **Bypasses injected repository for downloaded IDs**

   `VersionDownloadCache.downloadedVersions` is called directly instead of going through `versionRepository`, so the `MockBibleVersionRepository` in tests can never inject fake downloaded-version IDs for this code path. In production the static property always scans the real file system. This is intentional per the PR description (matching `main`), but it's worth noting that if a future test needs to verify the "downloaded version added to My Versions" branch, there is no seam to do it without stubbing the file system or adding `downloadedVersionIds` back to the protocol.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%0ALine%3A%2076-80%0A%0AComment%3A%0A**Bypasses%20injected%20repository%20for%20downloaded%20IDs**%0A%0A%60VersionDownloadCache.downloadedVersions%60%20is%20called%20directly%20instead%20of%20going%20through%20%60versionRepository%60%2C%20so%20the%20%60MockBibleVersionRepository%60%20in%20tests%20can%20never%20inject%20fake%20downloaded-version%20IDs%20for%20this%20code%20path.%20In%20production%20the%20static%20property%20always%20scans%20the%20real%20file%20system.%20This%20is%20intentional%20per%20the%20PR%20description%20%28matching%20%60main%60%29%2C%20but%20it's%20worth%20noting%20that%20if%20a%20future%20test%20needs%20to%20verify%20the%20%22downloaded%20version%20added%20to%20My%20Versions%22%20branch%2C%20there%20is%20no%20seam%20to%20do%20it%20without%20stubbing%20the%20file%20system%20or%20adding%20%60downloadedVersionIds%60%20back%20to%20the%20protocol.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%0ALine%3A%2076-80%0A%0AComment%3A%0A**Bypasses%20injected%20repository%20for%20downloaded%20IDs**%0A%0A%60VersionDownloadCache.downloadedVersions%60%20is%20called%20directly%20instead%20of%20going%20through%20%60versionRepository%60%2C%20so%20the%20%60MockBibleVersionRepository%60%20in%20tests%20can%20never%20inject%20fake%20downloaded-version%20IDs%20for%20this%20code%20path.%20In%20production%20the%20static%20property%20always%20scans%20the%20real%20file%20system.%20This%20is%20intentional%20per%20the%20PR%20description%20%28matching%20%60main%60%29%2C%20but%20it's%20worth%20noting%20that%20if%20a%20future%20test%20needs%20to%20verify%20the%20%22downloaded%20version%20added%20to%20My%20Versions%22%20branch%2C%20there%20is%20no%20seam%20to%20do%20it%20without%20stubbing%20the%20file%20system%20or%20adding%20%60downloadedVersionIds%60%20back%20to%20the%20protocol.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%3A76-80%0A**Bypasses%20injected%20repository%20for%20downloaded%20IDs**%0A%0A%60VersionDownloadCache.downloadedVersions%60%20is%20called%20directly%20instead%20of%20going%20through%20%60versionRepository%60%2C%20so%20the%20%60MockBibleVersionRepository%60%20in%20tests%20can%20never%20inject%20fake%20downloaded-version%20IDs%20for%20this%20code%20path.%20In%20production%20the%20static%20property%20always%20scans%20the%20real%20file%20system.%20This%20is%20intentional%20per%20the%20PR%20description%20%28matching%20%60main%60%29%2C%20but%20it's%20worth%20noting%20that%20if%20a%20future%20test%20needs%20to%20verify%20the%20%22downloaded%20version%20added%20to%20My%20Versions%22%20branch%2C%20there%20is%20no%20seam%20to%20do%20it%20without%20stubbing%20the%20file%20system%20or%20adding%20%60downloadedVersionIds%60%20back%20to%20the%20protocol.%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformCore%2FBible%2FBibleVersionRepository.swift%3A221-232%0A**Custom%20injected%20instances%20are%20silently%20discarded**%0A%0AThe%20deprecated%20initializer%20accepts%20%60apiClient%60%2C%20%60memoryCache%60%2C%20%60diskCache%60%2C%20and%20%60downloadCache%60%20but%20immediately%20delegates%20to%20%60self.init%28provider%3AdirectoryProvider%3A%29%60%2C%20which%20creates%20brand-new%20internal%20instances.%20Any%20custom%20objects%20the%20caller%20passes%20are%20dropped%20with%20no%20warning%20beyond%20the%20deprecation%20message%20itself.%20The%20deprecation%20message%20does%20say%20%22parameters%20are%20no%20longer%20honored%22%2C%20so%20this%20is%20documented%20%E2%80%94%20just%20flagging%20it%20as%20something%20existing%20call%20sites%20with%20non-default%20arguments%20should%20double-check%20before%20the%20next%20major%20version%20bump.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%3A76-80%0A**Bypasses%20injected%20repository%20for%20downloaded%20IDs**%0A%0A%60VersionDownloadCache.downloadedVersions%60%20is%20called%20directly%20instead%20of%20going%20through%20%60versionRepository%60%2C%20so%20the%20%60MockBibleVersionRepository%60%20in%20tests%20can%20never%20inject%20fake%20downloaded-version%20IDs%20for%20this%20code%20path.%20In%20production%20the%20static%20property%20always%20scans%20the%20real%20file%20system.%20This%20is%20intentional%20per%20the%20PR%20description%20%28matching%20%60main%60%29%2C%20but%20it's%20worth%20noting%20that%20if%20a%20future%20test%20needs%20to%20verify%20the%20%22downloaded%20version%20added%20to%20My%20Versions%22%20branch%2C%20there%20is%20no%20seam%20to%20do%20it%20without%20stubbing%20the%20file%20system%20or%20adding%20%60downloadedVersionIds%60%20back%20to%20the%20protocol.%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformCore%2FBible%2FBibleVersionRepository.swift%3A221-232%0A**Custom%20injected%20instances%20are%20silently%20discarded**%0A%0AThe%20deprecated%20initializer%20accepts%20%60apiClient%60%2C%20%60memoryCache%60%2C%20%60diskCache%60%2C%20and%20%60downloadCache%60%20but%20immediately%20delegates%20to%20%60self.init%28provider%3AdirectoryProvider%3A%29%60%2C%20which%20creates%20brand-new%20internal%20instances.%20Any%20custom%20objects%20the%20caller%20passes%20are%20dropped%20with%20no%20warning%20beyond%20the%20deprecation%20message%20itself.%20The%20deprecation%20message%20does%20say%20%22parameters%20are%20no%20longer%20honored%22%2C%20so%20this%20is%20documented%20%E2%80%94%20just%20flagging%20it%20as%20something%20existing%20call%20sites%20with%20non-default%20arguments%20should%20double-check%20before%20the%20next%20major%20version%20bump.%0A%0A&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift:76-80
**Bypasses injected repository for downloaded IDs**

`VersionDownloadCache.downloadedVersions` is called directly instead of going through `versionRepository`, so the `MockBibleVersionRepository` in tests can never inject fake downloaded-version IDs for this code path. In production the static property always scans the real file system. This is intentional per the PR description (matching `main`), but it's worth noting that if a future test needs to verify the "downloaded version added to My Versions" branch, there is no seam to do it without stubbing the file system or adding `downloadedVersionIds` back to the protocol.

### Issue 2 of 2
Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift:221-232
**Custom injected instances are silently discarded**

The deprecated initializer accepts `apiClient`, `memoryCache`, `diskCache`, and `downloadCache` but immediately delegates to `self.init(provider:directoryProvider:)`, which creates brand-new internal instances. Any custom objects the caller passes are dropped with no warning beyond the deprecation message itself. The deprecation message does say "parameters are no longer honored", so this is documented — just flagging it as something existing call sites with non-default arguments should double-check before the next major version bump.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: restore deprecated public API sur..."](https://github.com/youversion/platform-sdk-swift/commit/0101fa5fc3adf4589899ec6cd6010220d5d68bff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30360682)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->