### PR TITLE
test: replace polling waitFor with awaitable Tasks

### DIFF
--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+MyVersions.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+MyVersions.swift
@@ -8,15 +8,16 @@ extension BibleVersionsViewModel {
         showingVersionsStack = false
     }
 
-    @discardableResult
-    public func myVersionMoreInfoMenuTapped(_ versionId: Int) -> Task<Void, Never> {
-        Task {
-            do {
-                selectedVersion = try await versionRepository.version(withId: versionId)
-                versionsStackPush(to: .versionInfo)
-            } catch {
-                handleVersionLoadingError(error)
-            }
+    public func myVersionMoreInfoMenuTapped(_ versionId: Int) {
+        Task { await myVersionMoreInfoMenuTappedAsync(versionId) }
+    }
+
+    func myVersionMoreInfoMenuTappedAsync(_ versionId: Int) async {
+        do {
+            selectedVersion = try await versionRepository.version(withId: versionId)
+            versionsStackPush(to: .versionInfo)
+        } catch {
+            handleVersionLoadingError(error)
         }
     }
 
@@ -35,16 +36,17 @@ extension BibleVersionsViewModel {
         }
     }
 
-    @discardableResult
-    public func myVersionDownloadMenuTapped(_ versionId: Int) -> Task<Void, Never> {
-        Task {
-            if let version = try? await versionRepository.version(withId: versionId) {
-                conditionalDownloadButtonTapped(version: version)
-            } else {
-                showGenericAlert = true
-                textForGenericAlertTitle = .localized("generic.error")
-                textForGenericAlertBody = .localized("myVersions.downloadErrorBody")
-            }
+    public func myVersionDownloadMenuTapped(_ versionId: Int) {
+        Task { await myVersionDownloadMenuTappedAsync(versionId) }
+    }
+
+    func myVersionDownloadMenuTappedAsync(_ versionId: Int) async {
+        if let version = try? await versionRepository.version(withId: versionId) {
+            conditionalDownloadButtonTapped(version: version)
+        } else {
+            showGenericAlert = true
+            textForGenericAlertTitle = .localized("generic.error")
+            textForGenericAlertBody = .localized("myVersions.downloadErrorBody")
         }
     }
 

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+MyVersions.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+MyVersions.swift
@@ -9,10 +9,10 @@ extension BibleVersionsViewModel {
     }
 
     public func myVersionMoreInfoMenuTapped(_ versionId: Int) {
-        Task { await myVersionMoreInfoMenuTappedAsync(versionId) }
+        Task { await myVersionMoreInfoMenuTapped(versionId) }
     }
 
-    func myVersionMoreInfoMenuTappedAsync(_ versionId: Int) async {
+    func myVersionMoreInfoMenuTapped(_ versionId: Int) async {
         do {
             selectedVersion = try await versionRepository.version(withId: versionId)
             versionsStackPush(to: .versionInfo)
@@ -37,10 +37,10 @@ extension BibleVersionsViewModel {
     }
 
     public func myVersionDownloadMenuTapped(_ versionId: Int) {
-        Task { await myVersionDownloadMenuTappedAsync(versionId) }
+        Task { await myVersionDownloadMenuTapped(versionId) }
     }
 
-    func myVersionDownloadMenuTappedAsync(_ versionId: Int) async {
+    func myVersionDownloadMenuTapped(_ versionId: Int) async {
         if let version = try? await versionRepository.version(withId: versionId) {
             conditionalDownloadButtonTapped(version: version)
         } else {

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+MyVersions.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+MyVersions.swift
@@ -8,7 +8,8 @@ extension BibleVersionsViewModel {
         showingVersionsStack = false
     }
 
-    public func myVersionMoreInfoMenuTapped(_ versionId: Int) {
+    @discardableResult
+    public func myVersionMoreInfoMenuTapped(_ versionId: Int) -> Task<Void, Never> {
         Task {
             do {
                 selectedVersion = try await versionRepository.version(withId: versionId)
@@ -34,7 +35,8 @@ extension BibleVersionsViewModel {
         }
     }
 
-    public func myVersionDownloadMenuTapped(_ versionId: Int) {
+    @discardableResult
+    public func myVersionDownloadMenuTapped(_ versionId: Int) -> Task<Void, Never> {
         Task {
             if let version = try? await versionRepository.version(withId: versionId) {
                 conditionalDownloadButtonTapped(version: version)

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
@@ -26,32 +26,34 @@ extension BibleVersionsViewModel {
         return .notDownloadable
     }
 
-    @discardableResult
-    public func switchToVersion(_ versionId: Int) -> Task<Void, Never> {
-        Task {
-            do {
-                let version = try await versionRepository.version(withId: versionId)
-                onVersionChange(version)
-            } catch {
-                handleVersionLoadingError(error)
-            }
+    public func switchToVersion(_ versionId: Int) {
+        Task { await switchToVersionAsync(versionId) }
+    }
+
+    func switchToVersionAsync(_ versionId: Int) async {
+        do {
+            let version = try await versionRepository.version(withId: versionId)
+            onVersionChange(version)
+        } catch {
+            handleVersionLoadingError(error)
         }
     }
 
-    @discardableResult
-    public func handleVersionPickerTap(_ versionId: Int) -> Task<Void, Never> {
-        Task {
-            do {
-                showFullProgressViewOverlay = true
-                defer {
-                    showFullProgressViewOverlay = false
-                }
-                let version = try await versionRepository.version(withId: versionId)
-                selectedVersion = version
-                versionsStackPush(to: .versionInfo)
-            } catch {
-                handleVersionLoadingError(error)
+    public func handleVersionPickerTap(_ versionId: Int) {
+        Task { await handleVersionPickerTapAsync(versionId) }
+    }
+
+    func handleVersionPickerTapAsync(_ versionId: Int) async {
+        do {
+            showFullProgressViewOverlay = true
+            defer {
+                showFullProgressViewOverlay = false
             }
+            let version = try await versionRepository.version(withId: versionId)
+            selectedVersion = version
+            versionsStackPush(to: .versionInfo)
+        } catch {
+            handleVersionLoadingError(error)
         }
     }
 

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
@@ -26,7 +26,8 @@ extension BibleVersionsViewModel {
         return .notDownloadable
     }
 
-    public func switchToVersion(_ versionId: Int) {
+    @discardableResult
+    public func switchToVersion(_ versionId: Int) -> Task<Void, Never> {
         Task {
             do {
                 let version = try await versionRepository.version(withId: versionId)
@@ -37,7 +38,8 @@ extension BibleVersionsViewModel {
         }
     }
 
-    public func handleVersionPickerTap(_ versionId: Int) {
+    @discardableResult
+    public func handleVersionPickerTap(_ versionId: Int) -> Task<Void, Never> {
         Task {
             do {
                 showFullProgressViewOverlay = true

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
@@ -27,10 +27,10 @@ extension BibleVersionsViewModel {
     }
 
     public func switchToVersion(_ versionId: Int) {
-        Task { await switchToVersionAsync(versionId) }
+        Task { await switchToVersion(versionId) }
     }
 
-    func switchToVersionAsync(_ versionId: Int) async {
+    func switchToVersion(_ versionId: Int) async {
         do {
             let version = try await versionRepository.version(withId: versionId)
             onVersionChange(version)
@@ -40,10 +40,10 @@ extension BibleVersionsViewModel {
     }
 
     public func handleVersionPickerTap(_ versionId: Int) {
-        Task { await handleVersionPickerTapAsync(versionId) }
+        Task { await handleVersionPickerTap(versionId) }
     }
 
-    func handleVersionPickerTapAsync(_ versionId: Int) async {
+    func handleVersionPickerTap(_ versionId: Int) async {
         do {
             showFullProgressViewOverlay = true
             defer {

--- a/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
@@ -78,7 +78,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             versionRepository: repository
         )
 
-        await viewModel.switchToVersionAsync(version.id)
+        await viewModel.switchToVersion(version.id)
 
         #expect(changedVersion == version)
         #expect(viewModel.showGenericAlert == false)
@@ -93,7 +93,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             versionRepository: repository
         )
 
-        await viewModel.switchToVersionAsync(111)
+        await viewModel.switchToVersion(111)
 
         #expect(viewModel.showGenericAlert)
         #expect(viewModel.textForGenericAlertTitle == .localized("generic.error"))
@@ -110,7 +110,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             versionRepository: repository
         )
 
-        await viewModel.handleVersionPickerTapAsync(version.id)
+        await viewModel.handleVersionPickerTap(version.id)
 
         #expect(viewModel.selectedVersion == version)
         #expect(viewModel.versionsPickerStack == [.versionInfo])
@@ -128,7 +128,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             versionRepository: repository
         )
 
-        await viewModel.myVersionMoreInfoMenuTappedAsync(version.id)
+        await viewModel.myVersionMoreInfoMenuTapped(version.id)
 
         #expect(viewModel.selectedVersion == version)
         #expect(viewModel.versionsPickerStack == [.versionInfo])
@@ -143,7 +143,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             versionRepository: repository
         )
 
-        await viewModel.myVersionDownloadMenuTappedAsync(444)
+        await viewModel.myVersionDownloadMenuTapped(444)
 
         #expect(viewModel.showGenericAlert)
         #expect(viewModel.textForGenericAlertTitle == .localized("generic.error"))

--- a/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
@@ -78,8 +78,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             versionRepository: repository
         )
 
-        viewModel.switchToVersion(version.id)
-        await waitFor { changedVersion == version }
+        await viewModel.switchToVersion(version.id).value
 
         #expect(changedVersion == version)
         #expect(viewModel.showGenericAlert == false)
@@ -94,8 +93,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             versionRepository: repository
         )
 
-        viewModel.switchToVersion(111)
-        await waitFor { viewModel.showGenericAlert }
+        await viewModel.switchToVersion(111).value
 
         #expect(viewModel.showGenericAlert)
         #expect(viewModel.textForGenericAlertTitle == .localized("generic.error"))
@@ -112,8 +110,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             versionRepository: repository
         )
 
-        viewModel.handleVersionPickerTap(version.id)
-        await waitFor { viewModel.selectedVersion == version }
+        await viewModel.handleVersionPickerTap(version.id).value
 
         #expect(viewModel.selectedVersion == version)
         #expect(viewModel.versionsPickerStack == [.versionInfo])
@@ -131,8 +128,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             versionRepository: repository
         )
 
-        viewModel.myVersionMoreInfoMenuTapped(version.id)
-        await waitFor { viewModel.selectedVersion == version }
+        await viewModel.myVersionMoreInfoMenuTapped(version.id).value
 
         #expect(viewModel.selectedVersion == version)
         #expect(viewModel.versionsPickerStack == [.versionInfo])
@@ -147,8 +143,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             versionRepository: repository
         )
 
-        viewModel.myVersionDownloadMenuTapped(444)
-        await waitFor { viewModel.showGenericAlert }
+        await viewModel.myVersionDownloadMenuTapped(444).value
 
         #expect(viewModel.showGenericAlert)
         #expect(viewModel.textForGenericAlertTitle == .localized("generic.error"))
@@ -172,23 +167,5 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             books: nil,
             textDirection: "ltr"
         )
-    }
-
-    private func waitFor(
-        timeoutNanoseconds: UInt64 = 5_000_000_000,
-        condition: @escaping @MainActor () -> Bool
-    ) async {
-        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
-        while DispatchTime.now().uptimeNanoseconds < deadline {
-            if condition() {
-                return
-            }
-            await Task.yield()
-            try? await Task.sleep(nanoseconds: 10_000_000)
-        }
-        // One final check: Task.sleep can oversleep on a loaded machine, so the condition
-        // may have been satisfied during the last sleep even though the deadline has passed.
-        if condition() { return }
-        Issue.record("Timed out waiting for condition")
     }
 }

--- a/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
@@ -78,7 +78,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             versionRepository: repository
         )
 
-        await viewModel.switchToVersion(version.id).value
+        await viewModel.switchToVersionAsync(version.id)
 
         #expect(changedVersion == version)
         #expect(viewModel.showGenericAlert == false)
@@ -93,7 +93,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             versionRepository: repository
         )
 
-        await viewModel.switchToVersion(111).value
+        await viewModel.switchToVersionAsync(111)
 
         #expect(viewModel.showGenericAlert)
         #expect(viewModel.textForGenericAlertTitle == .localized("generic.error"))
@@ -110,7 +110,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             versionRepository: repository
         )
 
-        await viewModel.handleVersionPickerTap(version.id).value
+        await viewModel.handleVersionPickerTapAsync(version.id)
 
         #expect(viewModel.selectedVersion == version)
         #expect(viewModel.versionsPickerStack == [.versionInfo])
@@ -128,7 +128,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             versionRepository: repository
         )
 
-        await viewModel.myVersionMoreInfoMenuTapped(version.id).value
+        await viewModel.myVersionMoreInfoMenuTappedAsync(version.id)
 
         #expect(viewModel.selectedVersion == version)
         #expect(viewModel.versionsPickerStack == [.versionInfo])
@@ -143,7 +143,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
             versionRepository: repository
         )
 
-        await viewModel.myVersionDownloadMenuTapped(444).value
+        await viewModel.myVersionDownloadMenuTappedAsync(444)
 
         #expect(viewModel.showGenericAlert)
         #expect(viewModel.textForGenericAlertTitle == .localized("generic.error"))


### PR DESCRIPTION
## Summary

- The four `BibleVersionsViewModel` tap handlers (`switchToVersion`, `handleVersionPickerTap`, `myVersionMoreInfoMenuTapped`, `myVersionDownloadMenuTapped`) spawned detached `Task`s and discarded them, leaving callers no way to know when the async work finished. The tests worked around this with a `waitFor` helper that mixed `DispatchTime` (libdispatch) with Swift Concurrency to poll observable state until a deadline.
- Each handler now returns `Task<Void, Never>` and is marked `@discardableResult`, so SwiftUI call sites are unaffected but tests can `await viewModel.method(id).value` directly.
- `waitFor` is deleted along with its 5-second timeout. Tests now finish in 1–3 ms each instead of waiting on a polling loop, with no flakiness window.

## Test plan

- [x] `swift test --filter BibleVersionsViewModelTests` — all 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the four `BibleVersionsViewModel` tap handlers by splitting each into a thin `public` sync wrapper (which fires a `Task`) and a new `internal async` overload that holds the actual logic. Tests use `@testable import` to call the async overloads directly with `await`, eliminating the `waitFor` polling helper and making each test complete deterministically in milliseconds. The `@MainActor` actor context is correctly inherited by all `Task`s, so there are no thread-safety regressions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — clean structural refactor with no logic changes and deterministic tests.

No P0 or P1 findings. The overload pattern is idiomatic Swift, the @MainActor context is preserved throughout, and the mock-based tests now resolve without any polling races. The only delta is structural (split sync/async) with all observable behavior unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift | Adds internal async overloads for switchToVersion and handleVersionPickerTap; public sync wrappers now delegate to them via Task, preserving SwiftUI compatibility. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+MyVersions.swift | Same overload pattern applied to myVersionMoreInfoMenuTapped and myVersionDownloadMenuTapped; no logic changes, only structural refactor. |
| Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift | Replaces polling waitFor helper with direct await calls on the async overloads via @testable import; all six tests now resolve deterministically. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SwiftUI as SwiftUI View
    participant Pub as public func (sync)
    participant T as Task (MainActor)
    participant Async as internal func (async)
    participant Repo as BibleVersionRepository

    Note over SwiftUI,Repo: Production call path (unchanged for SwiftUI)
    SwiftUI->>Pub: switchToVersion(id)
    Pub->>T: Task { await switchToVersion(id) }
    T->>Async: await switchToVersion(id)
    Async->>Repo: await version(withId: id)
    Repo-->>Async: BibleVersion
    Async-->>T: onVersionChange(version)

    Note over SwiftUI,Repo: Test call path (new – direct await)
    participant Test as @MainActor Test
    Test->>Async: await viewModel.switchToVersion(id)
    Async->>Repo: await version(withId: id)
    Repo-->>Async: BibleVersion
    Async-->>Test: (completes deterministically)
```

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into claude/practica..."](https://github.com/youversion/platform-sdk-swift/commit/ffc8bc3a058683a46ae7a9249911ed3d5cf51728) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30476213)</sub>

<!-- /greptile_comment -->