### PR TITLE
fix: follow device's dark/light color scheme inside BibleCardView's sheets

### DIFF
--- a/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
@@ -79,13 +79,23 @@ public struct BibleCardView: View {
             }
         }
         .sheet(isPresented: $showingCopyrightSheet) {
-            ScrollView {
-                Text(version?.localizedTitle ?? version?.title ?? "")
-                    .font(YouVersionFonts.fontHeaderM)
-                    .padding(.vertical)
-                Text(version?.promotionalContent ?? version?.copyright ?? "")
-                    .padding()
+            ZStack {
+                backgroundColor
+                    .ignoresSafeArea()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(version?.localizedTitle ?? version?.title ?? "")
+                            .font(YouVersionFonts.fontHeaderM)
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                        Text(version?.promotionalContent ?? version?.copyright ?? "")
+                            .padding()
+                    }
+                    .frame(maxWidth: .infinity)
+                }
             }
+            .background(backgroundColor)
+            .foregroundStyle(foregroundColor)
             .presentationDragIndicator(.visible)
             .presentationDetents([.large])
         }

--- a/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
@@ -79,21 +79,18 @@ public struct BibleCardView: View {
             }
         }
         .sheet(isPresented: $showingCopyrightSheet) {
-            ZStack {
-                backgroundColor
-                    .ignoresSafeArea()
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 0) {
-                        Text(version?.localizedTitle ?? version?.title ?? "")
-                            .font(YouVersionFonts.fontHeaderM)
-                            .padding()
-                            .frame(maxWidth: .infinity)
-                        Text(version?.promotionalContent ?? version?.copyright ?? "")
-                            .padding()
-                    }
-                    .frame(maxWidth: .infinity)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(version?.localizedTitle ?? version?.title ?? "")
+                        .font(YouVersionFonts.fontHeaderM)
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                    Text(version?.promotionalContent ?? version?.copyright ?? "")
+                        .padding()
                 }
+                .frame(maxWidth: .infinity)
             }
+            .background(backgroundColor.ignoresSafeArea())
             .foregroundStyle(foregroundColor)
             .presentationDragIndicator(.visible)
             .presentationDetents([.large])

--- a/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
@@ -94,7 +94,6 @@ public struct BibleCardView: View {
                     .frame(maxWidth: .infinity)
                 }
             }
-            .background(backgroundColor)
             .foregroundStyle(foregroundColor)
             .presentationDragIndicator(.visible)
             .presentationDetents([.large])

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift
@@ -6,6 +6,7 @@ public struct BibleVersionPickingButton: View {
     @State private var version: BibleVersion?
     private let initialVersionId: Int
     private let onVersionChange: ((BibleVersion) -> Void)?
+    @Environment(\.colorScheme) private var colorScheme
 
     public init(
         initialVersionId: Int,
@@ -37,6 +38,14 @@ public struct BibleVersionPickingButton: View {
         .task {
             versionsViewModel.onVersionChange = handleVersionChange
             await versionsViewModel.loadInitialState(initialVersionId: initialVersionId)
+        }
+        .onChange(of: colorScheme, initial: true) { _, newScheme in
+            versionsViewModel.colorTheme = ReaderTheme(
+                id: 0,
+                foreground: newScheme == .dark ? Color(hex: "#ffffff") : Color(hex: "#121212"),
+                background: newScheme == .dark ? Color(hex: "#121212") : Color(hex: "#ffffff"),
+                colorScheme: newScheme
+            )
         }
     }
 


### PR DESCRIPTION
## Description

BibleCardView itself followed the environment's dark/light color scheme, but the sheets it could open didn't. 

Furthermore if the caller happened to have set a .foregroundStyle, that color sometimes still took effect even though the background color wouldn't.

## Type of Change

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [x] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] All commit messages follow [conventional commits](https://www.conventionalcommits.org/) format

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes dark/light color scheme support in the sheets opened by `BibleCardView`. The copyright sheet now receives explicit `backgroundColor` and `foregroundColor` overrides, and `BibleVersionPickingButton` uses `onChange(of: colorScheme, initial: true)` to keep `versionsViewModel.colorTheme` in sync with the device scheme whenever the view appears or the scheme toggles.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is straightforward, targets iOS 17+ (matching the package's minimum), and introduces no new logic paths that could cause regressions.

Only a P2 style comment (duplicated hex literals) was found. No P0 or P1 issues exist in the changed code.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformUI/Views/BibleCardView.swift | Copyright sheet now receives explicit `backgroundColor` and `foregroundColor` modifiers matching the card's color scheme; layout improved with `VStack` + `frame(maxWidth: .infinity)`. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift | Adds `@Environment(\.colorScheme)` and `onChange(of:initial:)` to sync `versionsViewModel.colorTheme` with the device color scheme on first appearance and on changes; hex color literals are duplicated from `BibleCardView`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Device as Device (colorScheme)
    participant BCV as BibleCardView
    participant BVPB as BibleVersionPickingButton
    participant VM as BibleVersionsViewModel
    participant CopyrightSheet as Copyright Sheet
    participant VersionSheet as BibleVersionsStack Sheet

    Device->>BCV: colorScheme changes
    BCV->>BCV: recompute foregroundColor / backgroundColor
    BCV->>CopyrightSheet: .background(backgroundColor) + .foregroundStyle(foregroundColor)

    Device->>BVPB: onChange(colorScheme, initial: true)
    BVPB->>VM: colorTheme = ReaderTheme(id:0, foreground:, background:, colorScheme:)
    VM->>VersionSheet: @Observable colorTheme propagates to sub-views
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionPickingButton.swift%3A43-48%0A**Duplicated%20hex%20color%20literals**%0A%0AThe%20hex%20values%20%60%23ffffff%60%20and%20%60%23121212%60%20used%20here%20to%20build%20the%20auto-scheme%20%60ReaderTheme%60%20are%20the%20same%20values%20already%20defined%20in%20%60BibleCardView.foregroundColor%60%2F%60backgroundColor%60%20and%20mirrored%20in%20%60ReaderTheme.allThemes%60%20%28IDs%201%20and%207%29.%20If%20the%20design%20tokens%20for%20the%20card's%20canonical%20dark%2Flight%20colors%20ever%20change%2C%20there%20are%20now%20three%20places%20to%20update%20in%20sync.%20Extracting%20them%20into%20shared%20constants%20%28e.g.%2C%20on%20%60ReaderTheme%60%29%20would%20make%20future%20changes%20safer.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=93&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionPickingButton.swift%3A43-48%0A**Duplicated%20hex%20color%20literals**%0A%0AThe%20hex%20values%20%60%23ffffff%60%20and%20%60%23121212%60%20used%20here%20to%20build%20the%20auto-scheme%20%60ReaderTheme%60%20are%20the%20same%20values%20already%20defined%20in%20%60BibleCardView.foregroundColor%60%2F%60backgroundColor%60%20and%20mirrored%20in%20%60ReaderTheme.allThemes%60%20%28IDs%201%20and%207%29.%20If%20the%20design%20tokens%20for%20the%20card's%20canonical%20dark%2Flight%20colors%20ever%20change%2C%20there%20are%20now%20three%20places%20to%20update%20in%20sync.%20Extracting%20them%20into%20shared%20constants%20%28e.g.%2C%20on%20%60ReaderTheme%60%29%20would%20make%20future%20changes%20safer.%0A%0A&pr=93&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift:43-48
**Duplicated hex color literals**

The hex values `#ffffff` and `#121212` used here to build the auto-scheme `ReaderTheme` are the same values already defined in `BibleCardView.foregroundColor`/`backgroundColor` and mirrored in `ReaderTheme.allThemes` (IDs 1 and 7). If the design tokens for the card's canonical dark/light colors ever change, there are now three places to update in sync. Extracting them into shared constants (e.g., on `ReaderTheme`) would make future changes safer.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["chore: tidy the code by setting backgrou..."](https://github.com/youversion/platform-sdk-swift/commit/0854b701c5ae97773261a770c861b16acee8d4b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30382714)</sub>

<!-- /greptile_comment -->