### PR TITLE
ci: replace Husky commit-msg hook with CI commit-lint + release preview

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -50,17 +50,23 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set +e
-          # On a PR, env-ci detects this branch (HEAD_REF) but it's not in the
-          # configured `branches: ["main"]` allowlist, so the analyzer bails.
-          # Override the allowlist for this invocation only with exactly one
-          # entry: the PR head branch. semantic-release then sees we're on a
-          # valid release branch and runs the full analysis against our merge
-          # base. `--no-ci` skips the refuse-on-PR check. The file config
-          # (`.releaserc.json`) is untouched, so real releases still only ship
-          # from `main`.
+          # Canonical workaround for running semantic-release --dry-run on a
+          # PR (see semantic-release discussions #1886 and #1937):
           #
-          # Why not `--branches '**'`? It expands to every branch in the repo
-          # and semantic-release rejects branch sets above 3.
+          #   1. Unset GITHUB_ACTIONS. env-ci uses that flag to decide it's on
+          #      GitHub Actions and to report the branch as `refs/pull/N/merge`.
+          #      With it gone, env-ci falls back to git-based branch detection
+          #      and sees us on the PR head branch.
+          #   2. Override the branches allowlist with just that head branch.
+          #      A single entry keeps us well under semantic-release's
+          #      max-3-release-branches validation.
+          #   3. --no-ci skips the refuse-on-PR check that runs even after
+          #      branch detection passes.
+          #
+          # The file config (`.releaserc.json`) is untouched, so real releases
+          # still only ship from `main`. actions/checkout uses the merge ref
+          # by default, which is what we want analyzed.
+          unset GITHUB_ACTIONS
           npx semantic-release --dry-run --no-ci --branches "$HEAD_REF" > semrel.log 2>&1
           STATUS=$?
           cat semrel.log

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,169 @@
+name: Commit Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: commit-lint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint-commits:
+    name: Lint commits & preview release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint commit messages
+        id: commitlint
+        run: |
+          set +e
+          npx commitlint \
+            --from "${{ github.event.pull_request.base.sha }}" \
+            --to "${{ github.event.pull_request.head.sha }}" \
+            --verbose > commitlint.log 2>&1
+          STATUS=$?
+          cat commitlint.log
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Semantic-release dry-run
+        id: semrel
+        if: steps.commitlint.outputs.status == '0'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          npx semantic-release --dry-run --no-ci --branches "${{ github.event.pull_request.base.ref }}" > semrel.log 2>&1
+          STATUS=$?
+          cat semrel.log
+          NEXT=$(grep -Eo "The next release version is [0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?" semrel.log | tail -1 | awk '{print $NF}')
+          [ -z "$NEXT" ] && NEXT="none"
+          BREAKING=$(grep -c "BREAKING CHANGE" semrel.log || echo 0)
+          awk '/BREAKING CHANGE:/{flag=1} flag{print; if(/^$/) flag=0}' semrel.log > breaking.txt || true
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "breaking_count=$BREAKING" >> "$GITHUB_OUTPUT"
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Build PR comment body
+        id: body
+        if: always()
+        run: |
+          set -e
+          MARKER='<!-- commit-lint-bot -->'
+          STATUS="${{ steps.commitlint.outputs.status }}"
+          NEXT="${{ steps.semrel.outputs.next }}"
+          BREAKING="${{ steps.semrel.outputs.breaking_count }}"
+          SEMREL_STATUS="${{ steps.semrel.outputs.status }}"
+
+          {
+            echo "$MARKER"
+            if [ "$STATUS" = "0" ]; then
+              echo '## ✅ Commit Lint: passed'
+              echo
+              echo 'All commit messages in this PR conform to [Conventional Commits](https://www.conventionalcommits.org/).'
+              echo
+              if [ "$SEMREL_STATUS" != "0" ]; then
+                echo '> ⚠️ `semantic-release --dry-run` exited non-zero. Release preview may be incomplete. This does not block the PR.'
+                echo
+              fi
+              if [ -z "$NEXT" ] || [ "$NEXT" = "none" ]; then
+                echo '### 📦 Release preview: _no release_'
+                echo
+                echo 'These commits would not trigger a new release on `main`.'
+              elif [ "${BREAKING:-0}" -gt 0 ]; then
+                echo "### 🚨🚨🚨 BREAKING CHANGES DETECTED — Next release: \`v$NEXT\` (MAJOR)"
+                echo
+                echo 'This PR introduces one or more **BREAKING CHANGE** footers. Merging will publish a **major** version bump.'
+                echo
+                echo '<details><summary>Breaking change notes</summary>'
+                echo
+                echo '```'
+                head -c 4000 breaking.txt 2>/dev/null || true
+                echo
+                echo '```'
+                echo '</details>'
+              else
+                echo "### 📦 Release preview: \`v$NEXT\`"
+                echo
+                echo 'Merging this PR will trigger a new release on `main`.'
+              fi
+              echo
+              echo '<details><summary>semantic-release dry-run output</summary>'
+              echo
+              echo '```'
+              tail -c 6000 semrel.log 2>/dev/null || true
+              echo
+              echo '```'
+              echo '</details>'
+            else
+              echo '## ❌ Commit Lint: failed'
+              echo
+              echo 'One or more commit messages in this PR do not conform to [Conventional Commits](https://www.conventionalcommits.org/).'
+              echo 'This must be fixed before this PR can be merged.'
+              echo
+              echo '### commitlint output'
+              echo
+              echo '```'
+              cat commitlint.log
+              echo '```'
+              echo
+              echo '### How to fix'
+              echo
+              echo '1. Reword the offending commit(s) so the subject matches `type(scope): description`.'
+              echo '   - Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.'
+              echo '   - Breaking changes: append `!` after the type/scope, or add a `BREAKING CHANGE:` footer.'
+              echo '2. Rewrite history on your branch:'
+              echo
+              echo '   ```bash'
+              echo '   # most recent commit'
+              echo '   git commit --amend'
+              echo '   # earlier commits'
+              echo '   git rebase -i origin/${{ github.event.pull_request.base.ref }}'
+              echo '   git push --force-with-lease'
+              echo '   ```'
+              echo
+              echo 'See `commitlint.config.js` for the full ruleset.'
+            fi
+          } > comment.md
+          echo "path=$PWD/comment.md" >> "$GITHUB_OUTPUT"
+
+      - name: Find existing bot comment
+        if: always()
+        id: find_comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- commit-lint-bot -->'
+
+      - name: Upsert PR comment
+        if: always()
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: ${{ steps.body.outputs.path }}
+          edit-mode: replace
+
+      - name: Fail job if commitlint failed
+        if: steps.commitlint.outputs.status != '0'
+        run: |
+          echo "Commit lint failed — see PR comment for details."
+          exit 1

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -47,9 +47,18 @@ jobs:
         if: steps.commitlint.outputs.status == '0'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set +e
-          npx semantic-release --dry-run --no-ci --branches "${{ github.event.pull_request.base.ref }}" > semrel.log 2>&1
+          # semantic-release refuses to run on branches outside its configured
+          # `branches` list. On a PR, HEAD is a detached merge ref like
+          # `refs/pull/N/merge` which doesn't match `main`, so the analyzer bails
+          # before computing a version. Simulate "merged to base" by pointing a
+          # local branch with the base's name at the PR's merge commit, then
+          # running semantic-release as if we were on that branch.
+          MERGE_SHA=$(git rev-parse HEAD)
+          git checkout -B "$BASE_REF" "$MERGE_SHA"
+          npx semantic-release --dry-run --no-ci > semrel.log 2>&1
           STATUS=$?
           cat semrel.log
           NEXT=$(grep -Eo "The next release version is [0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?" semrel.log | tail -1 | awk '{print $NF}')

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -47,16 +47,21 @@ jobs:
         if: steps.commitlint.outputs.status == '0'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set +e
-          # On a PR, env-ci reports the branch as `refs/pull/N/merge`, which
-          # doesn't match the configured `branches: ["main"]` allowlist — so
-          # the analyzer bails before computing a version. `--branches '**'`
-          # overrides the allowlist for this invocation only (the file config
-          # is untouched), and `--no-ci` skips semantic-release's refuse-on-PR
-          # check. Together they let the analyzer run against the PR's merge
-          # commit and report the version that `main` *would* land on.
-          npx semantic-release --dry-run --no-ci --branches '**' > semrel.log 2>&1
+          # On a PR, env-ci detects this branch (HEAD_REF) but it's not in the
+          # configured `branches: ["main"]` allowlist, so the analyzer bails.
+          # Override the allowlist for this invocation only with exactly one
+          # entry: the PR head branch. semantic-release then sees we're on a
+          # valid release branch and runs the full analysis against our merge
+          # base. `--no-ci` skips the refuse-on-PR check. The file config
+          # (`.releaserc.json`) is untouched, so real releases still only ship
+          # from `main`.
+          #
+          # Why not `--branches '**'`? It expands to every branch in the repo
+          # and semantic-release rejects branch sets above 3.
+          npx semantic-release --dry-run --no-ci --branches "$HEAD_REF" > semrel.log 2>&1
           STATUS=$?
           cat semrel.log
           NEXT=$(grep -Eo "The next release version is [0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?" semrel.log | tail -1 | awk '{print $NF}')

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -2,7 +2,7 @@ name: Commit Lint
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -54,10 +54,20 @@ jobs:
           cat semrel.log
           NEXT=$(grep -Eo "The next release version is [0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?" semrel.log | tail -1 | awk '{print $NF}')
           [ -z "$NEXT" ] && NEXT="none"
-          BREAKING=$(grep -c "BREAKING CHANGE" semrel.log || echo 0)
+          # Detect "major" via semantic-release's own release-type log line.
+          # This catches both `BREAKING CHANGE:` footers AND the `feat!:` /
+          # `fix!:` shorthand, which doesn't emit the footer keyword.
+          if grep -qiE "complete:[[:space:]]*major[[:space:]]+release|release type[[:space:]]+is[[:space:]]+major" semrel.log; then
+            IS_MAJOR=1
+          else
+            IS_MAJOR=0
+          fi
+          # Best-effort: pull any explicit BREAKING CHANGE footer text for the comment.
+          # `feat!:` commits without a footer won't have notes here, and that's fine —
+          # the banner is gated on IS_MAJOR, not on the presence of footer text.
           awk '/BREAKING CHANGE:/{flag=1} flag{print; if(/^$/) flag=0}' semrel.log > breaking.txt || true
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
-          echo "breaking_count=$BREAKING" >> "$GITHUB_OUTPUT"
+          echo "is_major=$IS_MAJOR" >> "$GITHUB_OUTPUT"
           echo "status=$STATUS" >> "$GITHUB_OUTPUT"
           exit 0
 
@@ -69,7 +79,7 @@ jobs:
           MARKER='<!-- commit-lint-bot -->'
           STATUS="${{ steps.commitlint.outputs.status }}"
           NEXT="${{ steps.semrel.outputs.next }}"
-          BREAKING="${{ steps.semrel.outputs.breaking_count }}"
+          IS_MAJOR="${{ steps.semrel.outputs.is_major }}"
           SEMREL_STATUS="${{ steps.semrel.outputs.status }}"
 
           {
@@ -87,18 +97,20 @@ jobs:
                 echo '### 📦 Release preview: _no release_'
                 echo
                 echo 'These commits would not trigger a new release on `main`.'
-              elif [ "${BREAKING:-0}" -gt 0 ]; then
+              elif [ "${IS_MAJOR:-0}" = "1" ]; then
                 echo "### 🚨🚨🚨 BREAKING CHANGES DETECTED — Next release: \`v$NEXT\` (MAJOR)"
                 echo
-                echo 'This PR introduces one or more **BREAKING CHANGE** footers. Merging will publish a **major** version bump.'
+                echo 'This PR introduces one or more breaking changes (either a `BREAKING CHANGE:` footer or a `feat!:` / `fix!:` shorthand). Merging will publish a **major** version bump.'
                 echo
-                echo '<details><summary>Breaking change notes</summary>'
-                echo
-                echo '```'
-                head -c 4000 breaking.txt 2>/dev/null || true
-                echo
-                echo '```'
-                echo '</details>'
+                if [ -s breaking.txt ]; then
+                  echo '<details><summary>Breaking change notes</summary>'
+                  echo
+                  echo '```'
+                  head -c 4000 breaking.txt
+                  echo
+                  echo '```'
+                  echo '</details>'
+                fi
               else
                 echo "### 📦 Release preview: \`v$NEXT\`"
                 echo
@@ -147,7 +159,7 @@ jobs:
       - name: Find existing bot comment
         if: always()
         id: find_comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
@@ -155,7 +167,7 @@ jobs:
 
       - name: Upsert PR comment
         if: always()
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -50,15 +50,22 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set +e
-          # semantic-release refuses to run on branches outside its configured
-          # `branches` list. On a PR, HEAD is a detached merge ref like
-          # `refs/pull/N/merge` which doesn't match `main`, so the analyzer bails
-          # before computing a version. Simulate "merged to base" by pointing a
-          # local branch with the base's name at the PR's merge commit, then
-          # running semantic-release as if we were on that branch.
+          # semantic-release uses env-ci to detect the current branch, and on
+          # GitHub Actions PRs env-ci reports the merge ref (refs/pull/N/merge),
+          # which never matches the configured `branches: ["main"]` — so it
+          # bails before analyzing commits. To get a real preview:
+          #   1. Point a local branch named after the base ref at the PR's
+          #      merge commit, so git HEAD looks like "merged to main".
+          #   2. Strip the GITHUB_* env vars that signal "we're in CI on a PR"
+          #      so env-ci falls back to git-based branch detection and sees
+          #      us on `main`. We keep GITHUB_TOKEN for the github plugin.
           MERGE_SHA=$(git rev-parse HEAD)
           git checkout -B "$BASE_REF" "$MERGE_SHA"
-          npx semantic-release --dry-run --no-ci > semrel.log 2>&1
+          env -u CI -u GITHUB_ACTIONS -u GITHUB_REF -u GITHUB_REF_NAME \
+              -u GITHUB_REF_TYPE -u GITHUB_HEAD_REF -u GITHUB_BASE_REF \
+              -u GITHUB_EVENT_NAME -u GITHUB_EVENT_PATH -u GITHUB_SHA \
+              -u GITHUB_RUN_ID -u GITHUB_RUN_NUMBER -u GITHUB_WORKFLOW \
+            npx semantic-release --dry-run > semrel.log 2>&1
           STATUS=$?
           cat semrel.log
           NEXT=$(grep -Eo "The next release version is [0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?" semrel.log | tail -1 | awk '{print $NF}')

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -47,25 +47,16 @@ jobs:
         if: steps.commitlint.outputs.status == '0'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set +e
-          # semantic-release uses env-ci to detect the current branch, and on
-          # GitHub Actions PRs env-ci reports the merge ref (refs/pull/N/merge),
-          # which never matches the configured `branches: ["main"]` — so it
-          # bails before analyzing commits. To get a real preview:
-          #   1. Point a local branch named after the base ref at the PR's
-          #      merge commit, so git HEAD looks like "merged to main".
-          #   2. Strip the GITHUB_* env vars that signal "we're in CI on a PR"
-          #      so env-ci falls back to git-based branch detection and sees
-          #      us on `main`. We keep GITHUB_TOKEN for the github plugin.
-          MERGE_SHA=$(git rev-parse HEAD)
-          git checkout -B "$BASE_REF" "$MERGE_SHA"
-          env -u CI -u GITHUB_ACTIONS -u GITHUB_REF -u GITHUB_REF_NAME \
-              -u GITHUB_REF_TYPE -u GITHUB_HEAD_REF -u GITHUB_BASE_REF \
-              -u GITHUB_EVENT_NAME -u GITHUB_EVENT_PATH -u GITHUB_SHA \
-              -u GITHUB_RUN_ID -u GITHUB_RUN_NUMBER -u GITHUB_WORKFLOW \
-            npx semantic-release --dry-run > semrel.log 2>&1
+          # On a PR, env-ci reports the branch as `refs/pull/N/merge`, which
+          # doesn't match the configured `branches: ["main"]` allowlist — so
+          # the analyzer bails before computing a version. `--branches '**'`
+          # overrides the allowlist for this invocation only (the file config
+          # is untouched), and `--no-ci` skips semantic-release's refuse-on-PR
+          # check. Together they let the analyzer run against the PR's merge
+          # commit and report the version that `main` *would* land on.
+          npx semantic-release --dry-run --no-ci --branches '**' > semrel.log 2>&1
           STATUS=$?
           cat semrel.log
           NEXT=$(grep -Eo "The next release version is [0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?" semrel.log | tail -1 | awk '{print $NF}')

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx --no -- commitlint --edit $1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ LINUX_SOURCEKIT_LIB_PATH=/root/.local/share/swiftly/toolchains/6.1.3/usr/lib swi
 - Unit tests for core functionality
 
 ### Code Style
-- [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) for commit messages (enforced by commitlint)
+- [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) for commit messages (enforced in CI by the `Commit Lint` workflow — no local hook required)
 - Protocol-oriented programming patterns
 - Extensive use of extensions for code organization
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ This SDK is organized as a Swift Package with multiple targets:
 
 This project follows idiomatic Swift conventions as outlined in [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/). Key points:
 
-- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages (validated in CI by the `Commit Lint` workflow; check locally with `npm run commitlint` or `npx commitlint --from=origin/main --to=HEAD --verbose`)
 - Run `swiftlint` before submitting PRs
 - Prefer `async`/`await` over completion handlers
 - Use protocol-oriented programming patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,33 +36,48 @@ This project follows idiomatic Swift conventions as outlined in [Swift API Desig
 
 - Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages — they drive semantic-release's version bumps and the auto-generated CHANGELOG. Validated in CI by the `Commit Lint` workflow; check locally with `npm run commitlint` (or `npx commitlint --from=origin/main --to=HEAD --verbose`).
 
+  > **⚠️ Important: every commit subject on `main` is scanned to compute the next version.**
+  >
+  > This repo squash-merges PRs. The **squash commit subject becomes a single commit on `main`** — its `<type>` is what semantic-release reads, not the individual commits on your branch. GitHub seeds the squash subject from the PR title by default, so **make sure your PR title is itself a valid Conventional Commit** (e.g. `feat(reader): add highlight color picker`). If the squash subject is `chore:` you'll get no release even if every commit on your branch was a `feat`.
+  >
+  > On each push to `main`, semantic-release walks the entire commit history back to the last release tag and picks the **highest** bump it finds — one `feat` among ten `chore`s still triggers a minor release; one `BREAKING CHANGE` anywhere triggers a major. The CI `Commit Lint` workflow on each PR previews the next version using the same logic.
+
   **Format:** `<type>(<optional scope>): <subject>`
 
   **Allowed types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
 
   **Version-bump behavior:**
-  - `feat:` → minor bump (e.g. `5.2.2` → `5.3.0`)
-  - `fix:` and `perf:` → patch bump (e.g. `5.2.2` → `5.2.3`)
-  - Everything else → no release
-  - Any commit with `!` after the type/scope, **or** a `BREAKING CHANGE:` footer → major bump (e.g. `5.2.2` → `6.0.0`)
+  - `feat:` → **minor** bump (e.g. `5.2.2` → `5.3.0`)
+  - `fix:` and `perf:` → **patch** bump (e.g. `5.2.2` → `5.2.3`)
+  - `docs`, `style`, `refactor`, `test`, `build`, `ci`, `chore`, `revert` → **no release**
+  - Any commit with `!` after the type/scope, **or** a `BREAKING CHANGE:` footer → **major** bump (e.g. `5.2.2` → `6.0.0`)
 
-  **Examples:**
+  **Examples (annotated with the bump each one would trigger):**
 
   ```text
   feat(reader): add highlight color picker to BibleReaderView
+  # → MINOR: 5.2.2 → 5.3.0
 
   fix(core): normalize bookUSFM case in overlaps/contains
+  # → PATCH: 5.2.2 → 5.2.3
+
+  perf(reader): cache verse layout to avoid recomputation on scroll
+  # → PATCH: 5.2.2 → 5.2.3
 
   docs: clarify SDK installation steps in README
+  # → NO RELEASE
 
   refactor(ui): extract VerseRow into its own SwiftUI view
+  # → NO RELEASE
 
   chore(deps): bump SwiftLint to 0.55.1
+  # → NO RELEASE
 
   feat(api)!: rename PlatformClient.fetch(_:) to PlatformClient.load(_:)
 
   BREAKING CHANGE: `fetch(_:)` has been removed. Migrate to `load(_:)`,
   which throws instead of returning an optional.
+  # → MAJOR: 5.2.2 → 6.0.0  (the `!` is enough; the footer adds CHANGELOG detail)
   ```
 
   Keep the subject in the imperative mood ("add", "fix", "rename" — not "added"/"fixes"). Use a `scope` (e.g. `reader`, `core`, `ui`, `api`) when the change is localized; omit it when the change is repo-wide.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,38 @@ This SDK is organized as a Swift Package with multiple targets:
 
 This project follows idiomatic Swift conventions as outlined in [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/). Key points:
 
-- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages (validated in CI by the `Commit Lint` workflow; check locally with `npm run commitlint` or `npx commitlint --from=origin/main --to=HEAD --verbose`)
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages — they drive semantic-release's version bumps and the auto-generated CHANGELOG. Validated in CI by the `Commit Lint` workflow; check locally with `npm run commitlint` (or `npx commitlint --from=origin/main --to=HEAD --verbose`).
+
+  **Format:** `<type>(<optional scope>): <subject>`
+
+  **Allowed types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+
+  **Version-bump behavior:**
+  - `feat:` → minor bump (e.g. `5.2.2` → `5.3.0`)
+  - `fix:` and `perf:` → patch bump (e.g. `5.2.2` → `5.2.3`)
+  - Everything else → no release
+  - Any commit with `!` after the type/scope, **or** a `BREAKING CHANGE:` footer → major bump (e.g. `5.2.2` → `6.0.0`)
+
+  **Examples:**
+
+  ```text
+  feat(reader): add highlight color picker to BibleReaderView
+
+  fix(core): normalize bookUSFM case in overlaps/contains
+
+  docs: clarify SDK installation steps in README
+
+  refactor(ui): extract VerseRow into its own SwiftUI view
+
+  chore(deps): bump SwiftLint to 0.55.1
+
+  feat(api)!: rename PlatformClient.fetch(_:) to PlatformClient.load(_:)
+
+  BREAKING CHANGE: `fetch(_:)` has been removed. Migrate to `load(_:)`,
+  which throws instead of returning an optional.
+  ```
+
+  Keep the subject in the imperative mood ("add", "fix", "rename" — not "added"/"fixes"). Use a `scope` (e.g. `reader`, `core`, `ui`, `api`) when the change is localized; omit it when the change is repo-wide.
 - Run `swiftlint` before submitting PRs
 - Prefer `async`/`await` over completion handlers
 - Use protocol-oriented programming patterns

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -123,12 +123,18 @@ This allows semantic-release to push release commits and tags directly to `main`
 
 ### Test commitlint
 
-```bash
-# Valid commit message
-echo "feat: add new feature" | npx commitlint
+Conventional Commits are enforced in CI by `.github/workflows/commit-lint.yml`. There is no local Git hook — Xcode commits and Windows contributors bypass hooks too unreliably for that to be worth maintaining. To check your branch's commits locally before pushing:
 
-# Invalid commit message (should fail)
-echo "invalid message" | npx commitlint
+```bash
+# Lint every commit on your branch that isn't on main
+npx commitlint --from=origin/main --to=HEAD --verbose
+
+# Or, equivalently:
+npm run commitlint
+
+# Pipe a single message to test rule changes
+echo "feat: add new feature" | npx commitlint
+echo "invalid message" | npx commitlint   # should fail
 ```
 
 ### Test semantic-release (dry-run)

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@semantic-release/github": "^9.2.4",
         "@semantic-release/release-notes-generator": "^12.1.0",
         "conventional-changelog-conventionalcommits": "^7.0.2",
-        "husky": "^8.0.3",
         "semantic-release": "^22.0.10"
       }
     },
@@ -371,7 +370,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -1474,7 +1472,6 @@
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -2615,22 +2612,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
-      }
-    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -3212,7 +3193,6 @@
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -5869,7 +5849,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6733,7 +6712,6 @@
       "integrity": "sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^11.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -7599,7 +7577,8 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "semantic-release": "semantic-release",
-    "prepare": "husky"
+    "commitlint": "commitlint --from=origin/main --to=HEAD --verbose"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",
@@ -21,7 +21,6 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^9.2.4",
     "@semantic-release/release-notes-generator": "^12.1.0",
-    "husky": "^8.0.3",
     "semantic-release": "^22.0.10"
   }
 }


### PR DESCRIPTION
## Summary

- Removes the local Husky `commit-msg` hook (unreliable across Xcode, Windows shells, and agent-driven commits) and the `husky` devDependency.
- Adds `.github/workflows/commit-lint.yml`, a **fail-fast PR gate** that lints every commit in the PR range against the existing `commitlint.config.js` and runs `semantic-release --dry-run` to preview the next version (with a loud warning when `BREAKING CHANGE` footers are present).
- Posts a sticky PR comment on both success and failure using `peter-evans/find-comment` + `peter-evans/create-or-update-comment`, with actionable fix instructions when a commit fails the rules.
- Adds `npm run commitlint` for contributors who want to pre-check locally before pushing.
- Updates `AGENTS.md`, `RELEASING.md`, and `CONTRIBUTING.md` to describe the new flow.

A non-zero `semantic-release --dry-run` is treated as a **warning only** so a release-config glitch can never block unrelated PRs.

Jira: [YPE-2398](https://lifechurch.atlassian.net/browse/YPE-2398)

## Follow-up (not in this PR)

- Add `lint-commits` as a required status check on `main` in branch protection (manual GitHub UI change — admin-only).
- Run two throwaway test PRs to validate (a) the failure-comment path with an intentionally bad commit, and (b) the BREAKING-CHANGE banner with a `feat!:` commit.

## Test plan

- [ ] CI: `Commit Lint` workflow runs on this PR and passes (all commits here use conventional format).
- [ ] CI: sticky PR comment appears with the next-release preview.
- [ ] Local: `npm install` runs without invoking husky.
- [ ] Local: `npm run commitlint` reports clean on this branch.
- [ ] Local: `git commit -m "bogus"` succeeds (no hook).
- [ ] Follow-up test PR: bad commit → workflow fails, PR comment shows the failure + fix instructions.
- [ ] Follow-up test PR: `feat!:` commit → PR comment shows the 🚨 BREAKING CHANGES banner with the correct next major version.

🤖 Generated with [Craft Agent](https://craft.do)

[YPE-2398]: https://lifechurch.atlassian.net/browse/YPE-2398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the local Husky `commit-msg` hook with a CI-based commit-lint workflow on GitHub Actions, adding a semantic-release dry-run preview and sticky PR comment for pass/fail feedback.

- **`.github/workflows/commit-lint.yml`** — new workflow that lints every PR commit against `commitlint.config.js`, runs `semantic-release --dry-run` for a version preview (warning-only on failure), and upserts a sticky bot comment using SHA-pinned third-party actions; concurrency is scoped per PR number with `cancel-in-progress: true`.
- **`package.json`** — removes `prepare: husky`, removes `husky` devDependency, adds `npm run commitlint` convenience script for local pre-push checks.
- **`AGENTS.md`, `CONTRIBUTING.md`, `RELEASING.md`** — updated with expanded Conventional Commits guidance, squash-merge semantics, version-bump behavior table, and local `npm run commitlint` instructions.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it replaces a brittle local git hook with a well-structured CI workflow and makes no changes to runtime library code.

The workflow correctly defers the actual job failure to a final step, uses SHA-pinned third-party actions, handles the semrel dry-run as warning-only, and guards all file reads on non-existent artifacts. The IS_MAJOR detection covers both BREAKING CHANGE footer and feat! shorthand via the semantic-release log grep. Documentation changes are accurate and thorough.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/commit-lint.yml | New CI workflow for commit linting and release preview; third-party actions pinned to full SHA, breaking-change detection uses IS_MAJOR from semrel log, failure path correctly deferred to a final step. |
| package.json | Removes husky devDependency and prepare script; adds npm run commitlint convenience shortcut. Clean change. |
| CONTRIBUTING.md | Expanded Conventional Commits section with squash-merge semantics, version-bump table, annotated examples, and local lint instructions. |
| RELEASING.md | Updated test-commitlint section to reflect the new CI-first approach and equivalent local commands. |
| AGENTS.md | One-line update noting enforcement moved to CI; correct and concise. |
| .husky/commit-msg | Deleted — local Husky hook intentionally removed as part of the CI migration. |
| package-lock.json | Lockfile reflects husky removal and peer-dependency flag corrections. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR opened / push / reopen] --> B[actions/checkout fetch-depth=0]
    B --> C[npm ci]
    C --> D[commitlint --from base.sha --to head.sha]
    D -->|status=0| E[semantic-release --dry-run]
    D -->|status!=0| F[Build failure comment]
    E --> G{IS_MAJOR?}
    G -->|yes| H[BREAKING CHANGES banner]
    G -->|no| I{NEXT version?}
    I -->|version found| J[Release preview vX.Y.Z]
    I -->|none| K[No release]
    H --> L[Build PR comment body]
    J --> L
    K --> L
    F --> L
    L --> M[find-comment: find existing bot comment]
    M --> N[create-or-update-comment: upsert sticky comment]
    N -->|commitlint passed| O[Job succeeds]
    N -->|commitlint failed| P[exit 1 - job fails]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fcommit-lint.yml%3A153-155%0AThe%20%60commitlint.log%60%20is%20printed%20verbatim%20into%20the%20failure%20comment%20with%20no%20size%20cap.%20With%20%60--verbose%60%2C%20commitlint%20emits%20a%20header%20block%20per%20commit%2C%20so%20a%20PR%20with%20many%20bad%20commits%20%28or%20a%20single%20commit%20with%20a%20very%20long%20body%29%20can%20generate%20a%20comment%20large%20enough%20to%20hit%20GitHub's%2065%2C536-character%20comment%20body%20limit%2C%20causing%20the%20%60create-or-update-comment%60%20action%20to%20fail%20silently%20or%20error.%20%60semrel.log%60%20and%20%60breaking.txt%60%20are%20already%20guarded%20with%20%60tail%20-c%206000%60%20%2F%20%60head%20-c%204000%60%20%E2%80%94%20worth%20applying%20the%20same%20treatment%20here.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%20'%60%60%60'%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20head%20-c%206000%20commitlint.log%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%20'%60%60%60'%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=117&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fcommit-lint.yml%3A153-155%0AThe%20%60commitlint.log%60%20is%20printed%20verbatim%20into%20the%20failure%20comment%20with%20no%20size%20cap.%20With%20%60--verbose%60%2C%20commitlint%20emits%20a%20header%20block%20per%20commit%2C%20so%20a%20PR%20with%20many%20bad%20commits%20%28or%20a%20single%20commit%20with%20a%20very%20long%20body%29%20can%20generate%20a%20comment%20large%20enough%20to%20hit%20GitHub's%2065%2C536-character%20comment%20body%20limit%2C%20causing%20the%20%60create-or-update-comment%60%20action%20to%20fail%20silently%20or%20error.%20%60semrel.log%60%20and%20%60breaking.txt%60%20are%20already%20guarded%20with%20%60tail%20-c%206000%60%20%2F%20%60head%20-c%204000%60%20%E2%80%94%20worth%20applying%20the%20same%20treatment%20here.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%20'%60%60%60'%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20head%20-c%206000%20commitlint.log%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%20'%60%60%60'%0A%60%60%60%0A%0A&pr=117&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/commit-lint.yml:153-155
The `commitlint.log` is printed verbatim into the failure comment with no size cap. With `--verbose`, commitlint emits a header block per commit, so a PR with many bad commits (or a single commit with a very long body) can generate a comment large enough to hit GitHub's 65,536-character comment body limit, causing the `create-or-update-comment` action to fail silently or error. `semrel.log` and `breaking.txt` are already guarded with `tail -c 6000` / `head -c 4000` — worth applying the same treatment here.

```suggestion
              echo '```'
              head -c 6000 commitlint.log
              echo
              echo '```'
```

`````

</details>

<sub>Reviews (6): Last reviewed commit: ["fix(ci): unset GITHUB\_ACTIONS for semant..."](https://github.com/youversion/platform-sdk-swift/commit/886d66a140945dd581c9caa4e536507b62000e26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31676331)</sub>

<!-- /greptile_comment -->