### PR TITLE
test: add OrganizationsAPI tests

### DIFF
--- a/Tests/YouVersionPlatformCoreTests/OrganizationsAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/OrganizationsAPITests.swift
@@ -1,0 +1,153 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+@testable import YouVersionPlatformCore
+
+@Suite(.serialized) struct OrganizationsAPITests {
+
+    @MainActor
+    @Test func organizationSuccessReturnsDecodedOrganization() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        let json = """
+        {
+            "id": "org-123",
+            "parent_organization_id": "org-000",
+            "name": "Test Church",
+            "description": "A test church",
+            "email": "test@church.org",
+            "phone": "+1-555-0100",
+            "primary_language": "en",
+            "website_url": "https://church.org",
+            "address": "123 Main St"
+        }
+        """.data(using: .utf8)!
+        var capturedRequest: URLRequest?
+
+        HTTPMocking.setHandler(token: token) { request in
+            capturedRequest = request
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (json, response)
+        }
+
+        let org = try await YouVersionAPI.Organizations.organization(id: "org-123", session: session)
+
+        #expect(org.id == "org-123")
+        #expect(org.parentOrganizationId == "org-000")
+        #expect(org.name == "Test Church")
+        #expect(org.description == "A test church")
+        #expect(org.email == "test@church.org")
+        #expect(org.phone == "+1-555-0100")
+        #expect(org.primaryLanguage == "en")
+        #expect(org.websiteUrl == "https://church.org")
+        #expect(org.address == "123 Main St")
+        let req = try #require(capturedRequest)
+        #expect(req.url?.absoluteString.contains("org-123") == true)
+    }
+
+    @MainActor
+    @Test func organizationSuccessWithNullableFieldsAbsent() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        let json = """
+        {"id": "org-456"}
+        """.data(using: .utf8)!
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (json, response)
+        }
+
+        let org = try await YouVersionAPI.Organizations.organization(id: "org-456", session: session)
+
+        #expect(org.id == "org-456")
+        #expect(org.parentOrganizationId == nil)
+        #expect(org.name == nil)
+        #expect(org.description == nil)
+        #expect(org.email == nil)
+        #expect(org.phone == nil)
+        #expect(org.primaryLanguage == nil)
+        #expect(org.websiteUrl == nil)
+        #expect(org.address == nil)
+    }
+
+    @MainActor
+    @Test func organizationUnauthorizedThrowsNotPermitted() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil)!
+            return (Data(), response)
+        }
+
+        await #expect(throws: YouVersionAPIError.notPermitted) {
+            _ = try await YouVersionAPI.Organizations.organization(id: "org-123", session: session)
+        }
+    }
+
+    @MainActor
+    @Test func organizationForbiddenThrowsNotPermitted() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 403, httpVersion: nil, headerFields: nil)!
+            return (Data(), response)
+        }
+
+        await #expect(throws: YouVersionAPIError.notPermitted) {
+            _ = try await YouVersionAPI.Organizations.organization(id: "org-123", session: session)
+        }
+    }
+
+    @MainActor
+    @Test func organizationServerErrorThrowsCannotDownload() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+            return (Data(), response)
+        }
+
+        await #expect(throws: YouVersionAPIError.cannotDownload) {
+            _ = try await YouVersionAPI.Organizations.organization(id: "org-123", session: session)
+        }
+    }
+
+    @MainActor
+    @Test func organizationInvalidResponseThrows() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = URLResponse(url: request.url!, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+            return (Data(), response)
+        }
+
+        await #expect(throws: YouVersionAPIError.invalidResponse) {
+            _ = try await YouVersionAPI.Organizations.organization(id: "org-123", session: session)
+        }
+    }
+
+    @MainActor
+    @Test func organizationMalformedJSONThrowsBadServerResponse() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        HTTPMocking.setHandler(token: token) { request in
+            let malformed = "{ bad json }".data(using: .utf8)!
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (malformed, response)
+        }
+
+        await #expect(throws: URLError.self) {
+            _ = try await YouVersionAPI.Organizations.organization(id: "org-123", session: session)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `OrganizationsAPITests.swift` with 7 tests covering `YouVersionAPI.Organizations.organization(id:session:)`
- Tests follow the same pattern as `BibleVersionsAPITests.swift` and the existing `VOTDTests.swift`

## Tests added

| Test | Coverage |
|---|---|
| `organizationSuccessReturnsDecodedOrganization` | Full decode of all fields; verifies URL contains the org ID |
| `organizationSuccessWithNullableFieldsAbsent` | Minimal JSON response — all optional fields decode to `nil` |
| `organizationUnauthorizedThrowsNotPermitted` | 401 → `.notPermitted` |
| `organizationForbiddenThrowsNotPermitted` | 403 → `.notPermitted` |
| `organizationServerErrorThrowsCannotDownload` | 500 → `.cannotDownload` |
| `organizationInvalidResponseThrows` | Non-HTTP `URLResponse` → `.invalidResponse` |
| `organizationMalformedJSONThrowsBadServerResponse` | Valid 200 with bad JSON → `URLError` |

## Notes

`VOTDTests.swift` already exists with equivalent coverage for the VOTD API, so no new VOTD test file was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `OrganizationsAPITests.swift`, a new test file with 7 tests covering `YouVersionAPI.Organizations.organization(id:session:)`. The tests are well-structured and closely follow the established patterns from `VOTDTests.swift` and `BibleVersionsAPITests.swift`.

- **Full decode test** verifies all 9 fields (including snake_case → camelCase mappings) and confirms the org ID appears in the request URL.
- **Nullable fields test** ensures a minimal `{\"id\": \"...\"}` response correctly decodes all optional fields to `nil`.
- **Error path tests** cover 401 → `.notPermitted`, 403 → `.notPermitted`, 500 → `.cannotDownload`, non-HTTP `URLResponse` → `.invalidResponse`, and malformed JSON → `URLError`, matching the behavior in `Organizations.swift`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — adds test coverage only, no production code changes.

The change is purely additive test code that exercises an already-merged API. All test cases align correctly with the implementation in Organizations.swift, the mocking setup and teardown patterns are consistent with the rest of the test suite, and no production paths are modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Tests/YouVersionPlatformCoreTests/OrganizationsAPITests.swift | New test file with 7 tests covering all major code paths of YouVersionAPI.Organizations.organization(id:session:), following established patterns from VOTDTests.swift and BibleVersionsAPITests.swift |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as OrganizationsAPITests
    participant Mock as HTTPMocking
    participant API as YouVersionAPI.Organizations
    participant Decoder as JSONDecoder

    Test->>Mock: makeSession() → (session, token)
    Test->>Mock: "setHandler(token:) { request → (data, response) }"
    Test->>API: organization(id:session:)
    API->>Mock: data(at:url, session:session)
    Mock-->>API: (Data, URLResponse)
    API->>API: check HTTPURLResponse status code
    alt 200 OK
        API->>Decoder: decode(Organization.self, from: data)
        Decoder-->>API: Organization / URLError(.badServerResponse)
        API-->>Test: Organization
    else 401 / 403
        API-->>Test: throw YouVersionAPIError.notPermitted
    else 5xx
        API-->>Test: throw YouVersionAPIError.cannotDownload
    else non-HTTP URLResponse
        API-->>Test: throw YouVersionAPIError.invalidResponse
    end
    Test->>Mock: clear(token:)
```

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into claude/crazy-el..."](https://github.com/youversion/platform-sdk-swift/commit/96579343269571fcbbcec46b2b5a3a87d65b1096) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31080973)</sub>

<!-- /greptile_comment -->