### PR TITLE
test: add accessibility identifiers to BibleReader

### DIFF
--- a/Examples/SampleApp/SampleApp.swift
+++ b/Examples/SampleApp/SampleApp.swift
@@ -21,28 +21,24 @@ struct SampleApp: App {
                 BibleReaderView()
                     .tabItem {
                         Label("Bible", systemImage: "book.closed.fill")
-                            .accessibilityIdentifier("sampleApp.tab.bible")
                     }
                     .tag(0)
 
                 VotdContainerView()
                     .tabItem {
                         Label("VOTD", systemImage: "sun.max.fill")
-                            .accessibilityIdentifier("sampleApp.tab.verseOfTheDay")
                     }
                     .tag(1)
 
                 CardView()
                     .tabItem {
                         Label("Card", systemImage: "doc.plaintext")
-                            .accessibilityIdentifier("sampleApp.tab.card")
                     }
                     .tag(2)
 
                 ProfileView()
                     .tabItem {
                         Label("Profile", systemImage: "person.fill")
-                            .accessibilityIdentifier("sampleApp.tab.profile")
                     }
                     .tag(3)
             }

--- a/Examples/SampleApp/SampleApp.swift
+++ b/Examples/SampleApp/SampleApp.swift
@@ -18,29 +18,25 @@ struct SampleApp: App {
     var body: some Scene {
         WindowGroup {
             TabView(selection: $selectedTab) {
-                BibleReaderView()
-                .tabItem {
-                    Label("Bible", systemImage: "book.closed.fill")
+                Tab("Bible", systemImage: "book.closed.fill", value: 0) {
+                    BibleReaderView()
                 }
-                .tag(0)
+                .accessibilityIdentifier("sampleApp.tab.bible")
 
-                VotdContainerView()
-                    .tabItem {
-                        Label("VOTD", systemImage: "sun.max.fill")
-                    }
-                    .tag(1)
+                Tab("VOTD", systemImage: "sun.max.fill", value: 1) {
+                    VotdContainerView()
+                }
+                .accessibilityIdentifier("sampleApp.tab.verseOfTheDay")
 
-                CardView()
-                    .tabItem {
-                        Label("Card", systemImage: "doc.plaintext")
-                    }
-                    .tag(2)
+                Tab("Card", systemImage: "doc.plaintext", value: 2) {
+                    CardView()
+                }
+                .accessibilityIdentifier("sampleApp.tab.card")
 
-                ProfileView()
-                    .tabItem {
-                        Label("Profile", systemImage: "person.fill")
-                    }
-                    .tag(3)
+                Tab("Profile", systemImage: "person.fill", value: 3) {
+                    ProfileView()
+                }
+                .accessibilityIdentifier("sampleApp.tab.profile")
             }
         }
     }

--- a/Examples/SampleApp/SampleApp.swift
+++ b/Examples/SampleApp/SampleApp.swift
@@ -18,25 +18,33 @@ struct SampleApp: App {
     var body: some Scene {
         WindowGroup {
             TabView(selection: $selectedTab) {
-                Tab("Bible", systemImage: "book.closed.fill", value: 0) {
-                    BibleReaderView()
-                }
-                .accessibilityIdentifier("sampleApp.tab.bible")
+                BibleReaderView()
+                    .tabItem {
+                        Label("Bible", systemImage: "book.closed.fill")
+                            .accessibilityIdentifier("sampleApp.tab.bible")
+                    }
+                    .tag(0)
 
-                Tab("VOTD", systemImage: "sun.max.fill", value: 1) {
-                    VotdContainerView()
-                }
-                .accessibilityIdentifier("sampleApp.tab.verseOfTheDay")
+                VotdContainerView()
+                    .tabItem {
+                        Label("VOTD", systemImage: "sun.max.fill")
+                            .accessibilityIdentifier("sampleApp.tab.verseOfTheDay")
+                    }
+                    .tag(1)
 
-                Tab("Card", systemImage: "doc.plaintext", value: 2) {
-                    CardView()
-                }
-                .accessibilityIdentifier("sampleApp.tab.card")
+                CardView()
+                    .tabItem {
+                        Label("Card", systemImage: "doc.plaintext")
+                            .accessibilityIdentifier("sampleApp.tab.card")
+                    }
+                    .tag(2)
 
-                Tab("Profile", systemImage: "person.fill", value: 3) {
-                    ProfileView()
-                }
-                .accessibilityIdentifier("sampleApp.tab.profile")
+                ProfileView()
+                    .tabItem {
+                        Label("Profile", systemImage: "person.fill")
+                            .accessibilityIdentifier("sampleApp.tab.profile")
+                    }
+                    .tag(3)
             }
         }
     }

--- a/Sources/YouVersionPlatformReader/BibleReaderAccessibilityIdentifiers.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderAccessibilityIdentifiers.swift
@@ -1,43 +1,43 @@
-enum BibleReaderAccessibilityIdentifiers {
-    enum Header {
-        static let menuButton = "bibleReader.header.menuButton"
-        static let fontSettingsMenuButton = "bibleReader.header.fontSettingsMenuButton"
-        static let bookAndChapterPickerButton = "bibleReader.header.bookAndChapterPickerButton"
-        static let versionPickerButton = "bibleReader.header.versionPickerButton"
+public enum BibleReaderAccessibilityIdentifiers {
+    public enum Header {
+        public static let menuButton = "bibleReader.header.menuButton"
+        public static let fontSettingsMenuButton = "bibleReader.header.fontSettingsMenuButton"
+        public static let bookAndChapterPickerButton = "bibleReader.header.bookAndChapterPickerButton"
+        public static let versionPickerButton = "bibleReader.header.versionPickerButton"
     }
 
-    enum BookChapterPicker {
-        static let sheet = "bibleReader.bookAndChapterPicker.sheet"
-        static let cancelButton = "bibleReader.bookAndChapterPicker.cancelButton"
+    public enum BookChapterPicker {
+        public static let sheet = "bibleReader.bookAndChapterPicker.sheet"
+        public static let cancelButton = "bibleReader.bookAndChapterPicker.cancelButton"
 
-        static func bookButton(_ bookCode: String) -> String {
+        public static func bookButton(_ bookCode: String) -> String {
             "bibleReader.bookAndChapterPicker.bookButton.\(bookCode)"
         }
 
-        static func introButton(_ bookCode: String) -> String {
+        public static func introButton(_ bookCode: String) -> String {
             "bibleReader.bookAndChapterPicker.introButton.\(bookCode)"
         }
 
-        static func chapterButton(bookCode: String, chapter: Int) -> String {
+        public static func chapterButton(bookCode: String, chapter: Int) -> String {
             "bibleReader.bookAndChapterPicker.chapterButton.\(bookCode).\(chapter)"
         }
     }
 
-    enum FontSettings {
-        static let smallerFontButton = "bibleReader.fontSettings.smallerFontButton"
-        static let biggerFontButton = "bibleReader.fontSettings.biggerFontButton"
-        static let fontFamilyButton = "bibleReader.fontSettings.fontFamilyButton"
-        static let lineSpacingButton = "bibleReader.fontSettings.lineSpacingButton"
+    public enum FontSettings {
+        public static let smallerFontButton = "bibleReader.fontSettings.smallerFontButton"
+        public static let biggerFontButton = "bibleReader.fontSettings.biggerFontButton"
+        public static let fontFamilyButton = "bibleReader.fontSettings.fontFamilyButton"
+        public static let lineSpacingButton = "bibleReader.fontSettings.lineSpacingButton"
 
-        static func themeButton(_ themeID: Int) -> String {
+        public static func themeButton(_ themeID: Int) -> String {
             "bibleReader.fontSettings.themeButton.\(themeID)"
         }
     }
 
-    enum FontList {
-        static let backButton = "bibleReader.fontList.backButton"
+    public enum FontList {
+        public static let backButton = "bibleReader.fontList.backButton"
 
-        static func fontButton(family: String) -> String {
+        public static func fontButton(family: String) -> String {
             "bibleReader.fontList.fontButton.\(family)"
         }
     }

--- a/Sources/YouVersionPlatformReader/BibleReaderAccessibilityIdentifiers.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderAccessibilityIdentifiers.swift
@@ -2,8 +2,8 @@ enum BibleReaderAccessibilityIdentifiers {
     enum Header {
         static let menuButton = "bibleReader.header.menuButton"
         static let fontSettingsMenuButton = "bibleReader.header.fontSettingsMenuButton"
-        static let bookAndChapterPickerButton = "bibleReader.bookAndChapterPickerButton"
-        static let versionPickerButton = "bibleReader.versionPickerButton"
+        static let bookAndChapterPickerButton = "bibleReader.header.bookAndChapterPickerButton"
+        static let versionPickerButton = "bibleReader.header.versionPickerButton"
     }
 
     enum BookChapterPicker {
@@ -29,8 +29,8 @@ enum BibleReaderAccessibilityIdentifiers {
         static let fontFamilyButton = "bibleReader.fontSettings.fontFamilyButton"
         static let lineSpacingButton = "bibleReader.fontSettings.lineSpacingButton"
 
-        static func themeButton(_ themeId: Int) -> String {
-            "bibleReader.fontSettings.themeButton.\(themeId)"
+        static func themeButton(_ themeID: Int) -> String {
+            "bibleReader.fontSettings.themeButton.\(themeID)"
         }
     }
 

--- a/Sources/YouVersionPlatformReader/BibleReaderAccessibilityIdentifiers.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderAccessibilityIdentifiers.swift
@@ -1,0 +1,44 @@
+enum BibleReaderAccessibilityIdentifiers {
+    enum Header {
+        static let menuButton = "bibleReader.header.menuButton"
+        static let fontSettingsMenuButton = "bibleReader.header.fontSettingsMenuButton"
+        static let bookAndChapterPickerButton = "bibleReader.bookAndChapterPickerButton"
+        static let versionPickerButton = "bibleReader.versionPickerButton"
+    }
+
+    enum BookChapterPicker {
+        static let sheet = "bibleReader.bookAndChapterPicker.sheet"
+        static let cancelButton = "bibleReader.bookAndChapterPicker.cancelButton"
+
+        static func bookButton(_ bookCode: String) -> String {
+            "bibleReader.bookAndChapterPicker.bookButton.\(bookCode)"
+        }
+
+        static func introButton(_ bookCode: String) -> String {
+            "bibleReader.bookAndChapterPicker.introButton.\(bookCode)"
+        }
+
+        static func chapterButton(bookCode: String, chapter: Int) -> String {
+            "bibleReader.bookAndChapterPicker.chapterButton.\(bookCode).\(chapter)"
+        }
+    }
+
+    enum FontSettings {
+        static let smallerFontButton = "bibleReader.fontSettings.smallerFontButton"
+        static let biggerFontButton = "bibleReader.fontSettings.biggerFontButton"
+        static let fontFamilyButton = "bibleReader.fontSettings.fontFamilyButton"
+        static let lineSpacingButton = "bibleReader.fontSettings.lineSpacingButton"
+
+        static func themeButton(_ themeId: Int) -> String {
+            "bibleReader.fontSettings.themeButton.\(themeId)"
+        }
+    }
+
+    enum FontList {
+        static let backButton = "bibleReader.fontList.backButton"
+
+        static func fontButton(family: String) -> String {
+            "bibleReader.fontList.fontButton.\(family)"
+        }
+    }
+}

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift
@@ -1,23 +1,6 @@
 import SwiftUI
 import YouVersionPlatformCore
 
-private enum BibleReaderBookAndChapterPickerAccessibilityIdentifier {
-    static let sheet = "bibleReader.bookAndChapterPicker.sheet"
-    static let cancelButton = "bibleReader.bookAndChapterPicker.cancelButton"
-
-    static func bookButton(_ bookCode: String) -> String {
-        "bibleReader.bookAndChapterPicker.bookButton.\(bookCode)"
-    }
-
-    static func introButton(_ bookCode: String) -> String {
-        "bibleReader.bookAndChapterPicker.introButton.\(bookCode)"
-    }
-
-    static func chapterButton(bookCode: String, chapter: Int) -> String {
-        "bibleReader.bookAndChapterPicker.chapterButton.\(bookCode).\(chapter)"
-    }
-}
-
 public struct BibleReaderBookAndChapterPickerView: View {
     @Binding var expandedBookCode: String?
     @Binding var isPresented: Bool
@@ -61,7 +44,7 @@ public struct BibleReaderBookAndChapterPickerView: View {
                     Button(String.localized("generic.cancel")) {
                         isPresented = false
                     }
-                    .accessibilityIdentifier(BibleReaderBookAndChapterPickerAccessibilityIdentifier.cancelButton)
+                    .accessibilityIdentifier(BibleReaderAccessibilityIdentifiers.BookChapterPicker.cancelButton)
                     .padding(.leading, 16)
                     HStack {
                         Spacer()
@@ -98,7 +81,7 @@ public struct BibleReaderBookAndChapterPickerView: View {
         }
         .foregroundStyle(viewModel.readerTextPrimaryColor)
         .background(viewModel.readerCanvasPrimaryColor)
-        .accessibilityIdentifier(BibleReaderBookAndChapterPickerAccessibilityIdentifier.sheet)
+        .accessibilityIdentifier(BibleReaderAccessibilityIdentifiers.BookChapterPicker.sheet)
     }
 
     private func sectionHeaderView(_ bookCode: String) -> some View {
@@ -117,7 +100,7 @@ public struct BibleReaderBookAndChapterPickerView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityIdentifier(BibleReaderBookAndChapterPickerAccessibilityIdentifier.bookButton(bookCode))
+        .accessibilityIdentifier(BibleReaderAccessibilityIdentifiers.BookChapterPicker.bookButton(bookCode))
         .listRowInsets(EdgeInsets(top: 2, leading: 16, bottom: 2, trailing: 16))
         .textCase(nil)
     }
@@ -134,7 +117,7 @@ public struct BibleReaderBookAndChapterPickerView: View {
                     chapterListButton(Text(Image("i-icon", bundle: .YouVersionUIBundle)))
                 }
                 .buttonStyle(.plain)
-                .accessibilityIdentifier(BibleReaderBookAndChapterPickerAccessibilityIdentifier.introButton(bookCode))
+                .accessibilityIdentifier(BibleReaderAccessibilityIdentifiers.BookChapterPicker.introButton(bookCode))
             }
             ForEach(Array(chapters.enumerated()), id: \.offset) { idx, label in
                 Button(action: {
@@ -145,7 +128,7 @@ public struct BibleReaderBookAndChapterPickerView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityIdentifier(
-                    BibleReaderBookAndChapterPickerAccessibilityIdentifier.chapterButton(
+                    BibleReaderAccessibilityIdentifiers.BookChapterPicker.chapterButton(
                         bookCode: bookCode,
                         chapter: idx + 1
                     )

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift
@@ -1,6 +1,23 @@
 import SwiftUI
 import YouVersionPlatformCore
 
+private enum BibleReaderBookAndChapterPickerAccessibilityIdentifier {
+    static let sheet = "bibleReader.bookAndChapterPicker.sheet"
+    static let cancelButton = "bibleReader.bookAndChapterPicker.cancelButton"
+
+    static func bookButton(_ bookCode: String) -> String {
+        "bibleReader.bookAndChapterPicker.bookButton.\(bookCode)"
+    }
+
+    static func introButton(_ bookCode: String) -> String {
+        "bibleReader.bookAndChapterPicker.introButton.\(bookCode)"
+    }
+
+    static func chapterButton(bookCode: String, chapter: Int) -> String {
+        "bibleReader.bookAndChapterPicker.chapterButton.\(bookCode).\(chapter)"
+    }
+}
+
 public struct BibleReaderBookAndChapterPickerView: View {
     @Binding var expandedBookCode: String?
     @Binding var isPresented: Bool
@@ -43,7 +60,9 @@ public struct BibleReaderBookAndChapterPickerView: View {
                 ZStack(alignment: .leading) {
                     Button(String.localized("generic.cancel")) {
                         isPresented = false
-                    }.padding(.leading, 16)
+                    }
+                    .accessibilityIdentifier(BibleReaderBookAndChapterPickerAccessibilityIdentifier.cancelButton)
+                    .padding(.leading, 16)
                     HStack {
                         Spacer()
                         Text(String.localized("bookChapterPicker.title"))
@@ -79,6 +98,7 @@ public struct BibleReaderBookAndChapterPickerView: View {
         }
         .foregroundStyle(viewModel.readerTextPrimaryColor)
         .background(viewModel.readerCanvasPrimaryColor)
+        .accessibilityIdentifier(BibleReaderBookAndChapterPickerAccessibilityIdentifier.sheet)
     }
 
     private func sectionHeaderView(_ bookCode: String) -> some View {
@@ -97,6 +117,7 @@ public struct BibleReaderBookAndChapterPickerView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier(BibleReaderBookAndChapterPickerAccessibilityIdentifier.bookButton(bookCode))
         .listRowInsets(EdgeInsets(top: 2, leading: 16, bottom: 2, trailing: 16))
         .textCase(nil)
     }
@@ -113,6 +134,7 @@ public struct BibleReaderBookAndChapterPickerView: View {
                     chapterListButton(Text(Image("i-icon", bundle: .YouVersionUIBundle)))
                 }
                 .buttonStyle(.plain)
+                .accessibilityIdentifier(BibleReaderBookAndChapterPickerAccessibilityIdentifier.introButton(bookCode))
             }
             ForEach(Array(chapters.enumerated()), id: \.offset) { idx, label in
                 Button(action: {
@@ -122,6 +144,12 @@ public struct BibleReaderBookAndChapterPickerView: View {
                     chapterListButton(Text(label))
                 }
                 .buttonStyle(.plain)
+                .accessibilityIdentifier(
+                    BibleReaderBookAndChapterPickerAccessibilityIdentifier.chapterButton(
+                        bookCode: bookCode,
+                        chapter: idx + 1
+                    )
+                )
             }
         }
         .padding(.vertical, 8)

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderHalfPillPickersView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderHalfPillPickersView.swift
@@ -1,6 +1,11 @@
 import SwiftUI
 import YouVersionPlatformCore
 
+private enum BibleReaderHalfPillPickersAccessibilityIdentifier {
+    static let bookAndChapterPickerButton = "bibleReader.bookAndChapterPickerButton"
+    static let versionPickerButton = "bibleReader.versionPickerButton"
+}
+
 struct BibleReaderHalfPillPickersView: View {
     let bookAndChapter: String
     let versionAbbreviation: String
@@ -25,6 +30,7 @@ struct BibleReaderHalfPillPickersView: View {
             }
             .buttonStyle(.plain)
             .clipShape(HalfPillShape(side: .left))
+            .accessibilityIdentifier(BibleReaderHalfPillPickersAccessibilityIdentifier.bookAndChapterPickerButton)
 
             Rectangle()
                 .frame(width: 2, height: compactMode ? 29 : 40)
@@ -42,6 +48,7 @@ struct BibleReaderHalfPillPickersView: View {
             }
             .buttonStyle(.plain)
             .clipShape(HalfPillShape(side: .right))
+            .accessibilityIdentifier(BibleReaderHalfPillPickersAccessibilityIdentifier.versionPickerButton)
         }
         .background(buttonColor)
         .clipShape(Capsule())

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderHalfPillPickersView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderHalfPillPickersView.swift
@@ -1,11 +1,6 @@
 import SwiftUI
 import YouVersionPlatformCore
 
-private enum BibleReaderHalfPillPickersAccessibilityIdentifier {
-    static let bookAndChapterPickerButton = "bibleReader.bookAndChapterPickerButton"
-    static let versionPickerButton = "bibleReader.versionPickerButton"
-}
-
 struct BibleReaderHalfPillPickersView: View {
     let bookAndChapter: String
     let versionAbbreviation: String
@@ -30,7 +25,7 @@ struct BibleReaderHalfPillPickersView: View {
             }
             .buttonStyle(.plain)
             .clipShape(HalfPillShape(side: .left))
-            .accessibilityIdentifier(BibleReaderHalfPillPickersAccessibilityIdentifier.bookAndChapterPickerButton)
+            .accessibilityIdentifier(BibleReaderAccessibilityIdentifiers.Header.bookAndChapterPickerButton)
 
             Rectangle()
                 .frame(width: 2, height: compactMode ? 29 : 40)
@@ -48,7 +43,7 @@ struct BibleReaderHalfPillPickersView: View {
             }
             .buttonStyle(.plain)
             .clipShape(HalfPillShape(side: .right))
-            .accessibilityIdentifier(BibleReaderHalfPillPickersAccessibilityIdentifier.versionPickerButton)
+            .accessibilityIdentifier(BibleReaderAccessibilityIdentifiers.Header.versionPickerButton)
         }
         .background(buttonColor)
         .clipShape(Capsule())

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderMenuView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderMenuView.swift
@@ -7,6 +7,7 @@ struct BibleReaderHeaderMenuView: View {
     var body: some View {
         Menu {
             Button(String.localized("menu.fontSettings"), action: openFontSettings)
+                .accessibilityIdentifier(BibleReaderAccessibilityIdentifiers.Header.fontSettingsMenuButton)
             if YouVersionPlatformConfiguration.isSignInEnabled {
                 if viewModel.isSignedIn {
                     Button(String.localized("menu.signOut"), role: .destructive, action: signOut)
@@ -23,6 +24,7 @@ struct BibleReaderHeaderMenuView: View {
         .onAppear {
             viewModel.updateSignInState()
         }
+        .accessibilityIdentifier(BibleReaderAccessibilityIdentifiers.Header.menuButton)
     }
 
     private func openFontSettings() {

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift
@@ -17,6 +17,7 @@ struct BibleReaderFontListView: View {
                         Image(systemName: "chevron.left")
                             .font(.system(size: 24, weight: .semibold))
                     }
+                    .accessibilityIdentifier(BibleReaderAccessibilityIdentifiers.FontList.backButton)
                     .padding()
                     Spacer()
                 }
@@ -62,6 +63,7 @@ struct BibleReaderFontListView: View {
                     isSelected ? viewModel.readerSurfacePrimaryColor : viewModel.readerCanvasPrimaryColor
                 )
             }
+            .accessibilityIdentifier(BibleReaderAccessibilityIdentifiers.FontList.fontButton(family: family))
         }
     }
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift
@@ -13,6 +13,7 @@ struct BibleReaderFontSettingsView: View {
             } label: {
                 fontDisplayButton
             }
+            .accessibilityIdentifier(BibleReaderAccessibilityIdentifiers.FontSettings.fontFamilyButton)
             themePicker
         }
         .padding(.horizontal, 24)
@@ -53,6 +54,7 @@ struct BibleReaderFontSettingsView: View {
                             selected: isSelected(theme)
                         )
                     }
+                    .accessibilityIdentifier(BibleReaderAccessibilityIdentifiers.FontSettings.themeButton(theme.id))
                 }
             }
             .padding(.bottom)
@@ -113,6 +115,7 @@ struct BibleReaderFontSettingsView: View {
                     HalfRoundedRectangleShape(side: .left)
                         .fill(viewModel.readerButtonPrimaryColor)
                 )
+                .accessibilityIdentifier(BibleReaderAccessibilityIdentifiers.FontSettings.smallerFontButton)
 
                 Rectangle()
                     .frame(width: 2, height: 40)
@@ -133,6 +136,7 @@ struct BibleReaderFontSettingsView: View {
                     HalfRoundedRectangleShape(side: .right)
                         .fill(viewModel.readerButtonPrimaryColor)
                 )
+                .accessibilityIdentifier(BibleReaderAccessibilityIdentifiers.FontSettings.biggerFontButton)
             }
 
             Spacer()
@@ -158,6 +162,7 @@ struct BibleReaderFontSettingsView: View {
                 )
             }
             .buttonStyle(.plain)
+            .accessibilityIdentifier(BibleReaderAccessibilityIdentifiers.FontSettings.lineSpacingButton)
 
         }
     }

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderAccessibilityIdentifiersTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderAccessibilityIdentifiersTests.swift
@@ -1,0 +1,36 @@
+import Testing
+import YouVersionPlatformReader
+
+struct BibleReaderAccessibilityIdentifiersTests {
+    @Test
+    func headerIdentifiersAreAccessible() {
+        #expect(BibleReaderAccessibilityIdentifiers.Header.menuButton == "bibleReader.header.menuButton")
+        #expect(BibleReaderAccessibilityIdentifiers.Header.fontSettingsMenuButton == "bibleReader.header.fontSettingsMenuButton")
+        #expect(BibleReaderAccessibilityIdentifiers.Header.bookAndChapterPickerButton == "bibleReader.header.bookAndChapterPickerButton")
+        #expect(BibleReaderAccessibilityIdentifiers.Header.versionPickerButton == "bibleReader.header.versionPickerButton")
+    }
+
+    @Test
+    func bookChapterPickerIdentifiersAreAccessible() {
+        #expect(BibleReaderAccessibilityIdentifiers.BookChapterPicker.sheet == "bibleReader.bookAndChapterPicker.sheet")
+        #expect(BibleReaderAccessibilityIdentifiers.BookChapterPicker.cancelButton == "bibleReader.bookAndChapterPicker.cancelButton")
+        #expect(BibleReaderAccessibilityIdentifiers.BookChapterPicker.bookButton("GEN") == "bibleReader.bookAndChapterPicker.bookButton.GEN")
+        #expect(BibleReaderAccessibilityIdentifiers.BookChapterPicker.introButton("GEN") == "bibleReader.bookAndChapterPicker.introButton.GEN")
+        #expect(BibleReaderAccessibilityIdentifiers.BookChapterPicker.chapterButton(bookCode: "GEN", chapter: 1) == "bibleReader.bookAndChapterPicker.chapterButton.GEN.1")
+    }
+
+    @Test
+    func fontSettingsIdentifiersAreAccessible() {
+        #expect(BibleReaderAccessibilityIdentifiers.FontSettings.smallerFontButton == "bibleReader.fontSettings.smallerFontButton")
+        #expect(BibleReaderAccessibilityIdentifiers.FontSettings.biggerFontButton == "bibleReader.fontSettings.biggerFontButton")
+        #expect(BibleReaderAccessibilityIdentifiers.FontSettings.fontFamilyButton == "bibleReader.fontSettings.fontFamilyButton")
+        #expect(BibleReaderAccessibilityIdentifiers.FontSettings.lineSpacingButton == "bibleReader.fontSettings.lineSpacingButton")
+        #expect(BibleReaderAccessibilityIdentifiers.FontSettings.themeButton(1) == "bibleReader.fontSettings.themeButton.1")
+    }
+
+    @Test
+    func fontListIdentifiersAreAccessible() {
+        #expect(BibleReaderAccessibilityIdentifiers.FontList.backButton == "bibleReader.fontList.backButton")
+        #expect(BibleReaderAccessibilityIdentifiers.FontList.fontButton(family: "Georgia") == "bibleReader.fontList.fontButton.Georgia")
+    }
+}


### PR DESCRIPTION
## Description

test: add accessibility identifiers to BibleReader

## Type of Change

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [ ] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [x] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

## Checklist

- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] All commit messages follow [conventional commits](https://www.conventionalcommits.org/) format

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a centralized `BibleReaderAccessibilityIdentifiers` enum and wires its string constants into the BibleReader views, making every major interactive element targetable by UI automation tests. All four nested namespaces (`Header`, `BookChapterPicker`, `FontSettings`, `FontList`) are `public`, and snapshot tests pin the string values to guard against accidental renames.

- **`BibleReaderAccessibilityIdentifiers.swift`** — new public namespace enum with static constants and factory functions (e.g. `chapterButton(bookCode:chapter:)`) covering every BibleReader interaction point.
- **View files** — `.accessibilityIdentifier(…)` applied to seven views across headers, pickers, font settings, and the font list; the chapter buttons use `idx + 1` for correct 1-based chapter numbers.
- **`BibleReaderAccessibilityIdentifiersTests.swift`** — Swift Testing suite that asserts the exact string value of every identifier, providing a compile-safe regression net.

<h3>Confidence Score: 5/5</h3>

Safe to merge — additive-only change with no modifications to business logic or data flow.

All changes are purely additive: a new enum file, `.accessibilityIdentifier` modifiers on existing views, and a new test file. No existing logic is altered, and the snapshot tests protect the string contracts going forward.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/BibleReaderAccessibilityIdentifiers.swift | New public enum centralizing all BibleReader accessibility identifier strings, with nested namespaces (Header, BookChapterPicker, FontSettings, FontList) and static factory functions for dynamic identifiers. All types and members are correctly marked `public`, and acronym casing follows project conventions (`themeID`). |
| Tests/YouVersionPlatformReaderTests/BibleReaderAccessibilityIdentifiersTests.swift | Unit tests using Swift Testing (`@Test`, `#expect`) that lock in the string values of every identifier, protecting against accidental renames that would silently break UI tests. Correctly imports `YouVersionPlatformReader` without `@testable` since the enum is public. |
| Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift | Adds identifiers to the sheet container, cancel button, book row buttons, intro buttons, and per-chapter buttons using `idx + 1` for correct 1-based chapter numbers. |
| Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift | Applies identifiers to the font-family link, per-theme buttons, smaller/bigger font buttons, and line-spacing button. All placements are on the correct view boundaries. |
| Sources/YouVersionPlatformReader/Components/BibleReaderHeaderMenuView.swift | Adds `menuButton` identifier to the `Menu` container and `fontSettingsMenuButton` to the Button inside the menu content builder. |
| Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift | Adds `backButton` and per-family `fontButton` identifiers in the correct locations. |
| Sources/YouVersionPlatformReader/Components/BibleReaderHalfPillPickersView.swift | Adds `bookAndChapterPickerButton` and `versionPickerButton` identifiers to the correct half-pill buttons. |
| Examples/SampleApp/SampleApp.swift | Indentation-only fix that aligns `.tabItem {}` and `.tag(0)` to match the indentation of the other tabs — no logic changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BibleReaderAccessibilityIdentifiers] --> B[Header]
    A --> C[BookChapterPicker]
    A --> D[FontSettings]
    A --> E[FontList]

    B --> B1["menuButton\nbibleReader.header.menuButton"]
    B --> B2["fontSettingsMenuButton\nbibleReader.header.fontSettingsMenuButton"]
    B --> B3["bookAndChapterPickerButton\nbibleReader.header.bookAndChapterPickerButton"]
    B --> B4["versionPickerButton\nbibleReader.header.versionPickerButton"]

    C --> C1["sheet\nbibleReader.bookAndChapterPicker.sheet"]
    C --> C2["cancelButton\nbibleReader.bookAndChapterPicker.cancelButton"]
    C --> C3["bookButton(_:)\nbibleReader.bookAndChapterPicker.bookButton.{code}"]
    C --> C4["introButton(_:)\nbibleReader.bookAndChapterPicker.introButton.{code}"]
    C --> C5["chapterButton(bookCode:chapter:)\nbibleReader.bookAndChapterPicker.chapterButton.{code}.{n}"]

    D --> D1["smallerFontButton\nbibleReader.fontSettings.smallerFontButton"]
    D --> D2["biggerFontButton\nbibleReader.fontSettings.biggerFontButton"]
    D --> D3["fontFamilyButton\nbibleReader.fontSettings.fontFamilyButton"]
    D --> D4["lineSpacingButton\nbibleReader.fontSettings.lineSpacingButton"]
    D --> D5["themeButton(_:)\nbibleReader.fontSettings.themeButton.{id}"]

    E --> E1["backButton\nbibleReader.fontList.backButton"]
    E --> E2["fontButton(family:)\nbibleReader.fontList.fontButton.{family}"]
```

<sub>Reviews (6): Last reviewed commit: ["test: remove spurious identifiers in sam..."](https://github.com/youversion/platform-sdk-swift/commit/5ce511bbfde319eedad887d439791874d731b914) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30915782)</sub>

<!-- /greptile_comment -->