### PR TITLE
feat: add x-yvp-sdk header reporting SDK version on configured requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,8 @@ jobs:
         run: |
           chmod +x scripts/update-pod-versions.sh
           chmod +x scripts/publish-pods.sh
+          chmod +x scripts/stamp-sdk-version.sh
+          chmod +x scripts/release-stamp-and-tag.sh
 
       - name: Setup Git
         run: |

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -25,7 +25,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "bash scripts/update-pod-versions.sh ${nextRelease.version}",
-        "publishCmd": "bash scripts/publish-pods.sh ${nextRelease.version}"
+        "publishCmd": "bash scripts/release-stamp-and-tag.sh ${nextRelease.version} && bash scripts/publish-pods.sh ${nextRelease.version}"
       }
     ],
     "@semantic-release/github",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,28 +68,30 @@ LINUX_SOURCEKIT_LIB_PATH=/root/.local/share/swiftly/toolchains/6.1.3/usr/lib swi
 ## Common Workflows
 
 ### Git Branching Process
-The project follows a structured git workflow with `main` as the primary branch.
 
-**⚠️ IMPORTANT: Never push directly to main. Always use feature/task branches and pull requests.**
+**⚠️ IMPORTANT: Every change goes on a branch, every branch is named after its Jira ticket, and every merge into `main` goes through a pull request. No direct edits or pushes to `main`.**
 
-**Small Tasks (Non-Urgent):**
-1. Create task branch from `main` using pattern: `initials/ticket-number` or `initials/ticket-number-description`
-   - Examples: `dk/BA-1204`, `ew/BA-1204-plans-update`, `jm/plans-update`, `ae/BA-5678`
-2. Complete work and create PR targeted back to `main`
+**Branch naming**: `<JIRA-TICKET>-<kebab-description>`
 
-**Feature Branches:**
-Use for large tasks or risky changes (SDK updates, major API adoption):
-1. Create feature branch from `main` with `feature/` prefix
-   - Examples: `feature/offline-search`
-2. Create task branches off the feature branch
-3. Create PRs targeting the feature branch
-4. Merge task branches into feature branch
-5. Merge feature branch into `main` once approved
+- Examples: `YPE-2293-swift-sdk-add-x-yvp-sdk-http-header-for-version-reporting`, `BA-1204-plans-update`, `BA-5678-bibles-cache-cleanup`
+- The ticket prefix comes first; no initials prefix, no `feature/` prefix.
+- Every branch — including doc-only edits, tooling changes, and small fixes — must have a Jira ticket and follow this pattern. If there's no ticket, create one before starting work.
 
-**Updating Feature Branches:**
-- Merge `main` into feature branch first
-- Then merge updated feature branch into task branch
-- Never merge `main` directly into task branch
+**Standard workflow**:
+1. Create the branch from `main`.
+2. Make changes on the branch.
+3. Open a PR back to `main`. PR title matches the first line of the commit message.
+
+**Feature branches** (for large tasks or risky changes spanning multiple sub-tickets):
+1. Create the feature branch from `main` using the parent epic's ticket: `<EPIC-TICKET>-<kebab-description>` (e.g., `YPE-1900-offline-search`).
+2. Create task branches off the feature branch using each sub-ticket: `<TASK-TICKET>-<kebab-description>`.
+3. Open PRs from task branches targeting the feature branch.
+4. Open a final PR from the feature branch to `main` once the feature is complete.
+
+**Updating feature branches with changes from `main`**:
+- Merge `main` into the feature branch first.
+- Then merge the updated feature branch into the task branch.
+- Never merge `main` directly into a task branch.
 
 ### Adding New Features
 1. Identify the appropriate internal framework or create new module
@@ -110,6 +112,28 @@ When writing or reviewing code in this repo, load the relevant skill:
 - **`audit-swift`** (`.claude/skills/audit-swift/SKILL.md`) — project Swift conventions: access control, async/await, code organization, idioms, formatting.
 - **`audit-swift-ui`** (`.claude/skills/audit-swift-ui/SKILL.md`) — SwiftUI-specific rules: Dynamic Type, `@State` privacy, view naming.
 - **`naming`** (`.claude/skills/naming/SKILL.md`) — naming Swift entities (types, protocols, functions, parameters, properties, cases).
+
+## Release Process
+
+Releases are driven by `semantic-release` from `main` (see `.github/workflows/release.yml` and `.releaserc.json`). Two pieces of state get version-bumped: the four `.podspec` files, and the `SDKVersion` constant used by the `x-yvp-sdk` HTTP header. They behave differently on purpose.
+
+**Podspecs** are bumped by `scripts/update-pod-versions.sh` during the prepare phase. The change is committed to `main` along with the `CHANGELOG.md` update.
+
+**`Sources/YouVersionPlatformCore/SDKVersion.swift`** is bumped by `scripts/release-stamp-and-tag.sh` during the publish phase, on a *separate child commit* that is **not pushed to `main`**. The release tag is force-moved to point at this stamped commit. Topology after a release:
+
+```
+main:  ... ─ X (podspec=4.9.2, CHANGELOG, SDKVersion="Dev")     ← main HEAD
+                  \
+                   Y (… +SDKVersion="4.9.2")                    ← tag 4.9.2
+```
+
+Why: `main` always reads `SDKVersion.current = "Dev"` so in-repo dev builds and PR CI report `SwiftSDK=Dev` rather than poisoning the data lake with stale or imprecise versions. SPM consumers resolving a tag and CocoaPods consumers (whose podspec source is `:tag => s.version.to_s`) both fetch `Y`, so production traffic reports the precise released version.
+
+**Footguns**:
+- `git checkout <tag>` lands on a detached commit not reachable from `main`. Expected.
+- `git log main` does not show any commit that ever modified `SDKVersion.swift` to a real version. Expected — those commits live only on tags.
+- Don't cherry-pick a tagged commit onto `main`; it would leak the stamped version.
+- If you change the shape of the `static let current = "..."` line in `SDKVersion.swift`, also update `scripts/stamp-sdk-version.sh`.
 
 ## Localization
 

--- a/Sources/YouVersionPlatformCore/APIs/URLRequest+YouVersion.swift
+++ b/Sources/YouVersionPlatformCore/APIs/URLRequest+YouVersion.swift
@@ -16,6 +16,7 @@ public extension URLRequest {
         var request = URLRequest(url: url, cachePolicy: cachePolicy)
         if let appKey = YouVersionPlatformConfiguration.appKey {
             request.setValue(appKey, forHTTPHeaderField: "x-yvp-app-key")
+            request.setValue("SwiftSDK=\(SDKVersion.current)", forHTTPHeaderField: "x-yvp-sdk")
         }
         if let installId = YouVersionPlatformConfiguration.installId {
             request.setValue(installId, forHTTPHeaderField: "x-yvp-installation-id")

--- a/Sources/YouVersionPlatformCore/SDKVersion.swift
+++ b/Sources/YouVersionPlatformCore/SDKVersion.swift
@@ -1,0 +1,9 @@
+// On `main` this constant always reads "Dev".
+// The release workflow rewrites the literal in the *tagged* release commit
+// only — that commit is not pushed to `main` — so production builds resolved
+// via SPM or CocoaPods at a release tag report the real version, while
+// in-repo and PR-CI builds report "Dev". If you change the shape of the
+// declaration below, also update scripts/stamp-sdk-version.sh.
+enum SDKVersion {
+    static let current = "Dev"
+}

--- a/Tests/YouVersionPlatformCoreTests/URLRequestYouVersionTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/URLRequestYouVersionTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+@testable import YouVersionPlatformCore
+
+@Suite(.serialized) struct URLRequestYouVersionTests {
+
+    @Test func sdkVersionHeaderIsSetWhenAppKeyConfigured() async throws {
+        let originalAppKey = YouVersionPlatformConfiguration.appKey
+        await YouVersionPlatformConfiguration.configure(appKey: "test-app")
+
+        let url = try #require(URL(string: "https://api.youversion.com/v1/bibles/1"))
+        let request = URLRequest.youVersion(url)
+
+        #expect(request.value(forHTTPHeaderField: "x-yvp-app-key") == "test-app")
+        #expect(request.value(forHTTPHeaderField: "x-yvp-sdk") == "SwiftSDK=\(SDKVersion.current)")
+
+        await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+    }
+
+    @Test func sdkVersionHeaderIsAbsentWhenAppKeyNotConfigured() async throws {
+        let originalAppKey = YouVersionPlatformConfiguration.appKey
+        await YouVersionPlatformConfiguration.configure(appKey: nil)
+
+        let url = try #require(URL(string: "https://api.youversion.com/v1/bibles/1"))
+        let request = URLRequest.youVersion(url)
+
+        #expect(request.value(forHTTPHeaderField: "x-yvp-app-key") == nil)
+        #expect(request.value(forHTTPHeaderField: "x-yvp-sdk") == nil)
+
+        await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+    }
+}

--- a/Tests/YouVersionPlatformCoreTests/URLRequestYouVersionTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/URLRequestYouVersionTests.swift
@@ -10,24 +10,26 @@ import Testing
     @Test func sdkVersionHeaderIsSetWhenAppKeyConfigured() async throws {
         let originalAppKey = YouVersionPlatformConfiguration.appKey
         await YouVersionPlatformConfiguration.configure(appKey: "test-app")
-        defer { Task { await YouVersionPlatformConfiguration.configure(appKey: originalAppKey) } }
 
         let url = try #require(URL(string: "https://api.youversion.com/v1/bibles/1"))
         let request = URLRequest.youVersion(url)
 
         #expect(request.value(forHTTPHeaderField: "x-yvp-app-key") == "test-app")
         #expect(request.value(forHTTPHeaderField: "x-yvp-sdk") == "SwiftSDK=\(SDKVersion.current)")
+
+        await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
     }
 
     @Test func sdkVersionHeaderIsAbsentWhenAppKeyNotConfigured() async throws {
         let originalAppKey = YouVersionPlatformConfiguration.appKey
         await YouVersionPlatformConfiguration.configure(appKey: nil)
-        defer { Task { await YouVersionPlatformConfiguration.configure(appKey: originalAppKey) } }
 
         let url = try #require(URL(string: "https://api.youversion.com/v1/bibles/1"))
         let request = URLRequest.youVersion(url)
 
         #expect(request.value(forHTTPHeaderField: "x-yvp-app-key") == nil)
         #expect(request.value(forHTTPHeaderField: "x-yvp-sdk") == nil)
+
+        await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
     }
 }

--- a/Tests/YouVersionPlatformCoreTests/URLRequestYouVersionTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/URLRequestYouVersionTests.swift
@@ -10,26 +10,24 @@ import Testing
     @Test func sdkVersionHeaderIsSetWhenAppKeyConfigured() async throws {
         let originalAppKey = YouVersionPlatformConfiguration.appKey
         await YouVersionPlatformConfiguration.configure(appKey: "test-app")
+        defer { Task { await YouVersionPlatformConfiguration.configure(appKey: originalAppKey) } }
 
         let url = try #require(URL(string: "https://api.youversion.com/v1/bibles/1"))
         let request = URLRequest.youVersion(url)
 
         #expect(request.value(forHTTPHeaderField: "x-yvp-app-key") == "test-app")
         #expect(request.value(forHTTPHeaderField: "x-yvp-sdk") == "SwiftSDK=\(SDKVersion.current)")
-
-        await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
     }
 
     @Test func sdkVersionHeaderIsAbsentWhenAppKeyNotConfigured() async throws {
         let originalAppKey = YouVersionPlatformConfiguration.appKey
         await YouVersionPlatformConfiguration.configure(appKey: nil)
+        defer { Task { await YouVersionPlatformConfiguration.configure(appKey: originalAppKey) } }
 
         let url = try #require(URL(string: "https://api.youversion.com/v1/bibles/1"))
         let request = URLRequest.youVersion(url)
 
         #expect(request.value(forHTTPHeaderField: "x-yvp-app-key") == nil)
         #expect(request.value(forHTTPHeaderField: "x-yvp-sdk") == nil)
-
-        await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
     }
 }

--- a/scripts/release-stamp-and-tag.sh
+++ b/scripts/release-stamp-and-tag.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Stamp the SDK version into source AND move the release tag to point at the
+# stamped commit (a child of main HEAD, NOT pushed to main).
+#
+# Topology after this script runs:
+#
+#   main:  ... ─ X (podspec=$VERSION, CHANGELOG, SDKVersion="Dev")    ← main HEAD
+#                     \
+#                      Y (… +SDKVersion="$VERSION")                   ← tag $VERSION
+#
+# Why: keep `main` reading "Dev" continuously (so in-repo dev builds and PR
+# CI report SwiftSDK=Dev), while production builds fetched via SPM or
+# CocoaPods at a release tag report the real version.
+#
+# This script runs during semantic-release's publish phase, *before*
+# publish-pods.sh, so that `pod trunk push`'s spec lint clones the
+# stamped tag commit.
+set -e
+
+VERSION=$1
+
+if [ -z "$VERSION" ]; then
+  echo "Error: Version parameter is required"
+  exit 1
+fi
+
+cd "$(dirname "$0")/.."
+
+echo "Stamping SDK version into source..."
+bash scripts/stamp-sdk-version.sh "$VERSION"
+
+echo "Creating tag-only commit Y as child of main HEAD..."
+git add Sources/YouVersionPlatformCore/SDKVersion.swift
+# Use chore(release): to match the on-main release commit format from
+# @semantic-release/git and to satisfy the commitlint config (which only
+# permits the conventional-commits type-enum: feat, fix, docs, style,
+# refactor, perf, test, build, ci, chore, revert). The husky commit-msg
+# hook runs in CI (npm ci → "prepare": "husky" installs it), so a
+# non-conforming type would reject the commit and abort the release.
+git commit -m "chore(release): stamp SDKVersion ${VERSION} (tag-only, not on main) [skip ci]"
+
+echo "Moving tag $VERSION to the stamped commit..."
+git tag -f "$VERSION"
+
+# Force-push the tag ref. This carries commit Y to origin (because the tag
+# points to it) but does NOT advance the main branch ref. If the tag already
+# exists on origin (semantic-release may have pushed it pointing at X), the
+# force flag overwrites it.
+#
+# This tag-only push does NOT trigger release.yml: that workflow's trigger
+# is `on: push: branches: [main]`, which matches refs/heads/main only —
+# refs/tags/* pushes are ignored. The on-main release commit X (created
+# earlier by @semantic-release/git) also carries `[skip ci]` per
+# .releaserc.json, so even an accidental main-ref push wouldn't loop.
+echo "Pushing tag $VERSION (force, tag-only — not pushing main)..."
+git push --force origin "refs/tags/$VERSION"
+
+# Reset working tree back to origin/main so any subsequent release steps see
+# a clean main and cannot accidentally push commit Y to main.
+echo "Resetting working tree to origin/main..."
+git reset --hard origin/main
+
+echo "✅ Release tag $VERSION now points at SDKVersion-stamped commit (off-main)."

--- a/scripts/stamp-sdk-version.sh
+++ b/scripts/stamp-sdk-version.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Stamp a version string into Sources/YouVersionPlatformCore/SDKVersion.swift.
+#
+# Idempotent: works whether the file currently reads "Dev" or any prior
+# version string. Replaces the value between the double-quotes on the
+# `static let current = "..."` line.
+#
+# Designed to be portable to other YouVersion SDKs that use semantic-release:
+# the only project-specific bits are the FILE path and the line marker.
+set -e
+
+cd "$(dirname "$0")/.."
+
+VERSION=$1
+
+if [ -z "$VERSION" ]; then
+  echo "Error: Version parameter is required"
+  exit 1
+fi
+
+FILE="Sources/YouVersionPlatformCore/SDKVersion.swift"
+
+if [ ! -f "$FILE" ]; then
+  echo "Error: $FILE not found"
+  exit 1
+fi
+
+echo "Stamping SDK version $VERSION into $FILE..."
+
+# Replace the literal between quotes on the `static let current = "..."` line.
+sed -i '' "s/static let current = \"[^\"]*\"/static let current = \"$VERSION\"/" "$FILE"
+
+if ! grep -q "static let current = \"$VERSION\"" "$FILE"; then
+  echo "Error: Failed to stamp version into $FILE"
+  exit 1
+fi
+
+echo "  ✓ $FILE now reads: $(grep 'static let current' "$FILE" | sed 's/^[[:space:]]*//')"
+echo "SDK version stamp complete."

--- a/scripts/stamp-sdk-version.sh
+++ b/scripts/stamp-sdk-version.sh
@@ -28,7 +28,11 @@ fi
 echo "Stamping SDK version $VERSION into $FILE..."
 
 # Replace the literal between quotes on the `static let current = "..."` line.
-sed -i '' "s/static let current = \"[^\"]*\"/static let current = \"$VERSION\"/" "$FILE"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "s/static let current = \"[^\"]*\"/static let current = \"$VERSION\"/" "$FILE"
+else
+  sed -i "s/static let current = \"[^\"]*\"/static let current = \"$VERSION\"/" "$FILE"
+fi
 
 if ! grep -q "static let current = \"$VERSION\"" "$FILE"; then
   echo "Error: Failed to stamp version into $FILE"


### PR DESCRIPTION
## Summary
- Adds `x-yvp-sdk: SwiftSDK=<version>` header alongside `x-yvp-app-key` on every configured API request, so platform telemetry can attribute traffic to a specific SDK version.
- Introduces a tag-only release-stamping flow: `main` always reads `SDKVersion = "Dev"`, but the release workflow stamps the real version onto a child commit Y, force-moves the release tag to Y, and pushes only the tag — `main` HEAD never advances to Y. SPM and CocoaPods consumers fetching a release tag see the precise version; in-repo dev builds and PR CI see `Dev` so the data lake isn't polluted with stale numbers.
- Documents the new release topology and tightens the branching policy in `AGENTS.md` to require Jira-ticket-named branches for all work.

Resolves YPE-2293.

## Test plan
- [x] `swift test` — full suite passes (262 tests; 2 new in `URLRequestYouVersionTests.swift`).
- [x] `scripts/check-api-stability.sh check` — passes (`SDKVersion` is `internal`, no public-surface change).
- [x] `scripts/stamp-sdk-version.sh` round-trip: `Dev → 4.9.2-test → Dev` is idempotent.
- [x] Local `git commit` cleared the husky `commit-msg` / commitlint hook (validates the `chore(release):` prefix the release script will use).
- [ ] CI: SwiftLint passes (not installed locally; CI runs it).
- [ ] **First real release after merge** — verify the topology lands correctly:
  - `git log main` does NOT contain a `chore(release): stamp SDKVersion ...` commit
  - `git show <tag>:Sources/YouVersionPlatformCore/SDKVersion.swift` shows the stamped version
  - `pod trunk push` succeeds (its `pod spec lint` clones the tagged commit; if the tag-move misordered, lint would fetch the un-stamped commit)
  - Data-lake traffic reports `SwiftSDK=<real-version>` from pod consumers; SPM consumers should follow once they bump
- [ ] Watch for any production traffic still reporting `SwiftSDK=Dev` after the next release — that would indicate a consumer building from source/main rather than a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces SDK version reporting via a new `x-yvp-sdk: SwiftSDK=<version>` header on every configured API request, backed by a new `SDKVersion.swift` constant that reads `\"Dev\"` on `main` and is stamped to the real version only in the tagged release commit (never pushed to `main`). It also tightens the branching policy in `AGENTS.md` and wires up the stamping scripts into the semantic-release workflow.

- `URLRequest+YouVersion.swift` gains one line setting the `x-yvp-sdk` header whenever an app key is present; two new Swift Testing tests cover the configured and unconfigured cases.
- `scripts/release-stamp-and-tag.sh` creates an off-`main` commit Y (SDKVersion stamped), force-moves the release tag to Y, then calls `publish-pods.sh` \u2014 but the `git reset --hard origin/main` before `publish-pods.sh` reverts the in-flight podspec changes, causing pod pushes to use stale version numbers (see inline comment).
- `AGENTS.md` now requires Jira-ticket-named branches for all work and documents the new off-`main` tag topology with explicit footgun warnings.

<h3>Confidence Score: 4/5</h3>

The Swift source changes and workflow wiring are safe; the release script has a reset ordering issue that would cause pod publishing to use stale podspec versions on the first real release.

The `git reset --hard origin/main` inside `release-stamp-and-tag.sh` discards the podspec version bumps applied during the prepare phase. Because `publish-pods.sh` runs immediately after that reset and uses the local `.podspec` files, it would submit the previous version number to CocoaPods trunk. Everything else looks correct.

scripts/release-stamp-and-tag.sh — the `git reset --hard origin/main` call on line 61 needs to be scoped to only unwinding commit Y, not the entire prepare-phase state.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/release-stamp-and-tag.sh | Stamps SDKVersion, commits off-main (Y), force-pushes tag to Y, then hard-resets to origin/main — but that reset reverts the podspec modifications made during semantic-release's prepare phase, leaving publish-pods.sh with stale local podspecs. |
| .releaserc.json | Adds release-stamp-and-tag.sh before publish-pods.sh in the exec publishCmd; plugin order is intentional. |
| Tests/YouVersionPlatformCoreTests/URLRequestYouVersionTests.swift | Two new tests covering the header-present and header-absent cases; teardown concerns already flagged in prior review threads. |
| Sources/YouVersionPlatformCore/SDKVersion.swift | New internal enum exposing SDKVersion.current; always Dev on main, stamped to the real version on tagged commits only. |
| Sources/YouVersionPlatformCore/APIs/URLRequest+YouVersion.swift | Adds x-yvp-sdk header alongside x-yvp-app-key when an app key is configured; clean, minimal change. |
| .github/workflows/release.yml | Adds chmod for the two new scripts; no other changes to the workflow itself. |
| AGENTS.md | Rewrites branching policy to require Jira-ticket-prefixed branches and documents the new off-main release topology with clear footgun notes. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SR as semantic-release core
    participant EXEC as @sr/exec
    participant GIT as @sr/git
    participant GH as @sr/github
    participant Origin as origin

    SR->>EXEC: prepare - update-pod-versions.sh bumps .podspecs
    SR->>GIT: prepare - commit X (CHANGELOG + .podspecs, SDKVersion=Dev)
    SR->>Origin: push tag to commit X
    note over SR,Origin: publish phase begins
    SR->>EXEC: publishCmd - release-stamp-and-tag.sh
    EXEC->>EXEC: stamp SDKVersion.swift to 4.9.2
    EXEC->>EXEC: git commit Y (parent=X, SDKVersion=4.9.2)
    EXEC->>Origin: git push force tag to Y
    EXEC->>EXEC: git reset hard origin/main - reverts podspecs to old version
    EXEC->>EXEC: publish-pods.sh uses stale local .podspec
    SR->>GH: publish - create GitHub Release tag=Y
    SR->>GIT: publish - push X to main
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Frelease-stamp-and-tag.sh%3A61%0A**%60git%20reset%20--hard%20origin%2Fmain%60%20discards%20the%20prepared%20podspec%20changes%20before%20%60publish-pods.sh%60%20runs**%0A%0A%60%40semantic-release%2Fgit%60%20creates%20its%20release%20commit%20%28podspecs%20%2B%20CHANGELOG%29%20during%20the%20**prepare**%20phase%2C%20so%20by%20the%20time%20this%20script%20runs%20in%20the%20publish%20phase%2C%20local%20HEAD%20is%20already%20at%20that%20prepare%20commit%20%28call%20it%20X%29.%20After%20creating%20Y%20and%20force-pushing%20the%20tag%2C%20%60git%20reset%20--hard%20origin%2Fmain%60%20resets%20HEAD%20all%20the%20way%20back%20to%20the%20original%20%60origin%2Fmain%60%20%E2%80%94%20before%20X.%20The%20working%20directory%20loses%20the%20version-bumped%20%60.podspec%60%20files.%20The%20immediately%20following%20%60publish-pods.sh%60%20then%20calls%20%60pod%20trunk%20push%20YouVersionPlatformCore.podspec%60%20against%20those%20stale%20local%20files%2C%20which%20still%20contain%20the%20**previous**%20version%20number.%20That%20will%20either%20fail%20with%20%22version%20already%20exists%22%20or%20publish%20the%20wrong%20version%20to%20the%20CocoaPods%20trunk.%0A%0AThe%20reset%20should%20only%20unwind%20commit%20Y%2C%20not%20X.%20Replacing%20%60git%20reset%20--hard%20origin%2Fmain%60%20with%20%60git%20reset%20HEAD~1%60%20%28mixed%2C%20default%29%20moves%20HEAD%20back%20to%20X%20without%20touching%20the%20working%20directory%2C%20so%20the%20updated%20podspecs%20remain%20in%20place%20for%20%60publish-pods.sh%60%2C%20and%20%60%40semantic-release%2Fgit%60's%20publish%20step%20can%20still%20push%20X%20to%20%60main%60%20as%20intended.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=103&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Frelease-stamp-and-tag.sh%3A61%0A**%60git%20reset%20--hard%20origin%2Fmain%60%20discards%20the%20prepared%20podspec%20changes%20before%20%60publish-pods.sh%60%20runs**%0A%0A%60%40semantic-release%2Fgit%60%20creates%20its%20release%20commit%20%28podspecs%20%2B%20CHANGELOG%29%20during%20the%20**prepare**%20phase%2C%20so%20by%20the%20time%20this%20script%20runs%20in%20the%20publish%20phase%2C%20local%20HEAD%20is%20already%20at%20that%20prepare%20commit%20%28call%20it%20X%29.%20After%20creating%20Y%20and%20force-pushing%20the%20tag%2C%20%60git%20reset%20--hard%20origin%2Fmain%60%20resets%20HEAD%20all%20the%20way%20back%20to%20the%20original%20%60origin%2Fmain%60%20%E2%80%94%20before%20X.%20The%20working%20directory%20loses%20the%20version-bumped%20%60.podspec%60%20files.%20The%20immediately%20following%20%60publish-pods.sh%60%20then%20calls%20%60pod%20trunk%20push%20YouVersionPlatformCore.podspec%60%20against%20those%20stale%20local%20files%2C%20which%20still%20contain%20the%20**previous**%20version%20number.%20That%20will%20either%20fail%20with%20%22version%20already%20exists%22%20or%20publish%20the%20wrong%20version%20to%20the%20CocoaPods%20trunk.%0A%0AThe%20reset%20should%20only%20unwind%20commit%20Y%2C%20not%20X.%20Replacing%20%60git%20reset%20--hard%20origin%2Fmain%60%20with%20%60git%20reset%20HEAD~1%60%20%28mixed%2C%20default%29%20moves%20HEAD%20back%20to%20X%20without%20touching%20the%20working%20directory%2C%20so%20the%20updated%20podspecs%20remain%20in%20place%20for%20%60publish-pods.sh%60%2C%20and%20%60%40semantic-release%2Fgit%60's%20publish%20step%20can%20still%20push%20X%20to%20%60main%60%20as%20intended.%0A%0A&pr=103&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/release-stamp-and-tag.sh:61
**`git reset --hard origin/main` discards the prepared podspec changes before `publish-pods.sh` runs**

`@semantic-release/git` creates its release commit (podspecs + CHANGELOG) during the **prepare** phase, so by the time this script runs in the publish phase, local HEAD is already at that prepare commit (call it X). After creating Y and force-pushing the tag, `git reset --hard origin/main` resets HEAD all the way back to the original `origin/main` — before X. The working directory loses the version-bumped `.podspec` files. The immediately following `publish-pods.sh` then calls `pod trunk push YouVersionPlatformCore.podspec` against those stale local files, which still contain the **previous** version number. That will either fail with "version already exists" or publish the wrong version to the CocoaPods trunk.

The reset should only unwind commit Y, not X. Replacing `git reset --hard origin/main` with `git reset HEAD~1` (mixed, default) moves HEAD back to X without touching the working directory, so the updated podspecs remain in place for `publish-pods.sh`, and `@semantic-release/git`'s publish step can still push X to `main` as intended.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: restore appKey inline to avoid race..."](https://github.com/youversion/platform-sdk-swift/commit/1e6858d6a987b9aaa10126f786c0132937f3f137) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30940550)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->