### PR TITLE
fix: BibleReaderViewModel created on every render

### DIFF
--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -4,18 +4,11 @@ import YouVersionPlatformCore
 import YouVersionPlatformUI
 
 public struct BibleReaderView: View {
-    @State private var viewModel: BibleReaderViewModel
-#if !os(tvOS)
-    @State private var contextProvider = ContextProvider()
-#endif
+    @State private var viewModel: BibleReaderViewModel?
 
-    @Environment(\.openURL) private var openURL
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
-    private let fontSettingsDetent = PresentationDetent.height(360)
-    private let fontListDetent = PresentationDetent.height(480)
-    @State private var selectedDetent: PresentationDetent
-    @State private var detents: Set<PresentationDetent>
+    private let initialReference: BibleReference?
+    private let verseSelectionStyle: VerseSelectionStyle
+    private let onVerseTap: ((BibleReference) -> Void)?
 
     /// Creates a Bible reader view.
     ///
@@ -40,9 +33,9 @@ public struct BibleReaderView: View {
             onVerseTap != nil || YouVersionPlatformConfiguration.isSignInEnabled,
             "onVerseTap must be provided OR YouVersion sign-in must be enabled"
         )
-        viewModel = BibleReaderViewModel(reference: reference, verseSelectionStyle: verseSelectionStyle, onVerseTap: onVerseTap)
-        detents = [fontSettingsDetent, fontListDetent]
-        selectedDetent = fontSettingsDetent
+        self.initialReference = reference
+        self.verseSelectionStyle = verseSelectionStyle
+        self.onVerseTap = onVerseTap
     }
 
     /// Creates a Bible reader view with sign-in configuration.
@@ -64,6 +57,40 @@ public struct BibleReaderView: View {
     }
 
     public var body: some View {
+        Group {
+            if let viewModel {
+                ReaderContent(viewModel: viewModel)
+            } else {
+                Color.clear
+            }
+        }
+        .task {
+            if viewModel == nil {
+                viewModel = BibleReaderViewModel(
+                    reference: initialReference,
+                    verseSelectionStyle: verseSelectionStyle,
+                    onVerseTap: onVerseTap
+                )
+            }
+        }
+    }
+}
+
+private struct ReaderContent: View {
+    @Bindable var viewModel: BibleReaderViewModel
+#if !os(tvOS)
+    @State private var contextProvider = ContextProvider()
+#endif
+
+    @Environment(\.openURL) private var openURL
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private let fontSettingsDetent = PresentationDetent.height(360)
+    private let fontListDetent = PresentationDetent.height(480)
+    @State private var selectedDetent = PresentationDetent.height(360)
+    @State private var detents: Set<PresentationDetent> = [.height(360), .height(480)]
+
+    var body: some View {
         VStack(spacing: 0) {
             header
             Spacer()


### PR DESCRIPTION
## Summary

`BibleReaderViewModel` was being constructed every time SwiftUI rebuilt the `BibleReaderView` struct — easy to confirm by setting a breakpoint on the first line of its initializer and watching it fire repeatedly while the SampleApp idled on the Bible tab.

## Root cause

`@State private var viewModel: BibleReaderViewModel` with `viewModel = BibleReaderViewModel(...)` in `init` is syntactic sugar for `_viewModel = State(wrappedValue: BibleReaderViewModel(...))`. `State.init(wrappedValue:)` takes a plain `Value`, not an `@autoclosure`, so Swift evaluates the right-hand side every time `init` runs. SwiftUI keeps only the *first* instance for the `@State` storage, but the constructor's side effects — `UserDefaults` reads, the spawned `Task { … loadInitialState }`, `observeCurrentVersion()`, font installation — all execute on every discarded instance.

`@State` re-runs whenever the parent body recomputes. With an `@Observable` view-model whose properties (`showChrome`, `version`, etc.) are read in body, the loop is self-sustaining: `onGeometryChange` → `handleScroll` → `showChrome = true` → body re-reads `showChrome` → struct rebuilt → `init` runs → new VM constructed and discarded → its spawned `loadInitialState` Task fires again → repeat.

`@StateObject` would solve this because its initializer takes `@autoclosure @escaping () -> ObjectType`, but `@StateObject` requires `ObservableObject`, which the `@Observable` macro doesn't conform to.

## Fix

Defer construction to first appearance:

- `@State private var viewModel: BibleReaderViewModel?` (optional)
- `init` stores `reference`, `verseSelectionStyle`, and `onVerseTap` as `let` properties — no view model construction here
- `.task` creates the view model exactly once on first appearance
- Body content extracted into a private `ReaderContent` view that takes the unwrapped `@Bindable var viewModel: BibleReaderViewModel`, keeping the existing body code essentially unchanged
- A `Color.clear` placeholder fills the `else` branch so the outer Group has layout, `.tabItem` registers, and `.task` actually fires (an `EmptyView` / empty Group would not)

Public API is unchanged — `BibleReaderView()` and the deprecated overload still work the same way. The only user-visible difference is a one-frame transparent placeholder before content appears on first show.

## Test plan

- [x] `swiftlint --strict` — 0 violations
- [x] `scripts/check-api-stability.sh check` — no breaking changes
- [x] `xcodebuild test` on iPhone 17 simulator — all suites pass
- [ ] Verify breakpoint on `BibleReaderViewModel.init` in the SampleApp fires exactly once
- [ ] Verify the Bible tab appears and renders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a self-sustaining render loop where `BibleReaderViewModel` was reconstructed on every SwiftUI body evaluation, causing repeated `UserDefaults` reads, redundant `loadInitialState` tasks, and font installation calls on every discarded instance. The fix defers construction to a `.task` modifier and extracts the full body into a private `ReaderContent` view that receives the unwrapped model via `@Bindable`.

- `BibleReaderView` now stores `@State private var viewModel: BibleReaderViewModel?` and only constructs the model once — on first appearance — via `.task`, with a `Color.clear` placeholder for the single pre-construction frame.
- `ReaderContent` (private) carries over all the original body logic, `@Environment` reads, sheet modifiers, and the `contextProvider`, keeping the public API fully unchanged.
- Two minor style observations are noted inline: a `guard`-style early exit in the `.task` closure, and a dead `.environment(BibleReaderViewModel.preview)` call in the preview block.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the fix correctly eliminates repeated ViewModel construction with no public API changes and no new concurrency risks.

The change is well-scoped and the deferred-construction pattern using `.task` + optional `@State` is a sound SwiftUI approach. The only items flagged are cosmetic: a `guard`-style early exit and a dead `.environment(...)` call in the preview that was already inert before this PR. No behavioral regressions were identified.

The single changed file, BibleReaderView.swift, is straightforward. The preview block's `.environment(BibleReaderViewModel.preview)` call is worth a second look since it no longer has any effect.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Refactors BibleReaderView to defer ViewModel construction to .task, eliminating repeated init side-effects; extracts body into private ReaderContent struct. Two minor style observations. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Parent as Parent View
    participant BRV as BibleReaderView
    participant State as @State viewModel?
    participant Task as .task closure
    participant RC as ReaderContent

    Parent->>BRV: body re-evaluates (e.g. onGeometryChange)
    BRV->>State: "viewModel == nil?"
    alt viewModel is nil (first appearance)
        BRV-->>Parent: renders Color.clear placeholder
        Task->>State: BibleReaderViewModel(...) constructed ONCE
        State-->>BRV: viewModel set, triggers re-render
        BRV->>RC: ReaderContent(viewModel: unwrapped)
        RC-->>Parent: full reader content visible
    else viewModel already set
        BRV->>RC: ReaderContent(viewModel: unwrapped)
        RC-->>Parent: full reader content visible (no re-init)
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/YouVersionPlatformReader/BibleReaderView.swift`, line 348 ([link](https://github.com/youversion/platform-sdk-swift/blob/2657326944e8aa93f4b987ca444400a40bad1ca1/Sources/YouVersionPlatformReader/BibleReaderView.swift#L348)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dead environment injection in preview** — `.environment(BibleReaderViewModel.preview)` has no effect. `BibleReaderView` now always constructs its own `BibleReaderViewModel` inside `.task`, and `ReaderContent.body` then overrides the environment with `.environment(viewModel)` (line 153), so the injected preview instance is never observed by any child. The preview will render correctly with a freshly constructed model, but the `BibleReaderViewModel.preview` instance is silently discarded — this can mislead readers into thinking the preview is using pre-configured state.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformReader/BibleReaderView.swift
   Line: 348

   Comment:
   **Dead environment injection in preview** — `.environment(BibleReaderViewModel.preview)` has no effect. `BibleReaderView` now always constructs its own `BibleReaderViewModel` inside `.task`, and `ReaderContent.body` then overrides the environment with `.environment(viewModel)` (line 153), so the injected preview instance is never observed by any child. The preview will render correctly with a freshly constructed model, but the `BibleReaderViewModel.preview` instance is silently discarded — this can mislead readers into thinking the preview is using pre-configured state.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformReader%2FBibleReaderView.swift%0ALine%3A%20348%0A%0AComment%3A%0A**Dead%20environment%20injection%20in%20preview**%20%E2%80%94%20%60.environment%28BibleReaderViewModel.preview%29%60%20has%20no%20effect.%20%60BibleReaderView%60%20now%20always%20constructs%20its%20own%20%60BibleReaderViewModel%60%20inside%20%60.task%60%2C%20and%20%60ReaderContent.body%60%20then%20overrides%20the%20environment%20with%20%60.environment%28viewModel%29%60%20%28line%20153%29%2C%20so%20the%20injected%20preview%20instance%20is%20never%20observed%20by%20any%20child.%20The%20preview%20will%20render%20correctly%20with%20a%20freshly%20constructed%20model%2C%20but%20the%20%60BibleReaderViewModel.preview%60%20instance%20is%20silently%20discarded%20%E2%80%94%20this%20can%20mislead%20readers%20into%20thinking%20the%20preview%20is%20using%20pre-configured%20state.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=122&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformReader%2FBibleReaderView.swift%0ALine%3A%20348%0A%0AComment%3A%0A**Dead%20environment%20injection%20in%20preview**%20%E2%80%94%20%60.environment%28BibleReaderViewModel.preview%29%60%20has%20no%20effect.%20%60BibleReaderView%60%20now%20always%20constructs%20its%20own%20%60BibleReaderViewModel%60%20inside%20%60.task%60%2C%20and%20%60ReaderContent.body%60%20then%20overrides%20the%20environment%20with%20%60.environment%28viewModel%29%60%20%28line%20153%29%2C%20so%20the%20injected%20preview%20instance%20is%20never%20observed%20by%20any%20child.%20The%20preview%20will%20render%20correctly%20with%20a%20freshly%20constructed%20model%2C%20but%20the%20%60BibleReaderViewModel.preview%60%20instance%20is%20silently%20discarded%20%E2%80%94%20this%20can%20mislead%20readers%20into%20thinking%20the%20preview%20is%20using%20pre-configured%20state.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=122&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformReader%2FBibleReaderView.swift%3A67-75%0AUsing%20%60guard%60%20for%20an%20early-exit%20pattern%20is%20more%20idiomatic%20Swift%20than%20a%20bare%20%60if%60%20check%20when%20the%20sole%20purpose%20is%20to%20skip%20execution%20%E2%80%94%20it%20signals%20intent%20more%20clearly%20and%20aligns%20with%20the%20project's%20preference%20for%20early%20returns.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.task%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20viewModel%20%3D%3D%20nil%20else%20%7B%20return%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20viewModel%20%3D%20BibleReaderViewModel%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reference%3A%20initialReference%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20verseSelectionStyle%3A%20verseSelectionStyle%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onVerseTap%3A%20onVerseTap%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformReader%2FBibleReaderView.swift%3A348%0A**Dead%20environment%20injection%20in%20preview**%20%E2%80%94%20%60.environment%28BibleReaderViewModel.preview%29%60%20has%20no%20effect.%20%60BibleReaderView%60%20now%20always%20constructs%20its%20own%20%60BibleReaderViewModel%60%20inside%20%60.task%60%2C%20and%20%60ReaderContent.body%60%20then%20overrides%20the%20environment%20with%20%60.environment%28viewModel%29%60%20%28line%20153%29%2C%20so%20the%20injected%20preview%20instance%20is%20never%20observed%20by%20any%20child.%20The%20preview%20will%20render%20correctly%20with%20a%20freshly%20constructed%20model%2C%20but%20the%20%60BibleReaderViewModel.preview%60%20instance%20is%20silently%20discarded%20%E2%80%94%20this%20can%20mislead%20readers%20into%20thinking%20the%20preview%20is%20using%20pre-configured%20state.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=122&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformReader%2FBibleReaderView.swift%3A67-75%0AUsing%20%60guard%60%20for%20an%20early-exit%20pattern%20is%20more%20idiomatic%20Swift%20than%20a%20bare%20%60if%60%20check%20when%20the%20sole%20purpose%20is%20to%20skip%20execution%20%E2%80%94%20it%20signals%20intent%20more%20clearly%20and%20aligns%20with%20the%20project's%20preference%20for%20early%20returns.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.task%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20viewModel%20%3D%3D%20nil%20else%20%7B%20return%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20viewModel%20%3D%20BibleReaderViewModel%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reference%3A%20initialReference%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20verseSelectionStyle%3A%20verseSelectionStyle%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onVerseTap%3A%20onVerseTap%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformReader%2FBibleReaderView.swift%3A348%0A**Dead%20environment%20injection%20in%20preview**%20%E2%80%94%20%60.environment%28BibleReaderViewModel.preview%29%60%20has%20no%20effect.%20%60BibleReaderView%60%20now%20always%20constructs%20its%20own%20%60BibleReaderViewModel%60%20inside%20%60.task%60%2C%20and%20%60ReaderContent.body%60%20then%20overrides%20the%20environment%20with%20%60.environment%28viewModel%29%60%20%28line%20153%29%2C%20so%20the%20injected%20preview%20instance%20is%20never%20observed%20by%20any%20child.%20The%20preview%20will%20render%20correctly%20with%20a%20freshly%20constructed%20model%2C%20but%20the%20%60BibleReaderViewModel.preview%60%20instance%20is%20silently%20discarded%20%E2%80%94%20this%20can%20mislead%20readers%20into%20thinking%20the%20preview%20is%20using%20pre-configured%20state.%0A%0A&pr=122&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
Sources/YouVersionPlatformReader/BibleReaderView.swift:67-75
Using `guard` for an early-exit pattern is more idiomatic Swift than a bare `if` check when the sole purpose is to skip execution — it signals intent more clearly and aligns with the project's preference for early returns.

```suggestion
        .task {
            guard viewModel == nil else { return }
            viewModel = BibleReaderViewModel(
                reference: initialReference,
                verseSelectionStyle: verseSelectionStyle,
                onVerseTap: onVerseTap
            )
        }
```

### Issue 2 of 2
Sources/YouVersionPlatformReader/BibleReaderView.swift:348
**Dead environment injection in preview** — `.environment(BibleReaderViewModel.preview)` has no effect. `BibleReaderView` now always constructs its own `BibleReaderViewModel` inside `.task`, and `ReaderContent.body` then overrides the environment with `.environment(viewModel)` (line 153), so the injected preview instance is never observed by any child. The preview will render correctly with a freshly constructed model, but the `BibleReaderViewModel.preview` instance is silently discarded — this can mislead readers into thinking the preview is using pre-configured state.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stop reconstructing BibleReaderView..."](https://github.com/youversion/platform-sdk-swift/commit/2657326944e8aa93f4b987ca444400a40bad1ca1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32319455)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->