### PR TITLE
test: fix fixture JSON, add pagination and missing API error coverage

### DIFF
--- a/Tests/YouVersionPlatformCoreTests/BibleVersionAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionAPITests.swift
@@ -79,7 +79,9 @@ import Testing
         {"content":"<div>ok</div>"}
         """.data(using: .utf8)!
 
+        var capturedRequest: URLRequest?
         HTTPMocking.setHandler(token: token) { request in
+            capturedRequest = request
             let resp = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
             return (json, resp)
         }
@@ -87,6 +89,13 @@ import Testing
         let ref = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
         let html = try await YouVersionAPI.Bible.chapter(reference: ref, accessToken: "swift-test-suite", session: session)
         #expect(html == "<div>ok</div>")
+
+        let req = try #require(capturedRequest)
+        let components = URLComponents(url: req.url!, resolvingAgainstBaseURL: false)
+        let queryItems = components?.queryItems ?? []
+        #expect(queryItems.contains(where: { $0.name == "format" && $0.value == "html" }))
+        #expect(queryItems.contains(where: { $0.name == "include_notes" && $0.value == "true" }))
+        #expect(queryItems.contains(where: { $0.name == "include_headings" && $0.value == "true" }))
     }
 
     @MainActor
@@ -133,6 +142,27 @@ import Testing
 
         let ref = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
         await #expect(throws: YouVersionAPIError.invalidResponse) {
+            _ = try await YouVersionAPI.Bible.chapter(reference: ref, accessToken: "swift-test-suite", session: session)
+        }
+    }
+
+    @MainActor
+    @Test func chapterInvalidContentThrowsInvalidDownload() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        // 200 response with valid JSON but missing the "content" key
+        let json = """
+        {"other_field": "no content here"}
+        """.data(using: .utf8)!
+
+        HTTPMocking.setHandler(token: token) { request in
+            let resp = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (json, resp)
+        }
+
+        let ref = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
+        await #expect(throws: YouVersionAPIError.invalidDownload) {
             _ = try await YouVersionAPI.Bible.chapter(reference: ref, accessToken: "swift-test-suite", session: session)
         }
     }

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionsAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionsAPITests.swift
@@ -14,8 +14,8 @@ import Testing
 
         let json = """
         {"data": [
-            {"id": 1, "title": "English Version", "abbreviation": "en", "language": "en"},
-            {"id": 2, "title": "German Version", "abbreviation": "de", "language": "de"}
+            {"id": 1, "title": "English Version", "abbreviation": "en", "language_tag": "en"},
+            {"id": 2, "title": "German Version", "abbreviation": "de", "language_tag": "de"}
         ]}
         """.data(using: .utf8)!
         var capturedRequest: URLRequest?
@@ -33,6 +33,7 @@ import Testing
 
         #expect(versions.count == 2)
         #expect(versions.first?.id == 1)
+        #expect(versions.first?.languageTag == "en")
         let _ = try #require(capturedRequest)
     }
 
@@ -79,5 +80,46 @@ import Testing
         await #expect(throws: YouVersionAPIError.invalidResponse) {
             _ = try await YouVersionAPI.Bible.versions(forLanguageTag: "en", accessToken: "swift-test-suite", session: session)
         }
+    }
+
+    @MainActor
+    @Test func versionsPaginationCombinesBothPages() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        let page1 = """
+        {"data": [
+            {"id": 1, "title": "Version One", "language_tag": "en"}
+        ], "next_page_token": "token-abc"}
+        """.data(using: .utf8)!
+
+        let page2 = """
+        {"data": [
+            {"id": 2, "title": "Version Two", "language_tag": "en"}
+        ]}
+        """.data(using: .utf8)!
+
+        var requestCount = 0
+
+        HTTPMocking.setHandler(token: token) { request in
+            requestCount += 1
+            let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+            let queryItems = components?.queryItems ?? []
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            if requestCount == 1 {
+                #expect(!queryItems.contains(where: { $0.name == "page_token" }))
+                return (page1, response)
+            } else {
+                #expect(queryItems.contains(where: { $0.name == "page_token" && $0.value == "token-abc" }))
+                return (page2, response)
+            }
+        }
+
+        let versions = try await YouVersionAPI.Bible.versions(forLanguageTag: "en", accessToken: "swift-test-suite", session: session)
+
+        #expect(requestCount == 2)
+        #expect(versions.count == 2)
+        #expect(versions[0].id == 1)
+        #expect(versions[1].id == 2)
     }
 }

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionsAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionsAPITests.swift
@@ -34,6 +34,7 @@ import Testing
         #expect(versions.count == 2)
         #expect(versions.first?.id == 1)
         #expect(versions.first?.languageTag == "en")
+        #expect(versions.last?.languageTag == "de")
         let _ = try #require(capturedRequest)
     }
 

--- a/Tests/YouVersionPlatformCoreTests/LanguagesAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/LanguagesAPITests.swift
@@ -59,8 +59,12 @@ import Testing
         #expect(languages[1].id == "es")
         #expect(languages[1].language == "Spanish")
         #expect(languages[1].defaultBibleId == 128)
-        
-        let _ = try #require(capturedRequest)
+
+        let request = try #require(capturedRequest)
+        #expect(request.url?.path.contains("/v1/languages") == true)
+        let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+        let queryItems = components?.queryItems ?? []
+        #expect(queryItems.contains(where: { $0.name == "page_size" && $0.value == "99" }))
     }
 
     @MainActor
@@ -178,6 +182,45 @@ import Testing
 
         let languages = try await YouVersionAPI.Languages.languages(accessToken: "swift-test-suite", session: session)
         #expect(languages.isEmpty)
+    }
+
+    @MainActor
+    @Test func languagesPaginationCombinesBothPages() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        let page1Languages = [
+            LanguageOverview(id: "en", language: "English", defaultBibleId: 3034)
+        ]
+        let page2Languages = [
+            LanguageOverview(id: "es", language: "Spanish", defaultBibleId: 128)
+        ]
+
+        let page1Data = try JSONEncoder().encode(LanguagesResponse(data: page1Languages, nextPageToken: "token-xyz", totalSize: nil))
+        let page2Data = try JSONEncoder().encode(LanguagesResponse(data: page2Languages, nextPageToken: nil, totalSize: nil))
+
+        var requestCount = 0
+
+        HTTPMocking.setHandler(token: token) { request in
+            requestCount += 1
+            let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+            let queryItems = components?.queryItems ?? []
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            if requestCount == 1 {
+                #expect(!queryItems.contains(where: { $0.name == "page_token" }))
+                return (page1Data, response)
+            } else {
+                #expect(queryItems.contains(where: { $0.name == "page_token" && $0.value == "token-xyz" }))
+                return (page2Data, response)
+            }
+        }
+
+        let languages = try await YouVersionAPI.Languages.languages(accessToken: "swift-test-suite", session: session)
+
+        #expect(requestCount == 2)
+        #expect(languages.count == 2)
+        #expect(languages[0].id == "en")
+        #expect(languages[1].id == "es")
     }
 
     // Helper struct for encoding test responses

--- a/Tests/YouVersionPlatformCoreTests/URLBuilderTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/URLBuilderTests.swift
@@ -62,6 +62,17 @@ struct URLBuilderTests {
     }
 
     @Test
+    func testHighlightsDeleteURLWithHyphenatedPassageId() throws {
+        // Hyphens are valid URL path characters (RFC 3986), so a verse-range passageId like
+        // "GEN.1.3-GEN.1.5" is safe to interpolate directly into the path.
+        // Note: only URL-path-safe passageIds are supported; the source does not percent-encode
+        // the passageId before embedding it in the path segment.
+        let url = try #require(URLBuilder.highlightsDeleteURL(bibleId: 1, passageId: "GEN.1.3-GEN.1.5"))
+        #expect(url.absoluteString == "https://api.youversion.com/v1/highlights/GEN.1.3-GEN.1.5?bible_id=1")
+        #expect(url.path.contains("GEN.1.3-GEN.1.5"))
+    }
+
+    @Test
     func testLanguagesURLs() throws {
         // Configure using defaults (no host environment)
 

--- a/Tests/YouVersionPlatformCoreTests/UsersObtainTokensTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/UsersObtainTokensTests.swift
@@ -26,7 +26,8 @@ import Testing
             let body = requestBodyString(request)
             #expect(body.contains("code=auth-code"))
             #expect(body.contains("code_verifier=verifier"))
-            #expect(body.contains("redirect_uri=youversionauth://callback"))
+            #expect(body.contains("redirect_uri=youversionauth"))
+            #expect(body.contains("grant_type=authorization_code"))
 
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
             return (responseData, response)
@@ -50,6 +51,50 @@ import Testing
 
         HTTPMocking.setHandler(token: token) { request in
             let response = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+            return (Data(), response)
+        }
+
+        await #expect(throws: URLError.self) {
+            _ = try await YouVersionAPI.Users.obtainTokens(
+                from: "auth-code",
+                codeVerifier: "verifier",
+                redirectUri: "youversionauth://callback",
+                session: session
+            )
+        }
+    }
+
+    @Test func obtainTokens400InvalidGrantThrows() async {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        // The source throws URLError(.badServerResponse) for any non-200 status
+        let errorBody = """
+        {"error": "invalid_grant"}
+        """.data(using: .utf8)!
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 400, httpVersion: nil, headerFields: nil)!
+            return (errorBody, response)
+        }
+
+        await #expect(throws: URLError.self) {
+            _ = try await YouVersionAPI.Users.obtainTokens(
+                from: "bad-code",
+                codeVerifier: "verifier",
+                redirectUri: "youversionauth://callback",
+                session: session
+            )
+        }
+    }
+
+    @Test func obtainTokens401UnauthorizedThrows() async {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        // The source throws URLError(.badServerResponse) for any non-200 status
+        HTTPMocking.setHandler(token: token) { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil)!
             return (Data(), response)
         }
 

--- a/Tests/YouVersionPlatformCoreTests/UsersObtainTokensTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/UsersObtainTokensTests.swift
@@ -26,7 +26,7 @@ import Testing
             let body = requestBodyString(request)
             #expect(body.contains("code=auth-code"))
             #expect(body.contains("code_verifier=verifier"))
-            #expect(body.contains("redirect_uri=youversionauth"))
+            #expect(body.contains("redirect_uri=youversionauth://callback"))
             #expect(body.contains("grant_type=authorization_code"))
 
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!

--- a/Tests/YouVersionPlatformCoreTests/UsersObtainTokensTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/UsersObtainTokensTests.swift
@@ -68,7 +68,6 @@ import Testing
         let (session, token) = HTTPMocking.makeSession()
         defer { HTTPMocking.clear(token: token) }
 
-        // The source throws URLError(.badServerResponse) for any non-200 status
         let errorBody = """
         {"error": "invalid_grant"}
         """.data(using: .utf8)!
@@ -78,7 +77,7 @@ import Testing
             return (errorBody, response)
         }
 
-        await #expect(throws: URLError.self) {
+        await #expect(throws: URLError(.badServerResponse)) {
             _ = try await YouVersionAPI.Users.obtainTokens(
                 from: "bad-code",
                 codeVerifier: "verifier",
@@ -92,13 +91,12 @@ import Testing
         let (session, token) = HTTPMocking.makeSession()
         defer { HTTPMocking.clear(token: token) }
 
-        // The source throws URLError(.badServerResponse) for any non-200 status
         HTTPMocking.setHandler(token: token) { request in
             let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil)!
             return (Data(), response)
         }
 
-        await #expect(throws: URLError.self) {
+        await #expect(throws: URLError(.badServerResponse)) {
             _ = try await YouVersionAPI.Users.obtainTokens(
                 from: "auth-code",
                 codeVerifier: "verifier",


### PR DESCRIPTION
## Summary

- **BibleVersionsAPITests**: Fix inline fixture JSON from `"language"` to `"language_tag"` (matching `BibleVersion` CodingKeys), add `languageTag == "en"` regression assertion, add two-page pagination test verifying `next_page_token` is followed and results are combined
- **BibleVersionAPITests**: Add URL query param assertions (`format=html`, `include_notes=true`, `include_headings=true`) to `chapterSuccessParsesContent`; add `chapterInvalidContentThrowsInvalidDownload` test verifying `.invalidDownload` is thrown when 200 response JSON lacks the `"content"` key
- **LanguagesAPITests**: Replace no-op `let _ = try #require(capturedRequest)` with real assertions on URL path (`/v1/languages`) and `page_size=99` query param; add two-page pagination test
- **URLBuilderTests**: Add `testHighlightsDeleteURLWithHyphenatedPassageId` documenting that hyphens are valid URL path characters and verse-range passageIds like `GEN.1.3-GEN.1.5` work correctly; includes note that only URL-path-safe passageIds are supported (source does not percent-encode the path segment)
- **UsersObtainTokensTests**: Add `grant_type=authorization_code` assertion to `obtainTokensSuccessDecodesResponse`; add `obtainTokens400InvalidGrantThrows` and `obtainTokens401UnauthorizedThrows` tests verifying `URLError` is thrown for non-200 OAuth responses

## Test plan

- [x] `swift test --filter "BibleVersionsAPITests|BibleVersionAPITests|LanguagesAPITests|URLBuilderTests|UsersObtainTokensTests"` — all 30 tests pass
- [x] `swift test` — all 338 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves test coverage across five test files by fixing a fixture JSON key mismatch (`"language"` → `"language_tag"`), adding regression assertions, and filling in previously missing contract tests for query parameters, pagination, and error scenarios.

- **BibleVersionsAPITests & LanguagesAPITests**: Fix fixture JSON and add two-page pagination tests verifying `next_page_token` is followed and both pages' results are combined into a single return value.
- **BibleVersionAPITests**: Adds query param assertions (`format=html`, `include_notes`, `include_headings`) to the success path, plus a new test confirming `.invalidDownload` is thrown when a 200 response omits the `\"content\"` key.
- **UsersObtainTokensTests & URLBuilderTests**: Adds `grant_type` assertion, 400/401 error-path tests for `obtainTokens`, and documents hyphen-safe passageId behavior in `URLBuilder`.

<h3>Confidence Score: 5/5</h3>

All changes are test-only additions and corrections; no production code is touched.

Every changed file is a test file. The fixture JSON key fix closes a real gap where decoded language tags were not being verified. The new pagination, error-path, and query-param tests all exercise paths that were previously uncovered. No logic that could affect users is modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Tests/YouVersionPlatformCoreTests/BibleVersionsAPITests.swift | Fixture JSON key corrected to language_tag, language tag assertions added, and a well-structured two-page pagination test added. |
| Tests/YouVersionPlatformCoreTests/BibleVersionAPITests.swift | Adds capturedRequest capture and query param assertions to the success test, plus a new chapterInvalidContentThrowsInvalidDownload test. |
| Tests/YouVersionPlatformCoreTests/LanguagesAPITests.swift | Replaces no-op request assertion with real URL path and page_size query checks; adds a correct two-page pagination test. |
| Tests/YouVersionPlatformCoreTests/URLBuilderTests.swift | Adds a well-commented test documenting that hyphens in passageIds are valid URL path characters. |
| Tests/YouVersionPlatformCoreTests/UsersObtainTokensTests.swift | Adds grant_type assertion to the success test and two new error-path tests for 400/401 responses. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test: assert second version&#39;s languageTa..."](https://github.com/youversion/platform-sdk-swift/commit/409290a774398f7fce328697a8eec5d055f20a8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31270814)</sub>

<!-- /greptile_comment -->