### PR TITLE
fix: normalize bookUSFM case in overlaps/contains and fix chapter-only USFM parsing

### DIFF
--- a/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
@@ -199,7 +199,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
 
     public func isAdjacentOrOverlapping(with otherReference: BibleReference) -> Bool {
         guard versionId == otherReference.versionId &&
-                bookUSFM == otherReference.bookUSFM &&
+                bookUSFM.uppercased() == otherReference.bookUSFM.uppercased() &&
                 chapter == otherReference.chapter else {
             return false
         }

--- a/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
@@ -33,6 +33,20 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         self.verseEnd = verseEnd
     }
 
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let versionId = try container.decode(Int.self, forKey: .versionId)
+        let bookUSFM = try container.decode(String.self, forKey: .bookUSFM)
+        let chapter = try container.decode(Int.self, forKey: .chapter)
+        let verseStart = try container.decodeIfPresent(Int.self, forKey: .verseStart)
+        let verseEnd = try container.decodeIfPresent(Int.self, forKey: .verseEnd)
+        if let verseStart, let verseEnd {
+            self.init(versionId: versionId, bookUSFM: bookUSFM, chapter: chapter, verseStart: verseStart, verseEnd: verseEnd)
+        } else {
+            self.init(versionId: versionId, bookUSFM: bookUSFM, chapter: chapter, verse: verseStart)
+        }
+    }
+
     public var debugDescription: String {
         let prefix = "bible\(versionId)__\(bookUSFM).\(chapter)"
         if let verseStart {

--- a/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
@@ -129,7 +129,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
 
     public func overlaps(with otherReference: BibleReference) -> Bool {
         guard versionId == otherReference.versionId &&
-                bookUSFM == otherReference.bookUSFM else {
+                bookUSFM.uppercased() == otherReference.bookUSFM.uppercased() else {
             return false
         }
 
@@ -164,7 +164,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
 
     public func contains(with otherReference: BibleReference) -> Bool {
         guard versionId == otherReference.versionId &&
-                bookUSFM == otherReference.bookUSFM else {
+                bookUSFM.uppercased() == otherReference.bookUSFM.uppercased() else {
             return false
         }
 
@@ -314,7 +314,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         if let match = usfm.wholeMatch(of: patBC) {
             let (_, bText, cText) = match.output
             if let c = Int(cText) {
-                return reference(bookUSFM: bText.uppercased(), chapter: c, verseStart: 1, verseEnd: 1)
+                return BibleReference(versionId: versionId, bookUSFM: bText.uppercased(), chapter: c)
             }
             return nil
         }

--- a/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
@@ -14,20 +14,20 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         }
         
         self.versionId = versionId
-        self.bookUSFM = bookUSFM
+        self.bookUSFM = bookUSFM.uppercased()
         self.chapter = chapter
         self.verseStart = verse
         self.verseEnd = verse
     }
-    
+
     public init(versionId: Int, bookUSFM: String, chapter: Int, verseStart: Int, verseEnd: Int) {
         assert(chapter >= 1, "Starting chapter must be greater than or equal to 1.")
         assert(verseStart >= 1, "Starting verse must be greater than or equal to 1.")
         assert(verseEnd >= 1, "Ending verse must be greater than or equal to 1.")
         assert(verseEnd >= verseStart, "Ending verse must be equal to or after starting verse.")
-        
+
         self.versionId = versionId
-        self.bookUSFM = bookUSFM
+        self.bookUSFM = bookUSFM.uppercased()
         self.chapter = chapter
         self.verseStart = verseStart
         self.verseEnd = verseEnd
@@ -88,30 +88,28 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
     }
 
     public var chapterUSFM: String? {
-        "\(bookUSFM.uppercased()).\(chapter)"
+        "\(bookUSFM).\(chapter)"
     }
 
     public var asUSFM: String {
-        let upperBookUSFM = bookUSFM.uppercased()
         if let verseStart {
             if let verseEnd, verseStart != verseEnd {
-                return "\(upperBookUSFM).\(chapter).\(verseStart)-\(upperBookUSFM).\(chapter).\(verseEnd)"
+                return "\(bookUSFM).\(chapter).\(verseStart)-\(bookUSFM).\(chapter).\(verseEnd)"
             } else {
-                return "\(upperBookUSFM).\(chapter).\(verseStart)"
+                return "\(bookUSFM).\(chapter).\(verseStart)"
             }
         } else {
-            return "\(upperBookUSFM).\(chapter)"
+            return "\(bookUSFM).\(chapter)"
         }
     }
 
     /// Returns whether this reference is available in the provided Bible version metadata.
     public func existsIn(version: BibleVersion) -> Bool {
-        let normalizedBookUSFM = bookUSFM.uppercased()
-        guard version.bookUSFMs.contains(where: { $0.uppercased() == normalizedBookUSFM }) else {
+        guard version.bookUSFMs.contains(where: { $0.uppercased() == bookUSFM }) else {
             return false
         }
 
-        guard let book = version.book(with: normalizedBookUSFM) else {
+        guard let book = version.book(with: bookUSFM) else {
             return true
         }
 
@@ -129,7 +127,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
 
     public func overlaps(with otherReference: BibleReference) -> Bool {
         guard versionId == otherReference.versionId &&
-                bookUSFM.uppercased() == otherReference.bookUSFM.uppercased() else {
+                bookUSFM == otherReference.bookUSFM else {
             return false
         }
 
@@ -164,7 +162,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
 
     public func contains(with otherReference: BibleReference) -> Bool {
         guard versionId == otherReference.versionId &&
-                bookUSFM.uppercased() == otherReference.bookUSFM.uppercased() else {
+                bookUSFM == otherReference.bookUSFM else {
             return false
         }
 
@@ -199,7 +197,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
 
     public func isAdjacentOrOverlapping(with otherReference: BibleReference) -> Bool {
         guard versionId == otherReference.versionId &&
-                bookUSFM.uppercased() == otherReference.bookUSFM.uppercased() &&
+                bookUSFM == otherReference.bookUSFM &&
                 chapter == otherReference.chapter else {
             return false
         }
@@ -271,7 +269,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         if let match = usfm.wholeMatch(of: patBCVCV) {
             let (_, bText, cText, vText, _, v2Text) = match.output
             if let c = Int(cText), let v = Int(vText), let v2 = Int(v2Text) {
-                return reference(bookUSFM: bText.uppercased(), chapter: c, verseStart: v, verseEnd: v2)
+                return reference(bookUSFM: String(bText), chapter: c, verseStart: v, verseEnd: v2)
             }
             return nil
         }
@@ -284,7 +282,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
                 if String(bText) != String(b2Text) {
                     return nil
                 }
-                return reference(bookUSFM: bText.uppercased(), chapter: c, verseStart: v, verseEnd: v2)
+                return reference(bookUSFM: String(bText), chapter: c, verseStart: v, verseEnd: v2)
             }
             return nil
         }
@@ -294,7 +292,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         if let match = usfm.wholeMatch(of: patBCVV) {
             let (_, bText, cText, vText, v2Text) = match.output
             if let c = Int(cText), let v = Int(vText), let v2 = Int(v2Text) {
-                return reference(bookUSFM: bText.uppercased(), chapter: c, verseStart: v, verseEnd: v2)
+                return reference(bookUSFM: String(bText), chapter: c, verseStart: v, verseEnd: v2)
             }
             return nil
         }
@@ -304,7 +302,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         if let match = usfm.wholeMatch(of: patBCV) {
             let (_, bText, cText, vText) = match.output
             if let c = Int(cText), let v = Int(vText) {
-                return reference(bookUSFM: bText.uppercased(), chapter: c, verseStart: v, verseEnd: v)
+                return reference(bookUSFM: String(bText), chapter: c, verseStart: v, verseEnd: v)
             }
             return nil
         }
@@ -314,7 +312,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         if let match = usfm.wholeMatch(of: patBC) {
             let (_, bText, cText) = match.output
             if let c = Int(cText) {
-                return BibleReference(versionId: versionId, bookUSFM: bText.uppercased(), chapter: c)
+                return BibleReference(versionId: versionId, bookUSFM: String(bText), chapter: c)
             }
             return nil
         }
@@ -324,7 +322,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         if let match = usfm.wholeMatch(of: patBCC) {
             let (_, bText, cText, _) = match.output
             if let c = Int(cText) {
-                return reference(bookUSFM: bText.uppercased(), chapter: c, verseStart: 1, verseEnd: 1)
+                return reference(bookUSFM: String(bText), chapter: c, verseStart: 1, verseEnd: 1)
             }
             return nil
         }

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_codable.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_codable.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+@testable import YouVersionPlatformCore
+
+// MARK: - Codable
+
+@Test func decodedBookUSFMIsUppercased() throws {
+    let json = """
+    {"versionId":1,"bookUSFM":"gen","chapter":1,"verseStart":1,"verseEnd":1}
+    """
+    let ref = try JSONDecoder().decode(BibleReference.self, from: Data(json.utf8))
+    #expect(ref.bookUSFM == "GEN")
+}
+
+@Test func decodedVerseReferenceRoundTrips() throws {
+    let original = BibleReference(versionId: 1, bookUSFM: "REV", chapter: 22, verse: 21)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(BibleReference.self, from: data)
+    #expect(decoded.bookUSFM == original.bookUSFM)
+    #expect(decoded.versionId == original.versionId)
+    #expect(decoded.chapter == original.chapter)
+    #expect(decoded.verseStart == original.verseStart)
+    #expect(decoded.verseEnd == original.verseEnd)
+}
+
+@Test func decodedRangeReferenceRoundTrips() throws {
+    let original = BibleReference(versionId: 2, bookUSFM: "PSA", chapter: 23, verseStart: 1, verseEnd: 6)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(BibleReference.self, from: data)
+    #expect(decoded.bookUSFM == original.bookUSFM)
+    #expect(decoded.verseStart == original.verseStart)
+    #expect(decoded.verseEnd == original.verseEnd)
+}
+
+@Test func decodedChapterReferenceRoundTrips() throws {
+    let original = BibleReference(versionId: 1, bookUSFM: "JHN", chapter: 3)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(BibleReference.self, from: data)
+    #expect(decoded.bookUSFM == original.bookUSFM)
+    #expect(decoded.chapter == original.chapter)
+    #expect(decoded.verseStart == nil)
+    #expect(decoded.verseEnd == nil)
+}
+
+@Test func decodedLowercaseBookUSFMOverlapsCorrectly() throws {
+    let json = """
+    {"versionId":1,"bookUSFM":"jhn","chapter":3,"verseStart":16,"verseEnd":16}
+    """
+    let decoded = try JSONDecoder().decode(BibleReference.self, from: Data(json.utf8))
+    let constructed = BibleReference(versionId: 1, bookUSFM: "JHN", chapter: 3, verse: 16)
+    #expect(decoded.overlaps(with: constructed))
+}

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_overlaps.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_overlaps.swift
@@ -179,12 +179,12 @@ func testOverlaps_EdgeCaseNilHandling() {
 
 @Test
 func testOverlaps_CaseSensitiveBookComparison() {
-    // Test that book comparison is case-sensitive (as implemented)
+    // Test that book comparison is case-insensitive (bookUSFM is normalized to uppercase)
     let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
     let ref2 = BibleReference(versionId: 1, bookUSFM: "gen", chapter: 1, verse: 1)
-    
-    #expect(!ref1.overlaps(with: ref2))
-    #expect(!ref2.overlaps(with: ref1))
+
+    #expect(ref1.overlaps(with: ref2))
+    #expect(ref2.overlaps(with: ref1))
 }
 
 @Test

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_unvalidatedReference.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_unvalidatedReference.swift
@@ -46,8 +46,13 @@ func testUnvalidatedReference_invalidVerseOrder() {
 @Test
 func testUnvalidatedReference_chapterOnly() throws {
     let ref = try #require(BibleReference.unvalidatedReference(with: "GEN.1", versionId: 1))
-    let expected = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 1)
+    let expected = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
     #expect(ref == expected)
+    #expect(ref.verseStart == nil)
+    #expect(ref.verseEnd == nil)
+    // A chapter-level reference should overlap any verse within that chapter
+    let verse5 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 5)
+    #expect(ref.overlaps(with: verse5))
 }
 
 


### PR DESCRIPTION
## Summary

- **Bug 1 (case inconsistency):** `overlaps` and `contains` now normalize `bookUSFM` with `.uppercased()` on both sides before comparing, consistent with the existing behavior in `existsIn`. A `BibleReference` with `bookUSFM: "gen"` now correctly overlaps/contains one with `bookUSFM: "GEN"`.
- **Bug 2 (chapter-only USFM parsing):** `unvalidatedReference(with:versionId:)` for a chapter-only string like `"GEN.1"` now returns a proper chapter-level reference (`verseStart: nil`, `verseEnd: nil`) instead of pinning to verse 1. This means it correctly overlaps any verse in that chapter.
- Tests updated: `testOverlaps_CaseSensitiveBookComparison` now asserts overlap is `true`; `testUnvalidatedReference_chapterOnly` now asserts `nil` verse fields and verifies overlap with an arbitrary verse.

## Test plan

- [x] `swift test --filter BibleReferenceTests` — all 81 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related bugs in `BibleReference`: `bookUSFM` is now normalized to uppercase at construction time (in both public inits and a new custom `init(from:)`), eliminating case-sensitivity issues in `overlaps`, `contains`, `isAdjacentOrOverlapping`, and `compare`; and chapter-only USFM strings like `"GEN.1"` now parse into proper chapter-level references (`verseStart: nil`, `verseEnd: nil`) instead of being pinned to verse 1.

- **Case normalization**: Both public `init` methods and a new `init(from: Decoder)` apply `.uppercased()` to `bookUSFM`, so all downstream comparison sites can use direct string equality without per-call normalization.
- **Custom `init(from:)`**: Routes through the existing public inits so decoded instances are subject to the same uppercasing and assertion guards; it correctly handles verse, verse-range, and chapter-only payloads.
- **Chapter-only parse fix**: `patBC` now constructs a `BibleReference` with no verse fields, restoring the intended "whole-chapter overlaps any verse" semantic.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are narrowly scoped to normalization at construction time and a chapter-only parse fix, both well-covered by new and updated tests.

The normalization strategy is sound: uppercasing happens once at the boundary (init) rather than at every comparison site, so all existing callers — `overlaps`, `contains`, `isAdjacentOrOverlapping`, `compare`, and `Hashable` synthesis — automatically benefit without modification. The custom `init(from:)` correctly routes through the public inits for all three reference shapes (verse, range, chapter), closing the previously flagged Codable bypass. The chapter-only parse change is a one-liner with a targeted test that verifies both the nil verse fields and the overlap semantic.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/Bible/BibleReference.swift | Normalizes `bookUSFM` to uppercase at init time in both public inits; adds a custom `init(from:)` so decoded instances share the same normalization; fixes chapter-only USFM parsing to return a chapter-level reference instead of pinning to verse 1; cleans up redundant `.uppercased()` call sites throughout. |
| Tests/YouVersionPlatformCoreTests/BibleReferenceTests_codable.swift | New test file covering the custom `init(from:)`: verifies lowercase book USFM is uppercased on decode, round-trips for verse/range/chapter references, and that a decoded lowercase ref overlaps a constructed uppercase ref. |
| Tests/YouVersionPlatformCoreTests/BibleReferenceTests_overlaps.swift | Updated `testOverlaps_CaseSensitiveBookComparison` to assert `true` instead of `false`, reflecting the now-correct case-insensitive normalization behavior. |
| Tests/YouVersionPlatformCoreTests/BibleReferenceTests_unvalidatedReference.swift | Updated `testUnvalidatedReference_chapterOnly` to expect `nil` verse fields and to verify that a chapter-level reference overlaps any verse within that chapter. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bookUSFM input] --> B{Construction path}

    B --> C["init(versionId:bookUSFM:chapter:verse:)"]
    B --> D["init(versionId:bookUSFM:chapter:verseStart:verseEnd:)"]
    B --> E["init(from: Decoder)  ← NEW"]

    C --> F[".uppercased()"]
    D --> F
    E --> G{verseStart & verseEnd present?}
    G -- Yes --> D
    G -- No --> C

    F --> H[bookUSFM stored as UPPERCASE]

    H --> I{Comparison sites}
    I --> J["overlaps(with:)  =="]
    I --> K["contains(with:)  =="]
    I --> L["isAdjacentOrOverlapping(with:)  =="]
    I --> M["compare(a:b:)  !="]

    J --> N[✅ always case-safe]
    K --> N
    L --> N
    M --> N
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `Sources/YouVersionPlatformCore/Bible/BibleReference.swift`, line 200-205 ([link](https://github.com/youversion/platform-sdk-swift/blob/ed7277cafad2f8408617b3a603764edd33d3b1c3/Sources/YouVersionPlatformCore/Bible/BibleReference.swift#L200-L205)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`isAdjacentOrOverlapping` still uses case-sensitive `bookUSFM` comparison**

   `isAdjacentOrOverlapping` at line 202 still uses `bookUSFM == otherReference.bookUSFM` without `.uppercased()`, so calling `isAdjacentOrOverlapping` with `"GEN"` vs `"gen"` would return `false` even after this fix. `referencesByMerging` delegates to this function, meaning merging a list of references with mixed-case book names would silently produce unmerged duplicates instead of a single consolidated reference — the same class of bug just fixed in `overlaps` and `contains`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformCore/Bible/BibleReference.swift
   Line: 200-205

   Comment:
   **`isAdjacentOrOverlapping` still uses case-sensitive `bookUSFM` comparison**

   `isAdjacentOrOverlapping` at line 202 still uses `bookUSFM == otherReference.bookUSFM` without `.uppercased()`, so calling `isAdjacentOrOverlapping` with `"GEN"` vs `"gen"` would return `false` even after this fix. `referencesByMerging` delegates to this function, meaning merging a list of references with mixed-case book names would silently produce unmerged duplicates instead of a single consolidated reference — the same class of bug just fixed in `overlaps` and `contains`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformCore%2FBible%2FBibleReference.swift%0ALine%3A%20200-205%0A%0AComment%3A%0A**%60isAdjacentOrOverlapping%60%20still%20uses%20case-sensitive%20%60bookUSFM%60%20comparison**%0A%0A%60isAdjacentOrOverlapping%60%20at%20line%20202%20still%20uses%20%60bookUSFM%20%3D%3D%20otherReference.bookUSFM%60%20without%20%60.uppercased%28%29%60%2C%20so%20calling%20%60isAdjacentOrOverlapping%60%20with%20%60%22GEN%22%60%20vs%20%60%22gen%22%60%20would%20return%20%60false%60%20even%20after%20this%20fix.%20%60referencesByMerging%60%20delegates%20to%20this%20function%2C%20meaning%20merging%20a%20list%20of%20references%20with%20mixed-case%20book%20names%20would%20silently%20produce%20unmerged%20duplicates%20instead%20of%20a%20single%20consolidated%20reference%20%E2%80%94%20the%20same%20class%20of%20bug%20just%20fixed%20in%20%60overlaps%60%20and%20%60contains%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=113&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformCore%2FBible%2FBibleReference.swift%0ALine%3A%20200-205%0A%0AComment%3A%0A**%60isAdjacentOrOverlapping%60%20still%20uses%20case-sensitive%20%60bookUSFM%60%20comparison**%0A%0A%60isAdjacentOrOverlapping%60%20at%20line%20202%20still%20uses%20%60bookUSFM%20%3D%3D%20otherReference.bookUSFM%60%20without%20%60.uppercased%28%29%60%2C%20so%20calling%20%60isAdjacentOrOverlapping%60%20with%20%60%22GEN%22%60%20vs%20%60%22gen%22%60%20would%20return%20%60false%60%20even%20after%20this%20fix.%20%60referencesByMerging%60%20delegates%20to%20this%20function%2C%20meaning%20merging%20a%20list%20of%20references%20with%20mixed-case%20book%20names%20would%20silently%20produce%20unmerged%20duplicates%20instead%20of%20a%20single%20consolidated%20reference%20%E2%80%94%20the%20same%20class%20of%20bug%20just%20fixed%20in%20%60overlaps%60%20and%20%60contains%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=113&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

2. `Sources/YouVersionPlatformCore/Bible/BibleReference.swift`, line 3-8 ([link](https://github.com/youversion/platform-sdk-swift/blob/96ce41fb6e89fe826e972791feac10015fcacada/Sources/YouVersionPlatformCore/Bible/BibleReference.swift#L3-L8)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`Codable` synthesized `init(from:)` bypasses `bookUSFM` normalization**

   `BibleReference` conforms to `Codable`, so Swift synthesizes an `init(from:)` that assigns stored properties directly — it does not route through your custom `init` methods. Any instance decoded from JSON (or another format) will have `bookUSFM` stored verbatim, bypassing `.uppercased()`. A decoded `"gen"` will then fail every direct comparison (`bookUSFM == otherReference.bookUSFM`) in `overlaps`, `contains`, `isAdjacentOrOverlapping`, and `compare`, since init-constructed peers always carry `"GEN"`. Adding a custom `init(from:)` that calls `self.init(versionId:bookUSFM:chapter:verse:)` (or that applies `.uppercased()` to the decoded string) would close this gap.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformCore/Bible/BibleReference.swift
   Line: 3-8

   Comment:
   **`Codable` synthesized `init(from:)` bypasses `bookUSFM` normalization**

   `BibleReference` conforms to `Codable`, so Swift synthesizes an `init(from:)` that assigns stored properties directly — it does not route through your custom `init` methods. Any instance decoded from JSON (or another format) will have `bookUSFM` stored verbatim, bypassing `.uppercased()`. A decoded `"gen"` will then fail every direct comparison (`bookUSFM == otherReference.bookUSFM`) in `overlaps`, `contains`, `isAdjacentOrOverlapping`, and `compare`, since init-constructed peers always carry `"GEN"`. Adding a custom `init(from:)` that calls `self.init(versionId:bookUSFM:chapter:verse:)` (or that applies `.uppercased()` to the decoded string) would close this gap.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformCore%2FBible%2FBibleReference.swift%0ALine%3A%203-8%0A%0AComment%3A%0A**%60Codable%60%20synthesized%20%60init%28from%3A%29%60%20bypasses%20%60bookUSFM%60%20normalization**%0A%0A%60BibleReference%60%20conforms%20to%20%60Codable%60%2C%20so%20Swift%20synthesizes%20an%20%60init%28from%3A%29%60%20that%20assigns%20stored%20properties%20directly%20%E2%80%94%20it%20does%20not%20route%20through%20your%20custom%20%60init%60%20methods.%20Any%20instance%20decoded%20from%20JSON%20%28or%20another%20format%29%20will%20have%20%60bookUSFM%60%20stored%20verbatim%2C%20bypassing%20%60.uppercased%28%29%60.%20A%20decoded%20%60%22gen%22%60%20will%20then%20fail%20every%20direct%20comparison%20%28%60bookUSFM%20%3D%3D%20otherReference.bookUSFM%60%29%20in%20%60overlaps%60%2C%20%60contains%60%2C%20%60isAdjacentOrOverlapping%60%2C%20and%20%60compare%60%2C%20since%20init-constructed%20peers%20always%20carry%20%60%22GEN%22%60.%20Adding%20a%20custom%20%60init%28from%3A%29%60%20that%20calls%20%60self.init%28versionId%3AbookUSFM%3Achapter%3Averse%3A%29%60%20%28or%20that%20applies%20%60.uppercased%28%29%60%20to%20the%20decoded%20string%29%20would%20close%20this%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=113&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformCore%2FBible%2FBibleReference.swift%0ALine%3A%203-8%0A%0AComment%3A%0A**%60Codable%60%20synthesized%20%60init%28from%3A%29%60%20bypasses%20%60bookUSFM%60%20normalization**%0A%0A%60BibleReference%60%20conforms%20to%20%60Codable%60%2C%20so%20Swift%20synthesizes%20an%20%60init%28from%3A%29%60%20that%20assigns%20stored%20properties%20directly%20%E2%80%94%20it%20does%20not%20route%20through%20your%20custom%20%60init%60%20methods.%20Any%20instance%20decoded%20from%20JSON%20%28or%20another%20format%29%20will%20have%20%60bookUSFM%60%20stored%20verbatim%2C%20bypassing%20%60.uppercased%28%29%60.%20A%20decoded%20%60%22gen%22%60%20will%20then%20fail%20every%20direct%20comparison%20%28%60bookUSFM%20%3D%3D%20otherReference.bookUSFM%60%29%20in%20%60overlaps%60%2C%20%60contains%60%2C%20%60isAdjacentOrOverlapping%60%2C%20and%20%60compare%60%2C%20since%20init-constructed%20peers%20always%20carry%20%60%22GEN%22%60.%20Adding%20a%20custom%20%60init%28from%3A%29%60%20that%20calls%20%60self.init%28versionId%3AbookUSFM%3Achapter%3Averse%3A%29%60%20%28or%20that%20applies%20%60.uppercased%28%29%60%20to%20the%20decoded%20string%29%20would%20close%20this%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=113&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/bible-refer..."](https://github.com/youversion/platform-sdk-swift/commit/e7f4de0894f427a672974d688be6a4adf80df975) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31270491)</sub>

<!-- /greptile_comment -->