### PR TITLE
feat(reader): limit versions by language and version id

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,19 @@ YouVersionPlatformConfiguration.configure(
 
 When sign-in is disabled, provide an `onVerseTap` closure to handle verse interactions yourself.
 
+#### Filtering Available Languages
+
+By default, the version picker offers Bible versions in every available language. To restrict it to a specific set of languages, pass `permittedLanguageTags` during configuration. For example, to make only English versions available:
+
+```swift
+YouVersionPlatformConfiguration.configure(
+    appKey: "YOUR_APP_KEY_HERE",
+    permittedLanguageTags: ["en"]
+)
+```
+
+Tags follow [BCP 47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) (e.g. `"en"` for English, `"es"` for Spanish). When the resulting list contains versions in only one language, the language button in the version picker is hidden automatically.
+
 
 ### Implementing Sign In
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,19 @@ YouVersionPlatformConfiguration.configure(
 
 Tags follow [BCP 47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) (e.g. `"en"` for English, `"es"` for Spanish). When the resulting list contains versions in only one language, the language button in the version picker is hidden automatically.
 
+#### Filtering Available Versions
+
+To restrict the version picker to a specific set of Bible versions, pass `permittedVersionIds` during configuration:
+
+```swift
+YouVersionPlatformConfiguration.configure(
+    appKey: "YOUR_APP_KEY_HERE",
+    permittedVersionIds: [12, 111, 1588]
+)
+```
+
+IDs are the YouVersion Bible version IDs (e.g. `111` for NIV, `1588` for AMP). Combines with `permittedLanguageTags` — a version must satisfy both filters to be shown.
+
 
 ### Implementing Sign In
 

--- a/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
+++ b/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
@@ -14,6 +14,11 @@ public struct YouVersionPlatformConfiguration {
     /// Defaults to `true`.
     nonisolated(unsafe) public private(set) static var isSignInEnabled = true
 
+    /// When set, only Bible versions whose `languageTag` is in this set are made available
+    /// in the version picker UI and other version listings. When `nil` (the default), versions
+    /// in all languages are available. Tags follow BCP 47 (e.g. `"en"` for English).
+    nonisolated(unsafe) public private(set) static var permittedLanguageTags: Set<String>?
+
     private static let installIdKey = "YouVersionPlatformInstallID"
     nonisolated(unsafe) public private(set) static var installId: String?
 
@@ -28,7 +33,8 @@ public struct YouVersionPlatformConfiguration {
         apiHost: String? = nil,
         appName: String? = nil,
         isSignInEnabled: Bool = true,
-        signInPromptMessage: String? = nil
+        signInPromptMessage: String? = nil,
+        permittedLanguageTags: Set<String>? = nil
     ) {
         let defaults = UserDefaults.standard
 
@@ -42,6 +48,7 @@ public struct YouVersionPlatformConfiguration {
         Self.appName = appName
         Self.isSignInEnabled = isSignInEnabled
         Self.signInPromptMessage = signInPromptMessage
+        Self.permittedLanguageTags = permittedLanguageTags
 
         // Create and save an Install ID if it's not present
         if let existing = defaults.string(forKey: installIdKey) {

--- a/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
+++ b/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
@@ -19,6 +19,12 @@ public struct YouVersionPlatformConfiguration {
     /// in all languages are available. Tags follow BCP 47 (e.g. `"en"` for English).
     nonisolated(unsafe) public private(set) static var permittedLanguageTags: Set<String>?
 
+    /// When set, only Bible versions whose `id` is in this set are made available in the
+    /// version picker UI and other version listings. When `nil` (the default), all versions
+    /// are available. Combines with ``permittedLanguageTags`` — a version must satisfy both
+    /// filters to be available.
+    nonisolated(unsafe) public private(set) static var permittedVersionIds: Set<Int>?
+
     private static let installIdKey = "YouVersionPlatformInstallID"
     nonisolated(unsafe) public private(set) static var installId: String?
 
@@ -34,7 +40,8 @@ public struct YouVersionPlatformConfiguration {
         appName: String? = nil,
         isSignInEnabled: Bool = true,
         signInPromptMessage: String? = nil,
-        permittedLanguageTags: Set<String>? = nil
+        permittedLanguageTags: Set<String>? = nil,
+        permittedVersionIds: Set<Int>? = nil
     ) {
         let defaults = UserDefaults.standard
 
@@ -49,6 +56,7 @@ public struct YouVersionPlatformConfiguration {
         Self.isSignInEnabled = isSignInEnabled
         Self.signInPromptMessage = signInPromptMessage
         Self.permittedLanguageTags = permittedLanguageTags
+        Self.permittedVersionIds = permittedVersionIds
 
         // Create and save an Install ID if it's not present
         if let existing = defaults.string(forKey: installIdKey) {

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift
@@ -11,12 +11,14 @@ public struct BibleVersionsListView: View {
                 Color.clear.frame(height: 72)
             }
             searchInput
-            Button {
-                viewModel.languageTapped()
-            } label: {
-                languageDisplay
+            if hasMultiplePermittedLanguages {
+                Button {
+                    viewModel.languageTapped()
+                } label: {
+                    languageDisplay
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
             Group {
                 if let versions = filteredVersions {
                     List(versions, id: \.id) { version in
@@ -88,6 +90,13 @@ public struct BibleVersionsListView: View {
         )
         .padding(.horizontal, 16)
         .padding(.bottom, 8)
+    }
+
+    private var hasMultiplePermittedLanguages: Bool {
+        guard let versions = viewModel.cachedPermittedVersions else {
+            return true
+        }
+        return Set(versions.compactMap { $0.languageTag }).count > 1
     }
 
     private var languageDisplay: some View {

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -145,6 +145,23 @@ public final class BibleVersionsViewModel {
         myVersions.insert(version)
     }
     
+    /// Returns true when a version satisfies the configured `permittedLanguageTags`
+    /// and `permittedVersionIds` filters. A `nil` filter means "no restriction" on
+    /// that dimension.
+    private func isPermitted(versionId: Int, languageTag: String?) -> Bool {
+        if let permittedTags = YouVersionPlatformConfiguration.permittedLanguageTags {
+            guard let languageTag, permittedTags.contains(languageTag) else {
+                return false
+            }
+        }
+        if let permittedIds = YouVersionPlatformConfiguration.permittedVersionIds {
+            guard permittedIds.contains(versionId) else {
+                return false
+            }
+        }
+        return true
+    }
+
     /// Picks a Bible version to fall back to when no specific version is selected,
     /// trying these sources in priority order:
     /// 1. The first version the user has already downloaded.
@@ -158,24 +175,14 @@ public final class BibleVersionsViewModel {
     ///   (typically because the device is offline).
     private func fallbackVersion(savedIds: Set<Int>) async -> Int? {
         let downloadedVersionIds = BibleVersionRepository.defaultDownloadedVersionIds
-        if let downloadedVersionId = downloadedVersionIds.first {
+        if let downloadedVersionId = downloadedVersionIds.first(where: {
+            YouVersionPlatformConfiguration.permittedVersionIds?.contains($0) ?? true
+        }) {
             return downloadedVersionId
         }
-        
+
         if let allVersions = try? await YouVersionAPI.Bible.versions() {
-            let versions = allVersions.filter { version in
-                if let permittedTags = YouVersionPlatformConfiguration.permittedLanguageTags {
-                    guard let tag = version.languageTag, permittedTags.contains(tag) else {
-                        return false
-                    }
-                }
-                if let permittedIds = YouVersionPlatformConfiguration.permittedVersionIds {
-                    guard permittedIds.contains(version.id) else {
-                        return false
-                    }
-                }
-                return true
-            }
+            let versions = allVersions.filter { isPermitted(versionId: $0.id, languageTag: $0.languageTag) }
 
             // are any of the permitted versions in their myVersions list?
             for version in versions where savedIds.contains(version.id) {
@@ -214,19 +221,7 @@ public final class BibleVersionsViewModel {
         }
         
         let fetched = try? await YouVersionAPI.Bible.permittedVersions()
-        let versions = fetched?.filter { version in
-            if let permittedTags = YouVersionPlatformConfiguration.permittedLanguageTags {
-                guard let tag = version.languageTag, permittedTags.contains(tag) else {
-                    return false
-                }
-            }
-            if let permittedIds = YouVersionPlatformConfiguration.permittedVersionIds {
-                guard permittedIds.contains(version.id) else {
-                    return false
-                }
-            }
-            return true
-        }
+        let versions = fetched?.filter { isPermitted(versionId: $0.id, languageTag: $0.languageTag) }
 
         if let versions, cachedPermittedVersions == nil {
             cachedPermittedVersions = versions
@@ -248,11 +243,7 @@ public final class BibleVersionsViewModel {
         languageTagsBeingFetched.insert(languageTag)
         Task {
             if let fetched = try? await YouVersionAPI.Bible.versions(forLanguageTag: languageTag) {
-                let unsortedVersions: [BibleVersion] = if let permittedIds = YouVersionPlatformConfiguration.permittedVersionIds {
-                    fetched.filter { permittedIds.contains($0.id) }
-                } else {
-                    fetched
-                }
+                let unsortedVersions = fetched.filter { isPermitted(versionId: $0.id, languageTag: $0.languageTag) }
                 let sortedVersions = unsortedVersions.sorted {
                     let a = $0.localizedTitle ?? $0.title ?? $0.localizedAbbreviation ?? $0.abbreviation ?? String($0.id)
                     let b = $1.localizedTitle ?? $1.title ?? $1.localizedAbbreviation ?? $1.abbreviation ?? String($1.id)

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -162,19 +162,31 @@ public final class BibleVersionsViewModel {
             return downloadedVersionId
         }
         
-        if let versions = try? await YouVersionAPI.Bible.versions() {
+        if let allVersions = try? await YouVersionAPI.Bible.versions() {
+            let versions: [BibleVersion]
+            if let permittedTags = YouVersionPlatformConfiguration.permittedLanguageTags {
+                versions = allVersions.filter {
+                    guard let tag = $0.languageTag else {
+                        return false
+                    }
+                    return permittedTags.contains(tag)
+                }
+            } else {
+                versions = allVersions
+            }
+
             // are any of the permitted versions in their myVersions list?
             for version in versions where savedIds.contains(version.id) {
                 return version.id
             }
-            
+
             // For now, fall back to a Bible in English.
             // It would be better to search for a bible in the device's language,
             // before defaulting to English.
             if let version = versions.first(where: { $0.languageTag == "en" }) {
                 return version.id
             }
-            
+
             if let version = versions.first {
                 return version.id
             }
@@ -199,7 +211,17 @@ public final class BibleVersionsViewModel {
             return cachedPermittedVersions
         }
         
-        let versions = try? await YouVersionAPI.Bible.permittedVersions(forLanguageTag: nil)
+        let fetched = try? await YouVersionAPI.Bible.permittedVersions()
+        let versions: [YouVersionAPI.Bible.BibleVersionMinimalInfo]? = if let fetched, let permittedTags = YouVersionPlatformConfiguration.permittedLanguageTags {
+            fetched.filter {
+                guard let tag = $0.languageTag else {
+                    return false
+                }
+                return permittedTags.contains(tag)
+            }
+        } else {
+            fetched
+        }
 
         if let versions, cachedPermittedVersions == nil {
             cachedPermittedVersions = versions

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -163,16 +163,18 @@ public final class BibleVersionsViewModel {
         }
         
         if let allVersions = try? await YouVersionAPI.Bible.versions() {
-            let versions: [BibleVersion]
-            if let permittedTags = YouVersionPlatformConfiguration.permittedLanguageTags {
-                versions = allVersions.filter {
-                    guard let tag = $0.languageTag else {
+            let versions = allVersions.filter { version in
+                if let permittedTags = YouVersionPlatformConfiguration.permittedLanguageTags {
+                    guard let tag = version.languageTag, permittedTags.contains(tag) else {
                         return false
                     }
-                    return permittedTags.contains(tag)
                 }
-            } else {
-                versions = allVersions
+                if let permittedIds = YouVersionPlatformConfiguration.permittedVersionIds {
+                    guard permittedIds.contains(version.id) else {
+                        return false
+                    }
+                }
+                return true
             }
 
             // are any of the permitted versions in their myVersions list?
@@ -212,15 +214,18 @@ public final class BibleVersionsViewModel {
         }
         
         let fetched = try? await YouVersionAPI.Bible.permittedVersions()
-        let versions: [YouVersionAPI.Bible.BibleVersionMinimalInfo]? = if let fetched, let permittedTags = YouVersionPlatformConfiguration.permittedLanguageTags {
-            fetched.filter {
-                guard let tag = $0.languageTag else {
+        let versions = fetched?.filter { version in
+            if let permittedTags = YouVersionPlatformConfiguration.permittedLanguageTags {
+                guard let tag = version.languageTag, permittedTags.contains(tag) else {
                     return false
                 }
-                return permittedTags.contains(tag)
             }
-        } else {
-            fetched
+            if let permittedIds = YouVersionPlatformConfiguration.permittedVersionIds {
+                guard permittedIds.contains(version.id) else {
+                    return false
+                }
+            }
+            return true
         }
 
         if let versions, cachedPermittedVersions == nil {
@@ -242,7 +247,12 @@ public final class BibleVersionsViewModel {
         }
         languageTagsBeingFetched.insert(languageTag)
         Task {
-            if let unsortedVersions = try? await YouVersionAPI.Bible.versions(forLanguageTag: languageTag) {
+            if let fetched = try? await YouVersionAPI.Bible.versions(forLanguageTag: languageTag) {
+                let unsortedVersions: [BibleVersion] = if let permittedIds = YouVersionPlatformConfiguration.permittedVersionIds {
+                    fetched.filter { permittedIds.contains($0.id) }
+                } else {
+                    fetched
+                }
                 let sortedVersions = unsortedVersions.sorted {
                     let a = $0.localizedTitle ?? $0.title ?? $0.localizedAbbreviation ?? $0.abbreviation ?? String($0.id)
                     let b = $1.localizedTitle ?? $1.title ?? $1.localizedAbbreviation ?? $1.abbreviation ?? String($1.id)


### PR DESCRIPTION
## Summary
- Adds `permittedLanguageTags` configuration so clients can restrict the version picker to specific BCP 47 languages.
- Adds `permittedVersionIds` configuration so clients can restrict to a specific set of Bible version IDs. Combines with `permittedLanguageTags` — a version must satisfy both filters.
- Documents both filters in the README with real platform version IDs.

## Verification

No filters
<img width="401" height="850" alt="SCR-20260505-jkvn" src="https://github.com/user-attachments/assets/c2be5bd4-61ee-42e8-a975-4468a6b7a784" />

Language filtered - "en"
<img width="394" height="848" alt="SCR-20260505-jkqt" src="https://github.com/user-attachments/assets/96018afb-7dde-455c-843c-7027a6446b1e" />

Language filtered - "de"
<img width="397" height="840" alt="SCR-20260505-jlbo" src="https://github.com/user-attachments/assets/b2e5e084-f2fd-4692-a955-5453b9d1af6e" />

Versions filtered - 12, 111
<img width="400" height="850" alt="SCR-20260505-jkbl" src="https://github.com/user-attachments/assets/8764b95f-7a25-43fa-9dfa-d91576e17869" />

## Test plan
- [ ] `swift test`
- [ ] `swiftlint --strict`
- [ ] `scripts/check-api-stability.sh check`
- [ ] Run SampleApp with `permittedLanguageTags: ["en"]` and confirm only English versions appear in the picker.
- [ ] Run SampleApp with `permittedVersionIds: [12, 111, 1588]` and confirm only ASV/NIV/AMP appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new configuration properties — `permittedLanguageTags` and `permittedVersionIds` — to restrict the version picker to a specific subset of languages and/or versions. Both filters are enforced via the new `isPermitted` helper and applied consistently across `fallbackVersion`, `permittedVersions()`, and `fetchVersions`.

- `YouVersionPlatformConfiguration` gains `permittedLanguageTags: Set<String>?` and `permittedVersionIds: Set<Int>?`, each defaulting to `nil` (no restriction), and are forwarded through the `configure(...)` call.
- `BibleVersionsViewModel` extracts the filtering logic into a single `isPermitted(versionId:languageTag:)` helper and applies it at every version-loading site; the early-return path for downloaded versions is also gated on `permittedVersionIds`.
- `BibleVersionsListView` hides the language-picker button when the permitted set resolves to a single language, though the computed property defaults to `true` while the cache is loading.

<h3>Confidence Score: 5/5</h3>

Safe to merge; filtering logic is applied consistently at all three version-loading sites, and the only open item is a minor language-button flicker in single-language configurations.

The isPermitted helper consolidates the filter logic cleanly and is used at every data-loading path. The change is well-scoped, additive, and does not alter any existing behavior when the new properties are left at their nil defaults.

BibleVersionsListView.swift — hasMultiplePermittedLanguages shows the language button during the initial loading window even when the configuration already implies a single language.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift | Adds permittedLanguageTags and permittedVersionIds static properties with proper nonisolated(unsafe) annotation and wires them into the configure call; clean change. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift | Introduces the isPermitted helper and applies it consistently across fallbackVersion, permittedVersions(), and fetchVersions; the early-return for downloaded versions now gates on permittedVersionIds. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift | Hides the language-picker button when only one language is available, but hasMultiplePermittedLanguages defaults to true while the cache loads, causing a visible flash in single-language configurations. |
| README.md | Documents both new configuration properties with code examples and BCP 47 tag guidance; accurate and clear. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant Config as YouVersionPlatformConfiguration
    participant VM as BibleVersionsViewModel
    participant API as YouVersionAPI
    participant View as BibleVersionsListView

    App->>Config: configure(permittedLanguageTags:, permittedVersionIds:)
    Note over Config: Stores filters as static properties

    App->>VM: loadInitialState()
    VM->>API: versions() [fallbackVersion path]
    API-->>VM: [BibleVersion]
    VM->>VM: filter via isPermitted(versionId:languageTag:)
    VM-->>App: currentVersion set

    App->>VM: permittedVersions()
    VM->>API: permittedVersions()
    API-->>VM: [BibleVersionMinimalInfo]
    VM->>VM: filter via isPermitted(versionId:languageTag:)
    VM->>VM: cachedPermittedVersions = filtered

    VM-->>View: cachedPermittedVersions published
    View->>View: hasMultiplePermittedLanguages computed
    alt single language
        View->>View: hide language button
    else multiple languages
        View->>View: show language button
    end

    View->>VM: fetchVersions(forLanguageTag:)
    VM->>API: versions(forLanguageTag:)
    API-->>VM: [BibleVersion]
    VM->>VM: filter via isPermitted(versionId:languageTag:)
    VM-->>View: versionsByLanguageTag updated
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift`, line 160-163 ([link](https://github.com/youversion/platform-sdk-swift/blob/6827d4dc99b26486c489ea544504edbefafcd1d8/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift#L160-L163)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Downloaded version bypasses the permitted filters**

   `defaultDownloadedVersionIds` is checked and returned before the `permittedLanguageTags`/`permittedVersionIds` filtering block executes. If the bundled download is not in `permittedVersionIds`, `fallbackVersion` returns it anyway — that non-permitted ID is then used to call `versionRepository.version(withId:)`, which can succeed because the file is on-device. Then `removeUnpermittedVersions` finds it again, calls `selectFallbackVersion` → `fallbackVersion`, and the same non-permitted ID comes back a second time, leaving the user stuck on a version that was meant to be hidden. At minimum, `permittedVersionIds` (whose membership can be checked without a network round-trip) should gate the early-return here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
   Line: 160-163

   Comment:
   **Downloaded version bypasses the permitted filters**

   `defaultDownloadedVersionIds` is checked and returned before the `permittedLanguageTags`/`permittedVersionIds` filtering block executes. If the bundled download is not in `permittedVersionIds`, `fallbackVersion` returns it anyway — that non-permitted ID is then used to call `versionRepository.version(withId:)`, which can succeed because the file is on-device. Then `removeUnpermittedVersions` finds it again, calls `selectFallbackVersion` → `fallbackVersion`, and the same non-permitted ID comes back a second time, leaving the user stuck on a version that was meant to be hidden. At minimum, `permittedVersionIds` (whose membership can be checked without a network round-trip) should gate the early-return here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%0ALine%3A%20160-163%0A%0AComment%3A%0A**Downloaded%20version%20bypasses%20the%20permitted%20filters**%0A%0A%60defaultDownloadedVersionIds%60%20is%20checked%20and%20returned%20before%20the%20%60permittedLanguageTags%60%2F%60permittedVersionIds%60%20filtering%20block%20executes.%20If%20the%20bundled%20download%20is%20not%20in%20%60permittedVersionIds%60%2C%20%60fallbackVersion%60%20returns%20it%20anyway%20%E2%80%94%20that%20non-permitted%20ID%20is%20then%20used%20to%20call%20%60versionRepository.version%28withId%3A%29%60%2C%20which%20can%20succeed%20because%20the%20file%20is%20on-device.%20Then%20%60removeUnpermittedVersions%60%20finds%20it%20again%2C%20calls%20%60selectFallbackVersion%60%20%E2%86%92%20%60fallbackVersion%60%2C%20and%20the%20same%20non-permitted%20ID%20comes%20back%20a%20second%20time%2C%20leaving%20the%20user%20stuck%20on%20a%20version%20that%20was%20meant%20to%20be%20hidden.%20At%20minimum%2C%20%60permittedVersionIds%60%20%28whose%20membership%20can%20be%20checked%20without%20a%20network%20round-trip%29%20should%20gate%20the%20early-return%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=101&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%0ALine%3A%20160-163%0A%0AComment%3A%0A**Downloaded%20version%20bypasses%20the%20permitted%20filters**%0A%0A%60defaultDownloadedVersionIds%60%20is%20checked%20and%20returned%20before%20the%20%60permittedLanguageTags%60%2F%60permittedVersionIds%60%20filtering%20block%20executes.%20If%20the%20bundled%20download%20is%20not%20in%20%60permittedVersionIds%60%2C%20%60fallbackVersion%60%20returns%20it%20anyway%20%E2%80%94%20that%20non-permitted%20ID%20is%20then%20used%20to%20call%20%60versionRepository.version%28withId%3A%29%60%2C%20which%20can%20succeed%20because%20the%20file%20is%20on-device.%20Then%20%60removeUnpermittedVersions%60%20finds%20it%20again%2C%20calls%20%60selectFallbackVersion%60%20%E2%86%92%20%60fallbackVersion%60%2C%20and%20the%20same%20non-permitted%20ID%20comes%20back%20a%20second%20time%2C%20leaving%20the%20user%20stuck%20on%20a%20version%20that%20was%20meant%20to%20be%20hidden.%20At%20minimum%2C%20%60permittedVersionIds%60%20%28whose%20membership%20can%20be%20checked%20without%20a%20network%20round-trip%29%20should%20gate%20the%20early-return%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=101&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsListView.swift%3A95-100%0AWhen%20%60cachedPermittedVersions%60%20is%20nil%20%28still%20loading%29%2C%20the%20property%20returns%20%60true%60%2C%20which%20shows%20the%20language-picker%20button.%20Once%20the%20cache%20populates%20with%20a%20single-language%20list%2C%20the%20button%20is%20hidden%20%E2%80%94%20causing%20a%20visible%20flash.%20If%20the%20host%20app%20sets%20%60permittedLanguageTags%60%20to%20a%20single-element%20set%2C%20that%20outcome%20is%20knowable%20at%20configuration%20time%20without%20waiting%20for%20the%20network.%20Short-circuiting%20early%20avoids%20the%20flicker%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20hasMultiplePermittedLanguages%3A%20Bool%20%7B%0A%20%20%20%20%20%20%20%20if%20let%20tags%20%3D%20YouVersionPlatformConfiguration.permittedLanguageTags%2C%20tags.count%20%3C%3D%201%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20false%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20guard%20let%20versions%20%3D%20viewModel.cachedPermittedVersions%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20true%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20return%20Set%28versions.compactMap%20%7B%20%240.languageTag%20%7D%29.count%20%3E%201%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=101&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsListView.swift%3A95-100%0AWhen%20%60cachedPermittedVersions%60%20is%20nil%20%28still%20loading%29%2C%20the%20property%20returns%20%60true%60%2C%20which%20shows%20the%20language-picker%20button.%20Once%20the%20cache%20populates%20with%20a%20single-language%20list%2C%20the%20button%20is%20hidden%20%E2%80%94%20causing%20a%20visible%20flash.%20If%20the%20host%20app%20sets%20%60permittedLanguageTags%60%20to%20a%20single-element%20set%2C%20that%20outcome%20is%20knowable%20at%20configuration%20time%20without%20waiting%20for%20the%20network.%20Short-circuiting%20early%20avoids%20the%20flicker%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20hasMultiplePermittedLanguages%3A%20Bool%20%7B%0A%20%20%20%20%20%20%20%20if%20let%20tags%20%3D%20YouVersionPlatformConfiguration.permittedLanguageTags%2C%20tags.count%20%3C%3D%201%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20false%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20guard%20let%20versions%20%3D%20viewModel.cachedPermittedVersions%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20true%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20return%20Set%28versions.compactMap%20%7B%20%240.languageTag%20%7D%29.count%20%3E%201%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=101&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift:95-100
When `cachedPermittedVersions` is nil (still loading), the property returns `true`, which shows the language-picker button. Once the cache populates with a single-language list, the button is hidden — causing a visible flash. If the host app sets `permittedLanguageTags` to a single-element set, that outcome is knowable at configuration time without waiting for the network. Short-circuiting early avoids the flicker entirely.

```suggestion
    private var hasMultiplePermittedLanguages: Bool {
        if let tags = YouVersionPlatformConfiguration.permittedLanguageTags, tags.count <= 1 {
            return false
        }
        guard let versions = viewModel.cachedPermittedVersions else {
            return true
        }
        return Set(versions.compactMap { $0.languageTag }).count > 1
    }
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(reader): consolidate version fi..."](https://github.com/youversion/platform-sdk-swift/commit/2df82f4bc297dbfd84c632d67d946c104ca48e2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30848058)</sub>

<!-- /greptile_comment -->