### PR TITLE
chore: extract two strings for localization

### DIFF
--- a/Sources/YouVersionPlatformReader/Components/BibleReaderIntroView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderIntroView.swift
@@ -31,7 +31,7 @@ public struct BibleReaderIntroView: View {
                    let html = try? await YouVersionAPI.Bible.introMaterial(versionId: reference.versionId, passageId: passageId) {
                     self.html = html
                 } else {
-                    self.html = "<div>Error loading Intro</div>"
+                    self.html = "<div>\(String.localized("reader.introLoadError"))</div>"
                 }
             }
         }

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderIntroView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderIntroView.swift
@@ -31,9 +31,17 @@ public struct BibleReaderIntroView: View {
                    let html = try? await YouVersionAPI.Bible.introMaterial(versionId: reference.versionId, passageId: passageId) {
                     self.html = html
                 } else {
-                    self.html = "<div>\(String.localized("reader.introLoadError"))</div>"
+                    self.html = "<div>\(String.localized("reader.introLoadError").htmlEscaped)</div>"
                 }
             }
         }
+    }
+}
+
+private extension String {
+    var htmlEscaped: String {
+        replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
     }
 }

--- a/Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings
+++ b/Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings
@@ -480,6 +480,17 @@
         }
       }
     },
+    "generic.ok" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        }
+      }
+    },
     "generic.search" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1114,6 +1125,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "En savoir plus"
+          }
+        }
+      }
+    },
+    "reader.introLoadError" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The Introductory material could not be loaded."
           }
         }
       }

--- a/Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings
+++ b/Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings
@@ -1129,17 +1129,6 @@
         }
       }
     },
-    "reader.introLoadError" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The Introductory material could not be loaded."
-          }
-        }
-      }
-    },
     "reader.footnoteTitle" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1147,6 +1136,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Footnote"
+          }
+        }
+      }
+    },
+    "reader.introLoadError" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The Introductory material could not be loaded."
           }
         }
       }

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -17,7 +17,7 @@ public final class BibleVersionsViewModel {
     var showGenericAlert = false
     var textForGenericAlertTitle = ""
     var textForGenericAlertBody = ""
-    private(set) var textForGenericAlertOKButton = "OK"
+    private(set) var textForGenericAlertOKButton = String.localized("generic.ok")
     
     private let userDefaultsKeyForMyVersions = "bible-reader-view--my-versions"
     private var hasLoadedInitialState = false


### PR DESCRIPTION
## Description

chore: extract two strings for localization

## Type of Change

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [ ] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [x] `chore:` Other changes (maintenance, etc.)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts two hardcoded English strings (`"OK"` and `"Error loading Intro"`) into `Localizable.xcstrings` under the keys `generic.ok` and `reader.introLoadError`, and also incorporates the HTML-escaping fix suggested in the previous review round. The changes are minimal and well-scoped.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a straightforward localization extraction with no logic changes.

No P0 or P1 issues found. The two previous review findings (HTML escaping and key ordering) were addressed. The HTML escaping extension is correct for text content inside a div. All changes are low-risk string extraction.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/Components/BibleReaderIntroView.swift | Replaced the hardcoded error string with a localized key and added a private `htmlEscaped` String extension to safely escape translator-supplied text before injecting it into HTML. |
| Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings | Added `generic.ok` ("OK") and `reader.introLoadError` ("The Introductory material could not be loaded.") string entries with manual extraction state and English translations. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift | Replaced the hardcoded `"OK"` default value with `String.localized("generic.ok")` so the alert button label is localizable. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[onChange: reference] --> B{book & passageId available?}
    B -- yes --> C[await introMaterial API call]
    C -- success --> D[self.html = html]
    C -- throws/nil --> E[String.localized reader.introLoadError]
    B -- no --> E
    E --> F[.htmlEscaped]
    F --> G[self.html = div wrapped error]
```

<sub>Reviews (2): Last reviewed commit: ["chore: do html escaping just in case, an..."](https://github.com/youversion/platform-sdk-swift/commit/c357177b91c215a549ac0cd971211bc7f25f91e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30702153)</sub>

<!-- /greptile_comment -->