### PR TITLE
test: update BibleVersionsViewModel deprecation coverage

### DIFF
--- a/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
@@ -62,13 +62,14 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
 @Suite struct BibleVersionsViewModelTests {
     @Test
     func initUsesSharedRepositoryByDefault() {
-        let viewModel = BibleVersionsViewModel { _ in }
+        let viewModel = BibleVersionsViewModel()
 
         #expect(viewModel.versionRepository is BibleVersionRepository)
     }
 
+    @available(*, deprecated, message: "Exercises the deprecated callback initializer for backwards compatibility.")
     @Test
-    func switchToVersionUsesInjectedRepository() async {
+    func deprecatedOnVersionChangeCallbackIsInvokedWhenVersionChanges() async {
         let repository = MockBibleVersionRepository()
         let version = makeBibleVersion(id: 111)
         await repository.setVersion(version)
@@ -81,6 +82,18 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
         await viewModel.switchToVersion(version.id)
 
         #expect(changedVersion == version)
+    }
+
+    @Test
+    func switchToVersionUsesInjectedRepository() async {
+        let repository = MockBibleVersionRepository()
+        let version = makeBibleVersion(id: 112)
+        await repository.setVersion(version)
+        let viewModel = BibleVersionsViewModel(versionRepository: repository)
+
+        await viewModel.switchToVersion(version.id)
+
+        #expect(viewModel.currentVersion == version)
         #expect(viewModel.showGenericAlert == false)
     }
 
@@ -88,10 +101,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
     func switchToVersionShowsAlertWhenRepositoryThrows() async {
         let repository = MockBibleVersionRepository()
         await repository.setThrownError(NSError(domain: "BibleVersionsViewModelTests", code: 99))
-        let viewModel = BibleVersionsViewModel(
-            onVersionChange: { _ in Issue.record("onVersionChange should not be called") },
-            versionRepository: repository
-        )
+        let viewModel = BibleVersionsViewModel(versionRepository: repository)
 
         await viewModel.switchToVersion(111)
 
@@ -105,10 +115,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
         let repository = MockBibleVersionRepository()
         let version = makeBibleVersion(id: 222)
         await repository.setVersion(version)
-        let viewModel = BibleVersionsViewModel(
-            onVersionChange: { _ in },
-            versionRepository: repository
-        )
+        let viewModel = BibleVersionsViewModel(versionRepository: repository)
 
         await viewModel.handleVersionPickerTap(version.id)
 
@@ -123,10 +130,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
         let repository = MockBibleVersionRepository()
         let version = makeBibleVersion(id: 333)
         await repository.setVersion(version)
-        let viewModel = BibleVersionsViewModel(
-            onVersionChange: { _ in },
-            versionRepository: repository
-        )
+        let viewModel = BibleVersionsViewModel(versionRepository: repository)
 
         await viewModel.myVersionMoreInfoMenuTapped(version.id)
 
@@ -138,10 +142,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
     @Test
     func myVersionDownloadMenuTappedShowsAlertWhenRepositoryCannotLoadVersion() async {
         let repository = MockBibleVersionRepository()
-        let viewModel = BibleVersionsViewModel(
-            onVersionChange: { _ in Issue.record("onVersionChange should not be called") },
-            versionRepository: repository
-        )
+        let viewModel = BibleVersionsViewModel(versionRepository: repository)
 
         await viewModel.myVersionDownloadMenuTapped(444)
 


### PR DESCRIPTION
## Description

test: improve BibleVersionsViewModel deprecation coverage, silence warnings

## Type of Change

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [ ] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [x] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves test coverage for `BibleVersionsViewModel` by migrating existing tests off the deprecated `onVersionChange` callback initializer and adding a dedicated test to verify the deprecated path still works correctly. The strategy of annotating the legacy-path test with `@available(*, deprecated, message:)` is the right Swift idiom for exercising deprecated APIs without introducing compiler noise across the rest of the suite.

- All tests that don't specifically exercise the deprecated callback now use `BibleVersionsViewModel(versionRepository:)`, making the preferred API the default in tests.
- The former `switchToVersionUsesInjectedRepository` test is split into two: one that asserts the deprecated callback fires correctly (annotated `@available(*, deprecated)`), and a new one that asserts `currentVersion` is set — which is a stronger and more direct assertion on the observable state the new API exposes.
- `switchToVersionShowsAlertWhenRepositoryThrows` and similar tests drop the `onVersionChange:` parameter that was previously used as a sentinel; this is safe because `setCurrentVersion` (which fires the callback) is only called on the success path, so the sentinel assertion was never reachable from those error-path tests anyway.

<h3>Confidence Score: 5/5</h3>

Test-only change with no modifications to production code; all updated tests use the preferred non-deprecated initializer and the new deprecated-path test is correctly scoped and annotated.

Every changed line is inside the test target. The new deprecatedOnVersionChangeCallbackIsInvokedWhenVersionChanges test correctly exercises the legacy callback and is properly annotated to silence warnings. The switchToVersionUsesInjectedRepository rewrite asserts currentVersion directly, which is a stronger guarantee than the previous indirect callback check. No production logic is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift | Migrates all non-deprecation tests to the new init(versionRepository:) API, adds an @available(*, deprecated) annotated test specifically exercising the legacy callback initializer, and splits the old switchToVersionUsesInjectedRepository test into two focused tests with clearer assertions. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BibleVersionsViewModelTests] --> B[initUsesSharedRepositoryByDefault]
    A --> C[deprecatedOnVersionChangeCallbackIsInvokedWhenVersionChanges]
    A --> D[switchToVersionUsesInjectedRepository]
    A --> E[switchToVersionShowsAlertWhenRepositoryThrows]
    A --> F[handleVersionPickerTapLoadsSelectedVersionAndPushesInfoScreen]
    A --> G[myVersionMoreInfoMenuTappedUsesInjectedRepository]
    A --> H[myVersionDownloadMenuTappedShowsAlertWhenRepositoryCannotLoadVersion]
    B -->|BibleVersionsViewModel()| I[assert: versionRepository is BibleVersionRepository]
    C -->|@available deprecated - BibleVersionsViewModel(onVersionChange:versionRepository:)| J[assert: callback fired with correct version]
    D -->|BibleVersionsViewModel(versionRepository:)| K[assert: currentVersion == version - showGenericAlert == false]
    E -->|BibleVersionsViewModel(versionRepository:)| L[assert: showGenericAlert == true]
    F -->|BibleVersionsViewModel(versionRepository:)| M[assert: selectedVersion, versionsPickerStack]
    G -->|BibleVersionsViewModel(versionRepository:)| N[assert: selectedVersion, versionsPickerStack]
    H -->|BibleVersionsViewModel(versionRepository:)| O[assert: showGenericAlert == true]
    style C fill:#fff3cd,stroke:#ffc107
```

<sub>Reviews (1): Last reviewed commit: ["test: update BibleVersionsViewModel depr..."](https://github.com/youversion/platform-sdk-swift/commit/4c85f13603df46be271dc577704ab3507600a417) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31066910)</sub>

<!-- /greptile_comment -->