### PR TITLE
fix: reader chrome hides/shows on scroll

### DIFF
--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -132,7 +132,7 @@ public struct BibleReaderView: View {
         HStack {
             if viewModel.version != nil {
                 BibleReaderHeaderView(
-                    showChrome: true,
+                    showChrome: viewModel.showChrome,
                     onSelectionChange: { version, book, chapter, passageId in
                         Task {
                             let reference = BibleReference(versionId: version, bookUSFM: book, chapter: chapter ?? 1)
@@ -226,11 +226,6 @@ public struct BibleReaderView: View {
     private var mainScroller: some View {
         ScrollViewReader { scrollProxy in
             ScrollView {
-                GeometryReader { geo in
-                    Color.clear
-                        .preference(key: ScrollOffsetPreferenceKey.self, value: geo.frame(in: .named("scrollView")).minY)
-                }
-                .frame(height: 0)
                 if viewModel.version != nil {
                     VStack(alignment: .leading) {
                         if viewModel.showBookIntro {
@@ -251,23 +246,18 @@ public struct BibleReaderView: View {
                     .padding(.vertical)
                     .padding(.horizontal, 30)
                     .id("topOfContent")
+                    .onGeometryChange(for: CGFloat.self) { proxy in
+                        proxy.frame(in: .named("scrollView")).minY
+                    } action: { newOffset in
+                        viewModel.handleScroll(offset: newOffset)
+                    }
                 } else {
                     ProgressView()
                         .tint(viewModel.readerTextMutedColor)
                         .padding(.vertical, 48)
                 }
-                GeometryReader { geo in
-                    Color.clear
-                        .preference(key: ScrollOffsetPreferenceKey.self, value: geo.frame(in: .named("scrollView")).maxY)
-                }
-                .frame(height: 0)
             }
             .coordinateSpace(.named("scrollView"))
-            .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
-                Task { @MainActor in
-                    viewModel.handleScroll(offset: value)
-                }
-            }
             .onChange(of: viewModel.scrollToTop) { _, shouldScroll in
                 if shouldScroll {
                     scrollProxy.scrollTo("topOfContent", anchor: .top)
@@ -297,15 +287,6 @@ public struct BibleReaderView: View {
         }
     }
 #endif
-
-    /// Helper to detect scroll offset in ScrollView
-    private struct ScrollOffsetPreferenceKey: PreferenceKey {
-        typealias Value = CGFloat
-        static var defaultValue: Value { .zero }
-        static func reduce(value: inout Value, nextValue: () -> Value) {
-            value = nextValue()
-        }
-    }
 
     // MARK: - Action handlers
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -24,8 +24,12 @@ extension BibleReaderViewModel {
             }
         }
 
-        // Reset scroll tracking to prevent chrome from hiding due to content change
+        // Reset scroll tracking and restore chrome so the new chapter lands
+        // in the same initial state as a fresh open. Without this, chrome
+        // stays hidden after a navigation tap that scrolls cached content
+        // back to minY = 0, since onGeometryChange won't fire again.
         lastScrollOffset = 0
+        showChrome = true
         scrollToTop = true
     }
 
@@ -52,8 +56,12 @@ extension BibleReaderViewModel {
             }
         }
 
-        // Reset scroll tracking to prevent chrome from hiding due to content change
+        // Reset scroll tracking and restore chrome so the new chapter lands
+        // in the same initial state as a fresh open. Without this, chrome
+        // stays hidden after a navigation tap that scrolls cached content
+        // back to minY = 0, since onGeometryChange won't fire again.
         lastScrollOffset = 0
+        showChrome = true
         scrollToTop = true
     }
 
@@ -223,8 +231,12 @@ extension BibleReaderViewModel {
             self.reference = reference
             self.showBookIntro = showIntro
 
-            // Reset scroll tracking to prevent chrome from hiding due to content change
+            // Reset scroll tracking and restore chrome so the new chapter lands
+            // in the same initial state as a fresh open. Without this, chrome
+            // stays hidden after a navigation tap that scrolls cached content
+            // back to minY = 0, since onGeometryChange won't fire again.
             lastScrollOffset = 0
+            showChrome = true
             scrollToTop = true
         } catch {
             YouVersionPlatformLogger.error("Error loading version/chapter: \(error)", category: "Reader")

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -71,7 +71,9 @@ extension BibleReaderViewModel {
 
         let threshold: CGFloat = 10
         let animation: Animation? = isReduceMotionEnabled ? nil : .easeInOut(duration: 0.1)
-        if offset <= 0 {
+        // offset is the content's minY in the scroll viewport: 0 at top,
+        // negative while scrolled down, positive when rubber-banding past top.
+        if offset >= 0 {
             withAnimation(animation) { showChrome = true }
         } else if abs(offset - lastScrollOffset) >= threshold {
             if offset < lastScrollOffset - threshold {


### PR DESCRIPTION
## Summary

The reader's header pills and floating chapter-nav chevrons were supposed to slide out as the user scrolled down through a chapter and slide back in on scroll-up, but the chrome was not actually moving. Three latent issues had to all be fixed:

1. **Scroll-offset tracking didn't fire on scroll.** A pair of `GeometryReader` + `PreferenceKey` markers at the top and bottom of the content fed the same key with a `value = nextValue()` reducer. SwiftUI doesn't invalidate that layout during scroll, so the preference rarely fired. Replaced with `onGeometryChange(for: CGFloat.self)` (iOS 17+) on the scrolled content, which observes named-coordinate-space frame changes as the user scrolls.

2. **`handleScroll`'s at-top branch had the wrong polarity for the new offset semantics.** With the new minY-based offset (`0` at top, negative while scrolled down), `if offset <= 0` became true on every event and short-circuited the relative-motion logic that actually flips `showChrome`. Inverted the test to `offset >= 0`, with a comment documenting the convention.

3. **`BibleReaderHeaderView` was hardcoded to `showChrome: true`** at its only call site, so the header could never react to `viewModel.showChrome` even when the math was correct. Wired it through.

## Verification

| Before | After |
| --- | --- |
|<img width="327" height="688" alt="before" src="https://github.com/user-attachments/assets/c1ed56fa-73a5-4f8f-9d2e-4a1891e9dfdd" />|<img width="327" height="688" alt="after" src="https://github.com/user-attachments/assets/c88caf68-7043-4176-b4be-af22e8fd8050" />|

## Test plan

- [ ] Build (`swift build`) — ✅ clean
- [ ] Tests (`swift test`) — ✅ 260 pass
- [ ] Public API stability check — ✅ no breaking changes
- [ ] Run SampleApp on iOS 17+ simulator, open BibleReaderView with a long chapter (e.g. Psalm 119)
- [ ] Scroll down → header collapses to compact "Book Chapter ABBR" label, bottom nav chevrons slide off-screen
- [ ] Scroll up → header expands back to pills, bottom chevrons slide back in
- [ ] Tiny finger jitter within ±10 pts → no flicker
- [ ] Rubber-band at top → chrome stays visible
- [ ] Tap ▶ next chapter → resets to top with chrome visible
- [ ] Reduce Motion on (Settings → Accessibility → Motion) → same transitions, no slide animation

Before/after videos to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three latent bugs that together prevented the reader chrome (header pills and bottom nav chevrons) from hiding/showing on scroll: a `GeometryReader`+`PreferenceKey` approach that SwiftUI rarely invalidated during scroll is replaced with `onGeometryChange(for:)`; an inverted polarity check in `handleScroll` (`<= 0` → `>= 0`) that short-circuited the show/hide logic is corrected; and a hardcoded `showChrome: true` at the `BibleReaderHeaderView` call site is wired to `viewModel.showChrome`. It also resolves the previously flagged issue where chrome would stay hidden after navigating to a cached chapter by explicitly resetting `showChrome = true` in all three navigation paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three root causes are addressed correctly and the previously flagged P1 is resolved.

No P0 or P1 issues remain. The only finding is a P2 style note about an inline comment inside a function body. The logic changes are sound: offset polarity is correct, all navigation paths reset chrome state, and onGeometryChange fires reliably during scroll on iOS 17+.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Replaces fragile GeometryReader+PreferenceKey scroll tracking with onGeometryChange(for:) (iOS 17+), and wires showChrome through to BibleReaderHeaderView instead of hardcoding true. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift | Fixes polarity bug in handleScroll (offset >= 0 for "at top"), adds showChrome = true to all three navigation paths to prevent chrome from staying hidden on cached-chapter navigation. One minor style note: new inline comment added inside handleScroll body. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ScrollView
    participant onGeometryChange
    participant handleScroll
    participant showChrome

    User->>ScrollView: scroll down
    ScrollView->>onGeometryChange: frame minY changes (negative)
    onGeometryChange->>handleScroll: offset = -50
    handleScroll->>showChrome: abs(-50 - 0) >= 10 && -50 < 0-10 → false

    User->>ScrollView: scroll up
    ScrollView->>onGeometryChange: frame minY changes (less negative)
    onGeometryChange->>handleScroll: offset = -20
    handleScroll->>showChrome: abs(-20 - (-50)) >= 10 && -20 > -50+10 → true

    User->>ScrollView: rubber-band past top
    ScrollView->>onGeometryChange: frame minY > 0
    onGeometryChange->>handleScroll: offset = +8
    handleScroll->>showChrome: offset >= 0 → true

    User->>ScrollView: tap next chapter
    Note over handleScroll,showChrome: isChangingChapter = true, showChrome = true (reset), scrollToTop = true
    ScrollView->>ScrollView: scroll to top
    Note over handleScroll: guard !isChangingChapter blocks callbacks
    Note over handleScroll: after 0.5s → isChangingChapter = false
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift`, line 27-29 ([link](https://github.com/youversion/platform-sdk-swift/blob/6f9dc0545f5a39f4b27367758c6451d9ca222e80/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift#L27-L29)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Chrome stays hidden after navigating cached chapters**

   When the user navigates chapters while chrome is already hidden, `showChrome` is never restored to `true`. Here's the sequence: `isChangingChapter = true` blocks `handleScroll`; the scroll-to-top animation fires `onGeometryChange` at `minY = 0` (all guarded); if content is cached and renders while `isChangingChapter` is still `true`, the frame stays at `minY = 0` — so after the 0.5 s delay flips `isChangingChapter = false`, `onGeometryChange` no longer fires (same `minY`), and `showChrome` remains `false` indefinitely.

   The same gap exists in `goToNextChapter()` and `onHeaderSelectionChange()`. Adding an explicit `showChrome = true` alongside the existing resets in all three navigation methods is the safest fix:

   ```swift
   // Reset scroll tracking to prevent chrome from hiding due to content change
   lastScrollOffset = 0
   showChrome = true   // ← add this
   scrollToTop = true
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
   Line: 27-29

   Comment:
   **Chrome stays hidden after navigating cached chapters**

   When the user navigates chapters while chrome is already hidden, `showChrome` is never restored to `true`. Here's the sequence: `isChangingChapter = true` blocks `handleScroll`; the scroll-to-top animation fires `onGeometryChange` at `minY = 0` (all guarded); if content is cached and renders while `isChangingChapter` is still `true`, the frame stays at `minY = 0` — so after the 0.5 s delay flips `isChangingChapter = false`, `onGeometryChange` no longer fires (same `minY`), and `showChrome` remains `false` indefinitely.

   The same gap exists in `goToNextChapter()` and `onHeaderSelectionChange()`. Adding an explicit `showChrome = true` alongside the existing resets in all three navigation methods is the safest fix:

   ```swift
   // Reset scroll tracking to prevent chrome from hiding due to content change
   lastScrollOffset = 0
   showChrome = true   // ← add this
   scrollToTop = true
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%0ALine%3A%2027-29%0A%0AComment%3A%0A**Chrome%20stays%20hidden%20after%20navigating%20cached%20chapters**%0A%0AWhen%20the%20user%20navigates%20chapters%20while%20chrome%20is%20already%20hidden%2C%20%60showChrome%60%20is%20never%20restored%20to%20%60true%60.%20Here's%20the%20sequence%3A%20%60isChangingChapter%20%3D%20true%60%20blocks%20%60handleScroll%60%3B%20the%20scroll-to-top%20animation%20fires%20%60onGeometryChange%60%20at%20%60minY%20%3D%200%60%20%28all%20guarded%29%3B%20if%20content%20is%20cached%20and%20renders%20while%20%60isChangingChapter%60%20is%20still%20%60true%60%2C%20the%20frame%20stays%20at%20%60minY%20%3D%200%60%20%E2%80%94%20so%20after%20the%200.5%20s%20delay%20flips%20%60isChangingChapter%20%3D%20false%60%2C%20%60onGeometryChange%60%20no%20longer%20fires%20%28same%20%60minY%60%29%2C%20and%20%60showChrome%60%20remains%20%60false%60%20indefinitely.%0A%0AThe%20same%20gap%20exists%20in%20%60goToNextChapter%28%29%60%20and%20%60onHeaderSelectionChange%28%29%60.%20Adding%20an%20explicit%20%60showChrome%20%3D%20true%60%20alongside%20the%20existing%20resets%20in%20all%20three%20navigation%20methods%20is%20the%20safest%20fix%3A%0A%0A%60%60%60swift%0A%2F%2F%20Reset%20scroll%20tracking%20to%20prevent%20chrome%20from%20hiding%20due%20to%20content%20change%0AlastScrollOffset%20%3D%200%0AshowChrome%20%3D%20true%20%20%20%2F%2F%20%E2%86%90%20add%20this%0AscrollToTop%20%3D%20true%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=96&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%0ALine%3A%2027-29%0A%0AComment%3A%0A**Chrome%20stays%20hidden%20after%20navigating%20cached%20chapters**%0A%0AWhen%20the%20user%20navigates%20chapters%20while%20chrome%20is%20already%20hidden%2C%20%60showChrome%60%20is%20never%20restored%20to%20%60true%60.%20Here's%20the%20sequence%3A%20%60isChangingChapter%20%3D%20true%60%20blocks%20%60handleScroll%60%3B%20the%20scroll-to-top%20animation%20fires%20%60onGeometryChange%60%20at%20%60minY%20%3D%200%60%20%28all%20guarded%29%3B%20if%20content%20is%20cached%20and%20renders%20while%20%60isChangingChapter%60%20is%20still%20%60true%60%2C%20the%20frame%20stays%20at%20%60minY%20%3D%200%60%20%E2%80%94%20so%20after%20the%200.5%20s%20delay%20flips%20%60isChangingChapter%20%3D%20false%60%2C%20%60onGeometryChange%60%20no%20longer%20fires%20%28same%20%60minY%60%29%2C%20and%20%60showChrome%60%20remains%20%60false%60%20indefinitely.%0A%0AThe%20same%20gap%20exists%20in%20%60goToNextChapter%28%29%60%20and%20%60onHeaderSelectionChange%28%29%60.%20Adding%20an%20explicit%20%60showChrome%20%3D%20true%60%20alongside%20the%20existing%20resets%20in%20all%20three%20navigation%20methods%20is%20the%20safest%20fix%3A%0A%0A%60%60%60swift%0A%2F%2F%20Reset%20scroll%20tracking%20to%20prevent%20chrome%20from%20hiding%20due%20to%20content%20change%0AlastScrollOffset%20%3D%200%0AshowChrome%20%3D%20true%20%20%20%2F%2F%20%E2%86%90%20add%20this%0AscrollToTop%20%3D%20true%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=96&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%3A82-84%0A**New%20inline%20comment%20inside%20function%20body**%0A%0AThe%20project%20style%20guide%20asks%20us%20not%20to%20add%20inline%20comments%20inside%20function%20bodies.%20The%20coordinate-space%20convention%20%28%60minY%20%3D%200%60%20at%20top%2C%20negative%20while%20scrolled%29%20is%20genuinely%20worth%20preserving%20%E2%80%94%20consider%20moving%20it%20to%20the%20%60handleScroll%60%20DocC%20comment%20instead%2C%20which%20is%20visible%20at%20call%20sites%20and%20keeps%20the%20function%20body%20clean.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=96&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%3A82-84%0A**New%20inline%20comment%20inside%20function%20body**%0A%0AThe%20project%20style%20guide%20asks%20us%20not%20to%20add%20inline%20comments%20inside%20function%20bodies.%20The%20coordinate-space%20convention%20%28%60minY%20%3D%200%60%20at%20top%2C%20negative%20while%20scrolled%29%20is%20genuinely%20worth%20preserving%20%E2%80%94%20consider%20moving%20it%20to%20the%20%60handleScroll%60%20DocC%20comment%20instead%2C%20which%20is%20visible%20at%20call%20sites%20and%20keeps%20the%20function%20body%20clean.%0A%0A&pr=96&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift:82-84
**New inline comment inside function body**

The project style guide asks us not to add inline comments inside function bodies. The coordinate-space convention (`minY = 0` at top, negative while scrolled) is genuinely worth preserving — consider moving it to the `handleScroll` DocC comment instead, which is visible at call sites and keeps the function body clean.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: restore chrome on chapter navigatio..."](https://github.com/youversion/platform-sdk-swift/commit/ac18eb113c8cc7bde5006bc723f9a04be155b1c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30456237)</sub>

<!-- /greptile_comment -->