### PR TITLE
Publish coverage badge to badges branch instead of main

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,6 +1,0 @@
-{
-  "schemaVersion": 1,
-  "label": "coverage",
-  "message": "89.5%",
-  "color": "brightgreen"
-}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -75,9 +75,9 @@ jobs:
           echo "percentage=$COVERAGE" >> $GITHUB_OUTPUT
           echo "Coverage: $COVERAGE%"
 
-      - name: Update coverage JSON for shields.io
+      - name: Build coverage JSON for shields.io
         run: |
-          mkdir -p .github/badges
+          mkdir -p coverage-output
           COVERAGE="${{ steps.coverage.outputs.percentage }}"
 
           # Determine color based on coverage
@@ -92,7 +92,7 @@ jobs:
           fi
 
           # Create JSON endpoint for shields.io
-          cat > .github/badges/coverage.json << EOF
+          cat > coverage-output/coverage.json << EOF
           {
             "schemaVersion": 1,
             "label": "coverage",
@@ -101,11 +101,19 @@ jobs:
           }
           EOF
 
-      - name: Commit coverage data
+      - name: Check out badges branch
+        uses: actions/checkout@v4
+        with:
+          ref: badges
+          path: badges-branch
+          ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
+
+      - name: Commit coverage data to badges branch
+        working-directory: badges-branch
         run: |
+          cp ../coverage-output/coverage.json coverage.json
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git pull --rebase --autostash origin main
-          git add .github/badges/coverage.json
-          git diff --staged --quiet || git commit -m "chore: update coverage badge [skip ci]"
+          git add coverage.json
+          git diff --staged --quiet || git commit -m "chore: update coverage badge"
           git push

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Platform](https://img.shields.io/badge/Platform-IOS-red)
 [![License](https://img.shields.io/badge/license-Apache-blue.svg)](LICENSE)
-[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/youversion/platform-sdk-swift/main/.github/badges/coverage.json)](./CONTRIBUTING.md#code-coverage)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/youversion/platform-sdk-swift/badges/coverage.json)](./CONTRIBUTING.md#code-coverage)
 
 # YouVersion Platform SDK for Swift
 


### PR DESCRIPTION
## Summary

Stops the coverage workflow from pushing a `chore: update coverage badge [skip ci]` commit to `main` after every release.

The badge JSON now lives on a dedicated orphan branch — `badges` — that holds only `coverage.json` at its root. shields.io fetches it from there. `main`'s history stays clean.

## Changes

- `.github/workflows/coverage.yml` — after computing the coverage JSON, the workflow checks the `badges` branch out under a sibling path and commits the file there instead of to `main`.
- `README.md` — updated the shields.io endpoint URL to point at the `badges` branch (`/badges/coverage.json`).
- `.github/badges/coverage.json` — deleted; no longer used on `main`.
- (Already pushed) `badges` branch — created as an orphan branch seeded with the current 89.5% value so the badge keeps working between merge and the next coverage run.

`[skip ci]` is dropped from the commit message because no workflow listens to pushes on `badges`.

## Test plan

- [x] `coverage.yml` parses as valid YAML.
- [x] Orphan `badges` branch exists with `coverage.json` at root and is reachable at `https://raw.githubusercontent.com/youversion/platform-sdk-swift/badges/coverage.json`.
- [ ] After this PR merges, the next Release run will trigger the coverage workflow; verify it pushes to `badges` branch and the README badge keeps rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cleanly separates the coverage badge artifact from `main`'s history by writing `coverage.json` to a dedicated orphan `badges` branch via a secondary `actions/checkout` step, and updates the shields.io URL in the README accordingly. The implementation is solid — the intermediate `coverage-output/` directory, SSH key wiring, and `working-directory` scoping are all correctly set up.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no new logic defects; the one resilience concern (missing pre-push rebase) was already noted in a prior thread.

All three changed files are straightforward. The workflow change is well-structured with correct path arithmetic and proper SSH key usage. No P0 or P1 issues were found beyond what was already raised.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/coverage.yml | Workflow now checks out `badges` branch into a sibling path, copies the generated JSON there, commits, and pushes via SSH deploy key — clean approach with a minor missing `git pull --rebase` before push (noted in prior thread). |
| README.md | Badge URL updated from `main/.github/badges/coverage.json` to `badges/coverage.json` on the new orphan branch — correct and straightforward. |
| .github/badges/coverage.json | Deleted from `main` as intended — content migrated to the orphan `badges` branch. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Release as Release Workflow
    participant Runner as GH Actions Runner
    participant Main as main branch (workspace)
    participant CovDir as coverage-output/
    participant BadgesBranch as badges branch (badges-branch/)
    participant ShieldsIO as shields.io

    Release->>Runner: Trigger coverage job
    Runner->>Main: actions/checkout (default)
    Runner->>Runner: Run tests & compute coverage %
    Runner->>CovDir: Write coverage-output/coverage.json
    Runner->>BadgesBranch: actions/checkout@v4 (ref: badges, ssh-key)
    Runner->>BadgesBranch: cp ../coverage-output/coverage.json coverage.json
    Runner->>BadgesBranch: git add + git commit + git push
    ShieldsIO->>BadgesBranch: Fetch coverage.json for badge rendering
```

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/youversion/platform-sdk-swift/commit/2ac642ad4422a4c677c98b4c9c1c43f7b8764542) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30387903)</sub>

<!-- /greptile_comment -->