### PR TITLE
ci: add manual pod publish workflow for release recovery

### DIFF
--- a/.github/workflows/manual-pod-publish.yml
+++ b/.github/workflows/manual-pod-publish.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Publish pods to trunk
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        # Note: publish-pods.sh has CDN-propagation sleeps commented out.
+        # --synchronous waits for trunk acknowledgement but CDN indexing can
+        # lag; if dependent pushes fail, uncomment the sleep lines in the script.
         run: bash scripts/publish-pods.sh "${{ inputs.version }}"
 
       - name: Restore SDKVersion to Dev on main

--- a/.github/workflows/manual-pod-publish.yml
+++ b/.github/workflows/manual-pod-publish.yml
@@ -1,0 +1,108 @@
+name: Manual Pod Publish
+
+# Manual recovery workflow. Use when the normal `Release` pipeline produced a
+# tag and a chore(release) commit on main but failed before publishCmd ran, so
+# CocoaPods trunk never received the version. Checks out the tag, runs
+# pod trunk push for each podspec in dependency order, and (optionally) pushes
+# a Dev-restore commit Y on top of main so SDKVersion.swift reads "Dev"
+# between releases.
+#
+# Pre-conditions:
+# - Tag <version> exists on origin and points at a commit on main with
+#   podspecs and SDKVersion.swift already stamped to <version> (this is the
+#   state semantic-release leaves behind after @semantic-release/git but
+#   before publishCmd).
+# - The CocoaPods trunk session has a valid token in COCOAPODS_TRUNK_TOKEN.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag to publish (e.g. 5.1.0). Must already exist on origin."
+        required: true
+      restore_dev:
+        description: "Push a Dev-restore commit on top of main after publishing."
+        type: boolean
+        default: true
+
+env:
+  XCODE_VERSION: latest-stable
+
+jobs:
+  publish:
+    runs-on: macos-26
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: false
+
+      - name: Install CocoaPods
+        run: gem install cocoapods
+
+      - name: Checkout tag ${{ inputs.version }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
+          fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
+
+      - name: Verify checkout matches tag
+        run: |
+          EXPECTED_LINE="static let current = \"${{ inputs.version }}\""
+          if ! grep -qF "$EXPECTED_LINE" Sources/YouVersionPlatformCore/SDKVersion.swift; then
+            echo "❌ Checked-out commit does not have SDKVersion.swift stamped to ${{ inputs.version }}." >&2
+            grep "static let current" Sources/YouVersionPlatformCore/SDKVersion.swift >&2 || true
+            exit 1
+          fi
+          for PODSPEC in YouVersionPlatform.podspec YouVersionPlatformCore.podspec YouVersionPlatformReader.podspec YouVersionPlatformUI.podspec; do
+            if ! grep -qF "s.version      = '${{ inputs.version }}'" "$PODSPEC"; then
+              echo "❌ $PODSPEC is not stamped to ${{ inputs.version }}." >&2
+              grep "s.version" "$PODSPEC" >&2 || true
+              exit 1
+            fi
+          done
+          echo "✓ Checkout looks consistent with ${{ inputs.version }}."
+
+      - name: Verify scripts are executable
+        run: |
+          chmod +x scripts/publish-pods.sh
+          chmod +x scripts/stamp-sdk-version.sh
+
+      - name: Publish pods to trunk
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: bash scripts/publish-pods.sh ${{ inputs.version }}
+
+      - name: Restore SDKVersion to Dev on main
+        if: ${{ inputs.restore_dev }}
+        env:
+          GIT_AUTHOR_NAME: "github-actions[bot][release]"
+          GIT_AUTHOR_EMAIL: "github-actions[bot][release]@users.noreply.github.com"
+          GIT_COMMITTER_NAME: "github-actions[bot][release]"
+          GIT_COMMITTER_EMAIL: "github-actions[bot][release]@users.noreply.github.com"
+        run: |
+          set -e
+          git config user.name "github-actions[bot][release]"
+          git config user.email "github-actions[bot][release]@users.noreply.github.com"
+          git remote set-url origin git@github.com:youversion/platform-sdk-swift.git
+          git fetch origin main
+          git checkout -B main origin/main
+
+          # If main HEAD already reads "Dev", nothing to do (e.g. a later
+          # release already restored it). Skip rather than create an empty Y.
+          if grep -qF 'static let current = "Dev"' Sources/YouVersionPlatformCore/SDKVersion.swift; then
+            echo "SDKVersion already reads \"Dev\" on main; nothing to restore."
+            exit 0
+          fi
+
+          bash scripts/stamp-sdk-version.sh Dev
+          git add Sources/YouVersionPlatformCore/SDKVersion.swift
+          git commit -m "chore(release): restore SDKVersion to Dev after ${{ inputs.version }} [skip ci]"
+          # Plain push — fail loudly if anything else landed on main since we fetched.
+          git push origin HEAD:main

--- a/.github/workflows/manual-pod-publish.yml
+++ b/.github/workflows/manual-pod-publish.yml
@@ -28,6 +28,9 @@ on:
 env:
   XCODE_VERSION: latest-stable
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     runs-on: macos-26
@@ -77,7 +80,7 @@ jobs:
       - name: Publish pods to trunk
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: bash scripts/publish-pods.sh ${{ inputs.version }}
+        run: bash scripts/publish-pods.sh "${{ inputs.version }}"
 
       - name: Restore SDKVersion to Dev on main
         if: ${{ inputs.restore_dev }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/manual-pod-publish.yml` — a `workflow_dispatch` workflow that checks out a given version tag, publishes each podspec to CocoaPods trunk in dependency order, and (optionally) pushes a Dev-restore commit on top of main.
- Recovery path for the failure mode we hit repeatedly on 5.1.0: semantic-release ran `@semantic-release/git`'s commit-and-push (X lands on main) but failed before `publishCmd` (so CocoaPods trunk never got the version, and SDKVersion.swift on main is stuck at the released number instead of "Dev").
- Pre-flight in the workflow asserts the checked-out commit's `SDKVersion.swift` and all four podspecs already read the input version — same shape of safety check that lives in `restore-dev-sdk-on-main.sh`. Aborts loudly rather than publishing a mismatched build.

## Test plan
- [ ] Merge this PR on its own — commit type is `ci:` so semantic-release runs and exits with no release.
- [ ] Trigger `Manual Pod Publish` from the Actions tab with `version=5.1.0`, `restore_dev=true`.
- [ ] Verify each `pod trunk push` step succeeds and `pod trunk info YouVersionPlatform` shows 5.1.0.
- [ ] Verify a new `chore(release): restore SDKVersion to Dev after 5.1.0 [skip ci]` commit lands on main and `SDKVersion.swift` reads `"Dev"`.
- [ ] Confirm `[skip ci]` skipped a release run, and a subsequent unrelated push to main produces a clean `Release` workflow run that picks 5.1.0 as the previous version (no `tag already exists` collision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `workflow_dispatch` recovery workflow that checks out a release tag, publishes all four podspecs to CocoaPods trunk in dependency order, and optionally pushes a Dev-restore commit on top of main — filling the gap left when semantic-release fails after `@semantic-release/git` but before `publishCmd`.

- **Pre-flight checks** verify that both `SDKVersion.swift` and all four podspecs are already stamped to the input version before any trunk push is attempted, aborting loudly on mismatch.
- **Dependency-ordered publishing** (Core → UI → Reader → Platform) mirrors the normal release pipeline, with an inline note about the commented-out CDN-propagation sleeps in `publish-pods.sh`.
- **Dev-restore step** fetches the latest `origin/main`, idempotently skips if `SDKVersion` already reads `\"Dev\"`, and uses a plain (non-force) push to fail safely if a concurrent commit raced ahead.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a new workflow_dispatch workflow that only runs when manually triggered and has no effect on the automated release pipeline.

The workflow is well-guarded: pre-flight assertions abort before any trunk push if the checked-out state doesn't match the requested version, the trunk pushes are ordered by dependency, the Dev-restore is idempotent, and the final push is non-force so concurrent commits cause a loud failure rather than silent data loss.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/manual-pod-publish.yml | New manual recovery workflow for CocoaPods publishing. Pre-flight checks, dependency-ordered trunk pushes, and optional Dev-restore are all well-structured. No blocking issues; missing concurrency guard is the only notable gap. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fmanual-pod-publish.yml%3A17-28%0AAdding%20a%20%60concurrency%60%20group%20scoped%20to%20the%20version%20would%20prevent%20a%20second%20accidental%20trigger%20from%20racing%20against%20an%20in-progress%20run.%20Without%20it%2C%20a%20double-click%20in%20the%20UI%20could%20start%20two%20parallel%20jobs%3A%20one%20succeeds%20with%20trunk%20%28CocoaPods%20rejects%20the%20duplicate%20on%20the%20second%29%2C%20and%20both%20try%20to%20push%20the%20Dev-restore%20commit%20%E2%80%94%20leaving%20noisy%20failures%20and%20ambiguous%20state.%0A%0A%60%60%60suggestion%0Aon%3A%0A%20%20workflow_dispatch%3A%0A%20%20%20%20inputs%3A%0A%20%20%20%20%20%20version%3A%0A%20%20%20%20%20%20%20%20description%3A%20%22Version%20tag%20to%20publish%20%28e.g.%205.1.0%29.%20Must%20already%20exist%20on%20origin.%22%0A%20%20%20%20%20%20%20%20required%3A%20true%0A%20%20%20%20%20%20restore_dev%3A%0A%20%20%20%20%20%20%20%20description%3A%20%22Push%20a%20Dev-restore%20commit%20on%20top%20of%20main%20after%20publishing.%22%0A%20%20%20%20%20%20%20%20type%3A%20boolean%0A%20%20%20%20%20%20%20%20default%3A%20true%0A%0Aconcurrency%3A%0A%20%20group%3A%20manual-pod-publish-%24%7B%7B%20github.event.inputs.version%20%7D%7D%0A%20%20cancel-in-progress%3A%20false%0A%0Aenv%3A%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fmanual-pod-publish.yml%3A17-28%0AAdding%20a%20%60concurrency%60%20group%20scoped%20to%20the%20version%20would%20prevent%20a%20second%20accidental%20trigger%20from%20racing%20against%20an%20in-progress%20run.%20Without%20it%2C%20a%20double-click%20in%20the%20UI%20could%20start%20two%20parallel%20jobs%3A%20one%20succeeds%20with%20trunk%20%28CocoaPods%20rejects%20the%20duplicate%20on%20the%20second%29%2C%20and%20both%20try%20to%20push%20the%20Dev-restore%20commit%20%E2%80%94%20leaving%20noisy%20failures%20and%20ambiguous%20state.%0A%0A%60%60%60suggestion%0Aon%3A%0A%20%20workflow_dispatch%3A%0A%20%20%20%20inputs%3A%0A%20%20%20%20%20%20version%3A%0A%20%20%20%20%20%20%20%20description%3A%20%22Version%20tag%20to%20publish%20%28e.g.%205.1.0%29.%20Must%20already%20exist%20on%20origin.%22%0A%20%20%20%20%20%20%20%20required%3A%20true%0A%20%20%20%20%20%20restore_dev%3A%0A%20%20%20%20%20%20%20%20description%3A%20%22Push%20a%20Dev-restore%20commit%20on%20top%20of%20main%20after%20publishing.%22%0A%20%20%20%20%20%20%20%20type%3A%20boolean%0A%20%20%20%20%20%20%20%20default%3A%20true%0A%0Aconcurrency%3A%0A%20%20group%3A%20manual-pod-publish-%24%7B%7B%20github.event.inputs.version%20%7D%7D%0A%20%20cancel-in-progress%3A%20false%0A%0Aenv%3A%0A%60%60%60%0A%0A&pr=111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/manual-pod-publish.yml:17-28
Adding a `concurrency` group scoped to the version would prevent a second accidental trigger from racing against an in-progress run. Without it, a double-click in the UI could start two parallel jobs: one succeeds with trunk (CocoaPods rejects the duplicate on the second), and both try to push the Dev-restore commit — leaving noisy failures and ambiguous state.

```suggestion
on:
  workflow_dispatch:
    inputs:
      version:
        description: "Version tag to publish (e.g. 5.1.0). Must already exist on origin."
        required: true
      restore_dev:
        description: "Push a Dev-restore commit on top of main after publishing."
        type: boolean
        default: true

concurrency:
  group: manual-pod-publish-${{ github.event.inputs.version }}
  cancel-in-progress: false

env:
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Update .github/workflows/manual-pod-publ..."](https://github.com/youversion/platform-sdk-swift/commit/b588ba080197932daae87bab06c5a57f1ad5bb43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31101125)</sub>

<!-- /greptile_comment -->