### PR TITLE
fix(ci): make pod publish resumable after partial trunk failure

### DIFF
--- a/.github/workflows/manual-pod-publish.yml
+++ b/.github/workflows/manual-pod-publish.yml
@@ -72,6 +72,15 @@ jobs:
           done
           echo "✓ Checkout looks consistent with ${{ inputs.version }}."
 
+      # The tagged commit is the source-of-truth for the *release artifact*
+      # (podspecs + SDKVersion.swift), but the *publish tooling* should always
+      # be the latest version on main — otherwise a fix to publish-pods.sh
+      # can't help a recovery run that checks out an older tag.
+      - name: Overlay publish scripts from main
+        run: |
+          git fetch origin main
+          git checkout origin/main -- scripts/
+
       - name: Verify scripts are executable
         run: |
           chmod +x scripts/publish-pods.sh

--- a/scripts/publish-pods.sh
+++ b/scripts/publish-pods.sh
@@ -18,6 +18,7 @@ pod_already_published() {
   local pod="$1"
   local version="$2"
   local escaped="${version//./\\.}"
+  # "**Regex anchored to a specific `pod trunk info` output format**"
   pod trunk info "$pod" 2>/dev/null \
     | grep -Eq "^[[:space:]]+- ${escaped} \("
 }

--- a/scripts/publish-pods.sh
+++ b/scripts/publish-pods.sh
@@ -8,36 +8,47 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
+# `pod trunk push` is non-idempotent (re-running for an already-published
+# version exits non-zero) and can also exit non-zero AFTER trunk has accepted
+# the spec (e.g. "Calling the GitHub commit API timed out"). Either case can
+# leave a release half-published. Before each push, ask trunk whether <pod>
+# already lists <version> and skip if so — making the script resumable after
+# a partial failure.
+pod_already_published() {
+  local pod="$1"
+  local escaped="${VERSION//./\\.}"
+  pod trunk info "$pod" 2>/dev/null \
+    | grep -Eq "^[[:space:]]+- ${escaped} \("
+}
+
+publish_pod() {
+  local pod_name="$1"
+  local podspec="$2"
+  if pod_already_published "$pod_name"; then
+    echo "  ✓ $pod_name $VERSION already on trunk — skipping"
+    return 0
+  fi
+  pod trunk push "$podspec" --allow-warnings --synchronous
+}
+
 echo "Publishing version $VERSION to CocoaPods trunk..."
-echo "IMPORTANT: Pods will be published in dependency order"
-
-# Publish in dependency order: Core -> UI -> Reader -> Platform
-#
-# To enable CocoaPods publishing, uncomment the `pod trunk push` lines below.
-# A delay between each push allows the CocoaPods CDN to index the previous pod
-# before a dependent pod is pushed.
+echo "IMPORTANT: Pods will be published in dependency order; already-published versions are skipped"
 
 echo ""
-echo "Step 1/4: Publishing YouVersionPlatformCore..."
-pod trunk push YouVersionPlatformCore.podspec --allow-warnings --synchronous
-#echo "Waiting for CDN propagation..."
-#sleep 60
+echo "Step 1/4: YouVersionPlatformCore"
+publish_pod YouVersionPlatformCore YouVersionPlatformCore.podspec
 
 echo ""
-echo "Step 2/4: Publishing YouVersionPlatformUI..."
-pod trunk push YouVersionPlatformUI.podspec --allow-warnings --synchronous
-#echo "Waiting for CDN propagation..."
-#sleep 60
+echo "Step 2/4: YouVersionPlatformUI"
+publish_pod YouVersionPlatformUI YouVersionPlatformUI.podspec
 
 echo ""
-echo "Step 3/4: Publishing YouVersionPlatformReader..."
-pod trunk push YouVersionPlatformReader.podspec --allow-warnings --synchronous
-#echo "Waiting for CDN propagation..."
-#sleep 60
+echo "Step 3/4: YouVersionPlatformReader"
+publish_pod YouVersionPlatformReader YouVersionPlatformReader.podspec
 
 echo ""
-echo "Step 4/4: Publishing YouVersionPlatform..."
-pod trunk push YouVersionPlatform.podspec --allow-warnings --synchronous
+echo "Step 4/4: YouVersionPlatform"
+publish_pod YouVersionPlatform YouVersionPlatform.podspec
 
 echo ""
-echo "✅ Pod version $VERSION was pushed to trunk."
+echo "✅ Pod version $VERSION is on trunk."

--- a/scripts/publish-pods.sh
+++ b/scripts/publish-pods.sh
@@ -16,7 +16,8 @@ fi
 # a partial failure.
 pod_already_published() {
   local pod="$1"
-  local escaped="${VERSION//./\\.}"
+  local version="$2"
+  local escaped="${version//./\\.}"
   pod trunk info "$pod" 2>/dev/null \
     | grep -Eq "^[[:space:]]+- ${escaped} \("
 }
@@ -24,7 +25,7 @@ pod_already_published() {
 publish_pod() {
   local pod_name="$1"
   local podspec="$2"
-  if pod_already_published "$pod_name"; then
+  if pod_already_published "$pod_name" "$VERSION"; then
     echo "  ✓ $pod_name $VERSION already on trunk — skipping"
     return 0
   fi


### PR DESCRIPTION
## Summary

`pod trunk push` is non-idempotent and can exit non-zero *after* trunk has accepted the spec (e.g. GitHub commit API timeouts). Together those make `scripts/publish-pods.sh` unrecoverable after a partial success — the prior run leaves some pods on trunk and some not, and a naive retry crashes on step 1 before reaching the unpublished pods. Hit on the 5.1.0 (YPE-2293) recovery: Core published, UI / Reader / umbrella did not.

- `scripts/publish-pods.sh`: pre-check `pod trunk info <pod>` for `<version>` and skip with a "(already on trunk)" message instead of pushing. Script is now resumable after a partial failure.
- `.github/workflows/manual-pod-publish.yml`: overlay `scripts/` from `main` on top of the tag checkout. Release artifacts (podspecs + `SDKVersion.swift`) still come from the tag, but the *publish tooling* always uses latest-on-main — so a fix to the script applies to recovery runs of older tags.

## Test plan

- [x] Verified the new `pod_already_published` helper against live trunk: correctly identifies Core 5.1.0 as published, the other three as not, and 4.9.0 as fully published across all four pods.
- [ ] After merge: re-run `manual-pod-publish.yml` with `version=5.1.0`, `restore_dev=true` to finish the YPE-2293 recovery (skips Core, publishes UI/Reader/umbrella, restores Dev on main).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the manual pod publish workflow resumable after a partial `pod trunk push` failure by pre-checking trunk before each push and skipping pods that are already published. It also ensures recovery runs always use the latest publish tooling from `main`, regardless of which tag is checked out.

- **`scripts/publish-pods.sh`**: Adds `pod_already_published` (queries `pod trunk info` and matches the version line) and a `publish_pod` wrapper that skips the push if the version is already on trunk, making the script idempotent.
- **`.github/workflows/manual-pod-publish.yml`**: Adds a step after the tag checkout that overlays `scripts/` from `origin/main`, so fixes to the publish script apply immediately to recovery runs against older tags.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are narrowly scoped to the CI publish script and workflow, with no impact on release artifacts or source code.

Both changed files contain straightforward, well-commented additions. The pod_already_published helper correctly handles the set -e context, the regex escaping of dots is correct, and the workflow step ordering preserves the tag-artifact verification before any scripts are overwritten from main. No functional defects were identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/publish-pods.sh | Adds pod_already_published helper and publish_pod wrapper so each step is a no-op if the version is already on trunk; makes the publish loop resumable after partial failures. |
| .github/workflows/manual-pod-publish.yml | New Overlay publish scripts from main step fetches and checks out the latest scripts/ directory on top of the tag checkout so recovery runs always use the newest tooling. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant WF as manual-pod-publish.yml
    participant Trunk as CocoaPods Trunk
    participant Script as publish-pods.sh

    WF->>WF: Checkout tag (podspecs + SDKVersion.swift)
    WF->>WF: Verify checkout matches tag
    WF->>WF: git checkout origin/main -- scripts/
    WF->>Script: bash publish-pods.sh VERSION

    loop For each pod
        Script->>Trunk: pod trunk info pod
        Trunk-->>Script: version list
        alt version already listed
            Script->>Script: skip
        else not listed
            Script->>Trunk: pod trunk push podspec --synchronous
            Trunk-->>Script: success or non-zero exit
        end
    end

    Script->>WF: exit 0
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fpublish-pods.sh%3A21%0AThe%20comment%20on%20this%20line%20appears%20to%20have%20been%20copied%20verbatim%20from%20a%20code-review%20thread%2C%20including%20its%20markdown%20syntax%20%28%60**...**%60%20and%20backtick-fenced%20identifiers%29.%20In%20a%20shell%20script%2C%20those%20asterisks%20and%20quotes%20read%20as%20literal%20punctuation%20and%20can%20confuse%20a%20future%20reader%20who%20expects%20plain%20prose.%20A%20reformatted%20version%20makes%20the%20intent%20clear%20without%20the%20markdown%20artifacts.%0A%0A%60%60%60suggestion%0A%20%20%23%20Regex%20is%20anchored%20to%20the%20pod%20trunk%20info%20output%20format%3A%20%22%20%20%20-%20X.Y.Z%20%28date%29%22%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=112&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fpublish-pods.sh%3A21%0AThe%20comment%20on%20this%20line%20appears%20to%20have%20been%20copied%20verbatim%20from%20a%20code-review%20thread%2C%20including%20its%20markdown%20syntax%20%28%60**...**%60%20and%20backtick-fenced%20identifiers%29.%20In%20a%20shell%20script%2C%20those%20asterisks%20and%20quotes%20read%20as%20literal%20punctuation%20and%20can%20confuse%20a%20future%20reader%20who%20expects%20plain%20prose.%20A%20reformatted%20version%20makes%20the%20intent%20clear%20without%20the%20markdown%20artifacts.%0A%0A%60%60%60suggestion%0A%20%20%23%20Regex%20is%20anchored%20to%20the%20pod%20trunk%20info%20output%20format%3A%20%22%20%20%20-%20X.Y.Z%20%28date%29%22%0A%60%60%60%0A%0A&pr=112&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/publish-pods.sh:21
The comment on this line appears to have been copied verbatim from a code-review thread, including its markdown syntax (`**...**` and backtick-fenced identifiers). In a shell script, those asterisks and quotes read as literal punctuation and can confuse a future reader who expects plain prose. A reformatted version makes the intent clear without the markdown artifacts.

```suggestion
  # Regex is anchored to the pod trunk info output format: "   - X.Y.Z (date)"
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Add comment for regex in pod\_already\_pub..."](https://github.com/youversion/platform-sdk-swift/commit/b775895c8bbee1b94c8dd1097a9f2ed310c79b19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31266964)</sub>

<!-- /greptile_comment -->