### PR TITLE
fix(reader): fire onChapterComplete when chapter end is reached

### DIFF
--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -50,9 +50,12 @@ public struct BibleReaderView: View {
     ///   - onReferenceChange: An optional closure called whenever the displayed
     ///     chapter reference changes — for example when the user taps the
     ///     next/previous chapter buttons or picks a new book/chapter from the header.
-    ///   - onChapterComplete: An optional closure called once when the user scrolls
-    ///     near the bottom of the chapter content. Fires at most once per chapter;
-    ///     resets when the reader navigates to a different chapter.
+    ///   - onChapterComplete: An optional closure called once when the bottom of
+    ///     the chapter content scrolls into the viewport — i.e. the reader has
+    ///     reached the end of the chapter. For chapters shorter than the
+    ///     viewport, this fires as soon as the chapter is displayed. Fires at
+    ///     most once per chapter; resets when the reader navigates to a
+    ///     different chapter.
     ///   - audioActiveReference: The verse currently being narrated by audio
     ///     playback. When this value changes, the reader auto-scrolls to keep
     ///     the active verse visible. Pass `nil` when audio is not playing.
@@ -318,10 +321,10 @@ public struct BibleReaderView: View {
                     .padding(.vertical)
                     .padding(.horizontal, 30)
                     .id("topOfContent")
-                    .onGeometryChange(for: CGFloat.self) { proxy in
-                        proxy.frame(in: .named("scrollView")).minY
-                    } action: { newOffset in
-                        viewModel.handleScroll(offset: newOffset)
+                    .onGeometryChange(for: CGRect.self) { proxy in
+                        proxy.frame(in: .named("scrollView"))
+                    } action: { newFrame in
+                        viewModel.handleScroll(offset: newFrame.minY, contentHeight: newFrame.height)
                     }
                 } else {
                     ProgressView()

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -73,6 +73,16 @@ extension BibleReaderViewModel {
     }
 
     func handleScroll(offset: CGFloat, contentHeight: CGFloat) {
+        // Always record the latest geometry so a freshly-navigated chapter has
+        // its contentHeight ready the moment the isChangingChapter guard clears.
+        // Without this, short chapters reached via prev/next would never fire
+        // onChapterComplete: every geometry event during the 0.5s scroll-reset
+        // window would be dropped, leaving contentHeight at 0 and no further
+        // scroll events to populate it.
+        let previousScrollOffset = lastScrollOffset
+        lastScrollOffset = offset
+        self.contentHeight = contentHeight
+
         guard !isChangingChapter else {
             return
         }
@@ -83,16 +93,21 @@ extension BibleReaderViewModel {
         // negative while scrolled down, positive when rubber-banding past top.
         if offset >= 0 {
             withAnimation(animation) { self.showChrome = true }
-        } else if abs(offset - lastScrollOffset) >= threshold {
-            if offset < lastScrollOffset - threshold {
+        } else if abs(offset - previousScrollOffset) >= threshold {
+            if offset < previousScrollOffset - threshold {
                 withAnimation(animation) { self.showChrome = false }
-            } else if offset > lastScrollOffset + threshold {
+            } else if offset > previousScrollOffset + threshold {
                 withAnimation(animation) { self.showChrome = true }
             }
         }
-        lastScrollOffset = offset
-        self.contentHeight = contentHeight
 
+        evaluateChapterCompleteFromCachedGeometry()
+    }
+
+    /// Fires `onChapterComplete` if the latest cached geometry indicates the
+    /// bottom of the content is in view. Safe to call any time; gated by
+    /// `hasNotifiedChapterComplete` so it fires at most once per chapter.
+    func evaluateChapterCompleteFromCachedGeometry() {
         // The bottom of the content has come into view when the content's
         // bottom edge (offset + contentHeight) is at or above the viewport's
         // bottom edge (scrollViewHeight). The small epsilon absorbs subpixel
@@ -100,11 +115,12 @@ extension BibleReaderViewModel {
         let bottomEpsilon: CGFloat = 8
         let bottomReached = scrollViewHeight > 0
             && contentHeight > 0
-            && (offset + contentHeight) <= (scrollViewHeight + bottomEpsilon)
+            && (lastScrollOffset + contentHeight) <= (scrollViewHeight + bottomEpsilon)
 
         if bottomReached
             && version != nil
-            && !hasNotifiedChapterComplete {
+            && !hasNotifiedChapterComplete
+            && !isChangingChapter {
             hasNotifiedChapterComplete = true
             onChapterComplete?(reference)
         }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -72,7 +72,7 @@ extension BibleReaderViewModel {
         showingVerseActionsDrawer = false
     }
 
-    func handleScroll(offset: CGFloat) {
+    func handleScroll(offset: CGFloat, contentHeight: CGFloat) {
         guard !isChangingChapter else {
             return
         }
@@ -91,10 +91,18 @@ extension BibleReaderViewModel {
             }
         }
         lastScrollOffset = offset
-        minObservedOffset = min(minObservedOffset, offset)
+        self.contentHeight = contentHeight
 
-        if scrollViewHeight > 0
-            && minObservedOffset < -(scrollViewHeight * 1.5)
+        // The bottom of the content has come into view when the content's
+        // bottom edge (offset + contentHeight) is at or above the viewport's
+        // bottom edge (scrollViewHeight). The small epsilon absorbs subpixel
+        // rounding so we don't miss a fire by a hair.
+        let bottomEpsilon: CGFloat = 8
+        let bottomReached = scrollViewHeight > 0
+            && contentHeight > 0
+            && (offset + contentHeight) <= (scrollViewHeight + bottomEpsilon)
+
+        if bottomReached
             && version != nil
             && !hasNotifiedChapterComplete {
             hasNotifiedChapterComplete = true
@@ -104,7 +112,7 @@ extension BibleReaderViewModel {
 
     func resetChapterCompleteTracking() {
         hasNotifiedChapterComplete = false
-        minObservedOffset = 0
+        contentHeight = 0
     }
 
     func handleVerseTap(reference: BibleReference, actionType: String, footnotes: [BibleFootnote]) {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -40,7 +40,16 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     var showChrome = true
     var lastScrollOffset: CGFloat = 0
     var scrollToTop = false
-    var isChangingChapter = false
+    var isChangingChapter = false {
+        didSet {
+            // When a chapter-change finishes, re-evaluate using cached geometry
+            // so short chapters reached via prev/next still fire onChapterComplete
+            // without requiring the user to scroll.
+            if oldValue && !isChangingChapter {
+                evaluateChapterCompleteFromCachedGeometry()
+            }
+        }
+    }
     var showingSignInSheet = false
     var showingFontSettings = false
     var showingFontList = false // swiftlint:disable:this collection_suffix_property

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -33,7 +33,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     let audioActiveIndicatorColor: Color?
     private let authentication: BibleReaderAuthentication
     var scrollViewHeight: CGFloat = 0
-    var minObservedOffset: CGFloat = 0
+    var contentHeight: CGFloat = 0
     var hasNotifiedChapterComplete = false
 
     // MARK: - UI state of the Reader itself

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
@@ -13,24 +13,24 @@ import Testing
         let viewModel = Support.makeViewModel()
         viewModel.showChrome = true
 
-        viewModel.handleScroll(offset: -5)
+        viewModel.handleScroll(offset: -5, contentHeight: 4000)
         #expect(viewModel.showChrome)
 
-        viewModel.handleScroll(offset: -30)
+        viewModel.handleScroll(offset: -30, contentHeight: 4000)
         #expect(viewModel.showChrome == false)
 
-        viewModel.handleScroll(offset: -25)
+        viewModel.handleScroll(offset: -25, contentHeight: 4000)
         #expect(viewModel.showChrome == false)
 
-        viewModel.handleScroll(offset: -5)
+        viewModel.handleScroll(offset: -5, contentHeight: 4000)
         #expect(viewModel.showChrome)
 
-        viewModel.handleScroll(offset: 0)
+        viewModel.handleScroll(offset: 0, contentHeight: 4000)
         #expect(viewModel.showChrome)
     }
 
     @Test
-    func handleScrollFiresChapterCompleteWhenScrolledPastOneAndAHalfViewports() {
+    func handleScrollFiresChapterCompleteWhenBottomOfContentReached() {
         var completedReference: BibleReference?
         let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1)
         let viewModel = Support.makeViewModel(
@@ -40,12 +40,28 @@ import Testing
         viewModel.scrollViewHeight = 800
         viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
 
-        // Scrolling less than 1.5x viewport should not fire
-        viewModel.handleScroll(offset: -1000)
+        // Content of height 2000 scrolled by -200 still has its bottom at 1800 — well below viewport bottom 800.
+        viewModel.handleScroll(offset: -200, contentHeight: 2000)
         #expect(completedReference == nil)
 
-        // Scrolling beyond 1.5x viewport (offset < -(800 * 1.5) = -1200) should fire
-        viewModel.handleScroll(offset: -1300)
+        // Scrolled by -1200, the bottom of content is at 2000 - 1200 = 800 ≤ 800 → fires.
+        viewModel.handleScroll(offset: -1200, contentHeight: 2000)
+        #expect(completedReference == reference)
+    }
+
+    @Test
+    func handleScrollFiresChapterCompleteImmediatelyForShortContent() {
+        var completedReference: BibleReference?
+        let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1)
+        let viewModel = Support.makeViewModel(
+            reference: reference,
+            onChapterComplete: { completedReference = $0 }
+        )
+        viewModel.scrollViewHeight = 800
+        viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
+
+        // Content shorter than the viewport: the bottom is already visible on first geometry event.
+        viewModel.handleScroll(offset: 0, contentHeight: 400)
         #expect(completedReference == reference)
     }
 
@@ -56,9 +72,9 @@ import Testing
         viewModel.scrollViewHeight = 800
         viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
 
-        viewModel.handleScroll(offset: -1300)
-        viewModel.handleScroll(offset: -1500)
-        viewModel.handleScroll(offset: -2000)
+        viewModel.handleScroll(offset: -1200, contentHeight: 2000)
+        viewModel.handleScroll(offset: -1400, contentHeight: 2000)
+        viewModel.handleScroll(offset: -1600, contentHeight: 2000)
 
         #expect(callCount == 1)
     }
@@ -70,15 +86,15 @@ import Testing
         viewModel.scrollViewHeight = 800
         viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
 
-        viewModel.handleScroll(offset: -1300)
+        viewModel.handleScroll(offset: -1200, contentHeight: 2000)
         #expect(callCount == 1)
 
         viewModel.resetChapterCompleteTracking()
-        // Sub-threshold scroll after reset must not fire: verifies minObservedOffset was zeroed
-        viewModel.handleScroll(offset: -100)
+        // Sub-threshold scroll after reset must not fire.
+        viewModel.handleScroll(offset: -100, contentHeight: 2000)
         #expect(callCount == 1)
 
-        viewModel.handleScroll(offset: -1300)
+        viewModel.handleScroll(offset: -1200, contentHeight: 2000)
         #expect(callCount == 2)
     }
 
@@ -89,7 +105,7 @@ import Testing
         viewModel.lastScrollOffset = -30
         viewModel.showChrome = true
 
-        viewModel.handleScroll(offset: -100)
+        viewModel.handleScroll(offset: -100, contentHeight: 2000)
 
         #expect(viewModel.lastScrollOffset == -30)
         #expect(viewModel.showChrome)

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
@@ -99,16 +99,27 @@ import Testing
     }
 
     @Test
-    func handleScrollDoesNothingWhileChangingChapter() {
-        let viewModel = Support.makeViewModel()
+    func handleScrollSkipsSideEffectsButRecordsGeometryWhileChangingChapter() {
+        var callCount = 0
+        let viewModel = Support.makeViewModel(onChapterComplete: { _ in callCount += 1 })
+        viewModel.scrollViewHeight = 800
+        viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
         viewModel.isChangingChapter = true
-        viewModel.lastScrollOffset = -30
         viewModel.showChrome = true
 
-        viewModel.handleScroll(offset: -100, contentHeight: 2000)
+        // Even though the bottom-of-content condition is met, no side effects
+        // fire while the chapter-change guard is active.
+        viewModel.handleScroll(offset: 0, contentHeight: 400)
 
-        #expect(viewModel.lastScrollOffset == -30)
         #expect(viewModel.showChrome)
+        #expect(callCount == 0)
+
+        // The geometry was recorded, so the moment the guard clears, the
+        // didSet on isChangingChapter re-evaluates and fires onChapterComplete.
+        // This is what allows short chapters reached via prev/next to fire
+        // without requiring any user scroll.
+        viewModel.isChangingChapter = false
+        #expect(callCount == 1)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `onChapterComplete` previously fired after the user scrolled past 1.5× the viewport height, which fired too early on long chapters (e.g. Psalm 119) and could never fire on short ones.
- Replace that heuristic with a true end-of-content check: the callback now fires once the content's bottom edge scrolls into the viewport (with an 8 pt epsilon for subpixel noise).
- Short chapters that fit within the viewport fire as soon as they're displayed; long chapters fire only after the user actually reaches the end.

## Test plan
- [x] `swift build` succeeds.
- [x] `swift test --filter BibleReaderViewModelInteractionTests` — all 16 tests pass, including a new `handleScrollFiresChapterCompleteImmediatelyForShortContent` case.
- [ ] Manual: open Psalm 117 (short) and confirm `onChapterComplete` fires on display.
- [ ] Manual: open Psalm 119 (long) and confirm it does **not** fire after 1.5 viewports of scrolling, and **does** fire once you scroll to the bottom of the copyright block.
- [ ] Manual: navigate next/previous mid-scroll and confirm the new chapter starts fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the 1.5× viewport-height heuristic for `onChapterComplete` with a precise bottom-of-content check: the callback fires once the content's bottom edge scrolls into the viewport (with an 8 pt epsilon for subpixel rounding). Geometry is now recorded unconditionally before the `isChangingChapter` guard, so short chapters navigated via prev/next correctly fire when the guard clears.

- **Core logic change**: `onGeometryChange` now captures `CGRect` (offset + height) instead of just `minY`, and `evaluateChapterCompleteFromCachedGeometry()` uses `(lastScrollOffset + contentHeight) ≤ (scrollViewHeight + ε)` to detect the end of content.
- **Short-chapter fix**: Geometry is cached during the 0.5 s scroll-reset window; a `didSet` on `isChangingChapter` calls `evaluateChapterCompleteFromCachedGeometry()` the moment the guard clears, firing for short chapters without requiring any user scroll.
- **Tests**: A new `handleScrollFiresChapterCompleteImmediatelyForShortContent` test case and an updated `handleScrollSkipsSideEffectsButRecordsGeometryWhileChangingChapter` test cover the new behaviour.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — the geometry-based check is correct, all existing tests pass, and the new test case validates the short-chapter path that previously could not fire.

The three navigation paths (prev/next buttons, header picker, initial load) all correctly cache geometry before the isChangingChapter guard, and the didSet on that flag fires the evaluation as soon as the guard clears. The math for bottom-of-content detection is sound, and the 8 pt epsilon handles subpixel rounding without creating premature fires on long content.

No files require special attention; the viewport-resize note in BibleReaderView.swift is a polish item for a follow-up.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Switches onGeometryChange from CGFloat (minY) to CGRect so both offset and content height reach the view model; the 0.5s isChangingChapter timer and scrollViewHeight capture are unchanged. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift | Core logic overhaul: geometry recorded before the isChangingChapter guard, new evaluateChapterCompleteFromCachedGeometry() replaces the 1.5x heuristic, and resetChapterCompleteTracking zeroes contentHeight instead of minObservedOffset. The scrollViewHeight change path (device rotation, keyboard) does not re-evaluate chapter completion. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Adds didSet on isChangingChapter that calls evaluateChapterCompleteFromCachedGeometry() when the flag clears (true to false); renames minObservedOffset to contentHeight. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift | All existing tests updated to pass contentHeight; new test for immediate short-content fire; guard test extended to verify didSet re-evaluation on isChangingChapter transition. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant View as BibleReaderView
    participant VM as BibleReaderViewModel

    User->>View: Tap next/previous chapter
    View->>VM: goToNextChapter()
    VM->>VM: "isChangingChapter = true"
    VM->>VM: resetChapterCompleteTracking()
    VM->>View: "scrollToTop = true"
    View->>View: Task.sleep(0.5s)

    Note over View,VM: During 0.5s window - geometry IS recorded, side-effects skipped
    View->>VM: handleScroll(offset, contentHeight)
    VM->>VM: records lastScrollOffset and contentHeight
    VM->>VM: guard isChangingChapter return early

    View->>VM: "isChangingChapter = false"
    VM->>VM: didSet calls evaluateChapterCompleteFromCachedGeometry()

    alt Short chapter
        VM->>VM: onChapterComplete fires immediately
    else Long chapter
        Note over VM: Waits for user to scroll to the end
    end

    User->>View: Scrolls to bottom
    View->>VM: handleScroll(offset, contentHeight)
    VM->>VM: "(lastScrollOffset + contentHeight) <= (scrollViewHeight + 8pt)"
    VM->>VM: onChapterComplete fires
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift`, line 76-111 ([link](https://github.com/youversion/platform-sdk-swift/blob/eaf3775aeb48f73a186d01f023e95fd5b52905c9/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift#L76-L111)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Short chapters won't fire after navigation**

   The `isChangingChapter` guard discards every `onGeometryChange` callback that arrives during the 0.5 s scroll-reset window — including the one that would store the new chapter's real `contentHeight`. After that window closes `contentHeight` is still 0 (zeroed by `resetChapterCompleteTracking`), so `contentHeight > 0` is permanently false until the user scrolls, which never happens for short content. The new test bypasses this entirely by calling `handleScroll` directly with no `isChangingChapter` flag set.

   Concretely: navigate next/previous to Psalm 117 and `onChapterComplete` will never fire, even though the same chapter fires correctly when the reader is opened on it directly. A minimal fix is to still capture `contentHeight` while `isChangingChapter` is true (but skip the `onChapterComplete` side-effect), so the value is ready the moment the flag clears.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
   Line: 76-111

   Comment:
   **Short chapters won't fire after navigation**

   The `isChangingChapter` guard discards every `onGeometryChange` callback that arrives during the 0.5 s scroll-reset window — including the one that would store the new chapter's real `contentHeight`. After that window closes `contentHeight` is still 0 (zeroed by `resetChapterCompleteTracking`), so `contentHeight > 0` is permanently false until the user scrolls, which never happens for short content. The new test bypasses this entirely by calling `handleScroll` directly with no `isChangingChapter` flag set.

   Concretely: navigate next/previous to Psalm 117 and `onChapterComplete` will never fire, even though the same chapter fires correctly when the reader is opened on it directly. A minimal fix is to still capture `contentHeight` while `isChangingChapter` is true (but skip the `onChapterComplete` side-effect), so the value is ready the moment the flag clears.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%0ALine%3A%2076-111%0A%0AComment%3A%0A**Short%20chapters%20won't%20fire%20after%20navigation**%0A%0AThe%20%60isChangingChapter%60%20guard%20discards%20every%20%60onGeometryChange%60%20callback%20that%20arrives%20during%20the%200.5%20s%20scroll-reset%20window%20%E2%80%94%20including%20the%20one%20that%20would%20store%20the%20new%20chapter's%20real%20%60contentHeight%60.%20After%20that%20window%20closes%20%60contentHeight%60%20is%20still%200%20%28zeroed%20by%20%60resetChapterCompleteTracking%60%29%2C%20so%20%60contentHeight%20%3E%200%60%20is%20permanently%20false%20until%20the%20user%20scrolls%2C%20which%20never%20happens%20for%20short%20content.%20The%20new%20test%20bypasses%20this%20entirely%20by%20calling%20%60handleScroll%60%20directly%20with%20no%20%60isChangingChapter%60%20flag%20set.%0A%0AConcretely%3A%20navigate%20next%2Fprevious%20to%20Psalm%20117%20and%20%60onChapterComplete%60%20will%20never%20fire%2C%20even%20though%20the%20same%20chapter%20fires%20correctly%20when%20the%20reader%20is%20opened%20on%20it%20directly.%20A%20minimal%20fix%20is%20to%20still%20capture%20%60contentHeight%60%20while%20%60isChangingChapter%60%20is%20true%20%28but%20skip%20the%20%60onChapterComplete%60%20side-effect%29%2C%20so%20the%20value%20is%20ready%20the%20moment%20the%20flag%20clears.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=119&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%0ALine%3A%2076-111%0A%0AComment%3A%0A**Short%20chapters%20won't%20fire%20after%20navigation**%0A%0AThe%20%60isChangingChapter%60%20guard%20discards%20every%20%60onGeometryChange%60%20callback%20that%20arrives%20during%20the%200.5%20s%20scroll-reset%20window%20%E2%80%94%20including%20the%20one%20that%20would%20store%20the%20new%20chapter's%20real%20%60contentHeight%60.%20After%20that%20window%20closes%20%60contentHeight%60%20is%20still%200%20%28zeroed%20by%20%60resetChapterCompleteTracking%60%29%2C%20so%20%60contentHeight%20%3E%200%60%20is%20permanently%20false%20until%20the%20user%20scrolls%2C%20which%20never%20happens%20for%20short%20content.%20The%20new%20test%20bypasses%20this%20entirely%20by%20calling%20%60handleScroll%60%20directly%20with%20no%20%60isChangingChapter%60%20flag%20set.%0A%0AConcretely%3A%20navigate%20next%2Fprevious%20to%20Psalm%20117%20and%20%60onChapterComplete%60%20will%20never%20fire%2C%20even%20though%20the%20same%20chapter%20fires%20correctly%20when%20the%20reader%20is%20opened%20on%20it%20directly.%20A%20minimal%20fix%20is%20to%20still%20capture%20%60contentHeight%60%20while%20%60isChangingChapter%60%20is%20true%20%28but%20skip%20the%20%60onChapterComplete%60%20side-effect%29%2C%20so%20the%20value%20is%20ready%20the%20moment%20the%20flag%20clears.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=119&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformReader%2FBibleReaderView.swift%3A337-343%0A**Viewport%20resize%20doesn't%20re-evaluate%20chapter%20completion**%0A%0AWhen%20%60scrollViewHeight%60%20updates%20%28device%20rotation%2C%20split-view%20resize%2C%20software%20keyboard%20appearing%2Fdisappearing%29%2C%20%60evaluateChapterCompleteFromCachedGeometry%60%20is%20never%20called.%20In%20practice%20this%20means%3A%20if%20a%20short%20chapter%20is%20already%20on%20screen%20and%20the%20user%20shrinks%20then%20enlarges%20the%20viewport%2C%20%60onChapterComplete%60%20won't%20fire%20until%20the%20next%20%60handleScroll%60%20call%20%E2%80%94%20which%20may%20never%20come%20if%20the%20content%20is%20short%20and%20the%20user%20isn't%20scrolling.%0A%0AAdding%20%60viewModel.evaluateChapterCompleteFromCachedGeometry%28%29%60%20after%20setting%20%60scrollViewHeight%60%20in%20the%20%60onChange%60%20handler%20would%20bring%20this%20path%20in%20line%20with%20the%20rest%20of%20the%20geometry-change%20paths.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=119&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformReader%2FBibleReaderView.swift%3A337-343%0A**Viewport%20resize%20doesn't%20re-evaluate%20chapter%20completion**%0A%0AWhen%20%60scrollViewHeight%60%20updates%20%28device%20rotation%2C%20split-view%20resize%2C%20software%20keyboard%20appearing%2Fdisappearing%29%2C%20%60evaluateChapterCompleteFromCachedGeometry%60%20is%20never%20called.%20In%20practice%20this%20means%3A%20if%20a%20short%20chapter%20is%20already%20on%20screen%20and%20the%20user%20shrinks%20then%20enlarges%20the%20viewport%2C%20%60onChapterComplete%60%20won't%20fire%20until%20the%20next%20%60handleScroll%60%20call%20%E2%80%94%20which%20may%20never%20come%20if%20the%20content%20is%20short%20and%20the%20user%20isn't%20scrolling.%0A%0AAdding%20%60viewModel.evaluateChapterCompleteFromCachedGeometry%28%29%60%20after%20setting%20%60scrollViewHeight%60%20in%20the%20%60onChange%60%20handler%20would%20bring%20this%20path%20in%20line%20with%20the%20rest%20of%20the%20geometry-change%20paths.%0A%0A&pr=119&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/YouVersionPlatformReader/BibleReaderView.swift:337-343
**Viewport resize doesn't re-evaluate chapter completion**

When `scrollViewHeight` updates (device rotation, split-view resize, software keyboard appearing/disappearing), `evaluateChapterCompleteFromCachedGeometry` is never called. In practice this means: if a short chapter is already on screen and the user shrinks then enlarges the viewport, `onChapterComplete` won't fire until the next `handleScroll` call — which may never come if the content is short and the user isn't scrolling.

Adding `viewModel.evaluateChapterCompleteFromCachedGeometry()` after setting `scrollViewHeight` in the `onChange` handler would bring this path in line with the rest of the geometry-change paths.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(reader): fire onChapterComplete on s..."](https://github.com/youversion/platform-sdk-swift/commit/6f53c36c421021f51efa88fb19f224498924286d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32014803)</sub>

<!-- /greptile_comment -->