### PR TITLE
fix(reader): correct chapter-complete scroll detection direction BL-1772

### DIFF
--- a/.api-baseline/YouVersionPlatformCore.json
+++ b/.api-baseline/YouVersionPlatformCore.json
@@ -6127,6 +6127,55 @@
               {
                 "kind": "Function",
                 "name": "version",
+                "printedName": "version(withId:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO7version6withId11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO7version6withId11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "isFromExtension": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "version",
                 "printedName": "version(versionId:accessToken:session:)",
                 "children": [
                   {
@@ -6167,6 +6216,58 @@
                 "declKind": "Func",
                 "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO7version0G2Id11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
                 "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO7version0G2Id11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "deprecated": true,
+                "declAttributes": [
+                  "Available"
+                ],
+                "isFromExtension": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "metadataForVersion",
+                "printedName": "metadataForVersion(withId:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO011metadataForB06withId11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO011metadataForB06withId11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
                 "moduleName": "YouVersionPlatformCore",
                 "static": true,
                 "isFromExtension": true,
@@ -6217,6 +6318,10 @@
                 "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO05basicB09versionId11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
                 "moduleName": "YouVersionPlatformCore",
                 "static": true,
+                "deprecated": true,
+                "declAttributes": [
+                  "Available"
+                ],
                 "isFromExtension": true,
                 "throwing": true,
                 "funcSelfKind": "NonMutating"
@@ -6740,6 +6845,68 @@
               },
               {
                 "kind": "Function",
+                "name": "highlights",
+                "printedName": "highlights(bibleId:passageId:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.HighlightResponse]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "HighlightResponse",
+                        "printedName": "YouVersionPlatformCore.HighlightResponse",
+                        "usr": "s:22YouVersionPlatformCore17HighlightResponseV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO10HighlightsO10highlights7bibleId07passageI011accessToken7sessionSayAA17HighlightResponseVGSi_S2SSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO10HighlightsO10highlights7bibleId07passageI011accessToken7sessionSayAA17HighlightResponseVGSi_S2SSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
                 "name": "getHighlights",
                 "printedName": "getHighlights(bibleId:passageId:accessToken:session:)",
                 "children": [
@@ -6797,6 +6964,10 @@
                 "mangledName": "$s22YouVersionPlatformCore0aB3APIO10HighlightsO03getF07bibleId07passageI011accessToken7sessionSayAA17HighlightResponseVGSi_S2SSgSo12NSURLSessionCtYaKFZ",
                 "moduleName": "YouVersionPlatformCore",
                 "static": true,
+                "deprecated": true,
+                "declAttributes": [
+                  "Available"
+                ],
                 "throwing": true,
                 "funcSelfKind": "NonMutating"
               },
@@ -7116,6 +7287,63 @@
             "children": [
               {
                 "kind": "Function",
+                "name": "signInResult",
+                "printedName": "signInResult(from:state:codeVerifier:redirectUri:nonce:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionResult",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO12signInResult4from5state12codeVerifier11redirectUri5nonce7sessionAA04Signh4WithabI0V10Foundation3URLV_S4SSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO12signInResult4from5state12codeVerifier11redirectUri5nonce7sessionAA04Signh4WithabI0V10Foundation3URLV_S4SSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
                 "name": "getSignInResult",
                 "printedName": "getSignInResult(from:state:codeVerifier:redirectUri:nonce:session:)",
                 "children": [
@@ -7168,6 +7396,57 @@
                 "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO15getSignInResult4from5state12codeVerifier11redirectUri5nonce7sessionAA0hi4WithabJ0V10Foundation3URLV_S4SSo12NSURLSessionCtYaKFZ",
                 "moduleName": "YouVersionPlatformCore",
                 "static": true,
+                "deprecated": true,
+                "declAttributes": [
+                  "Available"
+                ],
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "refreshSignIn",
+                "printedName": "refreshSignIn(withToken:idToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionResult",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO13refreshSignIn9withToken02idK07sessionAA0hi4WithaB6ResultVSS_SSSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO13refreshSignIn9withToken02idK07sessionAA0hi4WithaB6ResultVSS_SSSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
                 "throwing": true,
                 "funcSelfKind": "NonMutating"
               },
@@ -7215,6 +7494,10 @@
                 "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO14performRefresh4with7idToken7sessionAA010SignInWithaB6ResultVSS_SSSgSo12NSURLSessionCtYaKFZ",
                 "moduleName": "YouVersionPlatformCore",
                 "static": true,
+                "deprecated": true,
+                "declAttributes": [
+                  "Available"
+                ],
                 "throwing": true,
                 "funcSelfKind": "NonMutating"
               },
@@ -9188,287 +9471,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "ChapterDiskCache",
-        "printedName": "ChapterDiskCache",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(versionId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC06removeB09versionIdySi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC06removeB09versionIdySi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Var",
-            "name": "unownedExecutor",
-            "printedName": "unownedExecutor",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UnownedSerialExecutor",
-                "printedName": "_Concurrency.UnownedSerialExecutor",
-                "usr": "s:Sce"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevp",
-            "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
-            "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
-              "Available",
-              "Final",
-              "Nonisolated",
-              "Semantics"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UnownedSerialExecutor",
-                    "printedName": "_Concurrency.UnownedSerialExecutor",
-                    "usr": "s:Sce"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevg",
-                "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC",
-        "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC",
-        "moduleName": "YouVersionPlatformCore",
-        "hasMissingDesignatedInitializers": true,
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Actor",
-            "printedName": "Actor",
-            "usr": "s:ScA",
-            "mangledName": "$sScA"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "ChapterDownloadCache",
-        "printedName": "ChapterDownloadCache",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "chaptersArePresent",
-            "printedName": "chaptersArePresent(versionId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC18chaptersArePresent9versionIdSbSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC18chaptersArePresent9versionIdSbSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Nonisolated"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(versionId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC06removeB09versionIdySi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC06removeB09versionIdySi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Var",
-            "name": "unownedExecutor",
-            "printedName": "unownedExecutor",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UnownedSerialExecutor",
-                "printedName": "_Concurrency.UnownedSerialExecutor",
-                "usr": "s:Sce"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevp",
-            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
-            "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
-              "Available",
-              "Final",
-              "Nonisolated",
-              "Semantics"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UnownedSerialExecutor",
-                    "printedName": "_Concurrency.UnownedSerialExecutor",
-                    "usr": "s:Sce"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevg",
-                "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC",
-        "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC",
-        "moduleName": "YouVersionPlatformCore",
-        "hasMissingDesignatedInitializers": true,
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Actor",
-            "printedName": "Actor",
-            "usr": "s:ScA",
-            "mangledName": "$sScA"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "BibleChapterRepository",
         "printedName": "BibleChapterRepository",
         "children": [
@@ -9524,6 +9526,24 @@
             ]
           },
           {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleChapterRepository",
+                "printedName": "YouVersionPlatformCore.BibleChapterRepository",
+                "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Convenience"
+          },
+          {
             "kind": "Function",
             "name": "chapter",
             "printedName": "chapter(withReference:)",
@@ -9569,9 +9589,6 @@
             "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC06removeB06withIdySi_tYaF",
             "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryC06removeB06withIdySi_tYaF",
             "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Custom"
-            ],
             "funcSelfKind": "NonMutating"
           },
           {
@@ -13460,6 +13477,311 @@
       },
       {
         "kind": "TypeDecl",
+        "name": "BibleNoteIndicatorsCache",
+        "printedName": "BibleNoteIndicatorsCache",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "shared",
+            "printedName": "shared",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleNoteIndicatorsCache",
+                "printedName": "YouVersionPlatformCore.BibleNoteIndicatorsCache",
+                "usr": "s:22YouVersionPlatformCore24BibleNoteIndicatorsCacheC"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore24BibleNoteIndicatorsCacheC6sharedACvpZ",
+            "mangledName": "$s22YouVersionPlatformCore24BibleNoteIndicatorsCacheC6sharedACvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "Final",
+              "HasStorage",
+              "Custom"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleNoteIndicatorsCache",
+                    "printedName": "YouVersionPlatformCore.BibleNoteIndicatorsCache",
+                    "usr": "s:22YouVersionPlatformCore24BibleNoteIndicatorsCacheC"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore24BibleNoteIndicatorsCacheC6sharedACvgZ",
+                "mangledName": "$s22YouVersionPlatformCore24BibleNoteIndicatorsCacheC6sharedACvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Final",
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "indicatedUSFMs",
+            "printedName": "indicatedUSFMs",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.String>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore24BibleNoteIndicatorsCacheC14indicatedUSFMsShySSGvp",
+            "mangledName": "$s22YouVersionPlatformCore24BibleNoteIndicatorsCacheC14indicatedUSFMsShySSGvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasInitialValue",
+              "Final",
+              "SetterAccess",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Set",
+                    "printedName": "Swift.Set<Swift.String>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sh"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore24BibleNoteIndicatorsCacheC14indicatedUSFMsShySSGvg",
+                "mangledName": "$s22YouVersionPlatformCore24BibleNoteIndicatorsCacheC14indicatedUSFMsShySSGvg",
+                "moduleName": "YouVersionPlatformCore",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "setIndicators",
+            "printedName": "setIndicators(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.String>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore24BibleNoteIndicatorsCacheC03setG0yyShySSGF",
+            "mangledName": "$s22YouVersionPlatformCore24BibleNoteIndicatorsCacheC03setG0yyShySSGF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addIndicator",
+            "printedName": "addIndicator(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore24BibleNoteIndicatorsCacheC12addIndicator3forySS_tF",
+            "mangledName": "$s22YouVersionPlatformCore24BibleNoteIndicatorsCacheC12addIndicator3forySS_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeIndicator",
+            "printedName": "removeIndicator(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore24BibleNoteIndicatorsCacheC15removeIndicator3forySS_tF",
+            "mangledName": "$s22YouVersionPlatformCore24BibleNoteIndicatorsCacheC15removeIndicator3forySS_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hasNote",
+            "printedName": "hasNote(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore24BibleNoteIndicatorsCacheC03hasF03forSbSS_tF",
+            "mangledName": "$s22YouVersionPlatformCore24BibleNoteIndicatorsCacheC03hasF03forSbSS_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "reset",
+            "printedName": "reset()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore24BibleNoteIndicatorsCacheC5resetyyF",
+            "mangledName": "$s22YouVersionPlatformCore24BibleNoteIndicatorsCacheC5resetyyF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore24BibleNoteIndicatorsCacheC",
+        "mangledName": "$s22YouVersionPlatformCore24BibleNoteIndicatorsCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "declAttributes": [
+          "Final",
+          "Custom"
+        ],
+        "hasMissingDesignatedInitializers": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Observable",
+            "printedName": "Observable",
+            "usr": "s:11Observation10ObservableP",
+            "mangledName": "$s11Observation10ObservableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
         "name": "BibleReference",
         "printedName": "BibleReference",
         "children": [
@@ -16945,76 +17267,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "BibleVersionAPIClient",
-        "printedName": "BibleVersionAPIClient",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP7version6withIdAA0eB0VSi_tYaKF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP7version6withIdAA0eB0VSi_tYaKF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionAPIClient>",
-            "protocolReq": true,
-            "throwing": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          }
-        ],
-        "declKind": "Protocol",
-        "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP",
-        "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP",
-        "moduleName": "YouVersionPlatformCore",
-        "genericSig": "<Self : Swift.Sendable>",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "BibleVersionRepositoryProtocol",
         "printedName": "BibleVersionRepositoryProtocol",
         "children": [
@@ -17235,1146 +17487,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "BibleVersionCaching",
-        "printedName": "BibleVersionCaching",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "YouVersionPlatformCore.BibleVersion?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "BibleVersion",
-                    "printedName": "YouVersionPlatformCore.BibleVersion",
-                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP7version6withIdAA0eB0VSgSi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP7version6withIdAA0eB0VSgSi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
-            "protocolReq": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "addVersion",
-            "printedName": "addVersion(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP03addB0yyAA0eB0VYaF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP03addB0yyAA0eB0VYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
-            "protocolReq": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP06removeB06withIdySi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP06removeB06withIdySi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
-            "protocolReq": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "versionIsPresent",
-            "printedName": "versionIsPresent(for:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP16versionIsPresent3forSbSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP16versionIsPresent3forSbSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
-            "protocolReq": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeUnpermittedVersions",
-            "printedName": "removeUnpermittedVersions(permittedIds:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Set",
-                "printedName": "Swift.Set<Swift.Int>",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sh"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
-            "protocolReq": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          }
-        ],
-        "declKind": "Protocol",
-        "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
-        "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP",
-        "moduleName": "YouVersionPlatformCore",
-        "genericSig": "<Self : Swift.Sendable>",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "VersionClient",
-        "printedName": "VersionClient",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "VersionClient",
-                "printedName": "YouVersionPlatformCore.VersionClient",
-                "usr": "s:22YouVersionPlatformCore0B6ClientC"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore0B6ClientCACycfc",
-            "mangledName": "$s22YouVersionPlatformCore0B6ClientCACycfc",
-            "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B6ClientC7version6withIdAA05BibleB0VSi_tYaKF",
-            "mangledName": "$s22YouVersionPlatformCore0B6ClientC7version6withIdAA05BibleB0VSi_tYaKF",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Final"
-            ],
-            "throwing": true,
-            "funcSelfKind": "NonMutating"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore0B6ClientC",
-        "mangledName": "$s22YouVersionPlatformCore0B6ClientC",
-        "moduleName": "YouVersionPlatformCore",
-        "declAttributes": [
-          "Final"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "BibleVersionAPIClient",
-            "printedName": "BibleVersionAPIClient",
-            "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "VersionMemoryCache",
-        "printedName": "VersionMemoryCache",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "VersionMemoryCache",
-                "printedName": "YouVersionPlatformCore.VersionMemoryCache",
-                "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheCACycfc",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheCACycfc",
-            "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "YouVersionPlatformCore.BibleVersion?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "BibleVersion",
-                    "printedName": "YouVersionPlatformCore.BibleVersion",
-                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "versionIsPresent",
-            "printedName": "versionIsPresent(for:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC16versionIsPresent3forSbSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC16versionIsPresent3forSbSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Nonisolated"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "addVersion",
-            "printedName": "addVersion(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC03addB0yyAA05BibleB0VYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC03addB0yyAA05BibleB0VYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC06removeB06withIdySi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC06removeB06withIdySi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeUnpermittedVersions",
-            "printedName": "removeUnpermittedVersions(permittedIds:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Set",
-                "printedName": "Swift.Set<Swift.Int>",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sh"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Var",
-            "name": "unownedExecutor",
-            "printedName": "unownedExecutor",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UnownedSerialExecutor",
-                "printedName": "_Concurrency.UnownedSerialExecutor",
-                "usr": "s:Sce"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevp",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
-            "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
-              "Available",
-              "Final",
-              "Nonisolated",
-              "Semantics"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UnownedSerialExecutor",
-                    "printedName": "_Concurrency.UnownedSerialExecutor",
-                    "usr": "s:Sce"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevg",
-                "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC",
-        "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC",
-        "moduleName": "YouVersionPlatformCore",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "BibleVersionCaching",
-            "printedName": "BibleVersionCaching",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Actor",
-            "printedName": "Actor",
-            "usr": "s:ScA",
-            "mangledName": "$sScA"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "VersionDiskCache",
-        "printedName": "VersionDiskCache",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "VersionDiskCache",
-                "printedName": "YouVersionPlatformCore.VersionDiskCache",
-                "usr": "s:22YouVersionPlatformCore0B9DiskCacheC"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheCACycfc",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheCACycfc",
-            "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "YouVersionPlatformCore.BibleVersion?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "BibleVersion",
-                    "printedName": "YouVersionPlatformCore.BibleVersion",
-                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC7version6withIdAA05BibleB0VSgSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC7version6withIdAA05BibleB0VSgSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "versionIsPresent",
-            "printedName": "versionIsPresent(for:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC16versionIsPresent3forSbSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC16versionIsPresent3forSbSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Nonisolated"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "addVersion",
-            "printedName": "addVersion(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC03addB0yyAA05BibleB0VYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC03addB0yyAA05BibleB0VYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC06removeB06withIdySi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC06removeB06withIdySi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeUnpermittedVersions",
-            "printedName": "removeUnpermittedVersions(permittedIds:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Set",
-                "printedName": "Swift.Set<Swift.Int>",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sh"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Var",
-            "name": "unownedExecutor",
-            "printedName": "unownedExecutor",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UnownedSerialExecutor",
-                "printedName": "_Concurrency.UnownedSerialExecutor",
-                "usr": "s:Sce"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevp",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
-            "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
-              "Available",
-              "Final",
-              "Nonisolated",
-              "Semantics"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UnownedSerialExecutor",
-                    "printedName": "_Concurrency.UnownedSerialExecutor",
-                    "usr": "s:Sce"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevg",
-                "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore0B9DiskCacheC",
-        "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC",
-        "moduleName": "YouVersionPlatformCore",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "BibleVersionCaching",
-            "printedName": "BibleVersionCaching",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Actor",
-            "printedName": "Actor",
-            "usr": "s:ScA",
-            "mangledName": "$sScA"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "VersionDownloadCache",
-        "printedName": "VersionDownloadCache",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "VersionDownloadCache",
-                "printedName": "YouVersionPlatformCore.VersionDownloadCache",
-                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheCACycfc",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheCACycfc",
-            "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Function",
-            "name": "versionIsPresent",
-            "printedName": "versionIsPresent(for:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC16versionIsPresent3forSbSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC16versionIsPresent3forSbSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Nonisolated"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "YouVersionPlatformCore.BibleVersion?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "BibleVersion",
-                    "printedName": "YouVersionPlatformCore.BibleVersion",
-                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC7version6withIdAA05BibleB0VSgSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC7version6withIdAA05BibleB0VSgSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "addVersion",
-            "printedName": "addVersion(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC03addB0yyAA05BibleB0VYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC03addB0yyAA05BibleB0VYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC06removeB06withIdySi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC06removeB06withIdySi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeUnpermittedVersions",
-            "printedName": "removeUnpermittedVersions(permittedIds:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Set",
-                "printedName": "Swift.Set<Swift.Int>",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sh"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Var",
-            "name": "downloadedVersions",
-            "printedName": "downloadedVersions",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Array",
-                "printedName": "[Swift.Int]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sa"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvpZ",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvpZ",
-            "moduleName": "YouVersionPlatformCore",
-            "static": true,
-            "declAttributes": [
-              "Final"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Array",
-                    "printedName": "[Swift.Int]",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Int",
-                        "printedName": "Swift.Int",
-                        "usr": "s:Si"
-                      }
-                    ],
-                    "usr": "s:Sa"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvgZ",
-                "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvgZ",
-                "moduleName": "YouVersionPlatformCore",
-                "static": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "unownedExecutor",
-            "printedName": "unownedExecutor",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UnownedSerialExecutor",
-                "printedName": "_Concurrency.UnownedSerialExecutor",
-                "usr": "s:Sce"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevp",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
-            "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
-              "Available",
-              "Final",
-              "Nonisolated",
-              "Semantics"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UnownedSerialExecutor",
-                    "printedName": "_Concurrency.UnownedSerialExecutor",
-                    "usr": "s:Sce"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevg",
-                "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC",
-        "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC",
-        "moduleName": "YouVersionPlatformCore",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "BibleVersionCaching",
-            "printedName": "BibleVersionCaching",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Actor",
-            "printedName": "Actor",
-            "usr": "s:ScA",
-            "mangledName": "$sScA"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "BibleVersionRepository",
         "printedName": "BibleVersionRepository",
         "children": [
@@ -18432,6 +17544,24 @@
           {
             "kind": "Constructor",
             "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionRepository",
+                "printedName": "YouVersionPlatformCore.BibleVersionRepository",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Convenience"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
             "printedName": "init(apiClient:memoryCache:diskCache:downloadCache:)",
             "children": [
               {
@@ -18473,7 +17603,11 @@
             "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC9apiClient11memoryCache04diskJ008downloadJ0AcA0eB9APIClient_p_AA0eB7Caching_pAaI_pAaI_ptcfc",
             "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC9apiClient11memoryCache04diskJ008downloadJ0AcA0eB9APIClient_p_AA0eB7Caching_pAaI_pAaI_ptcfc",
             "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Designated"
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
+            "init_kind": "Convenience"
           },
           {
             "kind": "Function",
@@ -18535,6 +17669,30 @@
           },
           {
             "kind": "Function",
+            "name": "containsVersion",
+            "printedName": "containsVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC08containsB06withIdSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC08containsB06withIdSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
             "name": "versionIsPresent",
             "printedName": "versionIsPresent(for:)",
             "children": [
@@ -18555,6 +17713,10 @@
             "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC16versionIsPresent3forSbSi_tF",
             "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC16versionIsPresent3forSbSi_tF",
             "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
             "funcSelfKind": "NonMutating"
           },
           {
@@ -18876,6 +18038,125 @@
             "funcSelfKind": "NonMutating"
           },
           {
+            "kind": "Var",
+            "name": "downloadedVersionIds",
+            "printedName": "downloadedVersionIds",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.Int]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "defaultDownloadedVersionIds",
+            "printedName": "defaultDownloadedVersionIds",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC017defaultDownloadedB3IdsSaySiGvpZ",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC017defaultDownloadedB3IdsSaySiGvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "isInternal": true,
+            "declAttributes": [
+              "Final"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.Int]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC017defaultDownloadedB3IdsSaySiGvgZ",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC017defaultDownloadedB3IdsSaySiGvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "isInternal": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
             "kind": "Function",
             "name": "removeVersion",
             "printedName": "removeVersion(withId:)",
@@ -18989,6 +18270,7 @@
         "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC",
         "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC",
         "moduleName": "YouVersionPlatformCore",
+        "hasMissingDesignatedInitializers": true,
         "conformances": [
           {
             "kind": "Conformance",
@@ -19031,6 +18313,1545 @@
             "printedName": "BibleVersionRepositoryProtocol",
             "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP",
             "mangledName": "$s22YouVersionPlatformCore05BibleB18RepositoryProtocolP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersionAPIClient",
+        "printedName": "BibleVersionAPIClient",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP7version6withIdAA0eB0VSi_tYaKF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP7version6withIdAA0eB0VSi_tYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionAPIClient>",
+            "protocolReq": true,
+            "throwing": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP",
+        "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP",
+        "moduleName": "YouVersionPlatformCore",
+        "genericSig": "<Self : Swift.Sendable>",
+        "deprecated": true,
+        "declAttributes": [
+          "Available"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersionCaching",
+        "printedName": "BibleVersionCaching",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP7version6withIdAA0eB0VSgSi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP7version6withIdAA0eB0VSgSi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP03addB0yyAA0eB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP03addB0yyAA0eB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+        "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP",
+        "moduleName": "YouVersionPlatformCore",
+        "genericSig": "<Self : Swift.Sendable>",
+        "deprecated": true,
+        "declAttributes": [
+          "Available"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionClient",
+        "printedName": "VersionClient",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionClient",
+                "printedName": "YouVersionPlatformCore.VersionClient",
+                "usr": "s:22YouVersionPlatformCore0B6ClientC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B6ClientCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B6ClientCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B6ClientC7version6withIdAA05BibleB0VSi_tYaKF",
+            "mangledName": "$s22YouVersionPlatformCore0B6ClientC7version6withIdAA05BibleB0VSi_tYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final"
+            ],
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B6ClientC",
+        "mangledName": "$s22YouVersionPlatformCore0B6ClientC",
+        "moduleName": "YouVersionPlatformCore",
+        "deprecated": true,
+        "declAttributes": [
+          "Final",
+          "Available"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionAPIClient",
+            "printedName": "BibleVersionAPIClient",
+            "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionMemoryCache",
+        "printedName": "VersionMemoryCache",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionMemoryCache",
+                "printedName": "YouVersionPlatformCore.VersionMemoryCache",
+                "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC03addB0yyAA05BibleB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC03addB0yyAA05BibleB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC",
+        "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "deprecated": true,
+        "declAttributes": [
+          "Available"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionCaching",
+            "printedName": "BibleVersionCaching",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionDiskCache",
+        "printedName": "VersionDiskCache",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionDiskCache",
+                "printedName": "YouVersionPlatformCore.VersionDiskCache",
+                "usr": "s:22YouVersionPlatformCore0B9DiskCacheC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC03addB0yyAA05BibleB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC03addB0yyAA05BibleB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B9DiskCacheC",
+        "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "deprecated": true,
+        "declAttributes": [
+          "Available"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionCaching",
+            "printedName": "BibleVersionCaching",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionDownloadCache",
+        "printedName": "VersionDownloadCache",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionDownloadCache",
+                "printedName": "YouVersionPlatformCore.VersionDownloadCache",
+                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC03addB0yyAA05BibleB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC03addB0yyAA05BibleB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "downloadedVersions",
+            "printedName": "downloadedVersions",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "Final"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.Int]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC",
+        "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "deprecated": true,
+        "declAttributes": [
+          "Available"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionCaching",
+            "printedName": "BibleVersionCaching",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "ChapterDiskCache",
+        "printedName": "ChapterDiskCache",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC06removeB09versionIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC06removeB09versionIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC",
+        "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "deprecated": true,
+        "declAttributes": [
+          "Available"
+        ],
+        "hasMissingDesignatedInitializers": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "ChapterDownloadCache",
+        "printedName": "ChapterDownloadCache",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "chaptersArePresent",
+            "printedName": "chaptersArePresent(versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC18chaptersArePresent9versionIdSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC18chaptersArePresent9versionIdSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC06removeB09versionIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC06removeB09versionIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC",
+        "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "deprecated": true,
+        "declAttributes": [
+          "Available"
+        ],
+        "hasMissingDesignatedInitializers": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
           },
           {
             "kind": "Conformance",
@@ -20182,6 +21003,170 @@
           },
           {
             "kind": "Var",
+            "name": "permittedLanguageTags",
+            "printedName": "permittedLanguageTags",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Set<Swift.String>?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Set",
+                    "printedName": "Swift.Set<Swift.String>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sh"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV21permittedLanguageTagsShySSGSgvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV21permittedLanguageTagsShySSGSgvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "Nonisolated",
+              "SetterAccess",
+              "HasStorage"
+            ],
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.Set<Swift.String>?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Set",
+                        "printedName": "Swift.Set<Swift.String>",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:Sh"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV21permittedLanguageTagsShySSGSgvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV21permittedLanguageTagsShySSGSgvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "permittedVersionIds",
+            "printedName": "permittedVersionIds",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Set<Swift.Int>?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Set",
+                    "printedName": "Swift.Set<Swift.Int>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sh"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV09permittedB3IdsShySiGSgvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV09permittedB3IdsShySiGSgvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "Nonisolated",
+              "SetterAccess",
+              "HasStorage"
+            ],
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.Set<Swift.Int>?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Set",
+                        "printedName": "Swift.Set<Swift.Int>",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Int",
+                            "printedName": "Swift.Int",
+                            "usr": "s:Si"
+                          }
+                        ],
+                        "usr": "s:Sh"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV09permittedB3IdsShySiGSgvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV09permittedB3IdsShySiGSgvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
             "name": "installId",
             "printedName": "installId",
             "children": [
@@ -20249,7 +21234,7 @@
           {
             "kind": "Function",
             "name": "configure",
-            "printedName": "configure(appKey:apiHost:appName:isSignInEnabled:signInPromptMessage:)",
+            "printedName": "configure(appKey:apiHost:appName:isSignInEnabled:signInPromptMessage:permittedLanguageTags:permittedVersionIds:)",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -20321,11 +21306,57 @@
                 ],
                 "hasDefaultArg": true,
                 "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Set<Swift.String>?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Set",
+                    "printedName": "Swift.Set<Swift.String>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sh"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Set<Swift.Int>?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Set",
+                    "printedName": "Swift.Set<Swift.Int>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sh"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
               }
             ],
             "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV9configure6appKey7apiHost0G4Name15isSignInEnabled04signN13PromptMessageySSSg_A2JSbAJtFZ",
-            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV9configure6appKey7apiHost0G4Name15isSignInEnabled04signN13PromptMessageySSSg_A2JSbAJtFZ",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV9configure6appKey7apiHost0G4Name15isSignInEnabled04signN13PromptMessage21permittedLanguageTags0sB3IdsySSSg_A2LSbALShySSGSgShySiGSgtFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV9configure6appKey7apiHost0G4Name15isSignInEnabled04signN13PromptMessage21permittedLanguageTags0sB3IdsySSSg_A2LSbALShySSGSgShySiGSgtFZ",
             "moduleName": "YouVersionPlatformCore",
             "static": true,
             "declAttributes": [

--- a/.api-baseline/YouVersionPlatformReader.json
+++ b/.api-baseline/YouVersionPlatformReader.json
@@ -75,7 +75,7 @@
           {
             "kind": "Constructor",
             "name": "init",
-            "printedName": "init(reference:verseSelectionStyle:onVerseTap:)",
+            "printedName": "init(reference:selectedVerses:verseSelectionStyle:onVerseTap:onNoteIndicatorTap:onReferenceChange:onChapterComplete:audioActiveReference:audioActiveIndicatorColor:)",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -100,10 +100,69 @@
               },
               {
                 "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Binding<Swift.Set<YouVersionPlatformCore.BibleReference>>?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Binding",
+                    "printedName": "SwiftUI.Binding<Swift.Set<YouVersionPlatformCore.BibleReference>>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Set",
+                        "printedName": "Swift.Set<YouVersionPlatformCore.BibleReference>",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "BibleReference",
+                            "printedName": "YouVersionPlatformCore.BibleReference",
+                            "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                          }
+                        ],
+                        "usr": "s:Sh"
+                      }
+                    ],
+                    "usr": "s:7SwiftUI7BindingV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
                 "name": "VerseSelectionStyle",
                 "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
                 "hasDefaultArg": true,
                 "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "((YouVersionPlatformCore.BibleReference) -> YouVersionPlatformReader.VerseTapResponse)?",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleReference) -> YouVersionPlatformReader.VerseTapResponse",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "VerseTapResponse",
+                        "printedName": "YouVersionPlatformReader.VerseTapResponse",
+                        "usr": "s:24YouVersionPlatformReader16VerseTapResponseO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleReference",
+                        "printedName": "YouVersionPlatformCore.BibleReference",
+                        "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
               },
               {
                 "kind": "TypeNominal",
@@ -138,11 +197,109 @@
                 ],
                 "hasDefaultArg": true,
                 "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "((YouVersionPlatformCore.BibleReference) -> Swift.Void)?",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleReference) -> Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNameAlias",
+                        "name": "Void",
+                        "printedName": "Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Void",
+                            "printedName": "()"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleReference",
+                        "printedName": "YouVersionPlatformCore.BibleReference",
+                        "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "((YouVersionPlatformCore.BibleReference) -> Swift.Void)?",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleReference) -> Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNameAlias",
+                        "name": "Void",
+                        "printedName": "Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Void",
+                            "printedName": "()"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleReference",
+                        "printedName": "YouVersionPlatformCore.BibleReference",
+                        "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleReference?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
               }
             ],
             "declKind": "Constructor",
-            "usr": "s:24YouVersionPlatformReader05BibleD4ViewV9reference19verseSelectionStyle10onVerseTapAC0abC4Core0E9ReferenceVSg_0abC2UI0liJ0VyAIcSgtcfc",
-            "mangledName": "$s24YouVersionPlatformReader05BibleD4ViewV9reference19verseSelectionStyle10onVerseTapAC0abC4Core0E9ReferenceVSg_0abC2UI0liJ0VyAIcSgtcfc",
+            "usr": "s:24YouVersionPlatformReader05BibleD4ViewV9reference14selectedVerses19verseSelectionStyle10onVerseTap0m13NoteIndicatorO00M15ReferenceChange0M15ChapterComplete011audioActiveR00vwQ5ColorAC0abC4Core0eR0VSg_7SwiftUI7BindingVyShyAOGGSg0abC2UI0nkL0VAA0nO8ResponseOAOcSgyAOcSgA1_A1_ApQ0X0VSgtcfc",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD4ViewV9reference14selectedVerses19verseSelectionStyle10onVerseTap0m13NoteIndicatorO00M15ReferenceChange0M15ChapterComplete011audioActiveR00vwQ5ColorAC0abC4Core0eR0VSg_7SwiftUI7BindingVyShyAOGGSg0abC2UI0nkL0VAA0nO8ResponseOAOcSgyAOcSgA1_A1_ApQ0X0VSgtcfc",
             "moduleName": "YouVersionPlatformReader",
             "declAttributes": [
               "Preconcurrency",
@@ -153,7 +310,7 @@
           {
             "kind": "Constructor",
             "name": "init",
-            "printedName": "init(reference:appName:signInMessage:verseSelectionStyle:onVerseTap:)",
+            "printedName": "init(reference:appName:signInMessage:selectedVerses:verseSelectionStyle:onVerseTap:)",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -190,6 +347,37 @@
               },
               {
                 "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Binding<Swift.Set<YouVersionPlatformCore.BibleReference>>?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Binding",
+                    "printedName": "SwiftUI.Binding<Swift.Set<YouVersionPlatformCore.BibleReference>>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Set",
+                        "printedName": "Swift.Set<YouVersionPlatformCore.BibleReference>",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "BibleReference",
+                            "printedName": "YouVersionPlatformCore.BibleReference",
+                            "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                          }
+                        ],
+                        "usr": "s:Sh"
+                      }
+                    ],
+                    "usr": "s:7SwiftUI7BindingV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
                 "name": "VerseSelectionStyle",
                 "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
                 "hasDefaultArg": true,
@@ -198,24 +386,18 @@
               {
                 "kind": "TypeNominal",
                 "name": "Optional",
-                "printedName": "((YouVersionPlatformCore.BibleReference) -> Swift.Void)?",
+                "printedName": "((YouVersionPlatformCore.BibleReference) -> YouVersionPlatformReader.VerseTapResponse)?",
                 "children": [
                   {
                     "kind": "TypeFunc",
                     "name": "Function",
-                    "printedName": "(YouVersionPlatformCore.BibleReference) -> Swift.Void",
+                    "printedName": "(YouVersionPlatformCore.BibleReference) -> YouVersionPlatformReader.VerseTapResponse",
                     "children": [
                       {
-                        "kind": "TypeNameAlias",
-                        "name": "Void",
-                        "printedName": "Swift.Void",
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Void",
-                            "printedName": "()"
-                          }
-                        ]
+                        "kind": "TypeNominal",
+                        "name": "VerseTapResponse",
+                        "printedName": "YouVersionPlatformReader.VerseTapResponse",
+                        "usr": "s:24YouVersionPlatformReader16VerseTapResponseO"
                       },
                       {
                         "kind": "TypeNominal",
@@ -231,8 +413,8 @@
               }
             ],
             "declKind": "Constructor",
-            "usr": "s:24YouVersionPlatformReader05BibleD4ViewV9reference7appName13signInMessage19verseSelectionStyle10onVerseTapAC0abC4Core0E9ReferenceVSg_S2S0abC2UI0qnO0VyAKcSgtcfc",
-            "mangledName": "$s24YouVersionPlatformReader05BibleD4ViewV9reference7appName13signInMessage19verseSelectionStyle10onVerseTapAC0abC4Core0E9ReferenceVSg_S2S0abC2UI0qnO0VyAKcSgtcfc",
+            "usr": "s:24YouVersionPlatformReader05BibleD4ViewV9reference7appName13signInMessage14selectedVerses19verseSelectionStyle10onVerseTapAC0abC4Core0E9ReferenceVSg_S2S7SwiftUI7BindingVyShyALGGSg0abcX00spQ0VAA0sT8ResponseOALcSgtcfc",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD4ViewV9reference7appName13signInMessage14selectedVerses19verseSelectionStyle10onVerseTapAC0abC4Core0E9ReferenceVSg_S2S7SwiftUI7BindingVyShyALGGSg0abcX00spQ0VAA0sT8ResponseOALcSgtcfc",
             "moduleName": "YouVersionPlatformReader",
             "deprecated": true,
             "declAttributes": [
@@ -1084,6 +1266,236 @@
             ],
             "usr": "s:7SwiftUI4ViewP",
             "mangledName": "$s7SwiftUI4ViewP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VerseTapResponse",
+        "printedName": "VerseTapResponse",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "toggleSelection",
+            "printedName": "toggleSelection",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformReader.VerseTapResponse.Type) -> YouVersionPlatformReader.VerseTapResponse",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "VerseTapResponse",
+                    "printedName": "YouVersionPlatformReader.VerseTapResponse",
+                    "usr": "s:24YouVersionPlatformReader16VerseTapResponseO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformReader.VerseTapResponse.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "VerseTapResponse",
+                        "printedName": "YouVersionPlatformReader.VerseTapResponse",
+                        "usr": "s:24YouVersionPlatformReader16VerseTapResponseO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:24YouVersionPlatformReader16VerseTapResponseO15toggleSelectionyA2CmF",
+            "mangledName": "$s24YouVersionPlatformReader16VerseTapResponseO15toggleSelectionyA2CmF",
+            "moduleName": "YouVersionPlatformReader"
+          },
+          {
+            "kind": "Var",
+            "name": "handled",
+            "printedName": "handled",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformReader.VerseTapResponse.Type) -> YouVersionPlatformReader.VerseTapResponse",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "VerseTapResponse",
+                    "printedName": "YouVersionPlatformReader.VerseTapResponse",
+                    "usr": "s:24YouVersionPlatformReader16VerseTapResponseO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformReader.VerseTapResponse.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "VerseTapResponse",
+                        "printedName": "YouVersionPlatformReader.VerseTapResponse",
+                        "usr": "s:24YouVersionPlatformReader16VerseTapResponseO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:24YouVersionPlatformReader16VerseTapResponseO7handledyA2CmF",
+            "mangledName": "$s24YouVersionPlatformReader16VerseTapResponseO7handledyA2CmF",
+            "moduleName": "YouVersionPlatformReader"
+          },
+          {
+            "kind": "Function",
+            "name": "__derived_enum_equals",
+            "printedName": "__derived_enum_equals(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "VerseTapResponse",
+                "printedName": "YouVersionPlatformReader.VerseTapResponse",
+                "usr": "s:24YouVersionPlatformReader16VerseTapResponseO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "VerseTapResponse",
+                "printedName": "YouVersionPlatformReader.VerseTapResponse",
+                "usr": "s:24YouVersionPlatformReader16VerseTapResponseO"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:24YouVersionPlatformReader16VerseTapResponseO21__derived_enum_equalsySbAC_ACtFZ",
+            "mangledName": "$s24YouVersionPlatformReader16VerseTapResponseO21__derived_enum_equalsySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformReader",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Implements",
+              "Semantics"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hash",
+            "printedName": "hash(into:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Hasher",
+                "printedName": "Swift.Hasher",
+                "paramValueOwnership": "InOut",
+                "usr": "s:s6HasherV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:24YouVersionPlatformReader16VerseTapResponseO4hash4intoys6HasherVz_tF",
+            "mangledName": "$s24YouVersionPlatformReader16VerseTapResponseO4hash4intoys6HasherVz_tF",
+            "moduleName": "YouVersionPlatformReader",
+            "implicit": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "hashValue",
+            "printedName": "hashValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:24YouVersionPlatformReader16VerseTapResponseO9hashValueSivp",
+            "mangledName": "$s24YouVersionPlatformReader16VerseTapResponseO9hashValueSivp",
+            "moduleName": "YouVersionPlatformReader",
+            "implicit": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:24YouVersionPlatformReader16VerseTapResponseO9hashValueSivg",
+                "mangledName": "$s24YouVersionPlatformReader16VerseTapResponseO9hashValueSivg",
+                "moduleName": "YouVersionPlatformReader",
+                "implicit": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:24YouVersionPlatformReader16VerseTapResponseO",
+        "mangledName": "$s24YouVersionPlatformReader16VerseTapResponseO",
+        "moduleName": "YouVersionPlatformReader",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
           }
         ]
       },

--- a/.api-baseline/YouVersionPlatformUI.json
+++ b/.api-baseline/YouVersionPlatformUI.json
@@ -872,8 +872,8 @@
         "children": [
           {
             "kind": "Var",
-            "name": "fontSystemM",
-            "printedName": "fontSystemM",
+            "name": "systemMedium",
+            "printedName": "systemMedium",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -883,8 +883,8 @@
               }
             ],
             "declKind": "Var",
-            "usr": "s:20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvpZ",
-            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvpZ",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO12systemMedium05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12systemMedium05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
             "declAttributes": [
@@ -907,14 +907,400 @@
                   }
                 ],
                 "declKind": "Accessor",
-                "usr": "s:20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvgZ",
-                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvgZ",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO12systemMedium05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12systemMedium05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
                 "implicit": true,
                 "declAttributes": [
                   "Transparent"
                 ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "headerMedium",
+            "printedName": "headerMedium",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO12headerMedium05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12headerMedium05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO12headerMedium05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12headerMedium05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "headerSmall",
+            "printedName": "headerSmall",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO11headerSmall05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11headerSmall05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO11headerSmall05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11headerSmall05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "eyebrowSmall",
+            "printedName": "eyebrowSmall",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO12eyebrowSmall05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12eyebrowSmall05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO12eyebrowSmall05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12eyebrowSmall05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "labelMedium",
+            "printedName": "labelMedium",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO11labelMedium05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11labelMedium05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO11labelMedium05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11labelMedium05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "labelSmall",
+            "printedName": "labelSmall",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO10labelSmall05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10labelSmall05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO10labelSmall05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10labelSmall05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "captionsLarge",
+            "printedName": "captionsLarge",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO13captionsLarge05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13captionsLarge05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO13captionsLarge05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13captionsLarge05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "captionsSmall",
+            "printedName": "captionsSmall",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO13captionsSmall05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13captionsSmall05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO13captionsSmall05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13captionsSmall05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "fontSystemM",
+            "printedName": "fontSystemM",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
                 "accessorKind": "get"
               }
             ]
@@ -936,12 +1322,10 @@
             "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontHeaderM05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
-              "HasInitialValue",
-              "HasStorage"
+              "Available"
             ],
-            "isLet": true,
-            "hasStorage": true,
             "accessors": [
               {
                 "kind": "Accessor",
@@ -960,10 +1344,6 @@
                 "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontHeaderM05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
                 "accessorKind": "get"
               }
             ]
@@ -985,12 +1365,10 @@
             "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontHeaderS05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
-              "HasInitialValue",
-              "HasStorage"
+              "Available"
             ],
-            "isLet": true,
-            "hasStorage": true,
             "accessors": [
               {
                 "kind": "Accessor",
@@ -1009,10 +1387,6 @@
                 "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontHeaderS05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
                 "accessorKind": "get"
               }
             ]
@@ -1034,12 +1408,10 @@
             "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12fontEyebrowS05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
-              "HasInitialValue",
-              "HasStorage"
+              "Available"
             ],
-            "isLet": true,
-            "hasStorage": true,
             "accessors": [
               {
                 "kind": "Accessor",
@@ -1058,10 +1430,6 @@
                 "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12fontEyebrowS05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
                 "accessorKind": "get"
               }
             ]
@@ -1083,12 +1451,10 @@
             "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10fontLabelM05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
-              "HasInitialValue",
-              "HasStorage"
+              "Available"
             ],
-            "isLet": true,
-            "hasStorage": true,
             "accessors": [
               {
                 "kind": "Accessor",
@@ -1107,10 +1473,6 @@
                 "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10fontLabelM05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
                 "accessorKind": "get"
               }
             ]
@@ -1132,12 +1494,10 @@
             "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10fontLabelS05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
-              "HasInitialValue",
-              "HasStorage"
+              "Available"
             ],
-            "isLet": true,
-            "hasStorage": true,
             "accessors": [
               {
                 "kind": "Accessor",
@@ -1156,10 +1516,6 @@
                 "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10fontLabelS05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
                 "accessorKind": "get"
               }
             ]
@@ -1181,12 +1537,10 @@
             "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13fontCaptionsL05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
-              "HasInitialValue",
-              "HasStorage"
+              "Available"
             ],
-            "isLet": true,
-            "hasStorage": true,
             "accessors": [
               {
                 "kind": "Accessor",
@@ -1205,10 +1559,6 @@
                 "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13fontCaptionsL05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
                 "accessorKind": "get"
               }
             ]
@@ -1230,12 +1580,10 @@
             "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13fontCaptionsS05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
-              "HasInitialValue",
-              "HasStorage"
+              "Available"
             ],
-            "isLet": true,
-            "hasStorage": true,
             "accessors": [
               {
                 "kind": "Accessor",
@@ -1254,10 +1602,6 @@
                 "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13fontCaptionsS05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
                 "accessorKind": "get"
               }
             ]
@@ -1757,7 +2101,7 @@
           {
             "kind": "Constructor",
             "name": "init",
-            "printedName": "init(_:textOptions:selectedVerses:onVerseTap:placeholder:)",
+            "printedName": "init(_:textOptions:selectedVerses:onVerseTap:onAnchorsChanged:audioActiveVerse:placeholder:)",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -1893,6 +2237,63 @@
               {
                 "kind": "TypeNominal",
                 "name": "Optional",
+                "printedName": "(([Swift.Int]) -> Swift.Void)?",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "([Swift.Int]) -> Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNameAlias",
+                        "name": "Void",
+                        "printedName": "Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Void",
+                            "printedName": "()"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Array",
+                        "printedName": "[Swift.Int]",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Int",
+                            "printedName": "Swift.Int",
+                            "usr": "s:Si"
+                          }
+                        ],
+                        "usr": "s:Sa"
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Int?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
                 "printedName": "((YouVersionPlatformUI.BibleTextLoadingPhase) -> SwiftUI.AnyView)?",
                 "children": [
                   {
@@ -1920,8 +2321,131 @@
               }
             ],
             "declKind": "Constructor",
-            "usr": "s:20YouVersionPlatformUI13BibleTextViewV_11textOptions14selectedVerses10onVerseTap11placeholderAC0abC4Core0E9ReferenceV_AA0efI0VSg05SwiftD07BindingVyShyAJGGyAJ_SSSayAA0E8FootnoteVGSSSgtcSgAN03AnyG0VAA0eF12LoadingPhaseOcSgtcfc",
-            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV_11textOptions14selectedVerses10onVerseTap11placeholderAC0abC4Core0E9ReferenceV_AA0efI0VSg05SwiftD07BindingVyShyAJGGyAJ_SSSayAA0E8FootnoteVGSSSgtcSgAN03AnyG0VAA0eF12LoadingPhaseOcSgtcfc",
+            "usr": "s:20YouVersionPlatformUI13BibleTextViewV_11textOptions14selectedVerses10onVerseTap0L14AnchorsChanged011audioActiveM011placeholderAC0abC4Core0E9ReferenceV_AA0efI0VSg05SwiftD07BindingVyShyALGGyAL_SSSayAA0E8FootnoteVGSSSgtcSgySaySiGcSgSiSgAP03AnyG0VAA0eF12LoadingPhaseOcSgtcfc",
+            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV_11textOptions14selectedVerses10onVerseTap0L14AnchorsChanged011audioActiveM011placeholderAC0abC4Core0E9ReferenceV_AA0efI0VSg05SwiftD07BindingVyShyALGGyAL_SSSayAA0E8FootnoteVGSSSgtcSgySaySiGcSgSiSgAP03AnyG0VAA0eF12LoadingPhaseOcSgtcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(html:reference:textOptions:onVerseTap:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextView",
+                "printedName": "YouVersionPlatformUI.BibleTextView",
+                "usr": "s:20YouVersionPlatformUI13BibleTextViewV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextOptions",
+                "printedName": "YouVersionPlatformUI.BibleTextOptions",
+                "hasDefaultArg": true,
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.BibleTextView.VerseTapAction?",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "VerseTapAction",
+                    "printedName": "YouVersionPlatformUI.BibleTextView.VerseTapAction",
+                    "children": [
+                      {
+                        "kind": "TypeFunc",
+                        "name": "Function",
+                        "printedName": "(YouVersionPlatformCore.BibleReference, Swift.String, [YouVersionPlatformUI.BibleFootnote], Swift.String?) -> Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNameAlias",
+                            "name": "Void",
+                            "printedName": "Swift.Void",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Void",
+                                "printedName": "()"
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Tuple",
+                            "printedName": "(YouVersionPlatformCore.BibleReference, Swift.String, [YouVersionPlatformUI.BibleFootnote], Swift.String?)",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "BibleReference",
+                                "printedName": "YouVersionPlatformCore.BibleReference",
+                                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Array",
+                                "printedName": "[YouVersionPlatformUI.BibleFootnote]",
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "BibleFootnote",
+                                    "printedName": "YouVersionPlatformUI.BibleFootnote",
+                                    "usr": "s:20YouVersionPlatformUI13BibleFootnoteV"
+                                  }
+                                ],
+                                "usr": "s:Sa"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Optional",
+                                "printedName": "Swift.String?",
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "String",
+                                    "printedName": "Swift.String",
+                                    "usr": "s:SS"
+                                  }
+                                ],
+                                "usr": "s:Sq"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI13BibleTextViewV4html9reference11textOptions10onVerseTapACSS_0abC4Core0E9ReferenceVAA0efK0VyAJ_SSSayAA0E8FootnoteVGSSSgtcSgtcfc",
+            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV4html9reference11textOptions10onVerseTapACSS_0abC4Core0E9ReferenceVAA0efK0VyAJ_SSSayAA0E8FootnoteVGSSSgtcSgtcfc",
             "moduleName": "YouVersionPlatformUI",
             "declAttributes": [
               "Preconcurrency",
@@ -1983,64 +2507,6 @@
                 "accessorKind": "get"
               }
             ]
-          },
-          {
-            "kind": "Function",
-            "name": "viewWithPrefetchedData",
-            "printedName": "viewWithPrefetchedData(reference:fontFamily:fontSize:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "(some SwiftUI.View)?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "OpaqueTypeArchetype",
-                    "printedName": "some SwiftUI.View",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "View",
-                        "printedName": "SwiftUI.View",
-                        "usr": "s:7SwiftUI4ViewP"
-                      }
-                    ]
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleReference",
-                "printedName": "YouVersionPlatformCore.BibleReference",
-                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "hasDefaultArg": true,
-                "usr": "s:SS"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "CGFloat",
-                "printedName": "CoreGraphics.CGFloat",
-                "hasDefaultArg": true,
-                "usr": "s:14CoreFoundation7CGFloatV"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:20YouVersionPlatformUI13BibleTextViewV22viewWithPrefetchedData9reference10fontFamily0M4SizeQrSg0abC4Core0E9ReferenceV_SS0P10Foundation7CGFloatVtYaFZ",
-            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV22viewWithPrefetchedData9reference10fontFamily0M4SizeQrSg0abC4Core0E9ReferenceV_SS0P8Graphics7CGFloatVtYaFZ",
-            "moduleName": "YouVersionPlatformUI",
-            "static": true,
-            "declAttributes": [
-              "Preconcurrency",
-              "Custom"
-            ],
-            "funcSelfKind": "NonMutating"
           },
           {
             "kind": "Function",
@@ -2174,8 +2640,70 @@
             "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV12viewFromHtml4html9reference11textOptions10onVerseTapQrSgSS_0abC4Core0E9ReferenceVAA0efN0VyAL_SSSayAA0E8FootnoteVGSSSgtcSgtFZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
               "Preconcurrency",
+              "Available",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "viewWithPrefetchedData",
+            "printedName": "viewWithPrefetchedData(reference:fontFamily:fontSize:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "(some SwiftUI.View)?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "hasDefaultArg": true,
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "hasDefaultArg": true,
+                "usr": "s:14CoreFoundation7CGFloatV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI13BibleTextViewV22viewWithPrefetchedData9reference10fontFamily0M4SizeQrSg0abC4Core0E9ReferenceV_SS0P10Foundation7CGFloatVtYaFZ",
+            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV22viewWithPrefetchedData9reference10fontFamily0M4SizeQrSg0abC4Core0E9ReferenceV_SS0P8Graphics7CGFloatVtYaFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "deprecated": true,
+            "declAttributes": [
+              "Preconcurrency",
+              "Available",
               "Custom"
             ],
             "funcSelfKind": "NonMutating"
@@ -2559,8 +3087,8 @@
           },
           {
             "kind": "Var",
-            "name": "verseNumColor",
-            "printedName": "verseNumColor",
+            "name": "verseNumberColor",
+            "printedName": "verseNumberColor",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -2578,8 +3106,8 @@
               }
             ],
             "declKind": "Var",
-            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvp",
-            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvp",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV16verseNumberColor05SwiftD00J0VSgvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV16verseNumberColor05SwiftD00J0VSgvp",
             "moduleName": "YouVersionPlatformUI",
             "declAttributes": [
               "HasStorage"
@@ -2608,8 +3136,8 @@
                   }
                 ],
                 "declKind": "Accessor",
-                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvg",
-                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvg",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV16verseNumberColor05SwiftD00J0VSgvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV16verseNumberColor05SwiftD00J0VSgvg",
                 "moduleName": "YouVersionPlatformUI",
                 "implicit": true,
                 "declAttributes": [
@@ -2621,8 +3149,8 @@
           },
           {
             "kind": "Var",
-            "name": "wocColor",
-            "printedName": "wocColor",
+            "name": "wordsOfChristColor",
+            "printedName": "wordsOfChristColor",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -2632,8 +3160,8 @@
               }
             ],
             "declKind": "Var",
-            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvp",
-            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvp",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV18wordsOfChristColor05SwiftD00K0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV18wordsOfChristColor05SwiftD00K0Vvp",
             "moduleName": "YouVersionPlatformUI",
             "declAttributes": [
               "HasStorage"
@@ -2654,8 +3182,8 @@
                   }
                 ],
                 "declKind": "Accessor",
-                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvg",
-                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvg",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV18wordsOfChristColor05SwiftD00K0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV18wordsOfChristColor05SwiftD00K0Vvg",
                 "moduleName": "YouVersionPlatformUI",
                 "implicit": true,
                 "declAttributes": [
@@ -2912,9 +3440,195 @@
             ]
           },
           {
+            "kind": "Var",
+            "name": "noteIndicatorBoxColor",
+            "printedName": "noteIndicatorBoxColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV21noteIndicatorBoxColor05SwiftD00K0VSgvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV21noteIndicatorBoxColor05SwiftD00K0VSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "SwiftUI.Color?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Color",
+                        "printedName": "SwiftUI.Color",
+                        "usr": "s:7SwiftUI5ColorV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV21noteIndicatorBoxColor05SwiftD00K0VSgvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV21noteIndicatorBoxColor05SwiftD00K0VSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "noteIndicatorBoxHighlightColor",
+            "printedName": "noteIndicatorBoxHighlightColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV30noteIndicatorBoxHighlightColor05SwiftD00L0VSgvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV30noteIndicatorBoxHighlightColor05SwiftD00L0VSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "SwiftUI.Color?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Color",
+                        "printedName": "SwiftUI.Color",
+                        "usr": "s:7SwiftUI5ColorV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV30noteIndicatorBoxHighlightColor05SwiftD00L0VSgvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV30noteIndicatorBoxHighlightColor05SwiftD00L0VSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "audioActiveIndicatorColor",
+            "printedName": "audioActiveIndicatorColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV25audioActiveIndicatorColor05SwiftD00K0VSgvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV25audioActiveIndicatorColor05SwiftD00K0VSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "SwiftUI.Color?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Color",
+                        "printedName": "SwiftUI.Color",
+                        "usr": "s:7SwiftUI5ColorV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV25audioActiveIndicatorColor05SwiftD00K0VSgvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV25audioActiveIndicatorColor05SwiftD00K0VSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
             "kind": "Constructor",
             "name": "init",
-            "printedName": "init(fontFamily:fontSize:lineSpacing:paragraphSpacing:textColor:verseNumColor:wocColor:renderHeadlines:renderVerseNumbers:footnoteMode:footnoteMarker:verseSelectionStyle:)",
+            "printedName": "init(fontFamily:fontSize:lineSpacing:paragraphSpacing:textColor:verseNumberColor:wordsOfChristColor:renderHeadlines:renderVerseNumbers:footnoteMode:footnoteMarker:verseSelectionStyle:noteIndicatorBoxColor:noteIndicatorBoxHighlightColor:audioActiveIndicatorColor:)",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -3045,12 +3759,347 @@
                 "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
                 "hasDefaultArg": true,
                 "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
               }
             ],
             "declKind": "Constructor",
-            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV10fontFamily0H4Size11lineSpacing09paragraphL09textColor08verseNumO003wocO015renderHeadlines0S12VerseNumbers12footnoteMode0W6Marker0P14SelectionStyleACSS_14CoreFoundation7CGFloatVARSgAS05SwiftD00O0VSgAwVS2bAA0ef8FootnoteX0OAA0E16AttributedStringCSgAA0uZ5StyleVtcfc",
-            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV10fontFamily0H4Size11lineSpacing09paragraphL09textColor08verseNumO003wocO015renderHeadlines0S12VerseNumbers12footnoteMode0W6Marker0P14SelectionStyleACSS_12CoreGraphics7CGFloatVARSgAS05SwiftD00O0VSgAwVS2bAA0ef8FootnoteX0OAA0E16AttributedStringCSgAA0uZ5StyleVtcfc",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV10fontFamily0H4Size11lineSpacing09paragraphL09textColor011verseNumberO0013wordsOfChristO015renderHeadlines0U12VerseNumbers12footnoteMode0Y6Marker0P14SelectionStyle016noteIndicatorBoxO0025noteIndicatorBoxHighlightO0020audioActiveIndicatorO0ACSS_14CoreFoundation7CGFloatVAUSgAV05SwiftD00O0VSgAzYS2bAA0ef8FootnoteZ0OAA0E16AttributedStringCSgAA0W14SelectionStyleVA3Ztcfc",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV10fontFamily0H4Size11lineSpacing09paragraphL09textColor011verseNumberO0013wordsOfChristO015renderHeadlines0U12VerseNumbers12footnoteMode0Y6Marker0P14SelectionStyle016noteIndicatorBoxO0025noteIndicatorBoxHighlightO0020audioActiveIndicatorO0ACSS_12CoreGraphics7CGFloatVAUSgAV05SwiftD00O0VSgAzYS2bAA0ef8FootnoteZ0OAA0E16AttributedStringCSgAA0W14SelectionStyleVA3Ztcfc",
             "moduleName": "YouVersionPlatformUI",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "verseNumColor",
+            "printedName": "verseNumColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "SwiftUI.Color?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Color",
+                        "printedName": "SwiftUI.Color",
+                        "usr": "s:7SwiftUI5ColorV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "wocColor",
+            "printedName": "wocColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(fontFamily:fontSize:lineSpacing:paragraphSpacing:textColor:verseNumColor:wocColor:renderHeadlines:renderVerseNumbers:footnoteMode:footnoteMarker:verseSelectionStyle:noteIndicatorBoxColor:noteIndicatorBoxHighlightColor:audioActiveIndicatorColor:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextOptions",
+                "printedName": "YouVersionPlatformUI.BibleTextOptions",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "hasDefaultArg": true,
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "hasDefaultArg": true,
+                "usr": "s:14CoreFoundation7CGFloatV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "CoreGraphics.CGFloat?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CGFloat",
+                    "printedName": "CoreGraphics.CGFloat",
+                    "usr": "s:14CoreFoundation7CGFloatV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "CoreGraphics.CGFloat?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CGFloat",
+                    "printedName": "CoreGraphics.CGFloat",
+                    "usr": "s:14CoreFoundation7CGFloatV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "hasDefaultArg": true,
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextFootnoteMode",
+                "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                "hasDefaultArg": true,
+                "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleAttributedString",
+                    "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                    "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "VerseSelectionStyle",
+                "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                "hasDefaultArg": true,
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV10fontFamily0H4Size11lineSpacing09paragraphL09textColor08verseNumO003wocO015renderHeadlines0S12VerseNumbers12footnoteMode0W6Marker0P14SelectionStyle016noteIndicatorBoxO0025noteIndicatorBoxHighlightO0020audioActiveIndicatorO0ACSS_14CoreFoundation7CGFloatVAUSgAV05SwiftD00O0VSgAzYS2bAA0ef8FootnoteX0OAA0E16AttributedStringCSgAA0uZ5StyleVA3Ztcfc",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV10fontFamily0H4Size11lineSpacing09paragraphL09textColor08verseNumO003wocO015renderHeadlines0S12VerseNumbers12footnoteMode0W6Marker0P14SelectionStyle016noteIndicatorBoxO0025noteIndicatorBoxHighlightO0020audioActiveIndicatorO0ACSS_12CoreGraphics7CGFloatVAUSgAV05SwiftD00O0VSgAzYS2bAA0ef8FootnoteX0OAA0E16AttributedStringCSgAA0uZ5StyleVA3Ztcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "deprecated": true,
+            "declAttributes": [
+              "DisfavoredOverload",
+              "Available"
+            ],
             "init_kind": "Designated"
           }
         ],
@@ -3362,6 +4411,225 @@
             "printedName": "Hashable",
             "usr": "s:SH",
             "mangledName": "$sSH"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VerseAnchorsPreferenceKey",
+        "printedName": "VerseAnchorsPreferenceKey",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "defaultValue",
+            "printedName": "defaultValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI25VerseAnchorsPreferenceKeyV12defaultValueSaySiGvpZ",
+            "mangledName": "$s20YouVersionPlatformUI25VerseAnchorsPreferenceKeyV12defaultValueSaySiGvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "isInternal": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.Int]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI25VerseAnchorsPreferenceKeyV12defaultValueSaySiGvgZ",
+                "mangledName": "$s20YouVersionPlatformUI25VerseAnchorsPreferenceKeyV12defaultValueSaySiGvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "isInternal": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "reduce",
+            "printedName": "reduce(value:nextValue:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "paramValueOwnership": "InOut",
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "() -> [Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.Int]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "typeAttributes": [
+                  "noescape"
+                ]
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI25VerseAnchorsPreferenceKeyV6reduce5value9nextValueySaySiGz_AGyXEtFZ",
+            "mangledName": "$s20YouVersionPlatformUI25VerseAnchorsPreferenceKeyV6reduce5value9nextValueySaySiGz_AGyXEtFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "isInternal": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Value",
+            "printedName": "Value",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI25VerseAnchorsPreferenceKeyV5Valuea",
+            "mangledName": "$s20YouVersionPlatformUI25VerseAnchorsPreferenceKeyV5Valuea",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true,
+            "isInternal": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI25VerseAnchorsPreferenceKeyV",
+        "mangledName": "$s20YouVersionPlatformUI25VerseAnchorsPreferenceKeyV",
+        "moduleName": "YouVersionPlatformUI",
+        "isInternal": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "PreferenceKey",
+            "printedName": "PreferenceKey",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Value",
+                "printedName": "Value",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.Int]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI13PreferenceKeyP",
+            "mangledName": "$s7SwiftUI13PreferenceKeyP"
           }
         ]
       },
@@ -4190,6 +5458,68 @@
           },
           {
             "kind": "Var",
+            "name": "startVerse",
+            "printedName": "startVerse",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Int?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI14BibleTextBlockV10startVerseSiSgvp",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV10startVerseSiSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.Int?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI14BibleTextBlockV10startVerseSiSgvg",
+                "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV10startVerseSiSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
             "name": "rows",
             "printedName": "rows",
             "children": [
@@ -4515,7 +5845,7 @@
           {
             "kind": "Constructor",
             "name": "init",
-            "printedName": "init(text:chapter:firstLineHeadIndent:headIndent:marginTop:alignment:footnotes:rows:)",
+            "printedName": "init(text:chapter:startVerse:firstLineHeadIndent:headIndent:marginTop:alignment:footnotes:rows:)",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -4534,6 +5864,21 @@
                 "name": "Int",
                 "printedName": "Swift.Int",
                 "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Int?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
               },
               {
                 "kind": "TypeNominal",
@@ -4598,8 +5943,8 @@
               }
             ],
             "declKind": "Constructor",
-            "usr": "s:20YouVersionPlatformUI14BibleTextBlockV4text7chapter19firstLineHeadIndent04headM09marginTop9alignment9footnotes4rowsAcA0E16AttributedStringC_S3i14CoreFoundation7CGFloatV05SwiftD00F9AlignmentOSayAA0E8FootnoteVGSaySayAMGGtcfc",
-            "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV4text7chapter19firstLineHeadIndent04headM09marginTop9alignment9footnotes4rowsAcA0E16AttributedStringC_S3i12CoreGraphics7CGFloatV05SwiftD00F9AlignmentOSayAA0E8FootnoteVGSaySayAMGGtcfc",
+            "usr": "s:20YouVersionPlatformUI14BibleTextBlockV4text7chapter10startVerse19firstLineHeadIndent04headO09marginTop9alignment9footnotes4rowsAcA0E16AttributedStringC_S2iSgS2i14CoreFoundation7CGFloatV05SwiftD00F9AlignmentOSayAA0E8FootnoteVGSaySayANGGtcfc",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV4text7chapter10startVerse19firstLineHeadIndent04headO09marginTop9alignment9footnotes4rowsAcA0E16AttributedStringC_S2iSgS2i12CoreGraphics7CGFloatV05SwiftD00F9AlignmentOSayAA0E8FootnoteVGSaySayANGGtcfc",
             "moduleName": "YouVersionPlatformUI",
             "init_kind": "Designated"
           },
@@ -4907,6 +6252,43 @@
                 "declKind": "EnumElement",
                 "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO9referenceyA2EmF",
                 "mangledName": "$s20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO9referenceyA2EmF",
+                "moduleName": "YouVersionPlatformUI"
+              },
+              {
+                "kind": "Var",
+                "name": "noteIndicator",
+                "printedName": "noteIndicator",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformUI.BibleVersionRendering.LinkSchemes.Type) -> YouVersionPlatformUI.BibleVersionRendering.LinkSchemes",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "LinkSchemes",
+                        "printedName": "YouVersionPlatformUI.BibleVersionRendering.LinkSchemes",
+                        "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformUI.BibleVersionRendering.LinkSchemes.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "LinkSchemes",
+                            "printedName": "YouVersionPlatformUI.BibleVersionRendering.LinkSchemes",
+                            "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO13noteIndicatoryA2EmF",
+                "mangledName": "$s20YouVersionPlatformUI05BibleB9RenderingO11LinkSchemesO13noteIndicatoryA2EmF",
                 "moduleName": "YouVersionPlatformUI"
               },
               {
@@ -7501,6 +8883,55 @@
                 "accessorKind": "get"
               }
             ]
+          },
+          {
+            "kind": "Var",
+            "name": "dotted",
+            "printedName": "dotted",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VerseSelectionStyle",
+                "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV6dottedACvpZ",
+            "mangledName": "$s20YouVersionPlatformUI19VerseSelectionStyleV6dottedACvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "VerseSelectionStyle",
+                    "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                    "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV6dottedACvgZ",
+                "mangledName": "$s20YouVersionPlatformUI19VerseSelectionStyleV6dottedACvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
           }
         ],
         "declKind": "Struct",
@@ -8245,6 +9676,68 @@
         "children": [
           {
             "kind": "Var",
+            "name": "currentVersion",
+            "printedName": "currentVersion",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC07currentB00abC4Core0eB0VSgvp",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC07currentB00abC4Core0eB0VSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasInitialValue",
+              "Final",
+              "SetterAccess",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "YouVersionPlatformCore.BibleVersion?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVersion",
+                        "printedName": "YouVersionPlatformCore.BibleVersion",
+                        "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC07currentB00abC4Core0eB0VSgvg",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC07currentB00abC4Core0eB0VSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
             "name": "onVersionChange",
             "printedName": "onVersionChange",
             "children": [
@@ -8278,8 +9771,10 @@
             "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Changeyy0abC4Core0eB0Vcvp",
             "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Changeyy0abC4Core0eB0Vcvp",
             "moduleName": "YouVersionPlatformUI",
+            "deprecated": true,
             "declAttributes": [
               "Final",
+              "Available",
               "Custom"
             ],
             "accessors": [
@@ -8666,6 +10161,34 @@
           {
             "kind": "Constructor",
             "name": "init",
+            "printedName": "init(versionRepository:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionsViewModel",
+                "printedName": "YouVersionPlatformUI.BibleVersionsViewModel",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionRepositoryProtocol",
+                "printedName": "any YouVersionPlatformCore.BibleVersionRepositoryProtocol",
+                "hasDefaultArg": true,
+                "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC17versionRepositoryAC0abC4Core0ebJ8Protocol_p_tcfc",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC17versionRepositoryAC0abC4Core0ebJ8Protocol_p_tcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
             "printedName": "init(onVersionChange:versionRepository:)",
             "children": [
               {
@@ -8711,10 +10234,12 @@
             "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Change17versionRepositoryACy0abC4Core0eB0Vc_AF0ebL8Protocol_ptcfc",
             "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Change17versionRepositoryACy0abC4Core0eB0Vc_AF0ebL8Protocol_ptcfc",
             "moduleName": "YouVersionPlatformUI",
+            "deprecated": true,
             "declAttributes": [
+              "Available",
               "Custom"
             ],
-            "init_kind": "Designated"
+            "init_kind": "Convenience"
           },
           {
             "kind": "Function",
@@ -9407,6 +10932,34 @@
             "declKind": "Func",
             "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC08switchToB0yySiF",
             "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC08switchToB0yySiF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "switchToVersion",
+            "printedName": "switchToVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC08switchToB0yy0abC4Core0eB0VF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC08switchToB0yy0abC4Core0eB0VF",
             "moduleName": "YouVersionPlatformUI",
             "declAttributes": [
               "Final",
@@ -12678,8 +14231,10 @@
             "mangledName": "$s7SwiftUI4ViewP018YouVersionPlatformB0E2if_9transformQrSb_qd__xXEtAaBRd__lF",
             "moduleName": "YouVersionPlatformUI",
             "genericSig": "<Self, Content where Self : SwiftUI.View, Content : SwiftUI.View>",
+            "deprecated": true,
             "declAttributes": [
               "Preconcurrency",
+              "Available",
               "Custom",
               "Custom"
             ],

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -180,7 +180,12 @@ public struct BibleReaderView: View {
         .onChange(of: reduceMotion, initial: true) { _, newValue in
             viewModel.isReduceMotionEnabled = newValue
         }
-        .onChange(of: viewModel.reference, initial: true) { _, newReference in
+        .onAppear {
+            verseAnchors = []
+            lastScrolledVerse = nil
+            viewModel.resetChapterCompleteTracking()
+        }
+        .onChange(of: viewModel.reference) { _, newReference in
             verseAnchors = []
             lastScrolledVerse = nil
             viewModel.resetChapterCompleteTracking()

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -13,8 +13,8 @@ public struct BibleReaderView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    let fontSettingsDetent = PresentationDetent.height(360)
-    let fontListDetent = PresentationDetent.height(480)
+    private let fontSettingsDetent = PresentationDetent.height(360)
+    private let fontListDetent = PresentationDetent.height(480)
     @State private var selectedDetent: PresentationDetent
     @State private var detents: Set<PresentationDetent>
     private var externalSelectedVerses: Binding<Set<BibleReference>>?

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -419,7 +419,7 @@ public struct BibleReaderView: View {
                 
                 await viewModel.updateSignInState()
             } catch {
-                print(error)
+                YouVersionPlatformLogger.error("Sign-in error: \(error)", category: "BibleReader")
             }
         }
     }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -91,13 +91,10 @@ extension BibleReaderViewModel {
             }
         }
         lastScrollOffset = offset
-        maxObservedOffset = max(maxObservedOffset, offset)
+        minObservedOffset = min(minObservedOffset, offset)
 
-        let bottomThreshold: CGFloat = 100
         if scrollViewHeight > 0
-            && maxObservedOffset > scrollViewHeight * 1.5
-            && offset > 0
-            && offset <= scrollViewHeight + bottomThreshold
+            && minObservedOffset < -(scrollViewHeight * 1.5)
             && version != nil
             && !hasNotifiedChapterComplete {
             hasNotifiedChapterComplete = true
@@ -107,7 +104,7 @@ extension BibleReaderViewModel {
 
     func resetChapterCompleteTracking() {
         hasNotifiedChapterComplete = false
-        maxObservedOffset = 0
+        minObservedOffset = 0
     }
 
     func handleVerseTap(reference: BibleReference, actionType: String, footnotes: [BibleFootnote]) {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -180,7 +180,7 @@ extension BibleReaderViewModel {
 
     func addVerseColor(_ color: Color) {
         guard let hex = color.hexString else {
-            print("Unable to convert color to hex: \(color)")
+            YouVersionPlatformLogger.error("Unable to convert color to hex: \(color)", category: "BibleReader")
             return
         }
         highlightsViewModel.addHighlights(references: Array(selectedVerses), color: hex)
@@ -189,7 +189,7 @@ extension BibleReaderViewModel {
 
     func removeVerseColor(_ color: Color) {
         guard let hex = color.hexString else {
-            print("Unable to convert color to hex: \(color)")
+            YouVersionPlatformLogger.error("Unable to convert color to hex: \(color)", category: "BibleReader")
             return
         }
         for reference in selectedVerses {
@@ -274,7 +274,7 @@ extension BibleReaderViewModel {
             showChrome = true
             scrollToTop = true
         } catch {
-            print("Error loading version/chapter: \(error)")
+            YouVersionPlatformLogger.error("Error loading version/chapter: \(error)", category: "BibleReader")
         }
     }
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -121,7 +121,15 @@ extension BibleReaderViewModel {
 
         if let onVerseTap {
             let response = onVerseTap(reference)
-            if response == .handled {
+            switch response {
+            case .handled:
+                return
+            case .toggleSelection:
+                if selectedVerses.contains(reference) {
+                    selectedVerses.remove(reference)
+                } else {
+                    selectedVerses.insert(reference)
+                }
                 return
             }
         }
@@ -135,19 +143,13 @@ extension BibleReaderViewModel {
         } else if !YouVersionAPI.isSignedIn && YouVersionPlatformConfiguration.isSignInEnabled {
             showingSignInSheet = true
             return
-        }
-
-        if selectedVerses.contains(reference) {
-            selectedVerses.remove(reference)
         } else {
-            selectedVerses.insert(reference)
+            return
         }
 
-        if onVerseTap == nil {
-            let animation: Animation? = isReduceMotionEnabled ? nil : .interpolatingSpring(stiffness: 300, damping: 25)
-            withAnimation(animation) {
-                showingVerseActionsDrawer = !selectedVerses.isEmpty
-            }
+        let animation: Animation? = isReduceMotionEnabled ? nil : .interpolatingSpring(stiffness: 300, damping: 25)
+        withAnimation(animation) {
+            showingVerseActionsDrawer = !selectedVerses.isEmpty
         }
     }
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -33,7 +33,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     let audioActiveIndicatorColor: Color?
     private let authentication: BibleReaderAuthentication
     var scrollViewHeight: CGFloat = 0
-    var maxObservedOffset: CGFloat = 0
+    var minObservedOffset: CGFloat = 0
     var hasNotifiedChapterComplete = false
 
     // MARK: - UI state of the Reader itself

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
@@ -93,10 +93,12 @@ extension BibleTextView {
                         return
                     }
                     let padding: CGFloat = 2
-                    let boxRect = CGRect(x: start - padding,
-                                         y: boxY,
-                                         width: (boxEnd - start) + padding * 2,
-                                         height: boxHeight)
+                    let boxRect = CGRect(
+                        x: start - padding,
+                        y: boxY,
+                        width: (boxEnd - start) + padding * 2,
+                        height: boxHeight
+                    )
                     let path = RoundedRectangle(cornerRadius: 2).path(in: boxRect)
                     context.fill(path, with: .color(boxColor ?? .gray))
                     boxStart = nil
@@ -208,9 +210,11 @@ extension BibleTextView {
                 pencilAttr.backgroundColor = highlightColor
                 // swiftlint:disable:next shorthand_operator
                 textCombo = textCombo + Text(pencilAttr).customAttribute(
-                    RenderHowAttribute(noteIndicatorImage: true,
-                                       noteIndicatorBox: true,
-                                       noteIndicatorBoxColor: boxColor)
+                    RenderHowAttribute(
+                        noteIndicatorImage: true,
+                        noteIndicatorBox: true,
+                        noteIndicatorBoxColor: boxColor
+                    )
                 )
 
                 var spacerAttr = AttributedString("\u{2009}")
@@ -219,16 +223,20 @@ extension BibleTextView {
                 spacerAttr.backgroundColor = highlightColor
                 // swiftlint:disable:next shorthand_operator
                 textCombo = textCombo + Text(spacerAttr).customAttribute(
-                    RenderHowAttribute(noteIndicatorBox: true,
-                                       noteIndicatorBoxColor: boxColor)
+                    RenderHowAttribute(
+                        noteIndicatorBox: true,
+                        noteIndicatorBoxColor: boxColor
+                    )
                 )
 
                 var verseAttr = t
                 verseAttr.link = noteURL
                 // swiftlint:disable:next shorthand_operator
                 textCombo = textCombo + Text(verseAttr).customAttribute(
-                    RenderHowAttribute(noteIndicatorBox: true,
-                                       noteIndicatorBoxColor: boxColor)
+                    RenderHowAttribute(
+                        noteIndicatorBox: true,
+                        noteIndicatorBoxColor: boxColor
+                    )
                 )
 
                 // swiftlint:disable:next shorthand_operator

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift
@@ -171,8 +171,12 @@ public enum BibleVersionRendering {
     /// Verse index from a visible verse-number span (`yv-vlbl` / `vlbl`).
     /// Prefer the `v` HTML attribute; otherwise parse digits from descendant text (supports mild nesting).
     private static func verseNumberFromVerseLabelSpan(_ node: BibleTextNode) -> Int? {
-        guard node.type == .span else { return nil }
-        guard node.classes.contains("yv-vlbl") || node.classes.contains("vlbl") else { return nil }
+        guard node.type == .span else {
+            return nil
+        }
+        guard node.classes.contains("yv-vlbl") || node.classes.contains("vlbl") else {
+            return nil
+        }
         if let v = node.attributes["v"], let i = Int(v) {
             return i
         }

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
@@ -74,6 +74,10 @@ import Testing
         #expect(callCount == 1)
 
         viewModel.resetChapterCompleteTracking()
+        // Sub-threshold scroll after reset must not fire: verifies minObservedOffset was zeroed
+        viewModel.handleScroll(offset: -100)
+        #expect(callCount == 1)
+
         viewModel.handleScroll(offset: -1300)
         #expect(callCount == 2)
     }

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
@@ -30,6 +30,55 @@ import Testing
     }
 
     @Test
+    func handleScrollFiresChapterCompleteWhenScrolledPastOneAndAHalfViewports() {
+        var completedReference: BibleReference?
+        let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1)
+        let viewModel = Support.makeViewModel(
+            reference: reference,
+            onChapterComplete: { completedReference = $0 }
+        )
+        viewModel.scrollViewHeight = 800
+        viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
+
+        // Scrolling less than 1.5x viewport should not fire
+        viewModel.handleScroll(offset: -1000)
+        #expect(completedReference == nil)
+
+        // Scrolling beyond 1.5x viewport (offset < -(800 * 1.5) = -1200) should fire
+        viewModel.handleScroll(offset: -1300)
+        #expect(completedReference == reference)
+    }
+
+    @Test
+    func handleScrollFiresChapterCompleteAtMostOncePerChapter() {
+        var callCount = 0
+        let viewModel = Support.makeViewModel(onChapterComplete: { _ in callCount += 1 })
+        viewModel.scrollViewHeight = 800
+        viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
+
+        viewModel.handleScroll(offset: -1300)
+        viewModel.handleScroll(offset: -1500)
+        viewModel.handleScroll(offset: -2000)
+
+        #expect(callCount == 1)
+    }
+
+    @Test
+    func handleScrollResetsChapterCompleteOnReferenceChange() {
+        var callCount = 0
+        let viewModel = Support.makeViewModel(onChapterComplete: { _ in callCount += 1 })
+        viewModel.scrollViewHeight = 800
+        viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
+
+        viewModel.handleScroll(offset: -1300)
+        #expect(callCount == 1)
+
+        viewModel.resetChapterCompleteTracking()
+        viewModel.handleScroll(offset: -1300)
+        #expect(callCount == 2)
+    }
+
+    @Test
     func handleScrollDoesNothingWhileChangingChapter() {
         let viewModel = Support.makeViewModel()
         viewModel.isChangingChapter = true
@@ -62,7 +111,7 @@ import Testing
     func handleVerseTapUsesCustomVerseTapHandlerBeforeSelection() {
         let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
         var tappedReference: BibleReference?
-        let viewModel = Support.makeViewModel(onVerseTap: { tappedReference = $0 })
+        let viewModel = Support.makeViewModel(onVerseTap: { tappedReference = $0; return .handled })
 
         viewModel.handleVerseTap(reference: reference, actionType: "", footnotes: [])
 

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
@@ -66,7 +66,8 @@ enum BibleReaderViewModelTestSupport {
         reference: BibleReference? = BibleReference(versionId: versionId, bookUSFM: "JHN", chapter: 1),
         highlightsRepository: MockBibleHighlightsRepository = MockBibleHighlightsRepository(),
         versionRepository: any BibleVersionRepositoryProtocol = MockBibleVersionRepository(),
-        onVerseTap: ((BibleReference) -> Void)? = nil,
+        onVerseTap: ((BibleReference) -> VerseTapResponse)? = nil,
+        onChapterComplete: ((BibleReference) -> Void)? = nil,
         isSignedIn: Bool = false,
         hasValidToken: Bool? = nil,
         signOut: @escaping @MainActor () -> Void = {}
@@ -86,6 +87,7 @@ enum BibleReaderViewModelTestSupport {
             highlightsViewModel: highlightsViewModel,
             versionsViewModel: versionsViewModel,
             onVerseTap: onVerseTap,
+            onChapterComplete: onChapterComplete,
             authentication: authentication
         )
     }


### PR DESCRIPTION
## Summary
- `onChapterComplete` never fired during normal Bible chapter reading because the scroll offset tracking was inverted — the condition could never be satisfied
- Fix tracks the minimum (most-negative) observed offset instead of maximum, correctly detecting how far down the user has scrolled
- Also fixes a pre-existing compile error in `BibleReaderViewModelTestSupport` where `onVerseTap` had the wrong closure return type

## Root Cause
In `handleScroll`, `offset` is the content's `minY` in the scroll viewport: `0` at the top, going **negative** as the user scrolls down. The old code used `max(maxObservedOffset, offset)` — since offset goes negative during downward scrolling, `maxObservedOffset` stayed near `0`. The condition `maxObservedOffset > scrollViewHeight * 1.5` was therefore never true, so `onChapterComplete?(reference)` never fired. Streaks were never triggered from Bible chapter reading.

## Fix
- Renamed `maxObservedOffset` → `minObservedOffset`
- Changed `max(maxObservedOffset, offset)` → `min(minObservedOffset, offset)` to track furthest-down scroll position
- Updated the chapter-complete condition to `minObservedOffset < -(scrollViewHeight * 1.5)`

## Test plan
- [x] `handleScrollFiresChapterCompleteWhenScrolledPastOneAndAHalfViewports` — new test, passes
- [x] `handleScrollFiresChapterCompleteAtMostOncePerChapter` — new test, passes
- [x] `handleScrollResetsChapterCompleteOnReferenceChange` — new test, passes
- [x] All pre-existing passing tests continue to pass
- [x] Bible Loop iOS app builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `onChapterComplete` (and downstream Bible-Loop streak tracking) never firing during normal chapter reading. The bug was an inverted scroll-offset condition: `offset` is `0` at the top and goes **negative** as the user scrolls down, so `max(maxObservedOffset, offset)` always stayed near `0`, making the threshold unreachable. The fix tracks the most-negative observed offset with `min` and inverts the comparison.

- **Core fix** — `maxObservedOffset` → `minObservedOffset`, condition changed to `minObservedOffset < -(scrollViewHeight * 1.5)`, with three new unit tests confirming threshold, at-most-once firing, and reset behaviour.
- **Verse-tap fix** — resolves the previously flagged double-toggle regression where signed-in users could never select a verse; `handleVerseTap` now dispatches cleanly on `VerseTapResponse` with no fall-through side effects.
- **Housekeeping** — `print` → structured logger, `onAppear`-based reset to stop the spurious initial `onReferenceChange` event, and `private` access on two detent constants (all addressing prior review feedback).

<h3>Confidence Score: 4/5</h3>

Safe to merge; the scroll-detection inversion and verse-tap fixes are well-reasoned and covered by new tests, with one minor open question about drawer behaviour for the .toggleSelection response path.

The scroll fix is correct — the inverted condition explains exactly why onChapterComplete never fired, the threshold is clear, and three focused tests lock down the behaviour. The handleVerseTap refactor cleanly resolves the double-toggle regression. The one remaining gap is that .toggleSelection silently skips the verse-actions drawer update with no test documenting whether that is intentional.

Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift — the .toggleSelection branch in handleVerseTap (lines 127-134) does not update showingVerseActionsDrawer; worth confirming the intended contract with a test.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift | Core fix: inverted scroll offset tracking (max→min, condition inverted) correctly enables onChapterComplete; also fixes double-toggle regression in handleVerseTap and replaces bare print calls with logger — all changes are sound, though .toggleSelection skips the verse-actions drawer update |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Renames maxObservedOffset to minObservedOffset; no logic change beyond the rename |
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Splits .onChange(initial: true) into .onAppear + .onChange, fixing spurious onReferenceChange on first render; tightens access control on two let properties; logger fix |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift | Adds three targeted tests for the new scroll-complete detection; fixes onVerseTap closure return type in the existing test; good coverage for the core bug fix |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift | Fixes onVerseTap closure signature and adds onChapterComplete parameter to makeViewModel; straightforward and correct |
| Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift | Formatting-only changes: expands multi-argument constructor calls to multi-line style; no logic changes |
| Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift | Formatting-only: expands guard-return statements to multi-line braces; no logic changes |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handleScroll called
offset = content minY
0=top, negative=scrolled down] --> B[Update showChrome
based on scroll direction]
    B --> C[minObservedOffset =
min minObservedOffset, offset]
    C --> D{scrollViewHeight > 0
AND minObservedOffset < −height×1.5
AND version != nil
AND !hasNotifiedChapterComplete}
    D -- YES --> E[hasNotifiedChapterComplete = true
onChapterComplete? reference]
    D -- NO --> F[Done]
    E --> F

    G[resetChapterCompleteTracking] --> H[hasNotifiedChapterComplete = false
minObservedOffset = 0]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift`, line 113-154 ([link](https://github.com/youversion/platform-sdk-swift/blob/6e8ca5170faf8f114d587e976b858d994027ff2e/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift#L113-L154)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Double-toggle breaks verse selection for signed-in users**

   When `isSignedIn == true`, execution enters the first `if isSignedIn` block and toggles the verse into `selectedVerses`, then falls through to the unconditional second toggle block and immediately reverses the change — leaving `selectedVerses` unchanged. The net effect for any authenticated user is that tapping a verse does nothing: no underline appears and the drawer never shows. The same problem occurs when `onVerseTap` returns `.toggleSelection` and the user is signed in.

   The unconditional toggle block was presumably intended to replace the original `if isSignedIn` block entirely, but the first block was not removed. Removing the `if isSignedIn { … }` block (keeping only the unconditional toggle and the `showingSignInSheet` guard) would restore correct behaviour.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
   Line: 113-154

   Comment:
   **Double-toggle breaks verse selection for signed-in users**

   When `isSignedIn == true`, execution enters the first `if isSignedIn` block and toggles the verse into `selectedVerses`, then falls through to the unconditional second toggle block and immediately reverses the change — leaving `selectedVerses` unchanged. The net effect for any authenticated user is that tapping a verse does nothing: no underline appears and the drawer never shows. The same problem occurs when `onVerseTap` returns `.toggleSelection` and the user is signed in.

   The unconditional toggle block was presumably intended to replace the original `if isSignedIn` block entirely, but the first block was not removed. Removing the `if isSignedIn { … }` block (keeping only the unconditional toggle and the `showingSignInSheet` guard) would restore correct behaviour.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%0ALine%3A%20113-154%0A%0AComment%3A%0A**Double-toggle%20breaks%20verse%20selection%20for%20signed-in%20users**%0A%0AWhen%20%60isSignedIn%20%3D%3D%20true%60%2C%20execution%20enters%20the%20first%20%60if%20isSignedIn%60%20block%20and%20toggles%20the%20verse%20into%20%60selectedVerses%60%2C%20then%20falls%20through%20to%20the%20unconditional%20second%20toggle%20block%20and%20immediately%20reverses%20the%20change%20%E2%80%94%20leaving%20%60selectedVerses%60%20unchanged.%20The%20net%20effect%20for%20any%20authenticated%20user%20is%20that%20tapping%20a%20verse%20does%20nothing%3A%20no%20underline%20appears%20and%20the%20drawer%20never%20shows.%20The%20same%20problem%20occurs%20when%20%60onVerseTap%60%20returns%20%60.toggleSelection%60%20and%20the%20user%20is%20signed%20in.%0A%0AThe%20unconditional%20toggle%20block%20was%20presumably%20intended%20to%20replace%20the%20original%20%60if%20isSignedIn%60%20block%20entirely%2C%20but%20the%20first%20block%20was%20not%20removed.%20Removing%20the%20%60if%20isSignedIn%20%7B%20%E2%80%A6%20%7D%60%20block%20%28keeping%20only%20the%20unconditional%20toggle%20and%20the%20%60showingSignInSheet%60%20guard%29%20would%20restore%20correct%20behaviour.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=118&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%0ALine%3A%20113-154%0A%0AComment%3A%0A**Double-toggle%20breaks%20verse%20selection%20for%20signed-in%20users**%0A%0AWhen%20%60isSignedIn%20%3D%3D%20true%60%2C%20execution%20enters%20the%20first%20%60if%20isSignedIn%60%20block%20and%20toggles%20the%20verse%20into%20%60selectedVerses%60%2C%20then%20falls%20through%20to%20the%20unconditional%20second%20toggle%20block%20and%20immediately%20reverses%20the%20change%20%E2%80%94%20leaving%20%60selectedVerses%60%20unchanged.%20The%20net%20effect%20for%20any%20authenticated%20user%20is%20that%20tapping%20a%20verse%20does%20nothing%3A%20no%20underline%20appears%20and%20the%20drawer%20never%20shows.%20The%20same%20problem%20occurs%20when%20%60onVerseTap%60%20returns%20%60.toggleSelection%60%20and%20the%20user%20is%20signed%20in.%0A%0AThe%20unconditional%20toggle%20block%20was%20presumably%20intended%20to%20replace%20the%20original%20%60if%20isSignedIn%60%20block%20entirely%2C%20but%20the%20first%20block%20was%20not%20removed.%20Removing%20the%20%60if%20isSignedIn%20%7B%20%E2%80%A6%20%7D%60%20block%20%28keeping%20only%20the%20unconditional%20toggle%20and%20the%20%60showingSignInSheet%60%20guard%29%20would%20restore%20correct%20behaviour.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=118&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

2. `Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift`, line 178-195 ([link](https://github.com/youversion/platform-sdk-swift/blob/6e8ca5170faf8f114d587e976b858d994027ff2e/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift#L178-L195)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Structured logger replaced with `print`**

   Several error paths — `addVerseColor`, `removeVerseColor`, `onHeaderSelectionChange`, and `startSignIn` in `BibleReaderView` — now use bare `print` instead of `YouVersionPlatformLogger.error`. This loses the category/severity metadata that consumers of the SDK rely on for filtering and crash reporting. The same pattern appears in the new `loadSuggestedLanguages` method. Restoring the logger calls would keep parity with the rest of the reader.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
   Line: 178-195

   Comment:
   **Structured logger replaced with `print`**

   Several error paths — `addVerseColor`, `removeVerseColor`, `onHeaderSelectionChange`, and `startSignIn` in `BibleReaderView` — now use bare `print` instead of `YouVersionPlatformLogger.error`. This loses the category/severity metadata that consumers of the SDK rely on for filtering and crash reporting. The same pattern appears in the new `loadSuggestedLanguages` method. Restoring the logger calls would keep parity with the rest of the reader.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%0ALine%3A%20178-195%0A%0AComment%3A%0A**Structured%20logger%20replaced%20with%20%60print%60**%0A%0ASeveral%20error%20paths%20%E2%80%94%20%60addVerseColor%60%2C%20%60removeVerseColor%60%2C%20%60onHeaderSelectionChange%60%2C%20and%20%60startSignIn%60%20in%20%60BibleReaderView%60%20%E2%80%94%20now%20use%20bare%20%60print%60%20instead%20of%20%60YouVersionPlatformLogger.error%60.%20This%20loses%20the%20category%2Fseverity%20metadata%20that%20consumers%20of%20the%20SDK%20rely%20on%20for%20filtering%20and%20crash%20reporting.%20The%20same%20pattern%20appears%20in%20the%20new%20%60loadSuggestedLanguages%60%20method.%20Restoring%20the%20logger%20calls%20would%20keep%20parity%20with%20the%20rest%20of%20the%20reader.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=118&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%0ALine%3A%20178-195%0A%0AComment%3A%0A**Structured%20logger%20replaced%20with%20%60print%60**%0A%0ASeveral%20error%20paths%20%E2%80%94%20%60addVerseColor%60%2C%20%60removeVerseColor%60%2C%20%60onHeaderSelectionChange%60%2C%20and%20%60startSignIn%60%20in%20%60BibleReaderView%60%20%E2%80%94%20now%20use%20bare%20%60print%60%20instead%20of%20%60YouVersionPlatformLogger.error%60.%20This%20loses%20the%20category%2Fseverity%20metadata%20that%20consumers%20of%20the%20SDK%20rely%20on%20for%20filtering%20and%20crash%20reporting.%20The%20same%20pattern%20appears%20in%20the%20new%20%60loadSuggestedLanguages%60%20method.%20Restoring%20the%20logger%20calls%20would%20keep%20parity%20with%20the%20rest%20of%20the%20reader.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=118&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%3A127-134%0A**%60.toggleSelection%60%20skips%20drawer%20update**%0A%0AWhen%20%60onVerseTap%60%20returns%20%60.toggleSelection%60%2C%20the%20selection%20is%20correctly%20toggled%2C%20but%20%60showingVerseActionsDrawer%60%20is%20never%20set%20%E2%80%94%20unlike%20the%20%60onVerseTap%20%3D%3D%20nil%60%20path%20%28lines%20150-153%29%20which%20always%20syncs%20the%20drawer%20after%20toggling.%20A%20caller%20that%20returns%20%60.toggleSelection%60%20expecting%20SDK-managed%20selection%20UI%20will%20silently%20select%20verses%20with%20no%20drawer%20feedback.%20Adding%20a%20test%20that%20asserts%20the%20expected%20drawer%20state%20after%20a%20%60.toggleSelection%60%20response%20would%20pin%20the%20intended%20contract%20and%20make%20the%20choice%20%28drawer%20or%20no%20drawer%29%20explicit%20for%20future%20readers.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=118&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%3A127-134%0A**%60.toggleSelection%60%20skips%20drawer%20update**%0A%0AWhen%20%60onVerseTap%60%20returns%20%60.toggleSelection%60%2C%20the%20selection%20is%20correctly%20toggled%2C%20but%20%60showingVerseActionsDrawer%60%20is%20never%20set%20%E2%80%94%20unlike%20the%20%60onVerseTap%20%3D%3D%20nil%60%20path%20%28lines%20150-153%29%20which%20always%20syncs%20the%20drawer%20after%20toggling.%20A%20caller%20that%20returns%20%60.toggleSelection%60%20expecting%20SDK-managed%20selection%20UI%20will%20silently%20select%20verses%20with%20no%20drawer%20feedback.%20Adding%20a%20test%20that%20asserts%20the%20expected%20drawer%20state%20after%20a%20%60.toggleSelection%60%20response%20would%20pin%20the%20intended%20contract%20and%20make%20the%20choice%20%28drawer%20or%20no%20drawer%29%20explicit%20for%20future%20readers.%0A%0A&pr=118&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift:127-134
**`.toggleSelection` skips drawer update**

When `onVerseTap` returns `.toggleSelection`, the selection is correctly toggled, but `showingVerseActionsDrawer` is never set — unlike the `onVerseTap == nil` path (lines 150-153) which always syncs the drawer after toggling. A caller that returns `.toggleSelection` expecting SDK-managed selection UI will silently select verses with no drawer feedback. Adding a test that asserts the expected drawer state after a `.toggleSelection` response would pin the intended contract and make the choice (drawer or no drawer) explicit for future readers.


`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(reader): replace print with YouVersi..."](https://github.com/youversion/platform-sdk-swift/commit/b8832e016b3f37aff4bed376532b8049443c55bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32004410)</sub>

<!-- /greptile_comment -->