### PR TITLE
fix: stop the continuous recreation of the BibleReaderViewModel

### DIFF
--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -4,7 +4,7 @@ import YouVersionPlatformCore
 import YouVersionPlatformUI
 
 public struct BibleReaderView: View {
-    @StateObject private var viewModelStore: BibleReaderViewModelStore
+    @State private var viewModel = BibleReaderViewModel(loadInitialState: false)
 #if !os(tvOS)
     @State private var contextProvider = ContextProvider()
 #endif
@@ -14,6 +14,9 @@ public struct BibleReaderView: View {
 
     private let fontSettingsDetent = PresentationDetent.height(360)
     private let fontListDetent = PresentationDetent.height(480)
+    private let initialReference: BibleReference?
+    private let initialVerseSelectionStyle: VerseSelectionStyle
+    private let onVerseTap: ((BibleReference) -> Void)?
     @State private var selectedDetent: PresentationDetent
     @State private var detents: Set<PresentationDetent>
 
@@ -40,13 +43,11 @@ public struct BibleReaderView: View {
             onVerseTap != nil || YouVersionPlatformConfiguration.isSignInEnabled,
             "onVerseTap must be provided OR YouVersion sign-in must be enabled"
         )
-        _viewModelStore = StateObject(wrappedValue: BibleReaderViewModelStore(
-            reference: reference,
-            verseSelectionStyle: verseSelectionStyle,
-            onVerseTap: onVerseTap
-        ))
-        detents = [fontSettingsDetent, fontListDetent]
-        selectedDetent = fontSettingsDetent
+        self.initialReference = reference
+        self.initialVerseSelectionStyle = verseSelectionStyle
+        self.onVerseTap = onVerseTap
+        _detents = State(wrappedValue: [fontSettingsDetent, fontListDetent])
+        _selectedDetent = State(wrappedValue: fontSettingsDetent)
     }
 
     /// Creates a Bible reader view with sign-in configuration.
@@ -68,8 +69,6 @@ public struct BibleReaderView: View {
     }
 
     public var body: some View {
-        @Bindable var bindableViewModel = viewModel
-
         VStack(spacing: 0) {
             header
             Spacer()
@@ -94,31 +93,31 @@ public struct BibleReaderView: View {
         .background(viewModel.readerCanvasPrimaryColor)
         .alert(
             String.localized("signOut.question"),
-            isPresented: $bindableViewModel.showSignOutConfirmation
+            isPresented: $viewModel.showSignOutConfirmation
         ) {
             Button(String.localized("button.signOut"), role: .destructive) { viewModel.confirmSignOut() }
             Button(String.localized("generic.cancel"), role: .cancel) { }
         } message: {
             Text(String.localized("signOut.explanation"))
         }
-        .sheet(isPresented: $bindableViewModel.showingFontSettings, content: {
+        .sheet(isPresented: $viewModel.showingFontSettings, content: {
             fontSettingsSheet
         })
-        .sheet(isPresented: $bindableViewModel.showingFootnotes, content: {
+        .sheet(isPresented: $viewModel.showingFootnotes, content: {
             BibleReaderFootnotesView()
                 .foregroundStyle(viewModel.readerTextPrimaryColor)
                 .presentationBackground(viewModel.readerCanvasPrimaryColor)
                 .presentationDragIndicator(.visible)
                 .presentationDetents([.medium, .large])
         })
-        .sheet(isPresented: $bindableViewModel.showingIntroFootnoteSheet, content: {
+        .sheet(isPresented: $viewModel.showingIntroFootnoteSheet, content: {
             BibleReaderIntroFootnoteView()
                 .foregroundStyle(viewModel.readerTextPrimaryColor)
                 .presentationBackground(viewModel.readerCanvasPrimaryColor)
                 .presentationDragIndicator(.visible)
                 .presentationDetents([.height(250), .medium, .large])
         })
-        .sheet(isPresented: $bindableViewModel.showingSignInSheet) {
+        .sheet(isPresented: $viewModel.showingSignInSheet) {
             signInView
         }
         .onChange(of: viewModel.startSignInFlow) { _, newValue in
@@ -129,15 +128,17 @@ public struct BibleReaderView: View {
         .onChange(of: reduceMotion, initial: true) { _, newValue in
             viewModel.isReduceMotionEnabled = newValue
         }
+        .onAppear {
+            viewModel.configureInitialStateIfNeeded(
+                reference: initialReference,
+                verseSelectionStyle: initialVerseSelectionStyle
+            )
+        }
         .environment(viewModel)
         .environment(\.colorScheme, viewModel.colorTheme?.colorScheme ?? .dark)
     }
 
     // MARK: - Helper views
-
-    private var viewModel: BibleReaderViewModel {
-        viewModelStore.viewModel
-    }
 
     private var header: some View {
         HStack {
@@ -235,9 +236,7 @@ public struct BibleReaderView: View {
     }
 
     private var mainScroller: some View {
-        @Bindable var bindableViewModel = viewModel
-
-        return ScrollViewReader { scrollProxy in
+        ScrollViewReader { scrollProxy in
             ScrollView {
                 if viewModel.version != nil {
                     VStack(alignment: .leading) {
@@ -247,9 +246,14 @@ public struct BibleReaderView: View {
                             BibleTextView(
                                 viewModel.reference,
                                 textOptions: viewModel.textOptions,
-                                selectedVerses: $bindableViewModel.selectedVerses,
+                                selectedVerses: $viewModel.selectedVerses,
                                 onVerseTap: { reference, actionType, footnotes, footnoteId in
-                                    viewModel.handleVerseTap(reference: reference, actionType: actionType, footnotes: footnotes)
+                                    viewModel.handleVerseTap(
+                                        reference: reference,
+                                        actionType: actionType,
+                                        footnotes: footnotes,
+                                        onVerseTap: onVerseTap
+                                    )
                                 }
                             )
                         }
@@ -302,25 +306,6 @@ public struct BibleReaderView: View {
         }
     }
 #endif
-
-    // `@StateObject` owns this store so SwiftUI rebuilds of `BibleReaderView`
-    // do not create extra reader models and launch duplicate model tasks.
-    @MainActor
-    private final class BibleReaderViewModelStore: ObservableObject {
-        let viewModel: BibleReaderViewModel
-
-        init(
-            reference: BibleReference?,
-            verseSelectionStyle: VerseSelectionStyle,
-            onVerseTap: ((BibleReference) -> Void)?
-        ) {
-            viewModel = BibleReaderViewModel(
-                reference: reference,
-                verseSelectionStyle: verseSelectionStyle,
-                onVerseTap: onVerseTap
-            )
-        }
-    }
 
     // MARK: - Action handlers
 

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -4,7 +4,7 @@ import YouVersionPlatformCore
 import YouVersionPlatformUI
 
 public struct BibleReaderView: View {
-    @State private var viewModel: BibleReaderViewModel
+    @StateObject private var viewModelStore: BibleReaderViewModelStore
 #if !os(tvOS)
     @State private var contextProvider = ContextProvider()
 #endif
@@ -40,7 +40,11 @@ public struct BibleReaderView: View {
             onVerseTap != nil || YouVersionPlatformConfiguration.isSignInEnabled,
             "onVerseTap must be provided OR YouVersion sign-in must be enabled"
         )
-        viewModel = BibleReaderViewModel(reference: reference, verseSelectionStyle: verseSelectionStyle, onVerseTap: onVerseTap)
+        _viewModelStore = StateObject(wrappedValue: BibleReaderViewModelStore(
+            reference: reference,
+            verseSelectionStyle: verseSelectionStyle,
+            onVerseTap: onVerseTap
+        ))
         detents = [fontSettingsDetent, fontListDetent]
         selectedDetent = fontSettingsDetent
     }
@@ -64,6 +68,8 @@ public struct BibleReaderView: View {
     }
 
     public var body: some View {
+        @Bindable var bindableViewModel = viewModel
+
         VStack(spacing: 0) {
             header
             Spacer()
@@ -88,31 +94,31 @@ public struct BibleReaderView: View {
         .background(viewModel.readerCanvasPrimaryColor)
         .alert(
             String.localized("signOut.question"),
-            isPresented: $viewModel.showSignOutConfirmation
+            isPresented: $bindableViewModel.showSignOutConfirmation
         ) {
             Button(String.localized("button.signOut"), role: .destructive) { viewModel.confirmSignOut() }
             Button(String.localized("generic.cancel"), role: .cancel) { }
         } message: {
             Text(String.localized("signOut.explanation"))
         }
-        .sheet(isPresented: $viewModel.showingFontSettings, content: {
+        .sheet(isPresented: $bindableViewModel.showingFontSettings, content: {
             fontSettingsSheet
         })
-        .sheet(isPresented: $viewModel.showingFootnotes, content: {
+        .sheet(isPresented: $bindableViewModel.showingFootnotes, content: {
             BibleReaderFootnotesView()
                 .foregroundStyle(viewModel.readerTextPrimaryColor)
                 .presentationBackground(viewModel.readerCanvasPrimaryColor)
                 .presentationDragIndicator(.visible)
                 .presentationDetents([.medium, .large])
         })
-        .sheet(isPresented: $viewModel.showingIntroFootnoteSheet, content: {
+        .sheet(isPresented: $bindableViewModel.showingIntroFootnoteSheet, content: {
             BibleReaderIntroFootnoteView()
                 .foregroundStyle(viewModel.readerTextPrimaryColor)
                 .presentationBackground(viewModel.readerCanvasPrimaryColor)
                 .presentationDragIndicator(.visible)
                 .presentationDetents([.height(250), .medium, .large])
         })
-        .sheet(isPresented: $viewModel.showingSignInSheet) {
+        .sheet(isPresented: $bindableViewModel.showingSignInSheet) {
             signInView
         }
         .onChange(of: viewModel.startSignInFlow) { _, newValue in
@@ -128,6 +134,11 @@ public struct BibleReaderView: View {
     }
 
     // MARK: - Helper views
+
+    private var viewModel: BibleReaderViewModel {
+        viewModelStore.viewModel
+    }
+
     private var header: some View {
         HStack {
             if viewModel.version != nil {
@@ -224,7 +235,9 @@ public struct BibleReaderView: View {
     }
 
     private var mainScroller: some View {
-        ScrollViewReader { scrollProxy in
+        @Bindable var bindableViewModel = viewModel
+
+        return ScrollViewReader { scrollProxy in
             ScrollView {
                 if viewModel.version != nil {
                     VStack(alignment: .leading) {
@@ -234,7 +247,7 @@ public struct BibleReaderView: View {
                             BibleTextView(
                                 viewModel.reference,
                                 textOptions: viewModel.textOptions,
-                                selectedVerses: $viewModel.selectedVerses,
+                                selectedVerses: $bindableViewModel.selectedVerses,
                                 onVerseTap: { reference, actionType, footnotes, footnoteId in
                                     viewModel.handleVerseTap(reference: reference, actionType: actionType, footnotes: footnotes)
                                 }
@@ -289,6 +302,25 @@ public struct BibleReaderView: View {
         }
     }
 #endif
+
+    // `@StateObject` owns this store so SwiftUI rebuilds of `BibleReaderView`
+    // do not create extra reader models and launch duplicate model tasks.
+    @MainActor
+    private final class BibleReaderViewModelStore: ObservableObject {
+        let viewModel: BibleReaderViewModel
+
+        init(
+            reference: BibleReference?,
+            verseSelectionStyle: VerseSelectionStyle,
+            onVerseTap: ((BibleReference) -> Void)?
+        ) {
+            viewModel = BibleReaderViewModel(
+                reference: reference,
+                verseSelectionStyle: verseSelectionStyle,
+                onVerseTap: onVerseTap
+            )
+        }
+    }
 
     // MARK: - Action handlers
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -93,18 +93,23 @@ extension BibleReaderViewModel {
         lastScrollOffset = offset
     }
 
-    func handleVerseTap(reference: BibleReference, actionType: String, footnotes: [BibleFootnote]) {
+    func handleVerseTap(
+        reference: BibleReference,
+        actionType: String,
+        footnotes: [BibleFootnote],
+        onVerseTap: ((BibleReference) -> Void)? = nil
+    ) {
         if actionType == BibleVersionRendering.LinkSchemes.footnote.rawValue {
             showingFootnotes = true
             footnotesToDisplay = footnotes
             return
         }
-        
-        if let onVerseTap {
-            onVerseTap(reference)
+
+        if onVerseTap != nil {
+            onVerseTap?(reference)
             return
         }
-        
+
         if isSignedIn {
             if selectedVerses.contains(reference) {
                 selectedVerses.remove(reference)

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -25,9 +25,10 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     let highlightsViewModel: BibleHighlightsViewModel
     let versionsViewModel: BibleVersionsViewModel
     var version: BibleVersion? { versionsViewModel.currentVersion }
-    let onVerseTap: ((BibleReference) -> Void)?
-    let verseSelectionStyle: VerseSelectionStyle
+    var verseSelectionStyle: VerseSelectionStyle
     private let authentication: BibleReaderAuthentication
+    private let shouldLoadVersionsViewModel: Bool
+    private var hasConfiguredInitialState: Bool
 
     // MARK: - UI state of the Reader itself
     var showChrome = true
@@ -69,7 +70,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         highlightsViewModel: BibleHighlightsViewModel? = nil,
         verseSelectionStyle: VerseSelectionStyle = .solid,
         versionsViewModel: BibleVersionsViewModel? = nil,
-        onVerseTap: ((BibleReference) -> Void)? = nil,
+        loadInitialState: Bool = true,
         authentication: BibleReaderAuthentication? = nil
     ) {
         let authentication = authentication ?? .default
@@ -89,12 +90,12 @@ final class BibleReaderViewModel: ReaderThemeProviding {
             }
         }
 
-        self.onVerseTap = onVerseTap
         self.verseSelectionStyle = verseSelectionStyle
         self.authentication = authentication
         self.isSignedIn = authentication.isSignedIn
         self.highlightsViewModel = highlightsViewModel ?? BibleHighlightsViewModel()
-        let shouldLoadVersionsViewModel = versionsViewModel == nil
+        self.shouldLoadVersionsViewModel = versionsViewModel == nil
+        self.hasConfiguredInitialState = loadInitialState
         self.versionsViewModel = versionsViewModel ?? BibleVersionsViewModel()
         self.versionsViewModel.onSignInRequired = { [weak self] in
             self?.onSignInRequired()
@@ -105,14 +106,35 @@ final class BibleReaderViewModel: ReaderThemeProviding {
 
         ReaderFonts.installFontsIfNeeded()
 
-        if shouldLoadVersionsViewModel {
-            let initialVersionId = self.reference.versionId
-            Task { [weak self] in
-                await self?.versionsViewModel.loadInitialState(initialVersionId: initialVersionId)
-            }
+        if loadInitialState {
+            loadVersionsViewModelInitialStateIfNeeded()
         }
 
         observeCurrentVersion()
+    }
+
+    /// Applies the view's initial inputs and starts version loading once.
+    func configureInitialStateIfNeeded(reference: BibleReference?, verseSelectionStyle: VerseSelectionStyle) {
+        guard !hasConfiguredInitialState else {
+            return
+        }
+        hasConfiguredInitialState = true
+        self.verseSelectionStyle = verseSelectionStyle
+        if let reference {
+            self.reference = reference
+            self.showBookIntro = false
+        }
+        loadVersionsViewModelInitialStateIfNeeded()
+    }
+
+    private func loadVersionsViewModelInitialStateIfNeeded() {
+        guard shouldLoadVersionsViewModel else {
+            return
+        }
+        let initialVersionId = reference.versionId
+        Task { [weak self] in
+            await self?.versionsViewModel.loadInitialState(initialVersionId: initialVersionId)
+        }
     }
 
     // Reacts to BibleVersionsViewModel.currentVersion changes by updating

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
@@ -62,11 +62,42 @@ import Testing
     func handleVerseTapUsesCustomVerseTapHandlerBeforeSelection() {
         let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
         var tappedReference: BibleReference?
-        let viewModel = Support.makeViewModel(onVerseTap: { tappedReference = $0 })
+        let viewModel = Support.makeViewModel()
 
-        viewModel.handleVerseTap(reference: reference, actionType: "", footnotes: [])
+        viewModel.handleVerseTap(
+            reference: reference,
+            actionType: "",
+            footnotes: [],
+            onVerseTap: { tappedReference = $0 }
+        )
 
         #expect(tappedReference == reference)
+        #expect(viewModel.selectedVerses.isEmpty)
+        #expect(viewModel.showingVerseActionsDrawer == false)
+    }
+
+    @Test
+    func handleVerseTapUsesCurrentVerseTapHandlerBeforeSelection() {
+        let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        var tappedReferences: [BibleReference] = []
+        let viewModel = Support.makeViewModel()
+
+        viewModel.handleVerseTap(
+            reference: reference,
+            actionType: "",
+            footnotes: [],
+            onVerseTap: { _ in }
+        )
+
+        let updatedReference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 17)
+        viewModel.handleVerseTap(
+            reference: updatedReference,
+            actionType: "",
+            footnotes: [],
+            onVerseTap: { tappedReferences.append($0) }
+        )
+
+        #expect(tappedReferences == [updatedReference])
         #expect(viewModel.selectedVerses.isEmpty)
         #expect(viewModel.showingVerseActionsDrawer == false)
     }

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
@@ -66,7 +66,6 @@ enum BibleReaderViewModelTestSupport {
         reference: BibleReference? = BibleReference(versionId: versionId, bookUSFM: "JHN", chapter: 1),
         highlightsRepository: MockBibleHighlightsRepository = MockBibleHighlightsRepository(),
         versionRepository: any BibleVersionRepositoryProtocol = MockBibleVersionRepository(),
-        onVerseTap: ((BibleReference) -> Void)? = nil,
         isSignedIn: Bool = false,
         hasValidToken: Bool? = nil,
         signOut: @escaping @MainActor () -> Void = {}
@@ -85,7 +84,6 @@ enum BibleReaderViewModelTestSupport {
             reference: reference,
             highlightsViewModel: highlightsViewModel,
             versionsViewModel: versionsViewModel,
-            onVerseTap: onVerseTap,
             authentication: authentication
         )
     }


### PR DESCRIPTION
## Description

fix: stop the continuous recreation of the BibleReaderViewModel

During debugging, it was noticed that the Swift BibleReaderViewModel and/or related objects were being recreated over and over, even when the user was taking no action.

## Type of Change

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [x] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes continuous recreation of `BibleReaderViewModel` by changing the `@State` property from an imperatively-assigned view model (which SwiftUI treated as a new value on every re-render) to a default-initialized stub (`loadInitialState: false`) that SwiftUI preserves across renders, with actual configuration deferred to `.onAppear` via `configureInitialStateIfNeeded`.

- `BibleReaderView` now stores `initialReference`, `initialVerseSelectionStyle`, and `onVerseTap` as `let` properties on the view struct, passing them through at render-time rather than freezing them on the view model at init.
- `BibleReaderViewModel` gains `hasConfiguredInitialState` and `shouldLoadVersionsViewModel` flags for one-shot lazy setup, and `onVerseTap` is removed as a stored property — it is now passed directly at the `handleVerseTap` call-site, ensuring the closure is always the latest one from the current render.
- Tests are updated to match the new call-site API and a new test validates the per-call closure behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix correctly addresses the root cause and the lazy initialization path is guarded against double-invocation.

The root cause (assigning to the @State wrappedValue in the view's init, which forced a new object on every parent re-render) is cleanly eliminated. The one-shot guard (hasConfiguredInitialState) prevents double initialization on view reappearance, onVerseTap is now always current because it flows through the call-site rather than being frozen at init time, and the tests cover the changed behavior well.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Switches @State viewModel to a default-initialized instance (loadInitialState: false) so SwiftUI preserves it across re-renders; defers actual configuration to onAppear. Also stores onVerseTap on the view struct and passes it at call-site to keep the closure fresh on every render. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Removes stored onVerseTap; adds loadInitialState flag, shouldLoadVersionsViewModel, and hasConfiguredInitialState to enable lazy one-shot initialization. configureInitialStateIfNeeded safely applies the view's inputs exactly once. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift | handleVerseTap now accepts onVerseTap as a call-site parameter instead of reading a stored property; functionally correct but uses a slightly less idiomatic nil-check pattern. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift | Tests updated to pass onVerseTap at call-site; new test verifies that a fresh handler passed on the second tap is the one that fires, validating the per-call closure pattern. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift | Removes onVerseTap from makeViewModel helper to align with the new API that no longer stores the closure on the view model. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Parent as Parent View
    participant BRV as BibleReaderView
    participant VM as BibleReaderViewModel
    participant VVM as BibleVersionsViewModel

    Parent->>BRV: init(reference:, verseSelectionStyle:, onVerseTap:)
    Note over BRV: Stores initialReference, initialVerseSelectionStyle,<br/>onVerseTap as let properties
    Note over BRV: @State viewModel = BibleReaderViewModel(loadInitialState: false)
    BRV->>VM: init(loadInitialState: false)
    Note over VM: hasConfiguredInitialState = false<br/>No version loading yet

    BRV->>BRV: body evaluated
    BRV->>BRV: .onAppear fires
    BRV->>VM: configureInitialStateIfNeeded(reference:, verseSelectionStyle:)
    Note over VM: hasConfiguredInitialState = true
    VM->>VVM: loadInitialState(initialVersionId:)

    Parent->>BRV: re-render (new closure / state change)
    Note over BRV: @State viewModel preserved by SwiftUI
    BRV->>BRV: .onAppear NOT fired again
    Note over BRV: onVerseTap captured fresh from struct

    BRV->>VM: handleVerseTap(reference:, actionType:, footnotes:, onVerseTap:)
    Note over VM: Uses current onVerseTap from call-site
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%3A108-111%0AThe%20nil-check%20%2B%20optional-chaining%20pattern%20here%20is%20redundant%20and%20less%20idiomatic%20than%20Swift's%20%60if%20let%60%20binding.%20Since%20%60onVerseTap%60%20is%20already%20confirmed%20non-nil%20by%20the%20%60!%3D%20nil%60%20guard%2C%20the%20%60%3F%60%20on%20%60onVerseTap%3F%28reference%29%60%20is%20unnecessary.%20Using%20%60if%20let%60%20is%20cleaner%20and%20avoids%20the%20double%20evaluation%20of%20the%20optional.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20let%20onVerseTap%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20onVerseTap%28reference%29%0A%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=121&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformReader%2FViewModels%2FBibleReaderViewModel%2BNavigation.swift%3A108-111%0AThe%20nil-check%20%2B%20optional-chaining%20pattern%20here%20is%20redundant%20and%20less%20idiomatic%20than%20Swift's%20%60if%20let%60%20binding.%20Since%20%60onVerseTap%60%20is%20already%20confirmed%20non-nil%20by%20the%20%60!%3D%20nil%60%20guard%2C%20the%20%60%3F%60%20on%20%60onVerseTap%3F%28reference%29%60%20is%20unnecessary.%20Using%20%60if%20let%60%20is%20cleaner%20and%20avoids%20the%20double%20evaluation%20of%20the%20optional.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20let%20onVerseTap%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20onVerseTap%28reference%29%0A%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=121&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift:108-111
The nil-check + optional-chaining pattern here is redundant and less idiomatic than Swift's `if let` binding. Since `onVerseTap` is already confirmed non-nil by the `!= nil` guard, the `?` on `onVerseTap?(reference)` is unnecessary. Using `if let` is cleaner and avoids the double evaluation of the optional.

```suggestion
        if let onVerseTap {
            onVerseTap(reference)
            return
        }
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: better code to avoid viewmodel re-c..."](https://github.com/youversion/platform-sdk-swift/commit/44b5a423206dc29eb28948b4b76bb5b754fd3889) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32170510)</sub>

<!-- /greptile_comment -->