### PR TITLE
refactor: clarify language-tag naming in version picker

### DIFF
--- a/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift
@@ -4,13 +4,13 @@ import FoundationNetworking
 #endif
 
 public extension YouVersionAPI.Bible {
-    /// Retrieves a list of Bible versions available for a specified language code.
+    /// Retrieves a list of Bible versions available for a specified language tag.
     ///
-    /// This function fetches Bible version overviews for the provided three-letter language code (e.g., "eng").
+    /// This function fetches Bible version overviews for the provided BCP 47 language tag (e.g., "en").
     /// A valid `YouVersionPlatformConfiguration.appKey` must be set for the request to succeed.
     ///
     /// - Parameters:
-    ///   - languageTag: An optional language code per BCP 47 for filtering available Bible versions. If `nil`
+    ///   - languageTag: An optional language tag per BCP 47 for filtering available Bible versions. If `nil`
     ///     the function returns versions for all languages.
     ///   - session: The URLSession used to perform the request. Defaults to `URLSession.shared`.
     /// - Returns: An array of ``BibleVersion`` objects representing the available Bible versions for the language.

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsLanguagesView.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsLanguagesView.swift
@@ -145,8 +145,10 @@ struct BibleVersionsLanguagesView: View {
 
     // De-dup + locale-aware, case-insensitive sort
     private func sortedUniqueLanguageTags(_ items: [String]) -> [String] {
-        Array(Set(items)).sorted {
-            viewModel.languageName($0).localizedCaseInsensitiveCompare(viewModel.languageName($1)) == .orderedAscending
+        let unique = Array(Set(items))
+        let names = Dictionary(uniqueKeysWithValues: unique.map { ($0, viewModel.languageName($0)) })
+        return unique.sorted {
+            names[$0, default: $0].localizedCaseInsensitiveCompare(names[$1, default: $1]) == .orderedAscending
         }
     }
 }

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsLanguagesView.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsLanguagesView.swift
@@ -45,7 +45,7 @@ struct BibleVersionsLanguagesView: View {
                 Picker("", selection: $selectedSegment) {
                     let allMsg = String(
                         format: String.localized("languageList.allWithCount"),
-                        allPermittedLanguages.count,
+                        availableLanguageTags.count,
                         String.localized("languageList.all")
                     )
                     Text(String.localized("languageList.suggested"))
@@ -64,7 +64,7 @@ struct BibleVersionsLanguagesView: View {
                             .font(YouVersionFonts.headerMedium)
                             .padding(.leading)
                     }
-                    ForEach(languageCodes, id: \.self) { language in
+                    ForEach(languageTags, id: \.self) { language in
                         Button {
                             viewModel.chosenLanguage = language
                             viewModel.versionsStackPop()
@@ -121,21 +121,21 @@ struct BibleVersionsLanguagesView: View {
 
     // MARK: - Helpers
 
-    private var allPermittedLanguages: [String] {
-        guard let versionsInfo = viewModel.permittedVersionsList else {
+    private var availableLanguageTags: [String] {
+        guard let versionsInfo = viewModel.cachedPermittedVersions else {
             return []
         }
         return Array(Set(versionsInfo.compactMap { $0.languageTag }))
     }
 
-    private var languageCodes: [String] {
+    private var languageTags: [String] {
         switch selectedSegment {
         case .suggested:
-            return viewModel.suggestedLanguages
+            return viewModel.suggestedLanguageTags
         case .all:
-            return sortedUnique(allPermittedLanguages)
+            return sortedUniqueLanguageTags(availableLanguageTags)
         case .searching:
-            return sortedUnique(allPermittedLanguages.filter {
+            return sortedUniqueLanguageTags(availableLanguageTags.filter {
                 searchText.isEmpty ||
                 $0.localizedCaseInsensitiveContains(searchText) ||
                 viewModel.languageName($0).localizedCaseInsensitiveContains(searchText)
@@ -144,23 +144,9 @@ struct BibleVersionsLanguagesView: View {
     }
 
     // De-dup + locale-aware, case-insensitive sort
-    private func sortedUnique(_ items: [String]) -> [String] {
-        let list = Array(Set(items)).map {
-            LanguageAndCode(language: viewModel.languageName($0), code: $0)
-        }
-        return list.sorted().map { $0.code }
-    }
-
-    private struct LanguageAndCode: Comparable {
-        let language: String
-        let code: String
-
-        static func < (lhs: LanguageAndCode, rhs: LanguageAndCode) -> Bool {
-            lhs.language.localizedCaseInsensitiveCompare(rhs.language) == .orderedAscending
-        }
-
-        static func == (lhs: LanguageAndCode, rhs: LanguageAndCode) -> Bool {
-            lhs.language == rhs.language
+    private func sortedUniqueLanguageTags(_ items: [String]) -> [String] {
+        Array(Set(items)).sorted {
+            viewModel.languageName($0).localizedCaseInsensitiveCompare(viewModel.languageName($1)) == .orderedAscending
         }
     }
 }

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift
@@ -59,7 +59,7 @@ public struct BibleVersionsListView: View {
         .foregroundStyle(viewModel.readerTextPrimaryColor)
         .background(viewModel.readerCanvasPrimaryColor)
         .onChange(of: viewModel.activeLanguage, initial: true) { _, newValue in
-            viewModel.fetchVersionsInLanguage(code: newValue)
+            viewModel.fetchVersions(forLanguageTag: newValue)
         }
     }
 
@@ -92,7 +92,7 @@ public struct BibleVersionsListView: View {
 
     private var languageDisplay: some View {
         let language = viewModel.activeLanguage
-        let versionsInLanguage = viewModel.permittedVersionsList?.filter { $0.languageTag == language } ?? []
+        let versionsInLanguage = viewModel.cachedPermittedVersions?.filter { $0.languageTag == language } ?? []
         return HStack {
             Image(systemName: "globe")
             Text(viewModel.languageName(language))
@@ -112,7 +112,7 @@ public struct BibleVersionsListView: View {
 
     private var filteredVersions: [BibleVersion]? {
         let language = viewModel.activeLanguage
-        guard let versionsList = viewModel.versionsInLanguage[language] else {
+        guard let versionsList = viewModel.versionsByLanguageTag[language] else {
             return nil
         }
 

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
@@ -7,9 +7,9 @@ extension BibleVersionsViewModel {
     }
 
     public var bibleVersionStatisticsPromo: String {
-        guard let versions = permittedVersionsList, !versions.isEmpty else {
+        guard let versions = cachedPermittedVersions, !versions.isEmpty else {
             Task {
-                await permittedVersionsListing()
+                await permittedVersions()
             }
             return ""
         }
@@ -66,9 +66,9 @@ extension BibleVersionsViewModel {
             var map: [String: String] = [:]
             for language in languages where language.displayNames != nil {
                 if let displayNames = language.displayNames,
-                   let name = bestDisplayName(for: displayNames),
-                   let languageCode = language.language {
-                    map[languageCode] = name
+                   let name = preferredDisplayName(from: displayNames),
+                   let languageTag = language.language {
+                    map[languageTag] = name
                 }
             }
             YouVersionPlatformLogger.debug("loadLanguageNames filtered to \(map.count) with displayNames.", category: "Reader")
@@ -79,7 +79,7 @@ extension BibleVersionsViewModel {
     }
 
     public func languageTapped() {
-        if permittedVersionsList?.isEmpty ?? true {
+        if cachedPermittedVersions?.isEmpty ?? true {
             showGenericAlert = true
             textForGenericAlertTitle = .localized("generic.error")
             textForGenericAlertBody = .localized("reader.availableLanguagesErrorBody")
@@ -92,7 +92,7 @@ extension BibleVersionsViewModel {
     }
 
     /// Heuristically return the name from the map which is the "closest" for the user.
-    private func bestDisplayName(for names: [String: String?]) -> String? {
+    private func preferredDisplayName(from names: [String: String?]) -> String? {
         if names.isEmpty {
             return nil
         }

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsPicker.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsPicker.swift
@@ -20,10 +20,10 @@ extension BibleVersionsViewModel {
 
     public func openVersionsStack(currentBibleLanguage: String) {
         Task {
-            await permittedVersionsListing()
+            await permittedVersions()
         }
         currentBibleVersionLanguage = currentBibleLanguage
-        fetchVersionsInLanguage(code: activeLanguage)
+        fetchVersions(forLanguageTag: activeLanguage)
         chosenLanguage = nil  // reset the search field
         versionsPickerStack.removeAll()
         showingVersionsStack = true

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -28,7 +28,7 @@ public final class BibleVersionsViewModel {
         versionRepository: any BibleVersionRepositoryProtocol = BibleVersionRepository.shared
     ) {
         self.myVersions = []
-        self.suggestedLanguagesList = []
+        self.suggestedLanguages = []
         self.onVersionChange = onVersionChange
         self.versionRepository = versionRepository
     }
@@ -51,7 +51,7 @@ public final class BibleVersionsViewModel {
     }
     
     private func removeUnpermittedVersions(initialVersionId: Int?) async {
-        guard let permittedVersions = await permittedVersionsListing() else {
+        guard let permittedVersions = await permittedVersions() else {
             return  // when offline, we don't get a list, but don't delete anything!
         }
         let permittedIds = Set(permittedVersions.map(\.id))
@@ -156,49 +156,49 @@ public final class BibleVersionsViewModel {
     
     // MARK: - Versions list
     
-    /// Maps from a languageCode to a list of BibleVersion objects for that language.
-    var versionsInLanguage: [String: [BibleVersion]] = [:]
+    /// Maps from a language tag to a list of BibleVersion objects for that language.
+    var versionsByLanguageTag: [String: [BibleVersion]] = [:]
     
     /// Holds minimal information about all Bible versions available to this app, in all languages.
-    private(set) var permittedVersionsList: [YouVersionAPI.Bible.BibleVersionMinimalInfo]?
+    private(set) var cachedPermittedVersions: [YouVersionAPI.Bible.BibleVersionMinimalInfo]?
     
     /// Returns minimal information about all Bible versions available to this app, in all languages.
     /// On error or when offline, returns nil
-    func permittedVersionsListing() async -> [YouVersionAPI.Bible.BibleVersionMinimalInfo]? {
-        if let permittedVersionsList {
-            return permittedVersionsList
+    func permittedVersions() async -> [YouVersionAPI.Bible.BibleVersionMinimalInfo]? {
+        if let cachedPermittedVersions {
+            return cachedPermittedVersions
         }
         
         let versions = try? await YouVersionAPI.Bible.permittedVersions(forLanguageTag: nil)
 
-        if let versions, permittedVersionsList == nil {
-            permittedVersionsList = versions
+        if let versions, cachedPermittedVersions == nil {
+            cachedPermittedVersions = versions
         }
         return versions
     }
     
-    private var versionsBeingFetched: Set<String> = []
+    private var languageTagsBeingFetched: Set<String> = []
     
-    /// Causes data to be fetched, if necessary, to fill out `versionsInLanguage` for the given language code.
-    /// The fetch happens in a separate task. UI should observe `versionsInLanguage` and update when it does.
-    func fetchVersionsInLanguage(code: String) {
-        guard versionsInLanguage[code] == nil else {
+    /// Causes data to be fetched, if necessary, to fill out `versionsByLanguageTag` for the given language tag.
+    /// The fetch happens in a separate task. UI should observe `versionsByLanguageTag` and update when it does.
+    func fetchVersions(forLanguageTag languageTag: String) {
+        guard versionsByLanguageTag[languageTag] == nil else {
             return  // no need to fetch: we already have the data
         }
-        guard !versionsBeingFetched.contains(code) else {
+        guard !languageTagsBeingFetched.contains(languageTag) else {
             return
         }
-        versionsBeingFetched.insert(code)
+        languageTagsBeingFetched.insert(languageTag)
         Task {
-            if let unsortedVersions = try? await YouVersionAPI.Bible.versions(forLanguageTag: code) {
+            if let unsortedVersions = try? await YouVersionAPI.Bible.versions(forLanguageTag: languageTag) {
                 let sortedVersions = unsortedVersions.sorted {
                     let a = $0.localizedTitle ?? $0.title ?? $0.localizedAbbreviation ?? $0.abbreviation ?? String($0.id)
                     let b = $1.localizedTitle ?? $1.title ?? $1.localizedAbbreviation ?? $1.abbreviation ?? String($1.id)
                     return a < b
                 }
-                versionsInLanguage[code] = sortedVersions
+                versionsByLanguageTag[languageTag] = sortedVersions
             }
-            versionsBeingFetched.remove(code)
+            languageTagsBeingFetched.remove(languageTag)
         }
     }
     
@@ -220,49 +220,48 @@ public final class BibleVersionsViewModel {
     
     // MARK: - Languages picking
     
-    private(set) var suggestedLanguagesList: [LanguageOverview]
+    private(set) var suggestedLanguages: [LanguageOverview]
     var chosenLanguage: String?
     var languageNames: [String: String] = [:]
     
     private func loadSuggestedLanguages() async {
         let region = Locale.current.region?.identifier ?? "US"
         do {
-            suggestedLanguagesList = try await YouVersionAPI.Languages.languages(country: region, fields: ["language", "display_names"])
+            suggestedLanguages = try await YouVersionAPI.Languages.languages(country: region, fields: ["language", "display_names"])
         } catch {
             YouVersionPlatformLogger.error("Error fetching languages: \(error.localizedDescription)", category: "Reader")
         }
     }
     
-    /// Returns languages likely to be ones the user will want. Doesn't return any for which we have no Bible versions.
-    var suggestedLanguages: [String] {
-        guard !suggestedLanguagesList.isEmpty else {
+    /// Language tags likely to be ones the user will want. Doesn't return any for which we have no Bible versions.
+    var suggestedLanguageTags: [String] {
+        guard !suggestedLanguages.isEmpty else {
             return ["en", "es"]
         }
-        let codes = extractLanguageCodes(languages: suggestedLanguagesList)
-        guard let versionsInfo = permittedVersionsList else {
-            return codes
+        let tags = uniqueLanguageTags(from: suggestedLanguages)
+        guard let versionsInfo = cachedPermittedVersions else {
+            return tags
         }
-        let ret = codes.filter { code in
-            versionsInfo.isEmpty || versionsInfo.contains(where: { $0.languageTag == code })
+        let ret = tags.filter { tag in
+            versionsInfo.isEmpty || versionsInfo.contains(where: { $0.languageTag == tag })
         }
         return ret
     }
-    
+
     func languageName(_ lang: String) -> String {
         languageNames[lang] ?? Locale.current.localizedString(forLanguageCode: lang) ?? lang
     }
-    
-    /// Returns language codes from the list, preferring the 3-letter language codes
-    private func extractLanguageCodes(languages: [LanguageOverview]) -> [String] {
-        let languageCodes = languages.compactMap { $0.language }
-        
-        // Remove duplicates while preserving order
+
+    /// Returns deduplicated language tags from the list, preserving order.
+    private func uniqueLanguageTags(from languages: [LanguageOverview]) -> [String] {
+        let languageTags = languages.compactMap { $0.language }
+
         var seen = Set<String>()
-        return languageCodes.filter { languageCode in
-            if seen.contains(languageCode) {
+        return languageTags.filter { languageTag in
+            if seen.contains(languageTag) {
                 return false
             } else {
-                seen.insert(languageCode)
+                seen.insert(languageTag)
                 return true
             }
         }
@@ -283,13 +282,13 @@ public final class BibleVersionsViewModel {
     
     var selectedVersion: BibleVersion?
     
-    var organizationInfo: [String: Organization] = [:]
+    private var organizationsById: [String: Organization] = [:]
     
     func organizationName(id: String) -> String? {
-        guard let org = organizationInfo[id] else {
+        guard let org = organizationsById[id] else {
             Task {
                 if let data = try? await YouVersionAPI.Organizations.organization(id: id) {
-                    organizationInfo[id] = data
+                    organizationsById[id] = data
                 }
             }
             return nil

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -51,10 +51,10 @@ public final class BibleVersionsViewModel {
     }
     
     private func removeUnpermittedVersions(initialVersionId: Int?) async {
-        guard let permittedVersions = await permittedVersions() else {
+        guard let permitted = await permittedVersions() else {
             return  // when offline, we don't get a list, but don't delete anything!
         }
-        let permittedIds = Set(permittedVersions.map(\.id))
+        let permittedIds = Set(permitted.map(\.id))
         await versionRepository.removeUnpermittedVersions(permittedIds: permittedIds)
         
         for version in myVersions where !permittedIds.contains(version.id) {


### PR DESCRIPTION
## Summary
- Standardize on "language tag" (BCP 47) as the term for the strings keying Bible-version data, replacing inconsistent "language code" terminology in the version picker.
- Renames touch internal/private symbols only; public API surface is unchanged (verified by `scripts/check-api-stability.sh check`).
- Drops the `LanguageAndTag` decorate-sort-undecorate helper in favor of an inline `sorted(by:)` over `viewModel.languageName(_:)`.

Highlights:
- `versionsInLanguage` → `versionsByLanguageTag`
- `permittedVersionsListing()` → `permittedVersions()`; cache property `permittedVersionsList` → `cachedPermittedVersions`
- `fetchVersionsInLanguage(code:)` → `fetchVersions(forLanguageTag:)`
- `versionsBeingFetched` → `languageTagsBeingFetched`
- Doc comments reworded from "language code" to "language tag" (and the misleading "three-letter ... 'eng'" example corrected to BCP 47 / "en").

## Test plan
- [x] `swift test` (260/260 passing)
- [x] `scripts/check-api-stability.sh check` (no breaking changes)
- [x] `swiftlint --strict` (clean)
- [ ] Smoke-run the SampleApp's Bible Reader version picker to confirm the language picker still drives version fetches correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a well-executed rename-only refactor: every internal symbol that referred to "language code" is updated to "language tag" (BCP 47), public API is untouched, tests pass 260/260, and the `sortedUniqueLanguageTags` helper now pre-builds the display-name dictionary to avoid repeated `languageName` lookups during sorting. The only thing to tidy up is one `if-else` in `uniqueLanguageTags(from:)` that can be flattened to a `guard` early-return per the project style rule.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only a single P2 style nit, no logic or API changes.

All findings are P2 (style-only), so the confidence ceiling stays at 5. The rename coverage is thorough, public API is verified stable, and the performance fix in sortedUniqueLanguageTags is a clear improvement over the previous implementation.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift | Doc-comment only: corrects "three-letter language code / 'eng'" to "BCP 47 language tag / 'en'" and updates parameter label prose. No logic changes. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsLanguagesView.swift | Renames `allPermittedLanguages`→`availableLanguageTags`, `languageCodes`→`languageTags`, `sortedUnique`→`sortedUniqueLanguageTags`; replaces the old decorate-sort-undecorate helper with a pre-built name dictionary — addressing the O(2n log n) lookup concern from the previous review round. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift | Call-site renames only: `fetchVersionsInLanguage(code:)`→`fetchVersions(forLanguageTag:)`, `permittedVersionsList`→`cachedPermittedVersions`, `versionsInLanguage`→`versionsByLanguageTag`. No logic changes. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift | Renames `permittedVersionsList`→`cachedPermittedVersions`, `permittedVersionsListing()`→`permittedVersions()`, and `bestDisplayName(for:)`→`preferredDisplayName(from:)`; local variable `languageCode`→`languageTag`. No logic changes. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsPicker.swift | Call-site renames only: `permittedVersionsListing()`→`permittedVersions()` and `fetchVersionsInLanguage(code:)`→`fetchVersions(forLanguageTag:)`. No logic changes. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift | Core rename PR — `versionsInLanguage`→`versionsByLanguageTag`, `versionsBeingFetched`→`languageTagsBeingFetched`, `suggestedLanguagesList`→`suggestedLanguages` (stored), `suggestedLanguages`→`suggestedLanguageTags` (computed), `organizationInfo`→`private organizationsById`. One minor style nit: `if-else` in `uniqueLanguageTags(from:)` should use early return per project rule. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BibleVersionsListView\nonChange activeLanguage] -->|fetchVersions\nforLanguageTag:| B[BibleVersionsViewModel]
    B -->|guard not in\nlanguageTagsBeingFetched| C{Already fetched?}
    C -->|yes: versionsByLanguageTag has data| D[Return cached data]
    C -->|no| E[Add to languageTagsBeingFetched\nSpawn Task]
    E --> F[YouVersionAPI.Bible\n.versions forLanguageTag:]
    F -->|success| G[Sort versions\nStore in versionsByLanguageTag]
    F -->|failure| H[Remove from languageTagsBeingFetched\nwill retry next call]
    G --> H
    I[BibleVersionsLanguagesView] -->|availableLanguageTags| J[cachedPermittedVersions\ncompactMap languageTag]
    J -->|sortedUniqueLanguageTags| K[Array Set dedup\nbuild names Dictionary\nsorted by localizedCaseInsensitiveCompare]
    K --> L[languageTags displayed in list]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%3A260-267%0AThe%20%60if-else%60%20block%20inside%20the%20%60filter%60%20closure%20can%20be%20simplified%20to%20an%20early%20return%2C%20avoiding%20the%20dangling%20%60else%60%20branch.%20This%20matches%20the%20project%20rule%20against%20unnecessary%20%60else%60%20blocks%20where%20a%20guard%20%28or%20early%20return%29%20keeps%20the%20happy-path%20logic%20flat.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20languageTags.filter%20%7B%20languageTag%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20!seen.contains%28languageTag%29%20else%20%7B%20return%20false%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20seen.insert%28languageTag%29%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20true%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=100&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%3A260-267%0AThe%20%60if-else%60%20block%20inside%20the%20%60filter%60%20closure%20can%20be%20simplified%20to%20an%20early%20return%2C%20avoiding%20the%20dangling%20%60else%60%20branch.%20This%20matches%20the%20project%20rule%20against%20unnecessary%20%60else%60%20blocks%20where%20a%20guard%20%28or%20early%20return%29%20keeps%20the%20happy-path%20logic%20flat.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20languageTags.filter%20%7B%20languageTag%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20!seen.contains%28languageTag%29%20else%20%7B%20return%20false%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20seen.insert%28languageTag%29%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20true%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=100&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift:260-267
The `if-else` block inside the `filter` closure can be simplified to an early return, avoiding the dangling `else` branch. This matches the project rule against unnecessary `else` blocks where a guard (or early return) keeps the happy-path logic flat.

```suggestion
        return languageTags.filter { languageTag in
            guard !seen.contains(languageTag) else { return false }
            seen.insert(languageTag)
            return true
        }
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: address greptile review commen..."](https://github.com/youversion/platform-sdk-swift/commit/2561f372c5db3c2f2f72da416bae13f983c018dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30758137)</sub>

**Context used:**

- Rule used - Avoid unnecessary negations and else blocks to red... ([source](https://app.greptile.com/review/custom-context?memory=b2f865f5-91b5-4c90-89be-43dc9c513644))

**Learned From**
[lifechurch/youversion/user-applications/flutter/youversion-flutter-bal#417](https://gitlab.com/lifechurch/youversion/user-applications/flutter/youversion-flutter-bal/-/merge_requests/417)

<!-- /greptile_comment -->