### PR TITLE
test: extract and test version search filter and language tag sorting

### DIFF
--- a/Sources/YouVersionPlatformUI/Utilities/BibleVersionSearchFilter.swift
+++ b/Sources/YouVersionPlatformUI/Utilities/BibleVersionSearchFilter.swift
@@ -1,15 +1,16 @@
 import YouVersionPlatformCore
 
 func filteredBibleVersions(_ versions: [BibleVersion], matching searchText: String) -> [BibleVersion] {
-    guard !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+    let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !query.isEmpty else {
         return versions
     }
     return versions.filter { version in
         let title = version.title ?? ""
         let abbr = version.abbreviation ?? String(version.id)
         let lang = version.languageTag ?? ""
-        return title.localizedCaseInsensitiveContains(searchText) ||
-            abbr.localizedCaseInsensitiveContains(searchText) ||
-            lang.localizedCaseInsensitiveContains(searchText)
+        return title.localizedCaseInsensitiveContains(query) ||
+            abbr.localizedCaseInsensitiveContains(query) ||
+            lang.localizedCaseInsensitiveContains(query)
     }
 }

--- a/Sources/YouVersionPlatformUI/Utilities/BibleVersionSearchFilter.swift
+++ b/Sources/YouVersionPlatformUI/Utilities/BibleVersionSearchFilter.swift
@@ -1,0 +1,14 @@
+import YouVersionPlatformCore
+
+func filterBibleVersions(_ versions: [BibleVersion], matching searchText: String) -> [BibleVersion] {
+    guard !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        return versions
+    }
+    let query = searchText.lowercased()
+    return versions.filter { version in
+        let title = (version.title ?? "").lowercased()
+        let abbr = (version.abbreviation ?? String(version.id)).lowercased()
+        let lang = version.languageTag ?? ""
+        return title.contains(query) || abbr.contains(query) || lang.contains(query)
+    }
+}

--- a/Sources/YouVersionPlatformUI/Utilities/BibleVersionSearchFilter.swift
+++ b/Sources/YouVersionPlatformUI/Utilities/BibleVersionSearchFilter.swift
@@ -1,6 +1,6 @@
 import YouVersionPlatformCore
 
-func filterBibleVersions(_ versions: [BibleVersion], matching searchText: String) -> [BibleVersion] {
+func filteredBibleVersions(_ versions: [BibleVersion], matching searchText: String) -> [BibleVersion] {
     guard !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
         return versions
     }

--- a/Sources/YouVersionPlatformUI/Utilities/BibleVersionSearchFilter.swift
+++ b/Sources/YouVersionPlatformUI/Utilities/BibleVersionSearchFilter.swift
@@ -8,7 +8,7 @@ func filterBibleVersions(_ versions: [BibleVersion], matching searchText: String
     return versions.filter { version in
         let title = (version.title ?? "").lowercased()
         let abbr = (version.abbreviation ?? String(version.id)).lowercased()
-        let lang = version.languageTag ?? ""
+        let lang = (version.languageTag ?? "").lowercased()
         return title.contains(query) || abbr.contains(query) || lang.contains(query)
     }
 }

--- a/Sources/YouVersionPlatformUI/Utilities/BibleVersionSearchFilter.swift
+++ b/Sources/YouVersionPlatformUI/Utilities/BibleVersionSearchFilter.swift
@@ -4,11 +4,12 @@ func filteredBibleVersions(_ versions: [BibleVersion], matching searchText: Stri
     guard !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
         return versions
     }
-    let query = searchText.lowercased()
     return versions.filter { version in
-        let title = (version.title ?? "").lowercased()
-        let abbr = (version.abbreviation ?? String(version.id)).lowercased()
-        let lang = (version.languageTag ?? "").lowercased()
-        return title.contains(query) || abbr.contains(query) || lang.contains(query)
+        let title = version.title ?? ""
+        let abbr = version.abbreviation ?? String(version.id)
+        let lang = version.languageTag ?? ""
+        return title.localizedCaseInsensitiveContains(searchText) ||
+            abbr.localizedCaseInsensitiveContains(searchText) ||
+            lang.localizedCaseInsensitiveContains(searchText)
     }
 }

--- a/Sources/YouVersionPlatformUI/Utilities/LanguageTagSorter.swift
+++ b/Sources/YouVersionPlatformUI/Utilities/LanguageTagSorter.swift
@@ -6,8 +6,8 @@ func sortedUniqueLanguageTags(_ tags: [String], languageName: (String) -> String
     }
 }
 
-func filterLanguageTags(_ tags: [String], matching searchText: String, languageName: (String) -> String) -> [String] {
-    guard !searchText.isEmpty else {
+func filteredLanguageTags(_ tags: [String], matching searchText: String, languageName: (String) -> String) -> [String] {
+    guard !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
         return tags
     }
     return tags.filter {

--- a/Sources/YouVersionPlatformUI/Utilities/LanguageTagSorter.swift
+++ b/Sources/YouVersionPlatformUI/Utilities/LanguageTagSorter.swift
@@ -7,11 +7,12 @@ func sortedUniqueLanguageTags(_ tags: [String], languageName: (String) -> String
 }
 
 func filteredLanguageTags(_ tags: [String], matching searchText: String, languageName: (String) -> String) -> [String] {
-    guard !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+    let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !query.isEmpty else {
         return tags
     }
     return tags.filter {
-        $0.localizedCaseInsensitiveContains(searchText) ||
-        languageName($0).localizedCaseInsensitiveContains(searchText)
+        $0.localizedCaseInsensitiveContains(query) ||
+        languageName($0).localizedCaseInsensitiveContains(query)
     }
 }

--- a/Sources/YouVersionPlatformUI/Utilities/LanguageTagSorter.swift
+++ b/Sources/YouVersionPlatformUI/Utilities/LanguageTagSorter.swift
@@ -1,0 +1,17 @@
+func sortedUniqueLanguageTags(_ tags: [String], languageName: (String) -> String) -> [String] {
+    let unique = Array(Set(tags))
+    let names = Dictionary(uniqueKeysWithValues: unique.map { ($0, languageName($0)) })
+    return unique.sorted {
+        names[$0, default: $0].localizedCaseInsensitiveCompare(names[$1, default: $1]) == .orderedAscending
+    }
+}
+
+func filterLanguageTags(_ tags: [String], matching searchText: String, languageName: (String) -> String) -> [String] {
+    guard !searchText.isEmpty else {
+        return tags
+    }
+    return tags.filter {
+        $0.localizedCaseInsensitiveContains(searchText) ||
+        languageName($0).localizedCaseInsensitiveContains(searchText)
+    }
+}

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsLanguagesView.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsLanguagesView.swift
@@ -135,7 +135,7 @@ struct BibleVersionsLanguagesView: View {
         case .all:
             return sortedUniqueLanguageTags(availableLanguageTags, languageName: viewModel.languageName)
         case .searching:
-            let filtered = filterLanguageTags(availableLanguageTags, matching: searchText, languageName: viewModel.languageName)
+            let filtered = filteredLanguageTags(availableLanguageTags, matching: searchText, languageName: viewModel.languageName)
             return sortedUniqueLanguageTags(filtered, languageName: viewModel.languageName)
         }
     }

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsLanguagesView.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsLanguagesView.swift
@@ -133,22 +133,10 @@ struct BibleVersionsLanguagesView: View {
         case .suggested:
             return viewModel.suggestedLanguageTags
         case .all:
-            return sortedUniqueLanguageTags(availableLanguageTags)
+            return sortedUniqueLanguageTags(availableLanguageTags, languageName: viewModel.languageName)
         case .searching:
-            return sortedUniqueLanguageTags(availableLanguageTags.filter {
-                searchText.isEmpty ||
-                $0.localizedCaseInsensitiveContains(searchText) ||
-                viewModel.languageName($0).localizedCaseInsensitiveContains(searchText)
-            })
-        }
-    }
-
-    // De-dup + locale-aware, case-insensitive sort
-    private func sortedUniqueLanguageTags(_ items: [String]) -> [String] {
-        let unique = Array(Set(items))
-        let names = Dictionary(uniqueKeysWithValues: unique.map { ($0, viewModel.languageName($0)) })
-        return unique.sorted {
-            names[$0, default: $0].localizedCaseInsensitiveCompare(names[$1, default: $1]) == .orderedAscending
+            let filtered = filterLanguageTags(availableLanguageTags, matching: searchText, languageName: viewModel.languageName)
+            return sortedUniqueLanguageTags(filtered, languageName: viewModel.languageName)
         }
     }
 }

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift
@@ -115,20 +115,7 @@ public struct BibleVersionsListView: View {
         guard let versions = viewModel.versionsByLanguageTag[language] else {
             return nil
         }
-
-        guard !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return versions
-        }
-        let query = searchText.lowercased()
-        return versions.filter { version in
-            guard version.languageTag == language else {
-                return false
-            }
-            let title = (version.title ?? "").lowercased()
-            let abbr = (version.abbreviation ?? String(version.id)).lowercased()
-            let lang = (version.languageTag ?? "")
-            return title.contains(query) || abbr.contains(query) || lang.contains(query)
-        }
+        return filterBibleVersions(versions, matching: searchText)
     }
 
 }

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift
@@ -115,7 +115,7 @@ public struct BibleVersionsListView: View {
         guard let versions = viewModel.versionsByLanguageTag[language] else {
             return nil
         }
-        return filterBibleVersions(versions, matching: searchText)
+        return filteredBibleVersions(versions, matching: searchText)
     }
 
 }

--- a/Tests/YouVersionPlatformUITests/BibleVersionSearchFilterTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionSearchFilterTests.swift
@@ -1,0 +1,91 @@
+import Testing
+@testable import YouVersionPlatformCore
+@testable import YouVersionPlatformUI
+
+@Suite struct BibleVersionSearchFilterTests {
+    @Test func emptyQueryReturnsAll() {
+        let versions = [
+            makeVersion(id: 1, title: "English Standard Version", abbreviation: "ESV", languageTag: "en"),
+            makeVersion(id: 2, title: "Nueva Versión Internacional", abbreviation: "NVI", languageTag: "es"),
+        ]
+        #expect(filterBibleVersions(versions, matching: "") == versions)
+    }
+
+    @Test func whitespaceOnlyQueryReturnsAll() {
+        let versions = [makeVersion(id: 1, title: "King James Version", abbreviation: "KJV", languageTag: "en")]
+        #expect(filterBibleVersions(versions, matching: "   \t\n") == versions)
+    }
+
+    @Test func matchesTitleCaseInsensitively() {
+        let kjv = makeVersion(id: 1, title: "King James Version", abbreviation: "KJV", languageTag: "en")
+        let esv = makeVersion(id: 2, title: "English Standard Version", abbreviation: "ESV", languageTag: "en")
+
+        #expect(filterBibleVersions([kjv, esv], matching: "king") == [kjv])
+        #expect(filterBibleVersions([kjv, esv], matching: "KING") == [kjv])
+        #expect(filterBibleVersions([kjv, esv], matching: "standard") == [esv])
+    }
+
+    @Test func matchesAbbreviationCaseInsensitively() {
+        let kjv = makeVersion(id: 1, title: "King James Version", abbreviation: "KJV", languageTag: "en")
+        let nvi = makeVersion(id: 2, title: "Nueva Versión Internacional", abbreviation: "NVI", languageTag: "es")
+
+        #expect(filterBibleVersions([kjv, nvi], matching: "kjv") == [kjv])
+        #expect(filterBibleVersions([kjv, nvi], matching: "KJV") == [kjv])
+        #expect(filterBibleVersions([kjv, nvi], matching: "nvi") == [nvi])
+    }
+
+    @Test func matchesLanguageTag() {
+        let english = makeVersion(id: 1, title: "Bible", abbreviation: "BIB", languageTag: "en")
+        let spanish = makeVersion(id: 2, title: "Biblia", abbreviation: "BIB", languageTag: "es")
+
+        #expect(filterBibleVersions([english, spanish], matching: "en") == [english])
+        #expect(filterBibleVersions([english, spanish], matching: "es") == [spanish])
+    }
+
+    @Test func nilTitleMatchedAsEmpty() {
+        let version = makeVersion(id: 1, title: nil, abbreviation: "TST", languageTag: "en")
+        #expect(filterBibleVersions([version], matching: "tst") == [version])
+        #expect(filterBibleVersions([version], matching: "anything").isEmpty)
+    }
+
+    @Test func nilAbbreviationFallsBackToVersionId() {
+        let version = makeVersion(id: 1234, title: "Test Version", abbreviation: nil, languageTag: "en")
+        #expect(filterBibleVersions([version], matching: "1234") == [version])
+    }
+
+    @Test func noMatchReturnsEmpty() {
+        let versions = [makeVersion(id: 1, title: "King James Version", abbreviation: "KJV", languageTag: "en")]
+        #expect(filterBibleVersions(versions, matching: "xyz").isEmpty)
+    }
+
+    @Test func queryMatchingMultipleFieldsIncludesVersionOnce() {
+        // title and abbreviation both contain "test" — version should appear once
+        let version = makeVersion(id: 1, title: "Test Bible", abbreviation: "TEST", languageTag: "en")
+        #expect(filterBibleVersions([version], matching: "test") == [version])
+    }
+
+    @Test func emptyVersionListReturnsEmpty() {
+        #expect(filterBibleVersions([], matching: "anything").isEmpty)
+    }
+
+    // MARK: -
+
+    private func makeVersion(id: Int, title: String?, abbreviation: String?, languageTag: String?) -> BibleVersion {
+        BibleVersion(
+            id: id,
+            abbreviation: abbreviation,
+            promotionalContent: nil,
+            copyright: nil,
+            languageTag: languageTag,
+            localizedAbbreviation: nil,
+            localizedTitle: nil,
+            readerFooter: nil,
+            readerFooterUrl: nil,
+            title: title,
+            organizationId: nil,
+            bookCodes: nil,
+            books: nil,
+            textDirection: nil
+        )
+    }
+}

--- a/Tests/YouVersionPlatformUITests/BibleVersionSearchFilterTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionSearchFilterTests.swift
@@ -8,30 +8,30 @@ import Testing
             makeVersion(id: 1, title: "English Standard Version", abbreviation: "ESV", languageTag: "en"),
             makeVersion(id: 2, title: "Nueva Versión Internacional", abbreviation: "NVI", languageTag: "es"),
         ]
-        #expect(filterBibleVersions(versions, matching: "") == versions)
+        #expect(filteredBibleVersions(versions, matching: "") == versions)
     }
 
     @Test func whitespaceOnlyQueryReturnsAll() {
         let versions = [makeVersion(id: 1, title: "King James Version", abbreviation: "KJV", languageTag: "en")]
-        #expect(filterBibleVersions(versions, matching: "   \t\n") == versions)
+        #expect(filteredBibleVersions(versions, matching: "   \t\n") == versions)
     }
 
     @Test func matchesTitleCaseInsensitively() {
         let kjv = makeVersion(id: 1, title: "King James Version", abbreviation: "KJV", languageTag: "en")
         let esv = makeVersion(id: 2, title: "English Standard Version", abbreviation: "ESV", languageTag: "en")
 
-        #expect(filterBibleVersions([kjv, esv], matching: "king") == [kjv])
-        #expect(filterBibleVersions([kjv, esv], matching: "KING") == [kjv])
-        #expect(filterBibleVersions([kjv, esv], matching: "standard") == [esv])
+        #expect(filteredBibleVersions([kjv, esv], matching: "king") == [kjv])
+        #expect(filteredBibleVersions([kjv, esv], matching: "KING") == [kjv])
+        #expect(filteredBibleVersions([kjv, esv], matching: "standard") == [esv])
     }
 
     @Test func matchesAbbreviationCaseInsensitively() {
         let kjv = makeVersion(id: 1, title: "King James Version", abbreviation: "KJV", languageTag: "en")
         let nvi = makeVersion(id: 2, title: "Nueva Versión Internacional", abbreviation: "NVI", languageTag: "es")
 
-        #expect(filterBibleVersions([kjv, nvi], matching: "kjv") == [kjv])
-        #expect(filterBibleVersions([kjv, nvi], matching: "KJV") == [kjv])
-        #expect(filterBibleVersions([kjv, nvi], matching: "nvi") == [nvi])
+        #expect(filteredBibleVersions([kjv, nvi], matching: "kjv") == [kjv])
+        #expect(filteredBibleVersions([kjv, nvi], matching: "KJV") == [kjv])
+        #expect(filteredBibleVersions([kjv, nvi], matching: "nvi") == [nvi])
     }
 
     @Test func matchesLanguageTagCaseInsensitively() {
@@ -39,36 +39,36 @@ import Testing
         let spanish = makeVersion(id: 2, title: "Biblia", abbreviation: "BIB", languageTag: "es")
         let chineseTraditional = makeVersion(id: 3, title: "聖經", abbreviation: "CT", languageTag: "zh-TW")
 
-        #expect(filterBibleVersions([english, spanish], matching: "en") == [english])
-        #expect(filterBibleVersions([english, spanish], matching: "es") == [spanish])
+        #expect(filteredBibleVersions([english, spanish], matching: "en") == [english])
+        #expect(filteredBibleVersions([english, spanish], matching: "es") == [spanish])
         // Mixed-case tag: searching "TW" lowercases to "tw", must still match "zh-TW"
-        #expect(filterBibleVersions([english, chineseTraditional], matching: "TW") == [chineseTraditional])
+        #expect(filteredBibleVersions([english, chineseTraditional], matching: "TW") == [chineseTraditional])
     }
 
     @Test func nilTitleMatchedAsEmpty() {
         let version = makeVersion(id: 1, title: nil, abbreviation: "TST", languageTag: "en")
-        #expect(filterBibleVersions([version], matching: "tst") == [version])
-        #expect(filterBibleVersions([version], matching: "anything").isEmpty)
+        #expect(filteredBibleVersions([version], matching: "tst") == [version])
+        #expect(filteredBibleVersions([version], matching: "anything").isEmpty)
     }
 
     @Test func nilAbbreviationFallsBackToVersionId() {
         let version = makeVersion(id: 1234, title: "Test Version", abbreviation: nil, languageTag: "en")
-        #expect(filterBibleVersions([version], matching: "1234") == [version])
+        #expect(filteredBibleVersions([version], matching: "1234") == [version])
     }
 
     @Test func noMatchReturnsEmpty() {
         let versions = [makeVersion(id: 1, title: "King James Version", abbreviation: "KJV", languageTag: "en")]
-        #expect(filterBibleVersions(versions, matching: "xyz").isEmpty)
+        #expect(filteredBibleVersions(versions, matching: "xyz").isEmpty)
     }
 
     @Test func queryMatchingMultipleFieldsIncludesVersionOnce() {
         // title and abbreviation both contain "test" — version should appear once
         let version = makeVersion(id: 1, title: "Test Bible", abbreviation: "TEST", languageTag: "en")
-        #expect(filterBibleVersions([version], matching: "test") == [version])
+        #expect(filteredBibleVersions([version], matching: "test") == [version])
     }
 
     @Test func emptyVersionListReturnsEmpty() {
-        #expect(filterBibleVersions([], matching: "anything").isEmpty)
+        #expect(filteredBibleVersions([], matching: "anything").isEmpty)
     }
 
     // MARK: -

--- a/Tests/YouVersionPlatformUITests/BibleVersionSearchFilterTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionSearchFilterTests.swift
@@ -34,12 +34,15 @@ import Testing
         #expect(filterBibleVersions([kjv, nvi], matching: "nvi") == [nvi])
     }
 
-    @Test func matchesLanguageTag() {
+    @Test func matchesLanguageTagCaseInsensitively() {
         let english = makeVersion(id: 1, title: "Bible", abbreviation: "BIB", languageTag: "en")
         let spanish = makeVersion(id: 2, title: "Biblia", abbreviation: "BIB", languageTag: "es")
+        let chineseTraditional = makeVersion(id: 3, title: "聖經", abbreviation: "CT", languageTag: "zh-TW")
 
         #expect(filterBibleVersions([english, spanish], matching: "en") == [english])
         #expect(filterBibleVersions([english, spanish], matching: "es") == [spanish])
+        // Mixed-case tag: searching "TW" lowercases to "tw", must still match "zh-TW"
+        #expect(filterBibleVersions([english, chineseTraditional], matching: "TW") == [chineseTraditional])
     }
 
     @Test func nilTitleMatchedAsEmpty() {

--- a/Tests/YouVersionPlatformUITests/BibleVersionSearchFilterTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionSearchFilterTests.swift
@@ -16,6 +16,12 @@ import Testing
         #expect(filteredBibleVersions(versions, matching: "   \t\n") == versions)
     }
 
+    @Test func queryWithSurroundingSpacesMatchesAsIfTrimmed() {
+        let kjv = makeVersion(id: 1, title: "King James Version", abbreviation: "KJV", languageTag: "en")
+        let esv = makeVersion(id: 2, title: "English Standard Version", abbreviation: "ESV", languageTag: "en")
+        #expect(filteredBibleVersions([kjv, esv], matching: " king ") == [kjv])
+    }
+
     @Test func matchesTitleCaseInsensitively() {
         let kjv = makeVersion(id: 1, title: "King James Version", abbreviation: "KJV", languageTag: "en")
         let esv = makeVersion(id: 2, title: "English Standard Version", abbreviation: "ESV", languageTag: "en")

--- a/Tests/YouVersionPlatformUITests/LanguageTagSorterTests.swift
+++ b/Tests/YouVersionPlatformUITests/LanguageTagSorterTests.swift
@@ -56,6 +56,12 @@ import Testing
         #expect(filteredLanguageTags(tags, matching: "   \t\n", languageName: { $0 }) == tags)
     }
 
+    @Test func queryWithSurroundingSpacesMatchesAsIfTrimmed() {
+        let tags = ["en", "es", "fr"]
+        let names = ["en": "English", "es": "Español", "fr": "French"]
+        #expect(filteredLanguageTags(tags, matching: " French ", languageName: { names[$0] ?? $0 }) == ["fr"])
+    }
+
     @Test func matchesTagCaseInsensitively() {
         let tags = ["en", "zh-TW", "ar"]
         let names = ["en": "English", "zh-TW": "Chinese Traditional", "ar": "Arabic"]

--- a/Tests/YouVersionPlatformUITests/LanguageTagSorterTests.swift
+++ b/Tests/YouVersionPlatformUITests/LanguageTagSorterTests.swift
@@ -1,0 +1,86 @@
+import Testing
+@testable import YouVersionPlatformUI
+
+@Suite struct LanguageTagSorterTests {
+    // MARK: - sortedUniqueLanguageTags
+
+    @Test func emptyInputReturnsEmpty() {
+        #expect(sortedUniqueLanguageTags([], languageName: { $0 }).isEmpty)
+    }
+
+    @Test func singleTagReturnsSingleTag() {
+        #expect(sortedUniqueLanguageTags(["en"], languageName: { _ in "English" }) == ["en"])
+    }
+
+    @Test func deduplicatesDuplicateTags() {
+        let result = sortedUniqueLanguageTags(["en", "en", "es"], languageName: { $0 })
+        #expect(result.count == 2)
+        #expect(Set(result) == Set(["en", "es"]))
+    }
+
+    @Test func sortsByDisplayName() {
+        let names = ["en": "English", "fr": "French", "ar": "Arabic"]
+        let result = sortedUniqueLanguageTags(["en", "fr", "ar"], languageName: { names[$0] ?? $0 })
+        #expect(result == ["ar", "en", "fr"])
+    }
+
+    @Test func sortIsCaseInsensitive() {
+        let names = ["a": "Zebra", "b": "apple", "c": "Mango"]
+        let result = sortedUniqueLanguageTags(["a", "b", "c"], languageName: { names[$0] ?? $0 })
+        // localizedCaseInsensitiveCompare: apple < Mango < Zebra
+        #expect(result == ["b", "c", "a"])
+    }
+
+    @Test func deduplicatesBeforeSorting() {
+        // Three copies of "en", one of "fr" — dedup should leave two unique tags
+        let names = ["en": "English", "fr": "French"]
+        let result = sortedUniqueLanguageTags(["en", "en", "fr", "en"], languageName: { names[$0] ?? $0 })
+        #expect(result == ["en", "fr"])
+    }
+
+    @Test func fallsBackToTagWhenNameReturnsItself() {
+        // languageName returns the tag — sort should use the tag string itself
+        let result = sortedUniqueLanguageTags(["zh", "en", "ar"], languageName: { $0 })
+        #expect(result == ["ar", "en", "zh"])
+    }
+
+    // MARK: - filterLanguageTags
+
+    @Test func emptySearchReturnsAllTags() {
+        let tags = ["en", "es", "fr"]
+        #expect(filterLanguageTags(tags, matching: "", languageName: { $0 }) == tags)
+    }
+
+    @Test func matchesTagCaseInsensitively() {
+        let tags = ["en", "zh-TW", "ar"]
+        let names = ["en": "English", "zh-TW": "Chinese Traditional", "ar": "Arabic"]
+        let name: (String) -> String = { names[$0] ?? $0 }
+
+        #expect(filterLanguageTags(tags, matching: "EN", languageName: name) == ["en"])
+        #expect(filterLanguageTags(tags, matching: "zh", languageName: name) == ["zh-TW"])
+    }
+
+    @Test func matchesDisplayNameCaseInsensitively() {
+        let tags = ["en", "es", "fr"]
+        let names = ["en": "English", "es": "Español", "fr": "French"]
+        let name: (String) -> String = { names[$0] ?? $0 }
+
+        #expect(filterLanguageTags(tags, matching: "french", languageName: name) == ["fr"])
+        #expect(filterLanguageTags(tags, matching: "ENGLISH", languageName: name) == ["en"])
+    }
+
+    @Test func noMatchReturnsEmpty() {
+        let tags = ["en", "es", "fr"]
+        #expect(filterLanguageTags(tags, matching: "xyz", languageName: { $0 }).isEmpty)
+    }
+
+    @Test func queryMatchingAllTagsReturnsAll() {
+        let tags = ["en-US", "en-GB", "en-AU"]
+        let result = filterLanguageTags(tags, matching: "en", languageName: { $0 })
+        #expect(result == tags)
+    }
+
+    @Test func emptyTagListReturnsEmpty() {
+        #expect(filterLanguageTags([], matching: "en", languageName: { $0 }).isEmpty)
+    }
+}

--- a/Tests/YouVersionPlatformUITests/LanguageTagSorterTests.swift
+++ b/Tests/YouVersionPlatformUITests/LanguageTagSorterTests.swift
@@ -48,7 +48,12 @@ import Testing
 
     @Test func emptySearchReturnsAllTags() {
         let tags = ["en", "es", "fr"]
-        #expect(filterLanguageTags(tags, matching: "", languageName: { $0 }) == tags)
+        #expect(filteredLanguageTags(tags, matching: "", languageName: { $0 }) == tags)
+    }
+
+    @Test func whitespaceOnlySearchReturnsAllTags() {
+        let tags = ["en", "es", "fr"]
+        #expect(filteredLanguageTags(tags, matching: "   \t\n", languageName: { $0 }) == tags)
     }
 
     @Test func matchesTagCaseInsensitively() {
@@ -56,8 +61,8 @@ import Testing
         let names = ["en": "English", "zh-TW": "Chinese Traditional", "ar": "Arabic"]
         let name: (String) -> String = { names[$0] ?? $0 }
 
-        #expect(filterLanguageTags(tags, matching: "EN", languageName: name) == ["en"])
-        #expect(filterLanguageTags(tags, matching: "zh", languageName: name) == ["zh-TW"])
+        #expect(filteredLanguageTags(tags, matching: "EN", languageName: name) == ["en"])
+        #expect(filteredLanguageTags(tags, matching: "zh", languageName: name) == ["zh-TW"])
     }
 
     @Test func matchesDisplayNameCaseInsensitively() {
@@ -65,22 +70,22 @@ import Testing
         let names = ["en": "English", "es": "Español", "fr": "French"]
         let name: (String) -> String = { names[$0] ?? $0 }
 
-        #expect(filterLanguageTags(tags, matching: "french", languageName: name) == ["fr"])
-        #expect(filterLanguageTags(tags, matching: "ENGLISH", languageName: name) == ["en"])
+        #expect(filteredLanguageTags(tags, matching: "french", languageName: name) == ["fr"])
+        #expect(filteredLanguageTags(tags, matching: "ENGLISH", languageName: name) == ["en"])
     }
 
     @Test func noMatchReturnsEmpty() {
         let tags = ["en", "es", "fr"]
-        #expect(filterLanguageTags(tags, matching: "xyz", languageName: { $0 }).isEmpty)
+        #expect(filteredLanguageTags(tags, matching: "xyz", languageName: { $0 }).isEmpty)
     }
 
     @Test func queryMatchingAllTagsReturnsAll() {
         let tags = ["en-US", "en-GB", "en-AU"]
-        let result = filterLanguageTags(tags, matching: "en", languageName: { $0 })
+        let result = filteredLanguageTags(tags, matching: "en", languageName: { $0 })
         #expect(result == tags)
     }
 
     @Test func emptyTagListReturnsEmpty() {
-        #expect(filterLanguageTags([], matching: "en", languageName: { $0 }).isEmpty)
+        #expect(filteredLanguageTags([], matching: "en", languageName: { $0 }).isEmpty)
     }
 }


### PR DESCRIPTION
test: extract and test version search filter and language tag sorting

## Description

Pull search filter logic out of BibleVersionsListView and sort/dedup logic out of BibleVersionsLanguagesView into standalone functions (BibleVersionSearchFilter.swift, LanguageTagSorter.swift), then add unit tests covering empty queries, case-insensitive matching, nil fallbacks, deduplication, and locale-aware sort.


## Type of Change

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [ ] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [x] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [x] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the version search filter logic from `BibleVersionsListView` and the language-tag sort/dedup logic from `BibleVersionsLanguagesView` into two standalone utility files (`BibleVersionSearchFilter.swift`, `LanguageTagSorter.swift`), then adds thorough unit tests for both.

- **`filteredBibleVersions`** — trims the query, guards on empty, and uses `localizedCaseInsensitiveContains` across title, abbreviation, and language tag; covered by 10 test cases including nil fields, whitespace-only queries, and trimmed-query matching.
- **`sortedUniqueLanguageTags` / `filteredLanguageTags`** — extract dedup + locale-aware sort and tag filtering from the view, injecting `languageName` as a closure for testability; covered by 13 test cases including deduplication, case-insensitive matching, and mixed-case tags like `"zh-TW"`.
- Both call sites in the views are simplified to single-line delegations, and the behavioral fixes previously identified (case-sensitive `lang` comparison, discarded trimmed query, missing whitespace trim in `filteredLanguageTags`) are all resolved in this revision.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a pure refactor that extracts view-internal logic into well-tested standalone functions without changing observable behavior.

All three utility functions are tested end-to-end for the cases that previously contained bugs (case-sensitive lang matching, discarded trimmed query, missing whitespace trim). The view call sites are simplified to single delegations and the redundant languageTag guard in BibleVersionsListView is correctly dropped since versions are already scoped by the dictionary lookup. No logic has been altered beyond fixing the pre-existing issues.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformUI/Utilities/BibleVersionSearchFilter.swift | New utility function; correctly trims query, uses localizedCaseInsensitiveContains for all three fields, nil-safe fallbacks. Missing DocC comment (previously flagged). |
| Sources/YouVersionPlatformUI/Utilities/LanguageTagSorter.swift | Two new utility functions; dedup via Set + locale-aware sort, and a filter that trims whitespace before guarding. Missing DocC comments (previously flagged). |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsLanguagesView.swift | Cleanly delegates to filteredLanguageTags + sortedUniqueLanguageTags; private helper removed. Behavior-preserving refactor. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift | Replaces inline filter (which had a stale case-sensitivity bug) with a call to filteredBibleVersions. Redundant languageTag guard correctly dropped — versions are already scoped by the dictionary lookup. |
| Tests/YouVersionPlatformUITests/BibleVersionSearchFilterTests.swift | Comprehensive coverage: empty query, whitespace-only, trimmed-space matching, case-insensitive title/abbr/lang, nil fields, id fallback, no-match, multi-field overlap, empty list. |
| Tests/YouVersionPlatformUITests/LanguageTagSorterTests.swift | Thorough coverage of both functions: empty input, single tag, dedup, locale sort, case-insensitive compare, whitespace-only query, trimmed-space matching, mixed-case tags. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BibleVersionsListView] -->|versions from versionsByLanguageTag| B[filteredBibleVersions]
    B -->|trim + guard empty| C{query empty?}
    C -->|yes| D[return all versions]
    C -->|no| E[filter by title / abbreviation / languageTag using localizedCaseInsensitiveContains]

    F[BibleVersionsLanguagesView] -->|.all case| G[sortedUniqueLanguageTags]
    F -->|.searching case| H[filteredLanguageTags]
    H -->|trim + guard empty| I{query empty?}
    I -->|yes| J[return all tags]
    I -->|no| K[filter by tag + languageName using localizedCaseInsensitiveContains]
    K --> G
    G -->|Set dedup + locale sort| L[sorted unique tags]
```

<sub>Reviews (8): Last reviewed commit: ["Merge branch &#39;main&#39; into claude/version-..."](https://github.com/youversion/platform-sdk-swift/commit/fef914e6c4d6bc781f9f8e6a7a4cd23d4eefd588) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31065148)</sub>

<!-- /greptile_comment -->