### PR TITLE
fix(reader): suppress onChapterComplete during async content load

### DIFF
--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -81,6 +81,7 @@ extension BibleReaderViewModel {
         // scroll events to populate it.
         let previousScrollOffset = lastScrollOffset
         lastScrollOffset = offset
+        previousContentHeight = self.contentHeight
         self.contentHeight = contentHeight
 
         guard !isChangingChapter else {
@@ -117,7 +118,16 @@ extension BibleReaderViewModel {
             && contentHeight > 0
             && (lastScrollOffset + contentHeight) <= (scrollViewHeight + bottomEpsilon)
 
+        // Require contentHeight to be stable across two consecutive geometry
+        // events. BibleTextView loads its blocks asynchronously, so the first
+        // layout pass reports a small contentHeight (just the copyright block
+        // and padding) that can spuriously satisfy the bottom-reached check.
+        // Waiting for a stable height ensures we only fire once the chapter
+        // text has actually rendered.
+        let heightIsStable = contentHeight == previousContentHeight
+
         if bottomReached
+            && heightIsStable
             && version != nil
             && !hasNotifiedChapterComplete
             && !isChangingChapter {
@@ -129,6 +139,7 @@ extension BibleReaderViewModel {
     func resetChapterCompleteTracking() {
         hasNotifiedChapterComplete = false
         contentHeight = 0
+        previousContentHeight = 0
     }
 
     func handleVerseTap(reference: BibleReference, actionType: String, footnotes: [BibleFootnote]) {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -34,6 +34,13 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     private let authentication: BibleReaderAuthentication
     var scrollViewHeight: CGFloat = 0
     var contentHeight: CGFloat = 0
+    /// The contentHeight reported by the previous geometry event for the
+    /// current chapter. Used to detect when layout has settled: chapter
+    /// completion only fires once contentHeight matches across two events,
+    /// so the brief initial layout pass (small `blocks: []` placeholder
+    /// before the chapter text loads) can't spuriously satisfy the bottom-
+    /// reached check.
+    var previousContentHeight: CGFloat = 0
     var hasNotifiedChapterComplete = false
 
     // MARK: - UI state of the Reader itself

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
@@ -93,6 +93,11 @@ import Testing
         // User has not scrolled yet; bottom is not reached.
         viewModel.handleScroll(offset: 0, contentHeight: 3000)
         #expect(callCount == 0)
+
+        // User scrolls to the end of the long chapter: 3000 - 2200 = 800 ≤ 800,
+        // height is stable, so the deferred fire is now delivered.
+        viewModel.handleScroll(offset: -2200, contentHeight: 3000)
+        #expect(callCount == 1)
     }
 
     @Test

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
@@ -44,13 +44,14 @@ import Testing
         viewModel.handleScroll(offset: -200, contentHeight: 2000)
         #expect(completedReference == nil)
 
-        // Scrolled by -1200, the bottom of content is at 2000 - 1200 = 800 ≤ 800 → fires.
+        // Scrolled by -1200, the bottom of content is at 2000 - 1200 = 800 ≤ 800.
+        // contentHeight has been stable at 2000 across two events → fires.
         viewModel.handleScroll(offset: -1200, contentHeight: 2000)
         #expect(completedReference == reference)
     }
 
     @Test
-    func handleScrollFiresChapterCompleteImmediatelyForShortContent() {
+    func handleScrollFiresChapterCompleteForShortContentOnceHeightIsStable() {
         var completedReference: BibleReference?
         let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1)
         let viewModel = Support.makeViewModel(
@@ -60,9 +61,38 @@ import Testing
         viewModel.scrollViewHeight = 800
         viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
 
-        // Content shorter than the viewport: the bottom is already visible on first geometry event.
+        // First geometry event for short content: height is not yet stable
+        // (no prior observation), so the fire is suppressed.
+        viewModel.handleScroll(offset: 0, contentHeight: 400)
+        #expect(completedReference == nil)
+
+        // Second event with the same height: layout has settled, fire allowed.
         viewModel.handleScroll(offset: 0, contentHeight: 400)
         #expect(completedReference == reference)
+    }
+
+    @Test
+    func handleScrollSuppressesChapterCompleteDuringAsyncContentLoad() {
+        // Reproduces the bug where onChapterComplete fired on initial open of
+        // a long chapter: BibleTextView starts with empty blocks and lays out
+        // tiny, then text loads and content grows past the viewport. We must
+        // not fire during the tiny-initial-layout window.
+        var callCount = 0
+        let viewModel = Support.makeViewModel(onChapterComplete: { _ in callCount += 1 })
+        viewModel.scrollViewHeight = 800
+        viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
+
+        // Initial layout: copyright block only, fits in viewport.
+        viewModel.handleScroll(offset: 0, contentHeight: 120)
+        #expect(callCount == 0)
+
+        // Text loads — content height jumps to its real (long) value.
+        viewModel.handleScroll(offset: 0, contentHeight: 3000)
+        #expect(callCount == 0)
+
+        // User has not scrolled yet; bottom is not reached.
+        viewModel.handleScroll(offset: 0, contentHeight: 3000)
+        #expect(callCount == 0)
     }
 
     @Test
@@ -87,13 +117,16 @@ import Testing
         viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
 
         viewModel.handleScroll(offset: -1200, contentHeight: 2000)
+        viewModel.handleScroll(offset: -1200, contentHeight: 2000)
         #expect(callCount == 1)
 
         viewModel.resetChapterCompleteTracking()
         // Sub-threshold scroll after reset must not fire.
         viewModel.handleScroll(offset: -100, contentHeight: 2000)
+        viewModel.handleScroll(offset: -100, contentHeight: 2000)
         #expect(callCount == 1)
 
+        viewModel.handleScroll(offset: -1200, contentHeight: 2000)
         viewModel.handleScroll(offset: -1200, contentHeight: 2000)
         #expect(callCount == 2)
     }
@@ -107,8 +140,9 @@ import Testing
         viewModel.isChangingChapter = true
         viewModel.showChrome = true
 
-        // Even though the bottom-of-content condition is met, no side effects
-        // fire while the chapter-change guard is active.
+        // Two consecutive stable-height events while the guard is active:
+        // geometry is recorded but no side effects fire.
+        viewModel.handleScroll(offset: 0, contentHeight: 400)
         viewModel.handleScroll(offset: 0, contentHeight: 400)
 
         #expect(viewModel.showChrome)


### PR DESCRIPTION
## Summary
- `onChapterComplete` was firing immediately on initial open even for long chapters.
- Root cause: `BibleTextView` initializes with empty `blocks: []` and loads content asynchronously. The first `onGeometryChange` event reports a tiny `contentHeight` (just the copyright block and padding), which trivially satisfies the bottom-of-content check.
- Fix: require `contentHeight` to be stable across two consecutive geometry events before firing. The first event records the in-flight tiny height; the second confirms the layout has settled.
- Short chapters still fire as soon as they're fully visible (after layout settles); long chapters fire only when the user actually scrolls to the end.

## Test plan
- [x] `swift test --filter BibleReaderViewModelInteractionTests` — 17 tests pass, including a new `handleScrollSuppressesChapterCompleteDuringAsyncContentLoad` that reproduces the bug.
- [ ] Manual: open a long chapter (e.g. Psalm 119) and confirm `onChapterComplete` does **not** fire on open.
- [ ] Manual: scroll to the end of that long chapter and confirm `onChapterComplete` fires.
- [ ] Manual: open a short chapter (e.g. Psalm 117) and confirm `onChapterComplete` fires shortly after display (once layout settles).
- [ ] Manual: navigate next/previous to a short chapter and confirm it still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a spurious `onChapterComplete` event that fired immediately on opening long chapters by introducing a two-consecutive-event height-stability check before the callback is allowed to fire.

- Adds `previousContentHeight: CGFloat` that is snapshotted at the top of `handleScroll` and reset in `resetChapterCompleteTracking`; `evaluateChapterCompleteFromCachedGeometry` now requires `contentHeight == previousContentHeight` in addition to the bottom-reached condition, so the brief initial layout pass with an empty-blocks placeholder can no longer satisfy the check.
- All existing tests are updated to send two events with the same height before asserting a fire, and a new `handleScrollSuppressesChapterCompleteDuringAsyncContentLoad` test reproduces the original bug and verifies that the deferred event is delivered once the user scrolls to the end.

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to a single callback-suppression guard; the stability check is simple, deterministic, and fully exercised by the updated test suite.

The fix introduces one new boolean guard (`contentHeight == previousContentHeight`) gated behind the existing `bottomReached` and `!hasNotifiedChapterComplete` checks. All three call-sites — initial open, chapter reset, and the `isChangingChapter` didSet path — are covered by tests that were updated or newly added. No logic paths are left untested and the original regression is explicitly reproduced by the new test.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Adds `previousContentHeight: CGFloat = 0` with a clear DocC comment explaining its role in the stability check. Access level matches the existing pattern (`var`/internal) required by the multi-file extension architecture. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift | Snapshots `previousContentHeight` before updating `contentHeight` in `handleScroll`, adds the `heightIsStable` guard to `evaluateChapterCompleteFromCachedGeometry`, and zeroes `previousContentHeight` in `resetChapterCompleteTracking`. Logic is correct; one new inline comment inside the function body is a style-guide violation. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift | All existing tests updated to send two consecutive events with matching height before expecting `onChapterComplete` to fire. New `handleScrollSuppressesChapterCompleteDuringAsyncContentLoad` test reproduces the async-load bug and verifies the fix end-to-end, including the positive delivery assertion. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TV as BibleTextView
    participant VM as BibleReaderViewModel
    participant CB as onChapterComplete

    Note over TV,VM: Async content load (long chapter)
    TV->>VM: handleScroll(offset:0, contentHeight:120)
    Note over VM: previousContentHeight=0 to 120, heightIsStable false
    VM-->>CB: suppressed

    TV->>VM: handleScroll(offset:0, contentHeight:3000)
    Note over VM: previousContentHeight=120 to 3000, heightIsStable false
    VM-->>CB: suppressed

    TV->>VM: handleScroll(offset:0, contentHeight:3000)
    Note over VM: heightIsStable true, bottomReached false
    VM-->>CB: suppressed (not at bottom)

    Note over TV,VM: User scrolls to end
    TV->>VM: handleScroll(offset:-2200, contentHeight:3000)
    Note over VM: heightIsStable true, bottomReached true
    VM->>CB: fires onChapterComplete
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%3A121-127%0A**Inline%20comment%20added%20inside%20a%20function**%0A%0AThe%20project%20style%20guide%20forbids%20adding%20new%20inline%20comments%20inside%20function%20bodies%20%28%60evaluateChapterCompleteFromCachedGeometry%60%20already%20has%20a%20pre-existing%20block%20comment%20above%20%60bottomReached%60%29.%20The%20four-line%20comment%20above%20%60heightIsStable%60%20is%20new.%20Consider%20moving%20the%20explanation%20to%20a%20DocC%20comment%20on%20%60previousContentHeight%60%20itself%20%28which%20this%20PR%20already%20adds%20and%20which%20is%20the%20right%20home%20for%20this%20rationale%29%20and%20removing%20the%20in-function%20block.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=120&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%3A121-127%0A**Inline%20comment%20added%20inside%20a%20function**%0A%0AThe%20project%20style%20guide%20forbids%20adding%20new%20inline%20comments%20inside%20function%20bodies%20%28%60evaluateChapterCompleteFromCachedGeometry%60%20already%20has%20a%20pre-existing%20block%20comment%20above%20%60bottomReached%60%29.%20The%20four-line%20comment%20above%20%60heightIsStable%60%20is%20new.%20Consider%20moving%20the%20explanation%20to%20a%20DocC%20comment%20on%20%60previousContentHeight%60%20itself%20%28which%20this%20PR%20already%20adds%20and%20which%20is%20the%20right%20home%20for%20this%20rationale%29%20and%20removing%20the%20in-function%20block.%0A%0A&pr=120&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift:121-127
**Inline comment added inside a function**

The project style guide forbids adding new inline comments inside function bodies (`evaluateChapterCompleteFromCachedGeometry` already has a pre-existing block comment above `bottomReached`). The four-line comment above `heightIsStable` is new. Consider moving the explanation to a DocC comment on `previousContentHeight` itself (which this PR already adds and which is the right home for this rationale) and removing the in-function block.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(reader): assert deferred onChapterC..."](https://github.com/youversion/platform-sdk-swift/commit/8abd9603527c85d5037b633933fbc7454a43dc7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32018358)</sub>

<!-- /greptile_comment -->