### PR TITLE
refactor: observable currentVersion replaces onVersionChange callback

### DIFF
--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -225,7 +225,7 @@ extension BibleReaderViewModel {
         do {
             if version?.id != reference.versionId {
                 let newVersion = try await versionsViewModel.versionRepository.version(withId: reference.versionId)
-                version = newVersion
+                versionsViewModel.switchToVersion(newVersion)
                 versionsViewModel.myVersions.insert(newVersion)
             }
             self.reference = reference

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Preview.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Preview.swift
@@ -10,7 +10,7 @@ extension BibleReaderViewModel {
         let vm = BibleReaderViewModel(reference: BibleReference(versionId: 3034, bookUSFM: "GEN", chapter: 1))
 
         let previewVersion = BibleVersion.preview
-        vm.version = previewVersion
+        vm.versionsViewModel.switchToVersion(previewVersion)
 
         let footnoteReference = BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 21, verse: 1)
         vm.footnotesToDisplay = [

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -110,9 +110,9 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         observeCurrentVersion()
     }
 
-    /// Reacts to ``BibleVersionsViewModel/currentVersion`` changes by updating
-    /// the reader's reference. The Observation framework's tracking is one-shot,
-    /// so the method re-arms itself after each fired change.
+    // Reacts to BibleVersionsViewModel.currentVersion changes by updating
+    // the reader's reference. The Observation framework's tracking is one-shot,
+    // so the method re-arms itself after each fired change.
     private func observeCurrentVersion() {
         withObservationTracking {
             _ = versionsViewModel.currentVersion
@@ -148,10 +148,12 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         )
     }
 
+    /// Aligns the reader's reference to a newly picked version and triggers a
+    /// header selection change to load its content. No-ops when the reference's
+    /// versionId already matches — this is the guard that prevents
+    /// `onHeaderSelectionChange` from looping back through the
+    /// `currentVersion` observation chain.
     func handleVersionPicked(_ version: BibleVersion) {
-        // If the reference is already aligned with this version (e.g., the
-        // version was set as a side effect of onHeaderSelectionChange), there's
-        // nothing to do — avoid recursing back into onHeaderSelectionChange.
         guard reference.versionId != version.id else {
             return
         }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -23,8 +23,8 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         }
     }
     let highlightsViewModel: BibleHighlightsViewModel
-    var versionsViewModel: BibleVersionsViewModel
-    var version: BibleVersion?
+    let versionsViewModel: BibleVersionsViewModel
+    var version: BibleVersion? { versionsViewModel.currentVersion }
     let onVerseTap: ((BibleReference) -> Void)?
     let verseSelectionStyle: VerseSelectionStyle
 
@@ -90,10 +90,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         self.verseSelectionStyle = verseSelectionStyle
         self.highlightsViewModel = highlightsViewModel ?? BibleHighlightsViewModel()
         let shouldLoadVersionsViewModel = versionsViewModel == nil
-        self.versionsViewModel = versionsViewModel ?? BibleVersionsViewModel { _ in }
-        self.versionsViewModel.onVersionChange = { [weak self] version in
-            self?.onVersionChange(version: version)
-        }
+        self.versionsViewModel = versionsViewModel ?? BibleVersionsViewModel()
         self.versionsViewModel.onSignInRequired = { [weak self] in
             self?.onSignInRequired()
         }
@@ -107,6 +104,24 @@ final class BibleReaderViewModel: ReaderThemeProviding {
             let initialVersionId = self.reference.versionId
             Task { [weak self] in
                 await self?.versionsViewModel.loadInitialState(initialVersionId: initialVersionId)
+            }
+        }
+
+        observeCurrentVersion()
+    }
+
+    /// Reacts to ``BibleVersionsViewModel/currentVersion`` changes by updating
+    /// the reader's reference. The Observation framework's tracking is one-shot,
+    /// so the method re-arms itself after each fired change.
+    private func observeCurrentVersion() {
+        withObservationTracking {
+            _ = versionsViewModel.currentVersion
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                self?.observeCurrentVersion()
+                if let version = self?.versionsViewModel.currentVersion {
+                    self?.handleVersionPicked(version)
+                }
             }
         }
     }
@@ -133,8 +148,13 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         )
     }
 
-    func onVersionChange(version: BibleVersion) {
-        self.version = version
+    func handleVersionPicked(_ version: BibleVersion) {
+        // If the reference is already aligned with this version (e.g., the
+        // version was set as a side effect of onHeaderSelectionChange), there's
+        // nothing to do — avoid recursing back into onHeaderSelectionChange.
+        guard reference.versionId != version.id else {
+            return
+        }
         reference = BibleReference(versionId: version.id, bookUSFM: reference.bookUSFM, chapter: reference.chapter)
         Task {
             await onHeaderSelectionChange(reference, showIntro: false)

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift
@@ -3,7 +3,6 @@ import YouVersionPlatformCore
 
 public struct BibleVersionPickingButton: View {
     @State private var versionsViewModel: BibleVersionsViewModel
-    @State private var version: BibleVersion?
     private let initialVersionId: Int
     private let onVersionChange: ((BibleVersion) -> Void)?
     @Environment(\.colorScheme) private var colorScheme
@@ -13,12 +12,13 @@ public struct BibleVersionPickingButton: View {
         onVersionChange: ((BibleVersion) -> Void)? = nil
     ) {
         self.initialVersionId = initialVersionId
-        self._versionsViewModel = State(wrappedValue: BibleVersionsViewModel { _ in })
+        self._versionsViewModel = State(wrappedValue: BibleVersionsViewModel())
         self.onVersionChange = onVersionChange
     }
 
     public var body: some View {
         @Bindable var bindableVersionsViewModel = versionsViewModel
+        let version = versionsViewModel.currentVersion
 
         Button {
             versionsViewModel.openVersionsStack(currentBibleLanguage: version?.languageTag ?? "en")
@@ -36,8 +36,12 @@ public struct BibleVersionPickingButton: View {
                 .presentationDetents([.large])
         }
         .task {
-            versionsViewModel.onVersionChange = handleVersionChange
             await versionsViewModel.loadInitialState(initialVersionId: initialVersionId)
+        }
+        .onChange(of: versionsViewModel.currentVersion) { _, newVersion in
+            if let newVersion {
+                onVersionChange?(newVersion)
+            }
         }
         .onChange(of: colorScheme, initial: true) { _, newScheme in
             versionsViewModel.colorTheme = ReaderTheme(
@@ -47,11 +51,6 @@ public struct BibleVersionPickingButton: View {
                 colorScheme: newScheme
             )
         }
-    }
-
-    private func handleVersionChange(_ version: BibleVersion) {
-        self.version = version
-        onVersionChange?(version)
     }
 }
 

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
@@ -33,10 +33,16 @@ extension BibleVersionsViewModel {
     func switchToVersion(_ versionId: Int) async {
         do {
             let version = try await versionRepository.version(withId: versionId)
-            onVersionChange(version)
+            setCurrentVersion(version)
         } catch {
             handleVersionLoadingError(error)
         }
+    }
+
+    /// Sets the current version directly when the caller has already resolved a
+    /// ``BibleVersion`` (skipping the network fetch).
+    public func switchToVersion(_ version: BibleVersion) {
+        setCurrentVersion(version)
     }
 
     public func handleVersionPickerTap(_ versionId: Int) {

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -6,7 +6,20 @@ import YouVersionPlatformCore
 @MainActor
 @Observable
 public final class BibleVersionsViewModel {
-    public var onVersionChange: ((BibleVersion) -> Void)
+    /// The currently selected Bible version. Observe this property to react
+    /// when the user picks a version (either at initial load or from the
+    /// version picker UI).
+    public private(set) var currentVersion: BibleVersion?
+
+    @available(*, deprecated, message: "Observe currentVersion instead.")
+    public var onVersionChange: ((BibleVersion) -> Void) {
+        get { _onVersionChange }
+        set { _onVersionChange = newValue }
+    }
+
+    @ObservationIgnored
+    private var _onVersionChange: (BibleVersion) -> Void
+
     /// called when the user chooses to download a version and they're not yet signed in.
     public var onSignInRequired: (() -> Void)?
     public var colorTheme: ReaderTheme?
@@ -22,15 +35,32 @@ public final class BibleVersionsViewModel {
     private let userDefaultsKeyForMyVersions = "bible-reader-view--my-versions"
     private var hasLoadedInitialState = false
 
-    /// onVersionChange: called when the user has chosen a new version (or their first). The caller should ensure their current reference exists in this new version and choose a new one if not.
+    /// Creates a Bible versions view model.
+    ///
+    /// Observe ``currentVersion`` to react when a version is selected.
     public init(
-        onVersionChange: @escaping (BibleVersion) -> Void,
         versionRepository: any BibleVersionRepositoryProtocol = BibleVersionRepository.shared
     ) {
         self.myVersions = []
         self.suggestedLanguagesList = []
-        self.onVersionChange = onVersionChange
+        self._onVersionChange = { _ in }
         self.versionRepository = versionRepository
+    }
+
+    @available(*, deprecated, message: "Use init(versionRepository:) and observe currentVersion instead.")
+    public convenience init(
+        onVersionChange: @escaping (BibleVersion) -> Void,
+        versionRepository: any BibleVersionRepositoryProtocol = BibleVersionRepository.shared
+    ) {
+        self.init(versionRepository: versionRepository)
+        self._onVersionChange = onVersionChange
+    }
+
+    /// Sets the current version and fires the deprecated ``onVersionChange``
+    /// callback for callers that haven't migrated to observing ``currentVersion``.
+    func setCurrentVersion(_ version: BibleVersion) {
+        currentVersion = version
+        _onVersionChange(version)
     }
 
     /// Loads the initial version data once for this model instance.
@@ -96,7 +126,7 @@ public final class BibleVersionsViewModel {
 
         if let version = loadedVersion {
             myVersions.insert(version)
-            onVersionChange(version)
+            setCurrentVersion(version)
         } else {
             await selectFallbackVersion(savedIds: savedIds)
         }
@@ -110,7 +140,7 @@ public final class BibleVersionsViewModel {
             versionsStackPush(to: .moreVersions)
             return
         }
-        onVersionChange(version)
+        setCurrentVersion(version)
 
         myVersions.insert(version)
     }
@@ -319,7 +349,7 @@ public final class BibleVersionsViewModel {
 
     public static var preview: BibleVersionsViewModel {
         // Create a minimal BibleVersionsViewModel for preview purposes
-        let vm = BibleVersionsViewModel { _ in }
+        let vm = BibleVersionsViewModel()
 
         let previewVersion = BibleVersion.preview
         vm.myVersions = [previewVersion]

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -354,6 +354,7 @@ public final class BibleVersionsViewModel {
         let previewVersion = BibleVersion.preview
         vm.myVersions = [previewVersion]
         vm.selectedVersion = previewVersion
+        vm.switchToVersion(previewVersion)
 
         return vm
     }

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
@@ -203,7 +203,7 @@ let previousChapterCases: [PreviousChapterCase] = [
         )
         let selectedReference = BibleReference(versionId: Self.versionId, bookUSFM: "GEN", chapter: 2, verse: 1)
         vm.showBookIntro = showIntro
-        vm.version = nil
+        // currentVersion is nil by default — the "no loaded version" state.
         vm.isChangingChapter = false
         vm.lastScrollOffset = 123
         vm.scrollToTop = false
@@ -228,7 +228,7 @@ let previousChapterCases: [PreviousChapterCase] = [
         )
         let selectedReference = BibleReference(versionId: Self.versionId, bookUSFM: "GEN", chapter: 2, verse: 1)
         vm.showBookIntro = showIntro
-        vm.version = nil
+        // currentVersion is nil by default — the "no loaded version" state.
         vm.isChangingChapter = false
         vm.lastScrollOffset = 123
         vm.scrollToTop = false
@@ -363,7 +363,7 @@ let previousChapterCases: [PreviousChapterCase] = [
         let reference = BibleReference(versionId: Self.versionId, bookUSFM: referenceBook, chapter: referenceChapter)
         let vm = BibleReaderViewModel(reference: reference)
         let selectedReference = BibleReference(versionId: Self.versionId, bookUSFM: referenceBook, chapter: referenceChapter, verse: 1)
-        vm.version = makeVersion(with: books)
+        vm.versionsViewModel.switchToVersion(makeVersion(with: books))
         vm.showBookIntro = showBookIntro
         vm.isChangingChapter = false
         vm.lastScrollOffset = 321


### PR DESCRIPTION
## What

`BibleVersionsViewModel` now exposes the currently selected Bible version as observable state:

```swift
public private(set) var currentVersion: BibleVersion?
```

Callers read or observe it instead of registering a closure callback. The two consumers that used to mirror the value (`BibleVersionPickingButton.version` `@State` and `BibleReaderViewModel.version`) drop their caches:

- The button reads `vm.currentVersion` directly for its label.
- The reader VM's `version` is now a computed property: `var version: BibleVersion? { versionsViewModel.currentVersion }`.
- The reader VM reacts to version-pick side effects via `withObservationTracking` in its own init (no view-layer bridging).

## Why

There were three places tracking the same fact (\"the currently selected version\"). The view model resolved versions internally but only exposed them via an `@escaping (BibleVersion) -> Void` closure stored as a mutable property. Every caller passed `{ _ in }` at init and overwrote it later — the init parameter was effectively a placeholder.

Both consumers had to keep their own copy of the value because the truth wasn't observable.

## Why this is idiomatic

The `@Observable` macro (iOS 17+) was designed for exactly this: declare observable stored properties on a model, and SwiftUI re-renders any view that reads them. Closure-stored-as-property is a UIKit-era pattern that doesn't compose with SwiftUI's observation graph — views that depend on the value have to maintain their own `@State` mirror, which is the duplication this PR removes.

For non-view code that needs to react to changes (the reader VM updating `reference` when the version changes), `withObservationTracking` is the canonical Observation API. The view stays a pure renderer.

## Public API impact

Additive:
- `BibleVersionsViewModel.currentVersion: BibleVersion?` (read-only)
- `BibleVersionsViewModel.init(versionRepository:)` (no closure required)
- `BibleVersionsViewModel.switchToVersion(_ version: BibleVersion)` (overload)

Deprecated, still functional:
- `BibleVersionsViewModel.init(onVersionChange:versionRepository:)` — \"Use `init(versionRepository:)` and observe `currentVersion` instead.\"
- `BibleVersionsViewModel.onVersionChange` — \"Observe `currentVersion` instead.\"

API stability check: PASSED (no breaking changes).

## Verification

- [x] `swift build` — clean
- [x] `swiftlint --strict` — clean
- [x] `swift test` — 260 / 260 pass
- [x] `scripts/check-api-stability.sh check` — passed
- [x] Manual SampleApp testing — `BibleReaderView` and `BibleCardView(showVersionPicker: true)` flows verified end-to-end (initial load, pick a different version, pick a different chapter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the UIKit-era closure-callback pattern (`onVersionChange`) with idiomatic `@Observable` state (`currentVersion`), eliminating three separate copies of the same "currently selected version" fact. The deprecated init and property are kept as shims so no existing callers break.

- **`BibleVersionsViewModel`** gains `public private(set) var currentVersion: BibleVersion?` as the single observable truth; `setCurrentVersion` is the internal write path that also fires the legacy callback for unmigrated callers.
- **`BibleReaderViewModel`** drops its stored `version` in favour of a computed forwarder and reacts to version changes via `withObservationTracking` (one-shot, self-re-arming), with a `reference.versionId == version.id` guard to prevent feedback loops through `onHeaderSelectionChange`.
- **`BibleVersionPickingButton`** removes its `@State` version mirror and reads `currentVersion` directly from the observable VM; version-change forwarding to the caller moves to `.onChange(of: versionsViewModel.currentVersion)`.

<h3>Confidence Score: 5/5</h3>

Clean refactor — no breaking changes, all 260 tests pass, and the observation-loop guard is correctly placed before `self.reference` is updated.

The change is purely additive/deprecation-based. The `withObservationTracking` re-arming pattern is implemented correctly, and the `reference.versionId == version.id` guard reliably breaks the potential feedback loop between `handleVersionPicked` and `onHeaderSelectionChange` because `self.reference` is always set synchronously before the re-armed observer's Task can run on MainActor.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift | Adds `currentVersion` as the single observable truth; deprecates `onVersionChange` closure via a computed-property shim backed by `@ObservationIgnored _onVersionChange`; introduces `setCurrentVersion` as the internal write path that also fires the legacy callback. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Replaces the closure-callback approach with `withObservationTracking`; adds loop-guard in `handleVersionPicked`; `versionsViewModel` promoted from `var` to `let`; `version` is now a computed forwarder to `versionsViewModel.currentVersion`. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionPickingButton.swift | Drops the `@State private var version` mirror; reads `versionsViewModel.currentVersion` directly in `body`; forwards changes to the caller via `.onChange(of: versionsViewModel.currentVersion)`. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift | Adds the public `switchToVersion(_ version: BibleVersion)` overload (skips network fetch) and replaces internal `onVersionChange` calls with `setCurrentVersion`. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift | Header-navigation path now calls `versionsViewModel.switchToVersion(newVersion)` instead of directly mutating the removed `version` stored property. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Preview.swift | Preview helper updated to call `versionsViewModel.switchToVersion` instead of the now-removed `version` stored property. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift | Three test setup sites updated: direct `vm.version = nil/version` assignments replaced by comments (nil is already the default) or `vm.versionsViewModel.switchToVersion(...)` calls. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Picker as VersionPickerUI
    participant VM as BibleVersionsViewModel
    participant Reader as BibleReaderViewModel
    participant Nav as onHeaderSelectionChange

    Picker->>VM: handleVersionPickerTap(id)
    VM->>VM: setCurrentVersion(version)
    Note over VM: currentVersion = version
    VM-->>Reader: onChange fires (withObservationTracking)
    Reader->>Reader: observeCurrentVersion() [re-arm]
    Reader->>Reader: handleVersionPicked(version)
    alt reference.versionId != version.id
        Reader->>Reader: reference = new BibleReference(version.id, ...)
        Reader->>Nav: Task { await onHeaderSelectionChange(reference) }
        Nav->>Nav: version?.id == reference.versionId → skip switchToVersion
        Nav->>Nav: self.reference = reference
    else already aligned
        Reader-->>Reader: guard exits (no-op)
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift`, line 350-358 ([link](https://github.com/youversion/platform-sdk-swift/blob/d5d223897718c33757012784487f46883d13c170/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift#L350-L358)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`preview` leaves `currentVersion` as `nil`**

   `selectedVersion` is a picker-UI property (it controls the version-info sheet), not the active reading version. Any SwiftUI preview that reads `vm.currentVersion` — including the label text in `BibleVersionPickingButton` — will get `nil` and render an empty abbreviation. Since `currentVersion` is now the primary observable API, the preview should set it via `switchToVersion`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
   Line: 350-358

   Comment:
   **`preview` leaves `currentVersion` as `nil`**

   `selectedVersion` is a picker-UI property (it controls the version-info sheet), not the active reading version. Any SwiftUI preview that reads `vm.currentVersion` — including the label text in `BibleVersionPickingButton` — will get `nil` and render an empty abbreviation. Since `currentVersion` is now the primary observable API, the preview should set it via `switchToVersion`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%0ALine%3A%20350-358%0A%0AComment%3A%0A**%60preview%60%20leaves%20%60currentVersion%60%20as%20%60nil%60**%0A%0A%60selectedVersion%60%20is%20a%20picker-UI%20property%20%28it%20controls%20the%20version-info%20sheet%29%2C%20not%20the%20active%20reading%20version.%20Any%20SwiftUI%20preview%20that%20reads%20%60vm.currentVersion%60%20%E2%80%94%20including%20the%20label%20text%20in%20%60BibleVersionPickingButton%60%20%E2%80%94%20will%20get%20%60nil%60%20and%20render%20an%20empty%20abbreviation.%20Since%20%60currentVersion%60%20is%20now%20the%20primary%20observable%20API%2C%20the%20preview%20should%20set%20it%20via%20%60switchToVersion%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20previewVersion%20%3D%20BibleVersion.preview%0A%20%20%20%20%20%20%20%20vm.myVersions%20%3D%20%5BpreviewVersion%5D%0A%20%20%20%20%20%20%20%20vm.switchToVersion%28previewVersion%29%0A%0A%20%20%20%20%20%20%20%20return%20vm%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=98&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%0ALine%3A%20350-358%0A%0AComment%3A%0A**%60preview%60%20leaves%20%60currentVersion%60%20as%20%60nil%60**%0A%0A%60selectedVersion%60%20is%20a%20picker-UI%20property%20%28it%20controls%20the%20version-info%20sheet%29%2C%20not%20the%20active%20reading%20version.%20Any%20SwiftUI%20preview%20that%20reads%20%60vm.currentVersion%60%20%E2%80%94%20including%20the%20label%20text%20in%20%60BibleVersionPickingButton%60%20%E2%80%94%20will%20get%20%60nil%60%20and%20render%20an%20empty%20abbreviation.%20Since%20%60currentVersion%60%20is%20now%20the%20primary%20observable%20API%2C%20the%20preview%20should%20set%20it%20via%20%60switchToVersion%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20previewVersion%20%3D%20BibleVersion.preview%0A%20%20%20%20%20%20%20%20vm.myVersions%20%3D%20%5BpreviewVersion%5D%0A%20%20%20%20%20%20%20%20vm.switchToVersion%28previewVersion%29%0A%0A%20%20%20%20%20%20%20%20return%20vm%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=98&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

2. `Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift`, line 151-162 ([link](https://github.com/youversion/platform-sdk-swift/blob/d5d223897718c33757012784487f46883d13c170/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift#L151-L162)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Inline comment inside a function**

   Project style asks us not to add new inline comments inside function bodies. The `// If the reference is already aligned…` block explains valid reasoning, but it fits better as a DocC comment above the function signature rather than inside the body.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
   Line: 151-162

   Comment:
   **Inline comment inside a function**

   Project style asks us not to add new inline comments inside function bodies. The `// If the reference is already aligned…` block explains valid reasoning, but it fits better as a DocC comment above the function signature rather than inside the body.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel.swift%0ALine%3A%20151-162%0A%0AComment%3A%0A**Inline%20comment%20inside%20a%20function**%0A%0AProject%20style%20asks%20us%20not%20to%20add%20new%20inline%20comments%20inside%20function%20bodies.%20The%20%60%2F%2F%20If%20the%20reference%20is%20already%20aligned%E2%80%A6%60%20block%20explains%20valid%20reasoning%2C%20but%20it%20fits%20better%20as%20a%20DocC%20comment%20above%20the%20function%20signature%20rather%20than%20inside%20the%20body.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=98&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel.swift%0ALine%3A%20151-162%0A%0AComment%3A%0A**Inline%20comment%20inside%20a%20function**%0A%0AProject%20style%20asks%20us%20not%20to%20add%20new%20inline%20comments%20inside%20function%20bodies.%20The%20%60%2F%2F%20If%20the%20reference%20is%20already%20aligned%E2%80%A6%60%20block%20explains%20valid%20reasoning%2C%20but%20it%20fits%20better%20as%20a%20DocC%20comment%20above%20the%20function%20signature%20rather%20than%20inside%20the%20body.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=98&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel.swift%3A156%0A%60handleVersionPicked%60%20is%20only%20ever%20called%20from%20the%20%60private%60%20method%20%60observeCurrentVersion%60%2C%20so%20it%20can%20be%20%60private%60%20per%20the%20project's%20%22make%20access%20control%20as%20strict%20as%20possible%22%20rule.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20func%20handleVersionPicked%28_%20version%3A%20BibleVersion%29%20%7B%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=98&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel.swift%3A156%0A%60handleVersionPicked%60%20is%20only%20ever%20called%20from%20the%20%60private%60%20method%20%60observeCurrentVersion%60%2C%20so%20it%20can%20be%20%60private%60%20per%20the%20project's%20%22make%20access%20control%20as%20strict%20as%20possible%22%20rule.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20func%20handleVersionPicked%28_%20version%3A%20BibleVersion%29%20%7B%0A%60%60%60%0A%0A&pr=98&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift:156
`handleVersionPicked` is only ever called from the `private` method `observeCurrentVersion`, so it can be `private` per the project's "make access control as strict as possible" rule.

```suggestion
    private func handleVersionPicked(_ version: BibleVersion) {
```


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/youversion/platform-sdk-swift/commit/f808ddef3622c310cdfa4467ddabded3474070eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30511182)</sub>

<!-- /greptile_comment -->