### PR TITLE
refactor: rename usfm/USFM to passageId/bookId across SDK

### DIFF
--- a/Examples/SampleApp/CardView.swift
+++ b/Examples/SampleApp/CardView.swift
@@ -5,7 +5,7 @@ struct CardView: View {
     var body: some View {
         BibleCardView(
             reference: BibleReference(
-                versionId: 3034, bookUSFM: "2CO", chapter: 1, verseStart: 3, verseEnd: 4
+                versionId: 3034, bookId: "2CO", chapter: 1, verseStart: 3, verseEnd: 4
             ),
             fontSize: 18,
             showVersionPicker: true

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ import YouVersionPlatform
 struct DemoView: View {
     var body: some View {
         BibleTextView(
-            BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16)
+            BibleReference(versionId: 3034, bookId: "JHN", chapter: 3, verse: 16)
         )
     }
 }
@@ -117,7 +117,7 @@ import YouVersionPlatform
 struct DemoView: View {
     var body: some View {
         BibleTextView(
-            BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verseStart: 16, verseEnd: 20)
+            BibleReference(versionId: 3034, bookId: "JHN", chapter: 3, verseStart: 16, verseEnd: 20)
         )
     }
 }
@@ -130,7 +130,7 @@ import YouVersionPlatform
 struct DemoView: View {
     var body: some View {
         BibleTextView(
-            BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3)
+            BibleReference(versionId: 3034, bookId: "JHN", chapter: 3)
         )
     }
 }
@@ -152,7 +152,7 @@ To open to a specific passage:
 
 ```swift
 BibleReaderView(
-    reference: BibleReference(versionId: 3034, bookUSFM: "PSA", chapter: 23)
+    reference: BibleReference(versionId: 3034, bookId: "PSA", chapter: 23)
 )
 ```
 

--- a/Sources/YouVersionPlatformCore/APIs/URLBuilder.swift
+++ b/Sources/YouVersionPlatformCore/APIs/URLBuilder.swift
@@ -77,7 +77,7 @@ public enum URLBuilder {
     /// URL to fetch text and metadata for a given BibleReference. "format" must be "text" or "html".
     public static func passageURL(reference: BibleReference, format: String = "text") -> URL? {
         var components = baseURLComponents
-        components.path = "/v1/bibles/\(reference.versionId)/passages/\(reference.asUSFM)"
+        components.path = "/v1/bibles/\(reference.versionId)/passages/\(reference.passageId)"
         components.queryItems = [
             URLQueryItem(name: "format", value: format),
             URLQueryItem(name: "include_notes", value: "true"),

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -25,7 +25,7 @@ actor ChapterMemoryCache {
     }
 
     private static func cacheKey(reference: BibleReference) -> String {
-        "\(reference.versionId)_\(reference.chapterPassageId ?? "unknown")"
+        "\(reference.versionId)_\(reference.chapterPassageId)"
     }
 }
 
@@ -38,18 +38,12 @@ actor BibleChapterDiskCache {
     }
 
     func chapterContent(withReference reference: BibleReference) -> String? {
-        guard let chapterPassageId = reference.chapterPassageId else {
-            return nil
-        }
-        return storage.string(for: .chapter(versionId: reference.versionId, passageId: chapterPassageId))
+        storage.string(for: .chapter(versionId: reference.versionId, passageId: reference.chapterPassageId))
     }
 
     func addChapterContent(_ content: String, reference: BibleReference) {
-        guard let chapterPassageId = reference.chapterPassageId else {
-            return
-        }
         do {
-            try storage.writeString(content, to: .chapter(versionId: reference.versionId, passageId: chapterPassageId))
+            try storage.writeString(content, to: .chapter(versionId: reference.versionId, passageId: reference.chapterPassageId))
         } catch {
             YouVersionPlatformLogger.notice(
                 "BibleChapterDiskCache failed to write data: \(error.localizedDescription)",
@@ -79,10 +73,7 @@ actor BibleChapterDownloadCache {
     }
 
     func chapterContent(withReference reference: BibleReference) -> String? {
-        guard let chapterPassageId = reference.chapterPassageId else {
-            return nil
-        }
-        return storage.string(for: .chapter(versionId: reference.versionId, passageId: chapterPassageId))
+        storage.string(for: .chapter(versionId: reference.versionId, passageId: reference.chapterPassageId))
     }
 
     nonisolated func chaptersArePresent(versionId: Int) -> Bool {

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -25,7 +25,7 @@ actor ChapterMemoryCache {
     }
 
     private static func cacheKey(reference: BibleReference) -> String {
-        "\(reference.versionId)_\(reference.chapterUSFM ?? "unknown")"
+        "\(reference.versionId)_\(reference.chapterPassageId ?? "unknown")"
     }
 }
 
@@ -38,18 +38,18 @@ actor BibleChapterDiskCache {
     }
 
     func chapterContent(withReference reference: BibleReference) -> String? {
-        guard let chapterUSFM = reference.chapterUSFM else {
+        guard let chapterPassageId = reference.chapterPassageId else {
             return nil
         }
-        return storage.string(for: .chapter(versionId: reference.versionId, usfm: chapterUSFM))
+        return storage.string(for: .chapter(versionId: reference.versionId, passageId: chapterPassageId))
     }
 
     func addChapterContent(_ content: String, reference: BibleReference) {
-        guard let chapterUSFM = reference.chapterUSFM else {
+        guard let chapterPassageId = reference.chapterPassageId else {
             return
         }
         do {
-            try storage.writeString(content, to: .chapter(versionId: reference.versionId, usfm: chapterUSFM))
+            try storage.writeString(content, to: .chapter(versionId: reference.versionId, passageId: chapterPassageId))
         } catch {
             YouVersionPlatformLogger.notice(
                 "BibleChapterDiskCache failed to write data: \(error.localizedDescription)",
@@ -79,10 +79,10 @@ actor BibleChapterDownloadCache {
     }
 
     func chapterContent(withReference reference: BibleReference) -> String? {
-        guard let chapterUSFM = reference.chapterUSFM else {
+        guard let chapterPassageId = reference.chapterPassageId else {
             return nil
         }
-        return storage.string(for: .chapter(versionId: reference.versionId, usfm: chapterUSFM))
+        return storage.string(for: .chapter(versionId: reference.versionId, passageId: chapterPassageId))
     }
 
     nonisolated func chaptersArePresent(versionId: Int) -> Bool {

--- a/Sources/YouVersionPlatformCore/Bible/BibleContentStorage.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleContentStorage.swift
@@ -26,7 +26,7 @@ enum BibleContentStorageResource: Sendable {
     case versionDirectory(versionId: Int)
     case versionMetadata(versionId: Int)
     case chaptersDirectory(versionId: Int)
-    case chapter(versionId: Int, usfm: String)
+    case chapter(versionId: Int, passageId: String)
 }
 
 struct BibleContentStorage: Sendable {
@@ -79,9 +79,9 @@ struct BibleContentStorage: Sendable {
         case let .chaptersDirectory(versionId):
             url(for: .versionDirectory(versionId: versionId))
                 .appending(path: "Chapters", directoryHint: .isDirectory)
-        case let .chapter(versionId, usfm):
+        case let .chapter(versionId, passageId):
             url(for: .chaptersDirectory(versionId: versionId))
-                .appending(path: usfm, directoryHint: .notDirectory)
+                .appending(path: passageId, directoryHint: .notDirectory)
         }
     }
 

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsCache.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsCache.swift
@@ -132,7 +132,7 @@ public final class BibleHighlightsCache {
 
         // Remove existing remote-synced highlights for this chapter
         cachedHighlights.removeAll { ch in
-            ch.state == .remoteSynced && ch.highlight.reference.bookUSFM == chapterRef.bookUSFM && ch.highlight.reference.chapter == chapterRef.chapter && ch.highlight.reference.versionId == chapterRef.versionId
+            ch.state == .remoteSynced && ch.highlight.reference.bookId == chapterRef.bookId && ch.highlight.reference.chapter == chapterRef.chapter && ch.highlight.reference.versionId == chapterRef.versionId
         }
 
         // Append server highlights as remoteSynced
@@ -143,7 +143,7 @@ public final class BibleHighlightsCache {
 
     // MARK: Utilities
     private func normalizeToChapter(_ reference: BibleReference) -> BibleReference {
-        BibleReference(versionId: reference.versionId, bookUSFM: reference.bookUSFM, chapter: reference.chapter)
+        BibleReference(versionId: reference.versionId, bookId: reference.bookId, chapter: reference.chapter)
     }
 
     // Called e.g. when the user signs out

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift
@@ -76,8 +76,8 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
         var result: [String: [BibleHighlight]] = [:]
 
         for reference in references {
-            let passageId = "\(reference.bookUSFM).\(reference.chapter)"
-            let chapterKey = "\(reference.versionId)_\(reference.bookUSFM)_\(reference.chapter)"
+            let passageId = "\(reference.bookId).\(reference.chapter)"
+            let chapterKey = "\(reference.versionId)_\(reference.bookId)_\(reference.chapter)"
             do {
                 let apiHighlights = try await api.highlights(bibleId: reference.versionId, passageId: passageId)
 
@@ -138,7 +138,7 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
         return BibleHighlight(
             BibleReference(
                 versionId: apiHighlight.bibleId,
-                bookUSFM: book,
+                bookId: book,
                 chapter: chapter,
                 verse: verse
             ),
@@ -166,7 +166,7 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
         
         var success = true
         for reference in operation.references {
-            let passageId = "\(reference.bookUSFM).\(reference.chapter).\(reference.verseStart ?? 1)"
+            let passageId = "\(reference.bookId).\(reference.chapter).\(reference.verseStart ?? 1)"
             let hexColor = color.hasPrefix("#") ? String(color.dropFirst()) : color
             
             do {
@@ -193,7 +193,7 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
     private func processRemoveOperation(_ operation: PendingHighlightOperation) async throws -> Bool {
         var success = true
         for reference in operation.references {
-            let passageId = "\(reference.bookUSFM).\(reference.chapter).\(reference.verseStart ?? 1)"
+            let passageId = "\(reference.bookId).\(reference.chapter).\(reference.verseStart ?? 1)"
             
             do {
                 let result = try await api.deleteHighlight(
@@ -224,7 +224,7 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
         
         var success = true
         for reference in operation.references {
-            let passageId = "\(reference.bookUSFM).\(reference.chapter).\(reference.verseStart ?? 1)"
+            let passageId = "\(reference.bookId).\(reference.chapter).\(reference.verseStart ?? 1)"
             let hexColor = color.hasPrefix("#") ? String(color.dropFirst()) : color
             
             do {

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
@@ -40,7 +40,7 @@ public class BibleHighlightsViewModel: ObservableObject {
     
     /// Ensure the chapter containing the range is loaded with throttling.
     public func ensureHighlightsForChapterLoaded(_ range: BibleReference, forceReload: Bool = false) {
-        let chapterRef = BibleReference(versionId: range.versionId, bookUSFM: range.bookUSFM, chapter: range.chapter)
+        let chapterRef = BibleReference(versionId: range.versionId, bookId: range.bookId, chapter: range.chapter)
         guard forceReload || !cache.hasRecentlyLoadedChapter(chapterRef) else {
             return
         }
@@ -68,7 +68,7 @@ public class BibleHighlightsViewModel: ObservableObject {
             BibleHighlight(
                 BibleReference(
                     versionId: reference.versionId,
-                    bookUSFM: reference.bookUSFM,
+                    bookId: reference.bookId,
                     chapter: reference.chapter,
                     verse: reference.verseStart ?? 1
                 ),
@@ -107,7 +107,7 @@ public class BibleHighlightsViewModel: ObservableObject {
     private func loadChapterFromServer(_ chapter: BibleReference) async {
         do {
             let serverHighlights = try await repository.highlights(for: [chapter])
-            let chapterKey = "\(chapter.versionId)_\(chapter.bookUSFM)_\(chapter.chapter)"
+            let chapterKey = "\(chapter.versionId)_\(chapter.bookId)_\(chapter.chapter)"
             let highlights = serverHighlights[chapterKey] ?? []
             cache.applyServerHighlights(for: chapter, highlights: highlights)
             cache.recordChapterFetch(chapter)

--- a/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
@@ -122,7 +122,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         compare(a: lhs, b: rhs) < 0
     }
 
-    public var chapterPassageId: String? {
+    public var chapterPassageId: String {
         "\(bookId).\(chapter)"
     }
 

--- a/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
@@ -2,53 +2,74 @@ import Foundation
 
 public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDebugStringConvertible {
     public let versionId: Int
-    public let bookUSFM: String
+    public let bookId: String
     public let chapter: Int
     public let verseStart: Int?
     public let verseEnd: Int?
 
-    public init(versionId: Int, bookUSFM: String, chapter: Int, verse: Int? = nil) {
+    enum CodingKeys: String, CodingKey {
+        case versionId
+        case bookId = "bookUSFM"
+        case chapter
+        case verseStart
+        case verseEnd
+    }
+
+    public init(versionId: Int, bookId: String, chapter: Int, verse: Int? = nil) {
         assert(chapter >= 1, "Chapter must be greater than or equal to 1.")
         if let verse {
             assert(verse >= 1, "Verse must be greater than or equal to 1.")
         }
-        
+
         self.versionId = versionId
-        self.bookUSFM = bookUSFM.uppercased()
+        self.bookId = bookId.uppercased()
         self.chapter = chapter
         self.verseStart = verse
         self.verseEnd = verse
     }
 
-    public init(versionId: Int, bookUSFM: String, chapter: Int, verseStart: Int, verseEnd: Int) {
+    public init(versionId: Int, bookId: String, chapter: Int, verseStart: Int, verseEnd: Int) {
         assert(chapter >= 1, "Starting chapter must be greater than or equal to 1.")
         assert(verseStart >= 1, "Starting verse must be greater than or equal to 1.")
         assert(verseEnd >= 1, "Ending verse must be greater than or equal to 1.")
         assert(verseEnd >= verseStart, "Ending verse must be equal to or after starting verse.")
 
         self.versionId = versionId
-        self.bookUSFM = bookUSFM.uppercased()
+        self.bookId = bookId.uppercased()
         self.chapter = chapter
         self.verseStart = verseStart
         self.verseEnd = verseEnd
     }
 
+    @available(*, deprecated, renamed: "init(versionId:bookId:chapter:verse:)")
+    public init(versionId: Int, bookUSFM: String, chapter: Int, verse: Int? = nil) {
+        self.init(versionId: versionId, bookId: bookUSFM, chapter: chapter, verse: verse)
+    }
+
+    @available(*, deprecated, renamed: "init(versionId:bookId:chapter:verseStart:verseEnd:)")
+    public init(versionId: Int, bookUSFM: String, chapter: Int, verseStart: Int, verseEnd: Int) {
+        self.init(versionId: versionId, bookId: bookUSFM, chapter: chapter, verseStart: verseStart, verseEnd: verseEnd)
+    }
+
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let versionId = try container.decode(Int.self, forKey: .versionId)
-        let bookUSFM = try container.decode(String.self, forKey: .bookUSFM)
+        let bookId = try container.decode(String.self, forKey: .bookId)
         let chapter = try container.decode(Int.self, forKey: .chapter)
         let verseStart = try container.decodeIfPresent(Int.self, forKey: .verseStart)
         let verseEnd = try container.decodeIfPresent(Int.self, forKey: .verseEnd)
         if let verseStart, let verseEnd {
-            self.init(versionId: versionId, bookUSFM: bookUSFM, chapter: chapter, verseStart: verseStart, verseEnd: verseEnd)
+            self.init(versionId: versionId, bookId: bookId, chapter: chapter, verseStart: verseStart, verseEnd: verseEnd)
         } else {
-            self.init(versionId: versionId, bookUSFM: bookUSFM, chapter: chapter, verse: verseStart)
+            self.init(versionId: versionId, bookId: bookId, chapter: chapter, verse: verseStart)
         }
     }
 
+    @available(*, deprecated, renamed: "bookId")
+    public var bookUSFM: String { bookId }
+
     public var debugDescription: String {
-        let prefix = "bible\(versionId)__\(bookUSFM).\(chapter)"
+        let prefix = "bible\(versionId)__\(bookId).\(chapter)"
         if let verseStart {
             if let verseEnd, verseStart != verseEnd {
                 return "\(prefix).\(verseStart)-\(verseEnd)"
@@ -62,17 +83,17 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
     public var isRange: Bool {
         verseEnd != nil && verseStart != verseEnd
     }
-    
+
     public static func compare(a: BibleReference, b: BibleReference) -> Int {
         // returns -1, 0, or 1
-        if a.bookUSFM != b.bookUSFM {
-            return a.bookUSFM < b.bookUSFM ? -1 : 1
+        if a.bookId != b.bookId {
+            return a.bookId < b.bookId ? -1 : 1
         }
-        
+
         if a.chapter != b.chapter {
             return a.chapter < b.chapter ? -1 : 1
         }
-        
+
         switch (a.verseStart, b.verseStart) {
         case let (lhs?, rhs?):
             if lhs == rhs {
@@ -96,34 +117,40 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
             return 1
         }
     }
-    
+
     public static func < (lhs: BibleReference, rhs: BibleReference) -> Bool {
         compare(a: lhs, b: rhs) < 0
     }
 
-    public var chapterUSFM: String? {
-        "\(bookUSFM).\(chapter)"
+    public var chapterPassageId: String? {
+        "\(bookId).\(chapter)"
     }
 
-    public var asUSFM: String {
+    @available(*, deprecated, renamed: "chapterPassageId")
+    public var chapterUSFM: String? { chapterPassageId }
+
+    public var passageId: String {
         if let verseStart {
             if let verseEnd, verseStart != verseEnd {
-                return "\(bookUSFM).\(chapter).\(verseStart)-\(bookUSFM).\(chapter).\(verseEnd)"
+                return "\(bookId).\(chapter).\(verseStart)-\(bookId).\(chapter).\(verseEnd)"
             } else {
-                return "\(bookUSFM).\(chapter).\(verseStart)"
+                return "\(bookId).\(chapter).\(verseStart)"
             }
         } else {
-            return "\(bookUSFM).\(chapter)"
+            return "\(bookId).\(chapter)"
         }
     }
+
+    @available(*, deprecated, renamed: "passageId")
+    public var asUSFM: String { passageId }
 
     /// Returns whether this reference is available in the provided Bible version metadata.
     public func existsIn(version: BibleVersion) -> Bool {
-        guard version.bookUSFMs.contains(where: { $0.uppercased() == bookUSFM }) else {
+        guard version.bookIds.contains(where: { $0.uppercased() == bookId }) else {
             return false
         }
 
-        guard let book = version.book(with: bookUSFM) else {
+        guard let book = version.book(with: bookId) else {
             return true
         }
 
@@ -135,13 +162,13 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         return chapters.contains { chapterMetadata in
             chapterMetadata.id == chapterText ||
             chapterMetadata.title == chapterText ||
-            chapterMetadata.passageId == chapterUSFM
+            chapterMetadata.passageId == chapterPassageId
         }
     }
 
     public func overlaps(with otherReference: BibleReference) -> Bool {
         guard versionId == otherReference.versionId &&
-                bookUSFM == otherReference.bookUSFM else {
+                bookId == otherReference.bookId else {
             return false
         }
 
@@ -176,14 +203,14 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
 
     public func contains(with otherReference: BibleReference) -> Bool {
         guard versionId == otherReference.versionId &&
-                bookUSFM == otherReference.bookUSFM else {
+                bookId == otherReference.bookId else {
             return false
         }
 
         if chapter != otherReference.chapter {
             return false  // TODO change this when we support cross-chapter ranges
         }
-        
+
         // Treat a reference with both verseStart and verseEnd nil as a whole chapter reference.
         // Whole chapter contains any reference within the same chapter.
         let aStart: Int
@@ -205,20 +232,20 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
             bStart = otherReference.verseStart ?? 1
             bEnd = otherReference.verseEnd ?? bStart
         }
-        
+
         return aStart <= bStart && aEnd >= bEnd
     }
 
     public func isAdjacentOrOverlapping(with otherReference: BibleReference) -> Bool {
         guard versionId == otherReference.versionId &&
-                bookUSFM == otherReference.bookUSFM &&
+                bookId == otherReference.bookId &&
                 chapter == otherReference.chapter else {
             return false
         }
-        
+
         let a = min(self, otherReference)
         let b = max(self, otherReference)
-        
+
         if let lastVerseOfA = a.verseEnd ?? a.verseStart {
             let firstVerseOfB = b.verseStart ?? 1
             return lastVerseOfA + 1 >= firstVerseOfB
@@ -226,7 +253,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
             return true
         }
     }
-    
+
     public static func referencesByMerging(references: [BibleReference]) -> [BibleReference] {
         var tmp = references
         tmp.sort()
@@ -243,104 +270,104 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         }
         return tmp
     }
-    
+
     public static func referenceByMerging(a: BibleReference, b: BibleReference) -> BibleReference {
         assert(a.isAdjacentOrOverlapping(with: b), "This function requires the two references to be adjacent or overlapping.")
-        
+
         if a.verseStart == nil {
             return a    // chapter reference
         }
-        
+
         if b.verseStart == nil {
             return b    // chapter reference
         }
-        
+
         let minReference = min(a, b)
-        
+
         let lastVerseOfA = a.verseEnd ?? a.verseStart
         let lastVerseOfB = b.verseEnd ?? b.verseStart
         let firstVerse = min(a.verseStart!, b.verseStart!)
         let lastVerse = max(lastVerseOfA!, lastVerseOfB!)
         return BibleReference(
             versionId: minReference.versionId,
-            bookUSFM: minReference.bookUSFM,
+            bookId: minReference.bookId,
             chapter: minReference.chapter,
             verseStart: firstVerse,
             verseEnd: lastVerse
         )
     }
-    
-    public static func unvalidatedReference(with usfm: String, versionId: Int) -> BibleReference? {
-        func reference(bookUSFM: String, chapter: Int, verseStart: Int, verseEnd: Int) -> BibleReference? {
+
+    public static func unvalidatedReference(with passageId: String, versionId: Int) -> BibleReference? {
+        func reference(bookId: String, chapter: Int, verseStart: Int, verseEnd: Int) -> BibleReference? {
             if verseStart > verseEnd {
                 return nil
             }
-            return BibleReference(versionId: versionId, bookUSFM: bookUSFM, chapter: chapter, verseStart: verseStart, verseEnd: verseEnd)
+            return BibleReference(versionId: versionId, bookId: bookId, chapter: chapter, verseStart: verseStart, verseEnd: verseEnd)
         }
-        
+
         // GEN.1.3-1.5
         let patBCVCV = /(\w\w\w)\.(\d+)\.(\d+)-(\d+)\.(\d+)/
-        if let match = usfm.wholeMatch(of: patBCVCV) {
+        if let match = passageId.wholeMatch(of: patBCVCV) {
             let (_, bText, cText, vText, _, v2Text) = match.output
             if let c = Int(cText), let v = Int(vText), let v2 = Int(v2Text) {
-                return reference(bookUSFM: String(bText), chapter: c, verseStart: v, verseEnd: v2)
+                return reference(bookId: String(bText), chapter: c, verseStart: v, verseEnd: v2)
             }
             return nil
         }
-        
+
         // GEN.1.3-GEN.1.5
         let patBCVBCV = /(\w\w\w)\.(\d+)\.(\d+)-(\w\w\w)\.(\d+)\.(\d+)/
-        if let match = usfm.wholeMatch(of: patBCVBCV) {
+        if let match = passageId.wholeMatch(of: patBCVBCV) {
             let (_, bText, cText, vText, b2Text, _, v2Text) = match.output
             if let c = Int(cText), let v = Int(vText), let v2 = Int(v2Text) {
                 if String(bText) != String(b2Text) {
                     return nil
                 }
-                return reference(bookUSFM: String(bText), chapter: c, verseStart: v, verseEnd: v2)
+                return reference(bookId: String(bText), chapter: c, verseStart: v, verseEnd: v2)
             }
             return nil
         }
-        
+
         // GEN.1.3-5
         let patBCVV = /(\w\w\w)\.(\d+)\.(\d+)-(\d+)/
-        if let match = usfm.wholeMatch(of: patBCVV) {
+        if let match = passageId.wholeMatch(of: patBCVV) {
             let (_, bText, cText, vText, v2Text) = match.output
             if let c = Int(cText), let v = Int(vText), let v2 = Int(v2Text) {
-                return reference(bookUSFM: String(bText), chapter: c, verseStart: v, verseEnd: v2)
+                return reference(bookId: String(bText), chapter: c, verseStart: v, verseEnd: v2)
             }
             return nil
         }
-        
+
         // GEN.1.3
         let patBCV = /(\w\w\w)\.(\d+)\.(\d+)/
-        if let match = usfm.wholeMatch(of: patBCV) {
+        if let match = passageId.wholeMatch(of: patBCV) {
             let (_, bText, cText, vText) = match.output
             if let c = Int(cText), let v = Int(vText) {
-                return reference(bookUSFM: String(bText), chapter: c, verseStart: v, verseEnd: v)
+                return reference(bookId: String(bText), chapter: c, verseStart: v, verseEnd: v)
             }
             return nil
         }
-        
+
         // GEN.1
         let patBC = /(\w\w\w)\.(\d+)/
-        if let match = usfm.wholeMatch(of: patBC) {
+        if let match = passageId.wholeMatch(of: patBC) {
             let (_, bText, cText) = match.output
             if let c = Int(cText) {
-                return BibleReference(versionId: versionId, bookUSFM: String(bText), chapter: c)
+                return BibleReference(versionId: versionId, bookId: String(bText), chapter: c)
             }
             return nil
         }
-        
+
         // GEN.1-2
         let patBCC = /(\w\w\w)\.(\d+)-(\d+)/
-        if let match = usfm.wholeMatch(of: patBCC) {
+        if let match = passageId.wholeMatch(of: patBCC) {
             let (_, bText, cText, _) = match.output
             if let c = Int(cText) {
-                return reference(bookUSFM: String(bText), chapter: c, verseStart: 1, verseEnd: 1)
+                return reference(bookId: String(bText), chapter: c, verseStart: 1, verseEnd: 1)
             }
             return nil
         }
-        
+
         return nil
     }
 }

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersion.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersion.swift
@@ -40,7 +40,7 @@ public struct BibleVersion: Codable, Sendable, Hashable, Equatable {
     public static func == (lhs: BibleVersion, rhs: BibleVersion) -> Bool {
         lhs.id == rhs.id
     }
-    
+
     public func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     }
@@ -49,22 +49,22 @@ public struct BibleVersion: Codable, Sendable, Hashable, Equatable {
         textDirection == "rtl"
     }
 
-    public func book(with usfm: String) -> BibleBook? {
+    public func book(with bookId: String) -> BibleBook? {
         guard let books else {
             return nil
         }
-        return books.first { $0.id == usfm }
+        return books.first { $0.id == bookId }
     }
 
-    private func isBookUSFMValid(_ usfm: String) -> Bool {
+    private func isBookIdValid(_ bookId: String) -> Bool {
         guard let books else {
             return false
         }
-        let usfmUpper = usfm.uppercased()
-        return books.contains(where: { $0.id == usfmUpper }) == true
+        let bookIdUpper = bookId.uppercased()
+        return books.contains(where: { $0.id == bookIdUpper }) == true
     }
 
-    public var bookUSFMs: [String] {
+    public var bookIds: [String] {
         if let bookCodes, !bookCodes.isEmpty {
             return bookCodes
         }
@@ -74,21 +74,24 @@ public struct BibleVersion: Codable, Sendable, Hashable, Equatable {
         return books.compactMap { $0.id }
     }
 
-    public func reference(with usfm: String) -> BibleReference? {
-        let trimmedUSFM = usfm.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
-        guard trimmedUSFM.count >= 3 else {
+    @available(*, deprecated, renamed: "bookIds")
+    public var bookUSFMs: [String] { bookIds }
+
+    public func reference(with passageId: String) -> BibleReference? {
+        let trimmed = passageId.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        guard trimmed.count >= 3 else {
             return nil
         }
 
-        let subUSFMs = trimmedUSFM.split(separator: "+")
-        if subUSFMs.count > 1 {
-            let references = subUSFMs.compactMap { reference(with: String($0)) }
+        let subPassageIds = trimmed.split(separator: "+")
+        if subPassageIds.count > 1 {
+            let references = subPassageIds.compactMap { reference(with: String($0)) }
             let merged = BibleReference.referencesByMerging(references: references)
             return merged.first
         }
 
-        guard let reference = BibleReference.unvalidatedReference(with: trimmedUSFM, versionId: id),
-              isBookUSFMValid(reference.bookUSFM) else {
+        guard let reference = BibleReference.unvalidatedReference(with: trimmed, versionId: id),
+              isBookIdValid(reference.bookId) else {
             return nil
         }
         return reference
@@ -97,8 +100,8 @@ public struct BibleVersion: Codable, Sendable, Hashable, Equatable {
     /// Returns an array of displayable labels for chapters.
     /// In standard English books, this'll be like ["1", "2"...] but other cases exist.
     /// If metadata hasn't yet been loaded, or if the book code is bad, this will return []
-    public func chapterLabels(_ bookUSFM: String) -> [String] {
-        guard let book = book(with: bookUSFM), let chapters = book.chapters else {
+    public func chapterLabels(_ bookId: String) -> [String] {
+        guard let book = book(with: bookId), let chapters = book.chapters else {
             return []
         }
         return chapters.compactMap { $0.title }

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -162,7 +162,7 @@ private struct ReaderContent: View {
                     showChrome: viewModel.showChrome,
                     onSelectionChange: { version, book, chapter, passageId in
                         Task {
-                            let reference = BibleReference(versionId: version, bookUSFM: book, chapter: chapter ?? 1)
+                            let reference = BibleReference(versionId: version, bookId: book, chapter: chapter ?? 1)
                             await viewModel.onHeaderSelectionChange(reference, showIntro: chapter == nil)
                         }
                     },
@@ -343,7 +343,7 @@ private struct ReaderContent: View {
 
 #Preview {
     BibleReaderView(
-        reference: BibleReference(versionId: 3034, bookUSFM: "PSA", chapter: 117)
+        reference: BibleReference(versionId: 3034, bookId: "PSA", chapter: 117)
     )
     .environment(BibleReaderViewModel.preview)
 }

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
@@ -64,7 +64,7 @@ public struct BibleReaderHeaderView: View {
                 BibleReaderBookAndChapterPickerView(
                     expandedBookCode: $viewModel.headerExpandedBookCode,
                     isPresented: $viewModel.showingBookPicker,
-                    bookCodes: version.bookUSFMs,
+                    bookCodes: version.bookIds,
                     versionId: viewModel.reference.versionId,
                     bookNameProvider: { bookCode in version.bookName(bookCode) },
                     chapterLabelsProvider: { bookCode in version.chapterLabels(bookCode) },
@@ -126,11 +126,11 @@ public struct BibleReaderHeaderView: View {
         guard let version = viewModel.version else {
             return ""
         }
-        return "\(version.bookName(viewModel.reference.bookUSFM) ?? viewModel.reference.bookUSFM) \(String(viewModel.reference.chapter))"
+        return "\(version.bookName(viewModel.reference.bookId) ?? viewModel.reference.bookId) \(String(viewModel.reference.chapter))"
     }
 
     private var introString: String {
-        guard let book = viewModel.version?.book(with: viewModel.reference.bookUSFM),
+        guard let book = viewModel.version?.book(with: viewModel.reference.bookId),
               let intro = book.intro
         else {
             return ""

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderIntroView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderIntroView.swift
@@ -26,7 +26,7 @@ public struct BibleReaderIntroView: View {
         .onChange(of: viewModel.reference, initial: true) { _, reference in
             self.html = nil
             Task {
-                if let book = viewModel.version?.book(with: reference.bookUSFM),
+                if let book = viewModel.version?.book(with: reference.bookId),
                    let passageId = book.intro?.passageId,
                    let html = try? await YouVersionAPI.Bible.introMaterial(versionId: reference.versionId, passageId: passageId) {
                     self.html = html

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -10,15 +10,15 @@ extension BibleReaderViewModel {
         isChangingChapter = true
         removeVerseSelection()
         if reference.chapter > 1 {
-            reference = BibleReference(versionId: reference.versionId, bookUSFM: reference.bookUSFM, chapter: reference.chapter - 1)
+            reference = BibleReference(versionId: reference.versionId, bookId: reference.bookId, chapter: reference.chapter - 1)
         } else {
-            if let books = version.books, let bookIndex = books.firstIndex(where: { $0.id == reference.bookUSFM }) {
+            if let books = version.books, let bookIndex = books.firstIndex(where: { $0.id == reference.bookId }) {
                 if showBookIntro == false && books[bookIndex].intro != nil {
                     showBookIntro = true  // and leave the reference at chapter 1
                 } else if bookIndex > 0 {
                     let previousBook = books[bookIndex - 1]
                     let maxChapter = previousBook.chapters?.count ?? 0
-                    reference = BibleReference(versionId: reference.versionId, bookUSFM: previousBook.id ?? "", chapter: maxChapter)
+                    reference = BibleReference(versionId: reference.versionId, bookId: previousBook.id ?? "", chapter: maxChapter)
                     showBookIntro = false
                 }
             }
@@ -39,17 +39,17 @@ extension BibleReaderViewModel {
         }
         isChangingChapter = true
         removeVerseSelection()
-        if let books = version.books, let index = books.firstIndex(where: { $0.id == reference.bookUSFM }) {
+        if let books = version.books, let index = books.firstIndex(where: { $0.id == reference.bookId }) {
             let currentBook = books[index]
             let maxChapter = currentBook.chapters?.count ?? 0
             if showBookIntro {
-                reference = BibleReference(versionId: reference.versionId, bookUSFM: currentBook.id ?? "", chapter: 1)
+                reference = BibleReference(versionId: reference.versionId, bookId: currentBook.id ?? "", chapter: 1)
                 showBookIntro = false
             } else if reference.chapter < maxChapter {
-                reference = BibleReference(versionId: reference.versionId, bookUSFM: currentBook.id ?? "", chapter: reference.chapter + 1)
+                reference = BibleReference(versionId: reference.versionId, bookId: currentBook.id ?? "", chapter: reference.chapter + 1)
             } else if index < books.count - 1 {
                 let nextBook = books[index + 1]
-                reference = BibleReference(versionId: reference.versionId, bookUSFM: nextBook.id ?? "", chapter: 1)
+                reference = BibleReference(versionId: reference.versionId, bookId: nextBook.id ?? "", chapter: 1)
                 if nextBook.intro != nil {
                     showBookIntro = true
                 }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Preview.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Preview.swift
@@ -7,12 +7,12 @@ extension BibleReaderViewModel {
 
     public static var preview: BibleReaderViewModel {
         // Create a minimal BibleReaderViewModel for preview purposes
-        let vm = BibleReaderViewModel(reference: BibleReference(versionId: 3034, bookUSFM: "GEN", chapter: 1))
+        let vm = BibleReaderViewModel(reference: BibleReference(versionId: 3034, bookId: "GEN", chapter: 1))
 
         let previewVersion = BibleVersion.preview
         vm.versionsViewModel.switchToVersion(previewVersion)
 
-        let footnoteReference = BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 21, verse: 1)
+        let footnoteReference = BibleReference(versionId: 3034, bookId: "JHN", chapter: 21, verse: 1)
         vm.footnotesToDisplay = [
             BibleFootnote(text: BibleAttributedString("Footnote text goes here."), reference: footnoteReference, id: "one"),
             BibleFootnote(text: BibleAttributedString("Second Footnote text goes here. This time the footnote is fairly long."), reference: footnoteReference, id: "two")

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -84,7 +84,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
             } else {
                 // no specified or saved version, so, pick a downloaded one, else a safe default.
                 let versionId = reference?.versionId ?? BibleVersionRepository.shared.downloadedVersionIds.first ?? 3034
-                self.reference = BibleReference(versionId: versionId, bookUSFM: "JHN", chapter: 1)
+                self.reference = BibleReference(versionId: versionId, bookId: "JHN", chapter: 1)
                 self.showBookIntro = false
             }
         }
@@ -168,7 +168,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         guard reference.versionId != version.id else {
             return
         }
-        reference = BibleReference(versionId: version.id, bookUSFM: reference.bookUSFM, chapter: reference.chapter)
+        reference = BibleReference(versionId: version.id, bookId: reference.bookId, chapter: reference.chapter)
         await onHeaderSelectionChange(reference, showIntro: false)
     }
 

--- a/Sources/YouVersionPlatformUI/Objects/BibleVersion+Additions.swift
+++ b/Sources/YouVersionPlatformUI/Objects/BibleVersion+Additions.swift
@@ -2,8 +2,8 @@ import Foundation
 import YouVersionPlatformCore
 
 public extension BibleVersion {
-    func bookName(_ bookUSFM: String) -> String? {
-        guard let book = book(with: bookUSFM) else {
+    func bookName(_ bookId: String) -> String? {
+        guard let book = book(with: bookId) else {
             return nil
         }
         return book.title ?? book.fullTitle
@@ -11,11 +11,11 @@ public extension BibleVersion {
     // Example: "https://www.bible.com/bible/3034/1SA.3.10.BSB"
     func shareUrl(reference: BibleReference) -> URL? {
         let prefix = "https://www.bible.com/bible/\(id)/"
-        let book = reference.bookUSFM
-        let version = (localizedAbbreviation?.isEmpty == false ? localizedAbbreviation : nil) ?? 
-                     (abbreviation?.isEmpty == false ? abbreviation : nil) ?? 
+        let book = reference.bookId
+        let version = (localizedAbbreviation?.isEmpty == false ? localizedAbbreviation : nil) ??
+                     (abbreviation?.isEmpty == false ? abbreviation : nil) ??
                      String(id)
-        
+
         let urlString = if let verseStart = reference.verseStart {
             if let verseEnd = reference.verseEnd, verseStart != verseEnd {
                 "\(prefix)\(book).\(reference.chapter).\(verseStart)-\(verseEnd).\(version)"
@@ -36,7 +36,7 @@ public extension BibleVersion {
         }
         let referenceOnlyTitle = referenceOnlyChunks.joined()
         var titleChunks = [referenceOnlyTitle]
-        
+
         if includesVersionAbbreviation, let abbreviation = localizedAbbreviation ?? abbreviation {
             titleChunks.append(abbreviation)
             if isRightToLeft {
@@ -47,10 +47,10 @@ public extension BibleVersion {
     }
 
     private func titleChunks(for reference: BibleReference) -> [String] {
-        let bookUSFM = reference.bookUSFM
-        let bookName = bookName(bookUSFM) ?? bookUSFM
+        let bookId = reference.bookId
+        let bookName = bookName(bookId) ?? bookId
 
-        let hasOneChapter = chapterLabels(bookUSFM).count == 1
+        let hasOneChapter = chapterLabels(bookId).count == 1
         let chapterSeparator = hasOneChapter ? " " : ":"
         let bookAndChapterSeparator = hasOneChapter ? "" : " "
         let chapter = hasOneChapter ? "" : String(reference.chapter)
@@ -59,11 +59,11 @@ public extension BibleVersion {
         case (_, let verseEnd?) where verseEnd == 999:
             // Whole chapter
             return [bookName, bookAndChapterSeparator, chapter]
-            
+
         case (nil, _):
             // Whole chapter
             return [bookName, bookAndChapterSeparator, chapter]
-            
+
         case let (verseStart?, verseEnd?):
             if verseStart == verseEnd {
                 // Single verse
@@ -72,7 +72,7 @@ public extension BibleVersion {
                 // Verse range
                 return [bookName, bookAndChapterSeparator, chapter, chapterSeparator, String(verseStart), "-", String(verseEnd)]
             }
-            
+
         case let (verseStart?, nil):
             // Single verse with no verseEnd
             return [bookName, bookAndChapterSeparator, chapter, chapterSeparator, String(verseStart)]

--- a/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleCardView.swift
@@ -149,7 +149,7 @@ public struct BibleCardView: View {
             if verseStart == verseEnd {
                 return BibleReference(
                     versionId: versionId,
-                    bookUSFM: reference.bookUSFM,
+                    bookId: reference.bookId,
                     chapter: reference.chapter,
                     verse: verseStart
                 )
@@ -157,7 +157,7 @@ public struct BibleCardView: View {
 
             return BibleReference(
                 versionId: versionId,
-                bookUSFM: reference.bookUSFM,
+                bookId: reference.bookId,
                 chapter: reference.chapter,
                 verseStart: verseStart,
                 verseEnd: verseEnd
@@ -166,7 +166,7 @@ public struct BibleCardView: View {
 
         return BibleReference(
             versionId: versionId,
-            bookUSFM: reference.bookUSFM,
+            bookId: reference.bookId,
             chapter: reference.chapter
         )
     }
@@ -177,14 +177,14 @@ public struct BibleCardView: View {
     VStack(spacing: 16) {
         BibleCardView(
             reference: BibleReference(
-                versionId: BibleVersion.preview.id, bookUSFM: "JHN", chapter: 1, verseStart: 1, verseEnd: 1
+                versionId: BibleVersion.preview.id, bookId: "JHN", chapter: 1, verseStart: 1, verseEnd: 1
             )
         )
         .environment(\.colorScheme, .dark)
-        
+
         BibleCardView(
             reference: BibleReference(
-                versionId: BibleVersion.preview.id, bookUSFM: "JHN", chapter: 1, verseStart: 2, verseEnd: 2
+                versionId: BibleVersion.preview.id, bookId: "JHN", chapter: 1, verseStart: 2, verseEnd: 2
             )
         )
         .environment(\.colorScheme, .light)

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
@@ -161,7 +161,7 @@ public struct BibleTextView: View {
         let book = String(parts[0])
         if let chapter = Int(parts[1]),
            let verse = Int(parts[2]) {
-            return BibleReference(versionId: versionId, bookUSFM: book, chapter: chapter, verse: verse)
+            return BibleReference(versionId: versionId, bookId: book, chapter: chapter, verse: verse)
         }
         return nil
     }

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleAttributedString.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleAttributedString.swift
@@ -77,7 +77,7 @@ public final class BibleAttributedString: Equatable, Hashable {
     func markWithReference(_ reference: BibleReference, scheme: String, id: String?) {
         two.bibleReference = reference
         let idString = id == nil ? "" : "#\(id!)"
-        two.link = URL(string: "\(scheme)://\(reference.versionId)/\(reference.asUSFM)\(idString)")
+        two.link = URL(string: "\(scheme)://\(reference.versionId)/\(reference.passageId)\(idString)")
     }
 
 }

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift
@@ -84,7 +84,7 @@ public enum BibleVersionRendering {
         footnoteMarker?.markWithTextCategory(.footnoteMarker)
         let stateIn = StateIn(
             versionId: reference.versionId,
-            bookUSFM: reference.bookUSFM,
+            bookId: reference.bookId,
             currentChapter: reference.chapter,
             fromVerse: verseStart,
             toVerse: verseEnd,
@@ -111,7 +111,7 @@ public enum BibleVersionRendering {
             firstLineHeadIndent: 0,
             headIndent: 0,
             versionId: reference.versionId,
-            bookUSFM: reference.bookUSFM,
+            bookId: reference.bookId,
             chapter: reference.chapter,
             verse: 0
         )
@@ -128,9 +128,9 @@ public enum BibleVersionRendering {
 
     /// Fetches the data for the given reference, returns it converted to a BibleTextNode tree.
     static func rootNode(from reference: BibleReference) async throws -> BibleTextNode? {
-        let book = reference.bookUSFM
+        let book = reference.bookId
         let c = reference.chapter
-        let chapterReference = BibleReference(versionId: reference.versionId, bookUSFM: book, chapter: c)
+        let chapterReference = BibleReference(versionId: reference.versionId, bookId: book, chapter: c)
 
         do {
             let data = try await BibleChapterRepository.shared.chapter(withReference: chapterReference)
@@ -258,7 +258,7 @@ public enum BibleVersionRendering {
             var footState = StateUp(
                 rendering: true,
                 versionId: stateUp.versionId,
-                bookUSFM: stateUp.bookUSFM,
+                bookId: stateUp.bookId,
                 chapter: stateUp.chapter,
                 verse: stateUp.verse
             )
@@ -506,7 +506,7 @@ public enum BibleVersionRendering {
     // input parameters to the rendering; read-only while walking the node structure.
     struct StateIn {
         var versionId: Int
-        var bookUSFM: String
+        var bookId: String
         var currentChapter: Int
         var fromVerse: Int  // in the chapter, the lowest number verse to render. Could be 0.
         var toVerse: Int  // in the chapter, the highest number verse to render. Could be 999.
@@ -539,7 +539,7 @@ public enum BibleVersionRendering {
         var firstLineHeadIndent = 0
         var headIndent = 0
         var versionId: Int
-        var bookUSFM: String
+        var bookId: String
         var chapter: Int
         var verse: Int
         var text = BibleAttributedString()
@@ -557,7 +557,7 @@ public enum BibleVersionRendering {
                 newText.markWithTextCategory(category)
                 let isFootnote = category == .footnoteMarker || category == .footnoteImage
                 if isFootnote || (verse > 0 && (category == .scripture || category == .verseLabel)) {
-                    let reference = BibleReference(versionId: versionId, bookUSFM: bookUSFM, chapter: chapter, verse: verse > 0 ? verse : 1)
+                    let reference = BibleReference(versionId: versionId, bookId: bookId, chapter: chapter, verse: verse > 0 ? verse : 1)
                     let scheme = isFootnote ? BibleVersionRendering.LinkSchemes.footnote.rawValue : BibleVersionRendering.LinkSchemes.reference.rawValue
                     newText.markWithReference(reference, scheme: scheme, id: id)
                 }
@@ -568,7 +568,7 @@ public enum BibleVersionRendering {
         mutating func appendFootnote(text: BibleAttributedString) -> BibleFootnote {
             let reference = BibleReference(
                 versionId: versionId,
-                bookUSFM: bookUSFM,
+                bookId: bookId,
                 chapter: chapter,
                 verse: verse > 0 ? verse : 1
             )

--- a/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
@@ -28,7 +28,7 @@ final class BibleChapterAPIRequestCounter: BibleChapterContentProviding, @unchec
 // MARK: - Tests
 
 struct BibleChapterRepositoryTests {
-    private let reference = BibleReference(versionId: 206, bookUSFM: "GEN", chapter: 1)
+    private let reference = BibleReference(versionId: 206, bookId: "GEN", chapter: 1)
 
     @discardableResult
     private func makeRepository(
@@ -175,9 +175,9 @@ struct BibleChapterRepositoryTests {
         reference: BibleReference,
         storage: RepositoryTemporaryStorage
     ) -> URL {
-        let chapterUSFM = reference.chapterUSFM ?? "unknown"
+        let chapterPassageId = reference.chapterPassageId ?? "unknown"
         return BibleContentStorage(storageKind: storageKind, directoryProvider: storage.provider)
-            .url(for: .chapter(versionId: reference.versionId, usfm: chapterUSFM))
+            .url(for: .chapter(versionId: reference.versionId, passageId: chapterPassageId))
     }
 }
 

--- a/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
@@ -175,9 +175,8 @@ struct BibleChapterRepositoryTests {
         reference: BibleReference,
         storage: RepositoryTemporaryStorage
     ) -> URL {
-        let chapterPassageId = reference.chapterPassageId ?? "unknown"
-        return BibleContentStorage(storageKind: storageKind, directoryProvider: storage.provider)
-            .url(for: .chapter(versionId: reference.versionId, passageId: chapterPassageId))
+        BibleContentStorage(storageKind: storageKind, directoryProvider: storage.provider)
+            .url(for: .chapter(versionId: reference.versionId, passageId: reference.chapterPassageId))
     }
 }
 

--- a/Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift
@@ -23,7 +23,7 @@ struct BibleContentStorageTests {
                 .appending(path: "BibleVersionMetadata_v1", directoryHint: .notDirectory)
         )
         #expect(
-            downloadStorage.url(for: .chapter(versionId: 206, usfm: "GEN.1")) ==
+            downloadStorage.url(for: .chapter(versionId: 206, passageId: "GEN.1")) ==
                 temporaryStorage.downloadRootURL
                 .appending(path: "bible_206", directoryHint: .isDirectory)
                 .appending(path: "Chapters", directoryHint: .isDirectory)
@@ -115,10 +115,10 @@ struct BibleContentStorageTests {
         let storage = BibleContentStorage(storageKind: .download, directoryProvider: temporaryStorage.provider)
         try temporaryStorage.write(
             Data("<div>In the beginning</div>".utf8),
-            to: storage.url(for: .chapter(versionId: 206, usfm: "GEN.1"))
+            to: storage.url(for: .chapter(versionId: 206, passageId: "GEN.1"))
         )
 
-        let content = storage.string(for: .chapter(versionId: 206, usfm: "GEN.1"))
+        let content = storage.string(for: .chapter(versionId: 206, passageId: "GEN.1"))
 
         #expect(content == "<div>In the beginning</div>")
     }
@@ -129,10 +129,10 @@ struct BibleContentStorageTests {
         defer { temporaryStorage.remove() }
 
         let storage = BibleContentStorage(storageKind: .download, directoryProvider: temporaryStorage.provider)
-        try temporaryStorage.write(Data([0xFF, 0xFE]), to: storage.url(for: .chapter(versionId: 206, usfm: "GEN.1")))
+        try temporaryStorage.write(Data([0xFF, 0xFE]), to: storage.url(for: .chapter(versionId: 206, passageId: "GEN.1")))
 
-        let missing = storage.string(for: .chapter(versionId: 206, usfm: "EXO.1"))
-        let invalid = storage.string(for: .chapter(versionId: 206, usfm: "GEN.1"))
+        let missing = storage.string(for: .chapter(versionId: 206, passageId: "EXO.1"))
+        let invalid = storage.string(for: .chapter(versionId: 206, passageId: "GEN.1"))
 
         #expect(missing == nil)
         #expect(invalid == nil)
@@ -166,7 +166,7 @@ struct BibleContentStorageTests {
 
         try temporaryStorage.write(
             Data("<div>content</div>".utf8),
-            to: storage.url(for: .chapter(versionId: 206, usfm: "GEN.1"))
+            to: storage.url(for: .chapter(versionId: 206, passageId: "GEN.1"))
         )
 
         #expect(storage.containsNonEmptyDirectory(.chaptersDirectory(versionId: 206)))
@@ -192,9 +192,9 @@ struct BibleContentStorageTests {
 
         let storage = BibleContentStorage(storageKind: .cache, directoryProvider: temporaryStorage.provider)
 
-        try storage.writeString("chapter content", to: .chapter(versionId: 206, usfm: "GEN.1"))
+        try storage.writeString("chapter content", to: .chapter(versionId: 206, passageId: "GEN.1"))
 
-        #expect(storage.string(for: .chapter(versionId: 206, usfm: "GEN.1")) == "chapter content")
+        #expect(storage.string(for: .chapter(versionId: 206, passageId: "GEN.1")) == "chapter content")
     }
 
     @Test
@@ -203,11 +203,11 @@ struct BibleContentStorageTests {
         defer { temporaryStorage.remove() }
 
         let storage = BibleContentStorage(storageKind: .download, directoryProvider: temporaryStorage.provider)
-        try storage.writeString("chapter content", to: .chapter(versionId: 206, usfm: "GEN.1"))
+        try storage.writeString("chapter content", to: .chapter(versionId: 206, passageId: "GEN.1"))
 
         try storage.remove(.versionDirectory(versionId: 206))
 
-        #expect(storage.contains(.chapter(versionId: 206, usfm: "GEN.1")) == false)
+        #expect(storage.contains(.chapter(versionId: 206, passageId: "GEN.1")) == false)
         #expect(storage.contains(.versionDirectory(versionId: 206)) == false)
     }
 

--- a/Tests/YouVersionPlatformCoreTests/BibleHighlightsCacheTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleHighlightsCacheTests.swift
@@ -7,7 +7,7 @@ struct BibleHighlightsCacheTests {
     @Test
     func testHighlightsEmptyState() {
         let cache = BibleHighlightsCache()
-        #expect(cache.highlights(overlapping: BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)).isEmpty)
+        #expect(cache.highlights(overlapping: BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)).isEmpty)
     }
 
     // MARK: - Test Basic CRUD Operations
@@ -15,15 +15,15 @@ struct BibleHighlightsCacheTests {
     @Test
     func testHighlightsAdd() {
         let cache = BibleHighlightsCache()
-        let highlight = BibleHighlight(BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1), color: "eefeef")
+        let highlight = BibleHighlight(BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1), color: "eefeef")
 
         cache.addHighlights([highlight])
 
-        let highlights = cache.highlights(overlapping: BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1))
+        let highlights = cache.highlights(overlapping: BibleReference(versionId: 1, bookId: "GEN", chapter: 1))
 
         #expect(highlights.count == 1)
         #expect(highlights.first?.reference.versionId == 1)
-        #expect(highlights.first?.reference.bookUSFM == "GEN")
+        #expect(highlights.first?.reference.bookId == "GEN")
         #expect(highlights.first?.reference.chapter == 1)
         #expect(highlights.first?.reference.verseStart == 1)
         #expect(highlights.first?.color == "eefeef")
@@ -32,12 +32,12 @@ struct BibleHighlightsCacheTests {
     @Test
     func testHighlightsRemove() {
         let cache = BibleHighlightsCache()
-        let highlight = BibleHighlight(BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1), color: "eefeef")
+        let highlight = BibleHighlight(BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1), color: "eefeef")
 
         cache.addHighlights([highlight])
-        cache.removeHighlights([BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)])
+        cache.removeHighlights([BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)])
 
-        let highlights = cache.highlights(overlapping: BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1))
+        let highlights = cache.highlights(overlapping: BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1))
 
         #expect(highlights.isEmpty)
     }
@@ -45,7 +45,7 @@ struct BibleHighlightsCacheTests {
     @Test
     func testHighlightsUpdateColors() {
         let cache = BibleHighlightsCache()
-        let ref = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let ref = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
         let highlight = BibleHighlight(ref, color: "eefeef")
 
         cache.addHighlights([highlight])
@@ -62,16 +62,16 @@ struct BibleHighlightsCacheTests {
     @Test
     func testHighlightsGetRange() {
         let cache = BibleHighlightsCache()
-        let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
-        let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 2)
-        let ref3 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 3)
+        let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
+        let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 2)
+        let ref3 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 3)
         let highlight1 = BibleHighlight(ref1, color: "eefeef")
         let highlight2 = BibleHighlight(ref2, color: "0000ff")
         let highlight3 = BibleHighlight(ref3, color: "00ffff")
 
         cache.addHighlights([highlight1, highlight2, highlight3])
 
-        let highlights = cache.highlights(overlapping: BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 3))
+        let highlights = cache.highlights(overlapping: BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 3))
 
         #expect(highlights.count == 3)
         #expect(highlights.contains { $0.reference.verseStart == 1 })
@@ -82,15 +82,15 @@ struct BibleHighlightsCacheTests {
     @Test
     func testHighlightsGetCrossChapter() {
         let cache = BibleHighlightsCache()
-        let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
-        let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 2, verse: 1)
+        let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
+        let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 2, verse: 1)
         let highlight1 = BibleHighlight(ref1, color: "eefeef")
         let highlight2 = BibleHighlight(ref2, color: "0000ff")
 
         cache.addHighlights([highlight1, highlight2])
 
         // Test that we only get highlights from chapter 1 when querying chapter 1
-        let highlights = cache.highlights(overlapping: BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 1))
+        let highlights = cache.highlights(overlapping: BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 1))
 
         #expect(highlights.count == 1)
         #expect(highlights.contains { $0.reference.chapter == 1 && $0.reference.verseStart == 1 })
@@ -102,9 +102,9 @@ struct BibleHighlightsCacheTests {
     @Test
     func testApplyServerHighlights() {
         let cache = BibleHighlightsCache()
-        let chapter = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
+        let chapter = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
         let server = [
-            BibleHighlight(BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1), color: "#ff0000")
+            BibleHighlight(BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1), color: "#ff0000")
         ]
 
         cache.applyServerHighlights(for: chapter, highlights: server)

--- a/Tests/YouVersionPlatformCoreTests/BibleHighlightsRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleHighlightsRepositoryTests.swift
@@ -97,14 +97,14 @@ struct BibleHighlightsRepositoryTests {
         ]
         mockAPI.mockGetHighlightsResult = mockResponse
         
-        let references = [BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)]
+        let references = [BibleReference(versionId: 1, bookId: "GEN", chapter: 1)]
         let result = try await repository.highlights(for: references)
         
         #expect(mockAPI.getHighlightsCallCount == 1)
         #expect(result.count == 1)
         #expect(result["1_GEN_1"]?.count == 2)
         #expect(result["1_GEN_1"]?.first?.reference.versionId == 1)
-        #expect(result["1_GEN_1"]?.first?.reference.bookUSFM == "GEN")
+        #expect(result["1_GEN_1"]?.first?.reference.bookId == "GEN")
         #expect(result["1_GEN_1"]?.first?.reference.chapter == 1)
         #expect(result["1_GEN_1"]?.first?.reference.verseStart == 1)
         #expect(result["1_GEN_1"]?.first?.color == "#FF0000")
@@ -123,8 +123,8 @@ struct BibleHighlightsRepositoryTests {
         mockAPI.mockGetHighlightsResult = mockResponse
         
         let references = [
-            BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1),
-            BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 2)
+            BibleReference(versionId: 1, bookId: "GEN", chapter: 1),
+            BibleReference(versionId: 1, bookId: "GEN", chapter: 2)
         ]
         let result = try await repository.highlights(for: references)
         
@@ -142,7 +142,7 @@ struct BibleHighlightsRepositoryTests {
         // Mock empty API response
         mockAPI.mockGetHighlightsResult = []
         
-        let references = [BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)]
+        let references = [BibleReference(versionId: 1, bookId: "GEN", chapter: 1)]
         let result = try await repository.highlights(for: references)
         
         #expect(mockAPI.getHighlightsCallCount == 1)
@@ -158,7 +158,7 @@ struct BibleHighlightsRepositoryTests {
         // Mock API error
         mockAPI.shouldThrowError = true
         
-        let references = [BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)]
+        let references = [BibleReference(versionId: 1, bookId: "GEN", chapter: 1)]
         let result = try await repository.highlights(for: references)
         
         #expect(mockAPI.getHighlightsCallCount == 1)
@@ -173,7 +173,7 @@ struct BibleHighlightsRepositoryTests {
         let mockAPI = setUp()
         let repository = BibleHighlightsRepository(api: mockAPI)
         
-        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
         let operation = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
         
         let result = try await repository.saveOperations([operation])
@@ -188,7 +188,7 @@ struct BibleHighlightsRepositoryTests {
         let mockAPI = setUp()
         let repository = BibleHighlightsRepository(api: mockAPI)
         
-        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
         let operation = PendingHighlightOperation(references: [reference], color: nil, operationType: .remove)
         
         let result = try await repository.saveOperations([operation])
@@ -203,7 +203,7 @@ struct BibleHighlightsRepositoryTests {
         let mockAPI = setUp()
         let repository = BibleHighlightsRepository(api: mockAPI)
         
-        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
         let operation = PendingHighlightOperation(references: [reference], color: "#00FF00", operationType: .update)
         
         let result = try await repository.saveOperations([operation])
@@ -218,8 +218,8 @@ struct BibleHighlightsRepositoryTests {
         let mockAPI = setUp()
         let repository = BibleHighlightsRepository(api: mockAPI)
         
-        let reference1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
-        let reference2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 2)
+        let reference1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
+        let reference2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 2)
         
         let operation1 = PendingHighlightOperation(references: [reference1], color: "#FF0000", operationType: .add)
         let operation2 = PendingHighlightOperation(references: [reference2], color: nil, operationType: .remove)
@@ -241,7 +241,7 @@ struct BibleHighlightsRepositoryTests {
         // Mock API error
         mockAPI.shouldThrowError = true
         
-        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
         let operation = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
         
         let result = try await repository.saveOperations([operation])
@@ -256,7 +256,7 @@ struct BibleHighlightsRepositoryTests {
         let mockAPI = setUp()
         let repository = BibleHighlightsRepository(api: mockAPI)
         
-        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
         let operation = PendingHighlightOperation(references: [reference], color: nil, operationType: .add)
         
         let result = try await repository.saveOperations([operation])
@@ -271,7 +271,7 @@ struct BibleHighlightsRepositoryTests {
         let mockAPI = setUp()
         let repository = BibleHighlightsRepository(api: mockAPI)
         
-        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
         let operation = PendingHighlightOperation(references: [reference], color: nil, operationType: .update)
         
         let result = try await repository.saveOperations([operation])
@@ -288,7 +288,7 @@ struct BibleHighlightsRepositoryTests {
         let mockAPI = setUp()
         let repository = BibleHighlightsRepository(api: mockAPI)
         
-        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
         let operation = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
         
         #expect(repository.pendingOperationCount == 0)
@@ -303,7 +303,7 @@ struct BibleHighlightsRepositoryTests {
         let mockAPI = setUp()
         let repository = BibleHighlightsRepository(api: mockAPI)
         
-        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
         
         // Create operations with different timestamps
         let operation1 = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
@@ -324,7 +324,7 @@ struct BibleHighlightsRepositoryTests {
         let mockAPI = setUp()
         let repository = BibleHighlightsRepository(api: mockAPI)
         
-        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
         let operation = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
         
         repository.queueOperation(operation)
@@ -345,7 +345,7 @@ struct BibleHighlightsRepositoryTests {
         // Mock API failure
         mockAPI.mockCreateHighlightResult = false
         
-        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
         let operation = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
         
         repository.queueOperation(operation)
@@ -368,7 +368,7 @@ struct BibleHighlightsRepositoryTests {
         // Mock API error
         mockAPI.shouldThrowError = true
         
-        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
         let operation = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
         
         repository.queueOperation(operation)
@@ -390,7 +390,7 @@ struct BibleHighlightsRepositoryTests {
         let mockAPI = setUp()
         let repository = BibleHighlightsRepository(api: mockAPI)
         
-        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
         let operation = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
         
         repository.queueOperation(operation)
@@ -409,7 +409,7 @@ struct BibleHighlightsRepositoryTests {
         let mockAPI = setUp()
         let repository = BibleHighlightsRepository(api: mockAPI)
         
-        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
         let operation = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
         
         repository.queueOperation(operation)
@@ -432,7 +432,7 @@ struct BibleHighlightsRepositoryTests {
         // Mock API failure
         mockAPI.mockCreateHighlightResult = false
         
-        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
         let operation = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
         
         repository.queueOperation(operation)

--- a/Tests/YouVersionPlatformCoreTests/BibleHighlightsViewModelTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleHighlightsViewModelTests.swift
@@ -88,7 +88,7 @@ struct BibleHighlightsViewModelTests {
         let viewModel = BibleHighlightsViewModel(cache: cache, repository: mockRepository)
         
         // This should work with our injected dependencies
-        let highlights = viewModel.highlights(for: BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 10))
+        let highlights = viewModel.highlights(for: BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 10))
         #expect(highlights.isEmpty)
     }
     
@@ -100,7 +100,7 @@ struct BibleHighlightsViewModelTests {
         let mockRepository = MockBibleHighlightsRepository()
         let viewModel = BibleHighlightsViewModel(cache: cache, repository: mockRepository)
         
-        let highlights = viewModel.highlights(for: BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 10))
+        let highlights = viewModel.highlights(for: BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 10))
         
         #expect(highlights.isEmpty)
     }
@@ -116,8 +116,8 @@ struct BibleHighlightsViewModelTests {
         let viewModel = BibleHighlightsViewModel(cache: cache, repository: mockRepository)
         
         let references = [
-            BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1),
-            BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 2)
+            BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1),
+            BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 2)
         ]
         let color = "eefeef"
         
@@ -134,8 +134,8 @@ struct BibleHighlightsViewModelTests {
         let viewModel = BibleHighlightsViewModel(cache: cache, repository: mockRepository)
         
         let references = [
-            BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1),
-            BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 2)
+            BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1),
+            BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 2)
         ]
         let color = "eefeef"
         
@@ -143,7 +143,7 @@ struct BibleHighlightsViewModelTests {
         
         // Verify highlights were added to cache
         let highlights = viewModel.highlights(
-            for: BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 2)
+            for: BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 2)
         )
         
         #expect(highlights.count == 2)
@@ -161,8 +161,8 @@ struct BibleHighlightsViewModelTests {
         let viewModel = BibleHighlightsViewModel(cache: cache, repository: mockRepository)
         
         let references = [
-            BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1),
-            BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 2)
+            BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1),
+            BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 2)
         ]
         
         viewModel.removeHighlights(references: references)
@@ -179,8 +179,8 @@ struct BibleHighlightsViewModelTests {
         
         // First add some highlights
         let references = [
-            BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1),
-            BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 2)
+            BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1),
+            BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 2)
         ]
         viewModel.addHighlights(references: references, color: "eefeef")
         
@@ -189,7 +189,7 @@ struct BibleHighlightsViewModelTests {
         
         // Verify they're gone
         let highlights = viewModel.highlights(
-            for: BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 2)
+            for: BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 2)
         )
         
         #expect(highlights.isEmpty)
@@ -204,8 +204,8 @@ struct BibleHighlightsViewModelTests {
         let viewModel = BibleHighlightsViewModel(cache: cache, repository: mockRepository)
         
         let references = [
-            BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1),
-            BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 2)
+            BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1),
+            BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 2)
         ]
         let newColor = "0000ff"
         
@@ -222,8 +222,8 @@ struct BibleHighlightsViewModelTests {
         
         // First add some highlights
         let references = [
-            BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1),
-            BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 2)
+            BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1),
+            BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 2)
         ]
         viewModel.addHighlights(references: references, color: "eefeef")
         
@@ -233,7 +233,7 @@ struct BibleHighlightsViewModelTests {
         
         // Verify colors were updated
         let highlights = viewModel.highlights(
-            for: BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 2)
+            for: BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 2)
         )
         
         #expect(highlights.count == 2)
@@ -249,7 +249,7 @@ struct BibleHighlightsViewModelTests {
         let viewModel = BibleHighlightsViewModel(cache: cache, repository: mockRepository)
 
         // This should trigger chapter loading
-        viewModel.ensureHighlightsForChapterLoaded(BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 10))
+        viewModel.ensureHighlightsForChapterLoaded(BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 10))
         // give the async task a moment
         try? await Task.sleep(nanoseconds: 50_000_000)
         #expect(mockRepository.highlightsCallCount > 0)
@@ -264,7 +264,7 @@ struct BibleHighlightsViewModelTests {
         // Simulate loading a chapter
         
         // This should trigger server load
-        viewModel.ensureHighlightsForChapterLoaded(BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 10))
+        viewModel.ensureHighlightsForChapterLoaded(BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 10))
         
         // Wait a bit for async operations
         try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
@@ -282,7 +282,7 @@ struct BibleHighlightsViewModelTests {
         // Simulate loading a chapter that will fail
         
         // This should trigger server load that fails
-        viewModel.ensureHighlightsForChapterLoaded(BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 10))
+        viewModel.ensureHighlightsForChapterLoaded(BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 10))
         
         // Wait a bit for async operations
         try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests.swift
@@ -5,10 +5,10 @@ import Testing
 
 @Test
 func testInitSingleVerse() {
-    let ref = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 2, verse: 3)
+    let ref = BibleReference(versionId: 1, bookId: "GEN", chapter: 2, verse: 3)
 
     #expect(ref.versionId == 1)
-    #expect(ref.bookUSFM == "GEN")
+    #expect(ref.bookId == "GEN")
     #expect(ref.chapter == 2)
     #expect(ref.verseStart == 3)
     #expect(ref.verseEnd == 3)
@@ -16,10 +16,10 @@ func testInitSingleVerse() {
 
 @Test
 func testInitVerseRange() {
-    let ref = BibleReference(versionId: 1, bookUSFM: "PSA", chapter: 23, verseStart: 1, verseEnd: 2)
+    let ref = BibleReference(versionId: 1, bookId: "PSA", chapter: 23, verseStart: 1, verseEnd: 2)
     
     #expect(ref.versionId == 1)
-    #expect(ref.bookUSFM == "PSA")
+    #expect(ref.bookId == "PSA")
     #expect(ref.chapter == 23)
     #expect(ref.verseStart == 1)
     #expect(ref.verseEnd == 2)
@@ -29,13 +29,13 @@ func testInitVerseRange() {
 
 @Test
 func testIsRange_SingleVerse() {
-    let ref = BibleReference(versionId: 1, bookUSFM: "EXO", chapter: 3, verse: 14)
+    let ref = BibleReference(versionId: 1, bookId: "EXO", chapter: 3, verse: 14)
     #expect(!ref.isRange)
 }
 
 @Test
 func testIsRange_VerseRange() {
-    let ref = BibleReference(versionId: 1, bookUSFM: "EXO", chapter: 3, verseStart: 14, verseEnd: 15)
+    let ref = BibleReference(versionId: 1, bookId: "EXO", chapter: 3, verseStart: 14, verseEnd: 15)
     #expect(ref.isRange)
 }
 
@@ -43,8 +43,8 @@ func testIsRange_VerseRange() {
 
 @Test
 func testCompare_SameReference() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
     
     #expect(ref1 == ref2)
 }
@@ -52,9 +52,9 @@ func testCompare_SameReference() {
 @Test
 func testCompare_DifferentBooks() {
     // Note: Comparing different books is not reliable without knowing the canonical book order
-    // This test just verifies the function doesn't crash with different book usfms
-    let genRef = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
-    let exoRef = BibleReference(versionId: 1, bookUSFM: "EXO", chapter: 1, verse: 1)
+    // This test just verifies the function doesn't crash with different book IDs
+    let genRef = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
+    let exoRef = BibleReference(versionId: 1, bookId: "EXO", chapter: 1, verse: 1)
     
     // Just verify the function can be called with different books
     // The actual comparison result is not validated
@@ -66,8 +66,8 @@ func testCompare_DifferentBooks() {
 
 @Test
 func testCompare_SameBookDifferentChapters() {
-    let gen1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
-    let gen2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 2, verse: 1)
+    let gen1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
+    let gen2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 2, verse: 1)
     
     #expect(gen1 < gen2)
     #expect(BibleReference.compare(a: gen1, b: gen2) == -1) // GEN 1 < GEN 2
@@ -76,8 +76,8 @@ func testCompare_SameBookDifferentChapters() {
 
 @Test
 func testCompare_SameChapterDifferentVerses() {
-    let gen1Verse1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
-    let gen1Verse2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 2)
+    let gen1Verse1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
+    let gen1Verse2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 2)
 
     #expect(gen1Verse1 < gen1Verse2)
     #expect(gen1Verse2 > gen1Verse1)
@@ -85,15 +85,15 @@ func testCompare_SameChapterDifferentVerses() {
 
 @Test
 func testCompare_Ranges() {
-    let gen1Verses1to3 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
-    let gen1Verses2to4 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 2, verseEnd: 4)
+    let gen1Verses1to3 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
+    let gen1Verses2to4 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 2, verseEnd: 4)
 
     // Compare based on starting verse first
     #expect(gen1Verses1to3 < gen1Verses2to4)
 
     // Same starting verse, compare end verse
-    let gen1Verses1to3Again = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
-    let gen1Verses1to4 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 4)
+    let gen1Verses1to3Again = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
+    let gen1Verses1to4 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 4)
 
     #expect(gen1Verses1to3Again < gen1Verses1to4)    // 1-3 < 1-4
 }
@@ -101,68 +101,68 @@ func testCompare_Ranges() {
 @Test
 func testSorting() {
     let refs = [
-        BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1),
-        BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 4, verse: 3),
-        BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 3, verse: 2),
-        BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 2, verse: 1),
-        BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 2)
+        BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1),
+        BibleReference(versionId: 1, bookId: "GEN", chapter: 4, verse: 3),
+        BibleReference(versionId: 1, bookId: "GEN", chapter: 3, verse: 2),
+        BibleReference(versionId: 1, bookId: "GEN", chapter: 2, verse: 1),
+        BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 2)
     ]
     
     let sorted = refs.sorted()
     
-    #expect(sorted[0].bookUSFM == "GEN")
+    #expect(sorted[0].bookId == "GEN")
     #expect(sorted[0].chapter == 1)
     #expect(sorted[0].verseStart == 1)
     
-    #expect(sorted[1].bookUSFM == "GEN")
+    #expect(sorted[1].bookId == "GEN")
     #expect(sorted[1].chapter == 1)
     #expect(sorted[1].verseStart == 2)
     
-    #expect(sorted[2].bookUSFM == "GEN")
+    #expect(sorted[2].bookId == "GEN")
     #expect(sorted[2].chapter == 2)
     #expect(sorted[2].verseStart == 1)
     
-    #expect(sorted[3].bookUSFM == "GEN")
+    #expect(sorted[3].bookId == "GEN")
     #expect(sorted[3].chapter == 3)
     #expect(sorted[3].verseStart == 2)
     
-    #expect(sorted[4].bookUSFM == "GEN")
+    #expect(sorted[4].bookId == "GEN")
     #expect(sorted[4].chapter == 4)
     #expect(sorted[4].verseStart == 3)
 }
 
-// MARK: - Test chapterUSFM
+// MARK: - Test chapterPassageId
 
 @Test
-func testChapterUSFM() {
-    let ref = BibleReference(versionId: 1, bookUSFM: "gen", chapter: 1, verse: 1)
-    #expect(ref.chapterUSFM == "GEN.1")
+func testChapterPassageId() {
+    let ref = BibleReference(versionId: 1, bookId: "gen", chapter: 1, verse: 1)
+    #expect(ref.chapterPassageId == "GEN.1")
 }
 
-// MARK: - Test asUSFM
+// MARK: - Test passageId
 
 @Test
-func testAsUSFM() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "gen", chapter: 1)
-    #expect(ref1.asUSFM == "GEN.1")
+func testPassageId() {
+    let ref1 = BibleReference(versionId: 1, bookId: "gen", chapter: 1)
+    #expect(ref1.passageId == "GEN.1")
 
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "gen", chapter: 1, verse: 1)
-    #expect(ref2.asUSFM == "GEN.1.1")
+    let ref2 = BibleReference(versionId: 1, bookId: "gen", chapter: 1, verse: 1)
+    #expect(ref2.passageId == "GEN.1.1")
 
-    let ref3 = BibleReference(versionId: 1, bookUSFM: "gen", chapter: 1, verseStart: 1, verseEnd: 5)
-    #expect(ref3.asUSFM == "GEN.1.1-GEN.1.5")
+    let ref3 = BibleReference(versionId: 1, bookId: "gen", chapter: 1, verseStart: 1, verseEnd: 5)
+    #expect(ref3.passageId == "GEN.1.1-GEN.1.5")
 }
 
 // MARK: - Test Merging references
 
 @Test
 func testMerge_adjacentReferences() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 4, verseEnd: 6)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 4, verseEnd: 6)
     
     let merged1To2 = BibleReference.referenceByMerging(a: ref1, b: ref2)
     #expect(merged1To2.versionId == 1)
-    #expect(merged1To2.bookUSFM == "GEN")
+    #expect(merged1To2.bookId == "GEN")
     #expect(merged1To2.chapter == 1)
     #expect(merged1To2.verseStart == 1)
     #expect(merged1To2.verseEnd == 6)
@@ -170,7 +170,7 @@ func testMerge_adjacentReferences() {
     // show that order does not matter
     let merged2To1 = BibleReference.referenceByMerging(a: ref2, b: ref1)
     #expect(merged2To1.versionId == 1)
-    #expect(merged2To1.bookUSFM == "GEN")
+    #expect(merged2To1.bookId == "GEN")
     #expect(merged2To1.chapter == 1)
     #expect(merged2To1.verseStart == 1)
     #expect(merged2To1.verseEnd == 6)
@@ -178,12 +178,12 @@ func testMerge_adjacentReferences() {
 
 @Test
 func testMerge_overlappingReferences() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 9)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 9)
     
     let merged1To2 = BibleReference.referenceByMerging(a: ref1, b: ref2)
     #expect(merged1To2.versionId == 1)
-    #expect(merged1To2.bookUSFM == "GEN")
+    #expect(merged1To2.bookId == "GEN")
     #expect(merged1To2.chapter == 1)
     #expect(merged1To2.verseStart == 3)
     #expect(merged1To2.verseEnd == 9)
@@ -191,7 +191,7 @@ func testMerge_overlappingReferences() {
     // show that order does not matter
     let merged2To1 = BibleReference.referenceByMerging(a: ref2, b: ref1)
     #expect(merged2To1.versionId == 1)
-    #expect(merged2To1.bookUSFM == "GEN")
+    #expect(merged2To1.bookId == "GEN")
     #expect(merged2To1.chapter == 1)
     #expect(merged2To1.verseStart == 3)
     #expect(merged2To1.verseEnd == 9)
@@ -199,12 +199,12 @@ func testMerge_overlappingReferences() {
 
 @Test
 func testMerge_oneReferenceContainsAnother() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 2, verseEnd: 10)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 7)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 2, verseEnd: 10)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 7)
     
     let merged1To2 = BibleReference.referenceByMerging(a: ref1, b: ref2)
     #expect(merged1To2.versionId == 1)
-    #expect(merged1To2.bookUSFM == "GEN")
+    #expect(merged1To2.bookId == "GEN")
     #expect(merged1To2.chapter == 1)
     #expect(merged1To2.verseStart == 2)
     #expect(merged1To2.verseEnd == 10)
@@ -212,7 +212,7 @@ func testMerge_oneReferenceContainsAnother() {
     // show that order does not matter
     let merged2To1 = BibleReference.referenceByMerging(a: ref2, b: ref1)
     #expect(merged2To1.versionId == 1)
-    #expect(merged2To1.bookUSFM == "GEN")
+    #expect(merged2To1.bookId == "GEN")
     #expect(merged2To1.chapter == 1)
     #expect(merged2To1.verseStart == 2)
     #expect(merged2To1.verseEnd == 10)
@@ -220,11 +220,11 @@ func testMerge_oneReferenceContainsAnother() {
 
 @Test
 func mergeMultipleGroupsOfReferences() throws {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "JHN", chapter: 4, verseStart: 2, verseEnd: 10)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "JHN", chapter: 2, verseStart: 5, verseEnd: 7)
-    let ref3 = BibleReference(versionId: 1, bookUSFM: "JHN", chapter: 4, verseStart: 5, verseEnd: 12)
-    let ref4 = BibleReference(versionId: 1, bookUSFM: "JHN", chapter: 2, verseStart: 8, verseEnd: 11)
-    let ref5 = BibleReference(versionId: 1, bookUSFM: "JHN", chapter: 1, verseStart: 5, verseEnd: 7)
+    let ref1 = BibleReference(versionId: 1, bookId: "JHN", chapter: 4, verseStart: 2, verseEnd: 10)
+    let ref2 = BibleReference(versionId: 1, bookId: "JHN", chapter: 2, verseStart: 5, verseEnd: 7)
+    let ref3 = BibleReference(versionId: 1, bookId: "JHN", chapter: 4, verseStart: 5, verseEnd: 12)
+    let ref4 = BibleReference(versionId: 1, bookId: "JHN", chapter: 2, verseStart: 8, verseEnd: 11)
+    let ref5 = BibleReference(versionId: 1, bookId: "JHN", chapter: 1, verseStart: 5, verseEnd: 7)
     
     let result = BibleReference.referencesByMerging(references: [ref1, ref2, ref3, ref4, ref5])
     #expect(result.count == 3)

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_adjacency.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_adjacency.swift
@@ -5,8 +5,8 @@ import Testing
 
 @Test
 func testAdjacent_individualVerses() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 3)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 4)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 3)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 4)
     
     #expect(ref1.isAdjacentOrOverlapping(with: ref2))
     #expect(ref2.isAdjacentOrOverlapping(with: ref1))  // order doesn't matter
@@ -15,8 +15,8 @@ func testAdjacent_individualVerses() {
 @Test
 func testAdjacent_verseRangesNotOverlapping() {
     // 1-3 contiguous with 4-6
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 4, verseEnd: 6)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 4, verseEnd: 6)
     
     #expect(ref1.isAdjacentOrOverlapping(with: ref2))
     #expect(ref2.isAdjacentOrOverlapping(with: ref1))
@@ -25,8 +25,8 @@ func testAdjacent_verseRangesNotOverlapping() {
 @Test
 func testAdjacent_verseRangesOverlapping() {
     // 1-3 contiguous with 4-6
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 4)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 6)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 4)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 6)
     
     #expect(ref1.isAdjacentOrOverlapping(with: ref2))
     #expect(ref2.isAdjacentOrOverlapping(with: ref1))
@@ -34,8 +34,8 @@ func testAdjacent_verseRangesOverlapping() {
 
 @Test
 func testNotAdjacent_differentBook() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "EXO", chapter: 1, verse: 1)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
+    let ref2 = BibleReference(versionId: 1, bookId: "EXO", chapter: 1, verse: 1)
     
     #expect(!ref1.isAdjacentOrOverlapping(with: ref2))
     #expect(!ref2.isAdjacentOrOverlapping(with: ref1))
@@ -43,8 +43,8 @@ func testNotAdjacent_differentBook() {
 
 @Test
 func testNotAdjacent_differentChapter() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 3)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 2, verse: 1)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 3)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 2, verse: 1)
     
     #expect(!ref1.isAdjacentOrOverlapping(with: ref2))
     #expect(!ref2.isAdjacentOrOverlapping(with: ref1))
@@ -53,8 +53,8 @@ func testNotAdjacent_differentChapter() {
 @Test
 func testNotAdjacent_verseGap() {
     // 1-3 not contiguous with 5-6
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 6)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 3)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 6)
     
     #expect(!ref1.isAdjacentOrOverlapping(with: ref2))
     #expect(!ref2.isAdjacentOrOverlapping(with: ref1))

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_codable.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_codable.swift
@@ -4,19 +4,19 @@ import Testing
 
 // MARK: - Codable
 
-@Test func decodedBookUSFMIsUppercased() throws {
+@Test func decodedBookIdIsUppercased() throws {
     let json = """
     {"versionId":1,"bookUSFM":"gen","chapter":1,"verseStart":1,"verseEnd":1}
     """
     let ref = try JSONDecoder().decode(BibleReference.self, from: Data(json.utf8))
-    #expect(ref.bookUSFM == "GEN")
+    #expect(ref.bookId == "GEN")
 }
 
 @Test func decodedVerseReferenceRoundTrips() throws {
-    let original = BibleReference(versionId: 1, bookUSFM: "REV", chapter: 22, verse: 21)
+    let original = BibleReference(versionId: 1, bookId: "REV", chapter: 22, verse: 21)
     let data = try JSONEncoder().encode(original)
     let decoded = try JSONDecoder().decode(BibleReference.self, from: data)
-    #expect(decoded.bookUSFM == original.bookUSFM)
+    #expect(decoded.bookId == original.bookId)
     #expect(decoded.versionId == original.versionId)
     #expect(decoded.chapter == original.chapter)
     #expect(decoded.verseStart == original.verseStart)
@@ -24,29 +24,29 @@ import Testing
 }
 
 @Test func decodedRangeReferenceRoundTrips() throws {
-    let original = BibleReference(versionId: 2, bookUSFM: "PSA", chapter: 23, verseStart: 1, verseEnd: 6)
+    let original = BibleReference(versionId: 2, bookId: "PSA", chapter: 23, verseStart: 1, verseEnd: 6)
     let data = try JSONEncoder().encode(original)
     let decoded = try JSONDecoder().decode(BibleReference.self, from: data)
-    #expect(decoded.bookUSFM == original.bookUSFM)
+    #expect(decoded.bookId == original.bookId)
     #expect(decoded.verseStart == original.verseStart)
     #expect(decoded.verseEnd == original.verseEnd)
 }
 
 @Test func decodedChapterReferenceRoundTrips() throws {
-    let original = BibleReference(versionId: 1, bookUSFM: "JHN", chapter: 3)
+    let original = BibleReference(versionId: 1, bookId: "JHN", chapter: 3)
     let data = try JSONEncoder().encode(original)
     let decoded = try JSONDecoder().decode(BibleReference.self, from: data)
-    #expect(decoded.bookUSFM == original.bookUSFM)
+    #expect(decoded.bookId == original.bookId)
     #expect(decoded.chapter == original.chapter)
     #expect(decoded.verseStart == nil)
     #expect(decoded.verseEnd == nil)
 }
 
-@Test func decodedLowercaseBookUSFMOverlapsCorrectly() throws {
+@Test func decodedLowercaseBookIdOverlapsCorrectly() throws {
     let json = """
     {"versionId":1,"bookUSFM":"jhn","chapter":3,"verseStart":16,"verseEnd":16}
     """
     let decoded = try JSONDecoder().decode(BibleReference.self, from: Data(json.utf8))
-    let constructed = BibleReference(versionId: 1, bookUSFM: "JHN", chapter: 3, verse: 16)
+    let constructed = BibleReference(versionId: 1, bookId: "JHN", chapter: 3, verse: 16)
     #expect(decoded.overlaps(with: constructed))
 }

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_contains.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_contains.swift
@@ -5,8 +5,8 @@ import Testing
 
 @Test
 func testContains_SameReference() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 3)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 3)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 3)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 3)
     
     #expect(ref1.contains(with: ref2))
     #expect(ref2.contains(with: ref1))
@@ -14,8 +14,8 @@ func testContains_SameReference() {
 
 @Test
 func testContains_RangeContainsSingleVerse() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 5)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 5)
     
     #expect(ref1.contains(with: ref2))
     #expect(!ref2.contains(with: ref1))
@@ -23,8 +23,8 @@ func testContains_RangeContainsSingleVerse() {
 
 @Test
 func testContains_RangeContainsSmallerRange() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 10)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 7)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 10)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 7)
     
     #expect(ref1.contains(with: ref2))
     #expect(!ref2.contains(with: ref1))
@@ -32,8 +32,8 @@ func testContains_RangeContainsSmallerRange() {
 
 @Test
 func testContains_RangeContainsRangeAtBoundary() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 10)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 10)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
     
     #expect(ref1.contains(with: ref2))
     #expect(!ref2.contains(with: ref1))
@@ -41,8 +41,8 @@ func testContains_RangeContainsRangeAtBoundary() {
 
 @Test
 func testContains_RangeContainsRangeAtEndBoundary() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 10)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 7, verseEnd: 10)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 10)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 7, verseEnd: 10)
     
     #expect(ref1.contains(with: ref2))
     #expect(!ref2.contains(with: ref1))
@@ -50,8 +50,8 @@ func testContains_RangeContainsRangeAtEndBoundary() {
 
 @Test
 func testContains_OverlappingRangesDoNotContain() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 9)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 9)
     
     #expect(!ref1.contains(with: ref2))
     #expect(!ref2.contains(with: ref1))
@@ -59,8 +59,8 @@ func testContains_OverlappingRangesDoNotContain() {
 
 @Test
 func testContains_AdjacentRangesDoNotContain() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 6, verseEnd: 8)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 6, verseEnd: 8)
     
     #expect(!ref1.contains(with: ref2))
     #expect(!ref2.contains(with: ref1))
@@ -68,8 +68,8 @@ func testContains_AdjacentRangesDoNotContain() {
 
 @Test
 func testContains_SeparateRangesDoNotContain() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 8, verseEnd: 10)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 8, verseEnd: 10)
     
     #expect(!ref1.contains(with: ref2))
     #expect(!ref2.contains(with: ref1))
@@ -77,8 +77,8 @@ func testContains_SeparateRangesDoNotContain() {
 
 @Test
 func testContains_DifferentChaptersDoNotContain() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 50)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 2, verseStart: 1, verseEnd: 10)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 50)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 2, verseStart: 1, verseEnd: 10)
     
     #expect(!ref1.contains(with: ref2))
     #expect(!ref2.contains(with: ref1))
@@ -86,8 +86,8 @@ func testContains_DifferentChaptersDoNotContain() {
 
 @Test
 func testContains_DifferentBooksDoNotContain() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 50)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "EXO", chapter: 1, verseStart: 1, verseEnd: 10)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 50)
+    let ref2 = BibleReference(versionId: 1, bookId: "EXO", chapter: 1, verseStart: 1, verseEnd: 10)
     
     #expect(!ref1.contains(with: ref2))
     #expect(!ref2.contains(with: ref1))
@@ -95,8 +95,8 @@ func testContains_DifferentBooksDoNotContain() {
 
 @Test
 func testContains_DifferentVersionsDoNotContain() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 50)
-    let ref2 = BibleReference(versionId: 2, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 10)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 50)
+    let ref2 = BibleReference(versionId: 2, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 10)
     
     #expect(!ref1.contains(with: ref2))
     #expect(!ref2.contains(with: ref1))
@@ -104,8 +104,8 @@ func testContains_DifferentVersionsDoNotContain() {
 
 @Test
 func testContains_EdgeCaseSingleVerseRanges() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 5)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 5)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 5)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 5)
     
     #expect(ref1.contains(with: ref2))
     #expect(ref2.contains(with: ref1))
@@ -113,8 +113,8 @@ func testContains_EdgeCaseSingleVerseRanges() {
 
 @Test
 func testContains_EdgeCaseLargeRanges() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "PSA", chapter: 119, verseStart: 1, verseEnd: 176)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "PSA", chapter: 119, verseStart: 80, verseEnd: 120)
+    let ref1 = BibleReference(versionId: 1, bookId: "PSA", chapter: 119, verseStart: 1, verseEnd: 176)
+    let ref2 = BibleReference(versionId: 1, bookId: "PSA", chapter: 119, verseStart: 80, verseEnd: 120)
     
     #expect(ref1.contains(with: ref2))
     #expect(!ref2.contains(with: ref1))
@@ -124,8 +124,8 @@ func testContains_EdgeCaseLargeRanges() {
 func testContains_EdgeCaseNilHandling() {
     // Test edge cases around nil handling in the contains function
     // The function defaults nil verseStart to 1 and nil verseEnd to verseStart
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
     
     #expect(!ref1.contains(with: ref2))
     #expect(ref2.contains(with: ref1))
@@ -133,32 +133,32 @@ func testContains_EdgeCaseNilHandling() {
 
 @Test
 func testContains_ChapterContainsSingleVerse() {
-    let chapter = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
-    let single = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 10)
+    let chapter = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
+    let single = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 10)
     #expect(chapter.contains(with: single))
     #expect(!single.contains(with: chapter))
 }
 
 @Test
 func testContains_ChapterContainsRange() {
-    let chapter = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
-    let range = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
+    let chapter = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
+    let range = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
     #expect(chapter.contains(with: range))
     #expect(!range.contains(with: chapter))
 }
 
 @Test
 func testContains_ChapterContainsChapter_SameChapter() {
-    let chapter1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
-    let chapter2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
+    let chapter1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
+    let chapter2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
     #expect(chapter1.contains(with: chapter2))
     #expect(chapter2.contains(with: chapter1))
 }
 
 @Test
 func testContains_ChapterDoesNotContainDifferentChapter() {
-    let chapter1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
-    let chapter2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 2)
+    let chapter1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
+    let chapter2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 2)
     #expect(!chapter1.contains(with: chapter2))
     #expect(!chapter2.contains(with: chapter1))
 }
@@ -168,17 +168,17 @@ func testContains_ComplexContainmentScenarios() {
     // Test various complex containment scenarios
     let scenarios: [(BibleReference, BibleReference, Bool, Bool)] = [
         // (ref1, ref2, ref1ContainsRef2, ref2ContainsRef1)
-        (BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 10),
-         BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 7), true, false),
+        (BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 10),
+         BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 7), true, false),
         
-        (BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 15),
-         BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 10), false, false),
+        (BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 15),
+         BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 10), false, false),
         
-        (BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 5),
-         BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 5), true, true),
+        (BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 5),
+         BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 5), true, true),
         
-        (BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 5),
-         BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 5), true, false),
+        (BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 5),
+         BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 5), true, false),
     ]
     
     for (ref1, ref2, ref1ContainsRef2, ref2ContainsRef1) in scenarios {

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_existsIn.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_existsIn.swift
@@ -18,42 +18,42 @@ struct BibleReferenceExistsInTests {
 
     @Test
     func existsInReturnsTrueWhenBookAndChapterArePresent() {
-        let reference = BibleReference(versionId: 206, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 206, bookId: "GEN", chapter: 1, verse: 1)
 
         #expect(reference.existsIn(version: Self.fixtureVersion))
     }
 
     @Test
     func existsInReturnsTrueForChapterOnlyReferenceWhenChapterIsPresent() {
-        let reference = BibleReference(versionId: 206, bookUSFM: "GEN", chapter: 1)
+        let reference = BibleReference(versionId: 206, bookId: "GEN", chapter: 1)
 
         #expect(reference.existsIn(version: Self.fixtureVersion))
     }
 
     @Test
     func existsInReturnsFalseForChapterOnlyReferenceWhenBookIsMissing() {
-        let reference = BibleReference(versionId: 206, bookUSFM: "ABC", chapter: 1)
+        let reference = BibleReference(versionId: 206, bookId: "ABC", chapter: 1)
 
         #expect(!reference.existsIn(version: Self.fixtureVersion))
     }
 
     @Test
     func existsInReturnsFalseForChapterOnlyReferenceWhenChapterIsMissing() {
-        let reference = BibleReference(versionId: 206, bookUSFM: "GEN", chapter: 51)
+        let reference = BibleReference(versionId: 206, bookId: "GEN", chapter: 51)
 
         #expect(!reference.existsIn(version: Self.fixtureVersion))
     }
 
     @Test
     func existsInReturnsFalseWhenBookIsMissing() {
-        let reference = BibleReference(versionId: 206, bookUSFM: "ABC", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 206, bookId: "ABC", chapter: 1, verse: 1)
 
         #expect(!reference.existsIn(version: Self.fixtureVersion))
     }
 
     @Test
     func existsInReturnsFalseWhenChapterIsMissing() {
-        let reference = BibleReference(versionId: 206, bookUSFM: "GEN", chapter: 51, verse: 1)
+        let reference = BibleReference(versionId: 206, bookId: "GEN", chapter: 51, verse: 1)
 
         #expect(!reference.existsIn(version: Self.fixtureVersion))
     }
@@ -76,7 +76,7 @@ struct BibleReferenceExistsInTests {
             books: nil,
             textDirection: "ltr"
         )
-        let reference = BibleReference(versionId: 206, bookUSFM: "GEN", chapter: 99, verse: 1)
+        let reference = BibleReference(versionId: 206, bookId: "GEN", chapter: 99, verse: 1)
 
         #expect(reference.existsIn(version: version))
     }

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_overlaps.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_overlaps.swift
@@ -5,8 +5,8 @@ import Testing
 
 @Test
 func testOverlaps_SameVerse() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 3)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 3)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 3)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 3)
     
     #expect(ref1.overlaps(with: ref2))
     #expect(ref2.overlaps(with: ref1))
@@ -14,8 +14,8 @@ func testOverlaps_SameVerse() {
 
 @Test
 func testOverlaps_DifferentVerses() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 3)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 4)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 3)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 4)
     
     #expect(!ref1.overlaps(with: ref2))
     #expect(!ref2.overlaps(with: ref1))
@@ -23,8 +23,8 @@ func testOverlaps_DifferentVerses() {
 
 @Test
 func testOverlaps_VerseRangeOverlaps() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 9)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 9)
     
     #expect(ref1.overlaps(with: ref2))
     #expect(ref2.overlaps(with: ref1))
@@ -32,8 +32,8 @@ func testOverlaps_VerseRangeOverlaps() {
 
 @Test
 func testOverlaps_VerseRangeNoOverlap() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 7, verseEnd: 9)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 7, verseEnd: 9)
     
     #expect(!ref1.overlaps(with: ref2))
     #expect(!ref2.overlaps(with: ref1))
@@ -41,8 +41,8 @@ func testOverlaps_VerseRangeNoOverlap() {
 
 @Test
 func testOverlaps_VerseRangeAdjacent() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 6, verseEnd: 8)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 6, verseEnd: 8)
     
     #expect(!ref1.overlaps(with: ref2))
     #expect(!ref2.overlaps(with: ref1))
@@ -50,8 +50,8 @@ func testOverlaps_VerseRangeAdjacent() {
 
 @Test
 func testOverlaps_OneContainsOther() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 10)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 7)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 10)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 7)
     
     #expect(ref1.overlaps(with: ref2))
     #expect(ref2.overlaps(with: ref1))
@@ -59,8 +59,8 @@ func testOverlaps_OneContainsOther() {
 
 @Test
 func testOverlaps_SingleVerseInRange() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 5)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 5)
     
     #expect(ref1.overlaps(with: ref2))
     #expect(ref2.overlaps(with: ref1))
@@ -68,8 +68,8 @@ func testOverlaps_SingleVerseInRange() {
 
 @Test
 func testOverlaps_SingleVerseAtRangeBoundary() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 3)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 3)
     
     #expect(ref1.overlaps(with: ref2))
     #expect(ref2.overlaps(with: ref1))
@@ -77,8 +77,8 @@ func testOverlaps_SingleVerseAtRangeBoundary() {
 
 @Test
 func testOverlaps_SingleVerseOutsideRange() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 8)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 8)
     
     #expect(!ref1.overlaps(with: ref2))
     #expect(!ref2.overlaps(with: ref1))
@@ -86,8 +86,8 @@ func testOverlaps_SingleVerseOutsideRange() {
 
 @Test
 func testOverlaps_DifferentChapters() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 3)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 2, verse: 3)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 3)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 2, verse: 3)
     
     #expect(!ref1.overlaps(with: ref2))
     #expect(!ref2.overlaps(with: ref1))
@@ -95,8 +95,8 @@ func testOverlaps_DifferentChapters() {
 
 @Test
 func testOverlaps_DifferentBooks() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 3)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "EXO", chapter: 1, verse: 3)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 3)
+    let ref2 = BibleReference(versionId: 1, bookId: "EXO", chapter: 1, verse: 3)
     
     #expect(!ref1.overlaps(with: ref2))
     #expect(!ref2.overlaps(with: ref1))
@@ -104,8 +104,8 @@ func testOverlaps_DifferentBooks() {
 
 @Test
 func testOverlaps_DifferentVersions() {
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 3)
-    let ref2 = BibleReference(versionId: 2, bookUSFM: "GEN", chapter: 1, verse: 3)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 3)
+    let ref2 = BibleReference(versionId: 2, bookId: "GEN", chapter: 1, verse: 3)
     
     #expect(!ref1.overlaps(with: ref2))
     #expect(!ref2.overlaps(with: ref1))
@@ -116,17 +116,17 @@ func testOverlaps_ComplexOverlapScenarios() {
     // Test various complex overlap scenarios
     let scenarios: [(BibleReference, BibleReference, Bool)] = [
         // (ref1, ref2, shouldOverlap)
-        (BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 10),
-         BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 15), true),
+        (BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 10),
+         BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 15), true),
         
-        (BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 15),
-         BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 10), true),
+        (BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 15),
+         BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 10), true),
         
-        (BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 5),
-         BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 6, verseEnd: 10), false),
+        (BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 5),
+         BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 6, verseEnd: 10), false),
         
-        (BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 5),
-         BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 10), true),
+        (BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 5),
+         BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 10), true),
     ]
     
     for (ref1, ref2, shouldOverlap) in scenarios {
@@ -139,8 +139,8 @@ func testOverlaps_ComplexOverlapScenarios() {
 func testOverlaps_OrderingDependency() {
     // Test that the min/max ordering in the overlaps function works correctly
     // This tests cases where the order of comparison might matter
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 10)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 7)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 10)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 7)
     
     #expect(ref1.overlaps(with: ref2))
     #expect(ref2.overlaps(with: ref1))
@@ -149,8 +149,8 @@ func testOverlaps_OrderingDependency() {
 @Test
 func testOverlaps_ExactBoundaryOverlap() {
     // Test cases where references touch exactly at boundaries
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 10)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 10)
     
     #expect(ref1.overlaps(with: ref2))
     #expect(ref2.overlaps(with: ref1))
@@ -159,8 +159,8 @@ func testOverlaps_ExactBoundaryOverlap() {
 @Test
 func testOverlaps_IdenticalRanges() {
     // Test identical ranges
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
     
     #expect(ref1.overlaps(with: ref2))
     #expect(ref2.overlaps(with: ref1))
@@ -170,8 +170,8 @@ func testOverlaps_IdenticalRanges() {
 func testOverlaps_EdgeCaseNilHandling() {
     // Test edge cases around nil handling in the overlaps function
     // The function defaults nil verseStart to 1 and nil verseEnd to verseStart
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
     
     #expect(ref1.overlaps(with: ref2))
     #expect(ref2.overlaps(with: ref1))
@@ -179,9 +179,9 @@ func testOverlaps_EdgeCaseNilHandling() {
 
 @Test
 func testOverlaps_CaseSensitiveBookComparison() {
-    // Test that book comparison is case-insensitive (bookUSFM is normalized to uppercase)
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "gen", chapter: 1, verse: 1)
+    // Test that book comparison is case-insensitive (bookId is normalized to uppercase)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
+    let ref2 = BibleReference(versionId: 1, bookId: "gen", chapter: 1, verse: 1)
 
     #expect(ref1.overlaps(with: ref2))
     #expect(ref2.overlaps(with: ref1))
@@ -190,8 +190,8 @@ func testOverlaps_CaseSensitiveBookComparison() {
 @Test
 func testOverlaps_EdgeCaseLargeRanges() {
     // Test with very large verse ranges
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "PSA", chapter: 119, verseStart: 1, verseEnd: 176)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "PSA", chapter: 119, verseStart: 80, verseEnd: 120)
+    let ref1 = BibleReference(versionId: 1, bookId: "PSA", chapter: 119, verseStart: 1, verseEnd: 176)
+    let ref2 = BibleReference(versionId: 1, bookId: "PSA", chapter: 119, verseStart: 80, verseEnd: 120)
     
     #expect(ref1.overlaps(with: ref2))
     #expect(ref2.overlaps(with: ref1))
@@ -200,8 +200,8 @@ func testOverlaps_EdgeCaseLargeRanges() {
 @Test
 func testOverlaps_EdgeCaseMinimalOverlap() {
     // Test minimal overlap scenarios
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 100)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 100, verseEnd: 200)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 100)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 100, verseEnd: 200)
     
     #expect(ref1.overlaps(with: ref2))
     #expect(ref2.overlaps(with: ref1))
@@ -210,8 +210,8 @@ func testOverlaps_EdgeCaseMinimalOverlap() {
 @Test
 func testOverlaps_EdgeCaseZeroLengthRange() {
     // Test edge case where a range has zero length (start == end)
-    let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 5)
-    let ref2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 5)
+    let ref1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 5)
+    let ref2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 5)
     
     #expect(ref1.overlaps(with: ref2))
     #expect(ref2.overlaps(with: ref1))
@@ -220,40 +220,40 @@ func testOverlaps_EdgeCaseZeroLengthRange() {
 @Test
 func testOverlaps_ChapterVsSingleVerse() {
     // Both verseStart and verseEnd nil means whole chapter reference
-    let chapter = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
-    let single = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+    let chapter = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
+    let single = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 1)
     #expect(chapter.overlaps(with: single))
     #expect(single.overlaps(with: chapter))
 }
 
 @Test
 func testOverlaps_ChapterVsRange() {
-    let chapter = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
-    let range = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
+    let chapter = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
+    let range = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 7)
     #expect(chapter.overlaps(with: range))
     #expect(range.overlaps(with: chapter))
 }
 
 @Test
 func testOverlaps_ChapterVsChapter_SameChapter() {
-    let chapter1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
-    let chapter2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
+    let chapter1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
+    let chapter2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
     #expect(chapter1.overlaps(with: chapter2))
     #expect(chapter2.overlaps(with: chapter1))
 }
 
 @Test
 func testOverlaps_ChapterVsChapter_DifferentChapter() {
-    let chapter1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
-    let chapter2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 2)
+    let chapter1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
+    let chapter2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 2)
     #expect(!chapter1.overlaps(with: chapter2))
     #expect(!chapter2.overlaps(with: chapter1))
 }
 
 @Test
 func testOverlaps_ChapterVsChapterVerseVerse_DifferentChapter() {
-    let chapter1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
-    let chapter2 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 2, verseStart: 3, verseEnd: 3)
+    let chapter1 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
+    let chapter2 = BibleReference(versionId: 1, bookId: "GEN", chapter: 2, verseStart: 3, verseEnd: 3)
     #expect(!chapter1.overlaps(with: chapter2))
     #expect(!chapter2.overlaps(with: chapter1))
 }

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_unvalidatedReference.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_unvalidatedReference.swift
@@ -6,28 +6,28 @@ import Testing
 @Test
 func testUnvalidatedReference_singleVerse() throws {
     let ref = try #require(BibleReference.unvalidatedReference(with: "GEN.1.3", versionId: 1))
-    let expected = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 3)
+    let expected = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 3)
     #expect(ref == expected)
 }
 
 @Test
 func testUnvalidatedReference_verseRange() throws {
     let ref = try #require(BibleReference.unvalidatedReference(with: "GEN.1.3-5", versionId: 1))
-    let expected = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
+    let expected = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
     #expect(ref == expected)
 }
 
 @Test
 func testUnvalidatedReference_fullRangeWithChapter() throws {
     let ref = try #require(BibleReference.unvalidatedReference(with: "GEN.1.3-1.5", versionId: 1))
-    let expected = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
+    let expected = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
     #expect(ref == expected)
 }
 
 @Test
 func testUnvalidatedReference_fullRangeWithBook() throws {
     let ref = try #require(BibleReference.unvalidatedReference(with: "GEN.1.3-GEN.1.5", versionId: 1))
-    let expected = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
+    let expected = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
     #expect(ref == expected)
 }
 
@@ -46,12 +46,12 @@ func testUnvalidatedReference_invalidVerseOrder() {
 @Test
 func testUnvalidatedReference_chapterOnly() throws {
     let ref = try #require(BibleReference.unvalidatedReference(with: "GEN.1", versionId: 1))
-    let expected = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
+    let expected = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
     #expect(ref == expected)
     #expect(ref.verseStart == nil)
     #expect(ref.verseEnd == nil)
     // A chapter-level reference should overlap any verse within that chapter
-    let verse5 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 5)
+    let verse5 = BibleReference(versionId: 1, bookId: "GEN", chapter: 1, verse: 5)
     #expect(ref.overlaps(with: verse5))
 }
 

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionAPITests.swift
@@ -86,7 +86,7 @@ import Testing
             return (json, resp)
         }
 
-        let ref = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
+        let ref = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
         let html = try await YouVersionAPI.Bible.chapter(reference: ref, accessToken: "swift-test-suite", session: session)
         #expect(html == "<div>ok</div>")
 
@@ -108,7 +108,7 @@ import Testing
             return (Data(), resp)
         }
 
-        let ref = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
+        let ref = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
         await #expect(throws: YouVersionAPIError.notPermitted) {
             _ = try await YouVersionAPI.Bible.chapter(reference: ref, accessToken: "swift-test-suite", session: session)
         }
@@ -124,7 +124,7 @@ import Testing
             return (Data(), resp)
         }
 
-        let ref = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
+        let ref = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
         await #expect(throws: YouVersionAPIError.cannotDownload) {
             _ = try await YouVersionAPI.Bible.chapter(reference: ref, accessToken: "swift-test-suite", session: session)
         }
@@ -140,7 +140,7 @@ import Testing
             return (Data(), resp)
         }
 
-        let ref = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
+        let ref = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
         await #expect(throws: YouVersionAPIError.invalidResponse) {
             _ = try await YouVersionAPI.Bible.chapter(reference: ref, accessToken: "swift-test-suite", session: session)
         }
@@ -161,7 +161,7 @@ import Testing
             return (json, resp)
         }
 
-        let ref = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
+        let ref = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
         await #expect(throws: YouVersionAPIError.invalidDownload) {
             _ = try await YouVersionAPI.Bible.chapter(reference: ref, accessToken: "swift-test-suite", session: session)
         }

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionTests.swift
@@ -46,7 +46,7 @@ struct BibleVersionTests {
         ("REEV", false),
         ("R", false)
     ])
-    func bookUSFMValidation(passageId: String, isValid: Bool) {
+    func bookIdValidation(passageId: String, isValid: Bool) {
         let normalized = passageId.uppercased()
         #expect(Self.canonicalBookIds.contains(normalized) == isValid)
     }

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionTests.swift
@@ -16,7 +16,7 @@ struct BibleVersionTests {
         }
     }()
 
-    private static let canonicalUSFMs = Set(version.books?.filter { $0.isCanonical }.map(\.id) ?? [])
+    private static let canonicalBookIds = Set(version.books?.filter { $0.isCanonical }.map(\.id) ?? [])
 
     @Test
     func decodesCoreMetadata() throws {
@@ -27,9 +27,9 @@ struct BibleVersionTests {
         #expect(version.title == "World English Bible, American English Edition, without Strong's Numbers")
         #expect(version.localizedTitle == "World English Bible, American English Edition, without Strong's Numbers")
         #expect(version.languageTag == "en")
-        #expect(version.bookUSFMs.count == 80)
+        #expect(version.bookIds.count == 80)
         let bookCodes = try #require(version.bookCodes)
-        #expect(bookCodes == version.bookUSFMs)
+        #expect(bookCodes == version.bookIds)
         #expect(bookCodes.first == "GEN")
         #expect(bookCodes.last == "REV")
         #expect(version.copyright == "PUBLIC DOMAIN (not copyrighted)")
@@ -46,9 +46,9 @@ struct BibleVersionTests {
         ("REEV", false),
         ("R", false)
     ])
-    func bookUSFMValidation(usfm: String, isValid: Bool) {
-        let normalized = usfm.uppercased()
-        #expect(Self.canonicalUSFMs.contains(normalized) == isValid)
+    func bookUSFMValidation(passageId: String, isValid: Bool) {
+        let normalized = passageId.uppercased()
+        #expect(Self.canonicalBookIds.contains(normalized) == isValid)
     }
 
     @Test
@@ -69,19 +69,19 @@ struct BibleVersionTests {
         ("REV", "Revelation", "Rev", 22, "REV.1")
     ])
     func bookMetadata(
-        bookUSFM: String,
+        bookId: String,
         expectedTitle: String,
         expectedAbbreviation: String,
         expectedChapterCount: Int,
         expectedFirstChapterId: String
     ) throws {
-        let book = try #require(Self.version.book(with: bookUSFM))
+        let book = try #require(Self.version.book(with: bookId))
         #expect(book.title == expectedTitle)
         #expect(book.abbreviation == expectedAbbreviation)
         let chapters = try #require(book.chapters)
         #expect(chapters.count == expectedChapterCount)
         #expect(chapters.first?.passageId == expectedFirstChapterId)
-        let labels = Self.version.chapterLabels(bookUSFM)
+        let labels = Self.version.chapterLabels(bookId)
         #expect(labels.count == expectedChapterCount)
         #expect(labels.first == "1")
         #expect(labels.last == String(expectedChapterCount))
@@ -90,7 +90,7 @@ struct BibleVersionTests {
     @Test
     func referenceTrimsWhitespace() throws {
         let reference = try #require(Self.version.reference(with: "  GEN.1.5  "))
-        #expect(reference.bookUSFM == "GEN")
+        #expect(reference.bookId == "GEN")
         #expect(reference.chapter == 1)
         #expect(reference.verseStart == 5)
     }
@@ -98,7 +98,7 @@ struct BibleVersionTests {
     @Test
     func referenceMergesAdjacentVersesSeparatedByPlus() throws {
         let reference = try #require(Self.version.reference(with: "GEN.1.1+GEN.1.2"))
-        #expect(reference.bookUSFM == "GEN")
+        #expect(reference.bookId == "GEN")
         #expect(reference.chapter == 1)
         #expect(reference.verseStart == 1)
         #expect(reference.verseEnd == 2)
@@ -107,7 +107,7 @@ struct BibleVersionTests {
     @Test
     func referenceSkipsInvalidSegments() throws {
         let reference = try #require(Self.version.reference(with: "GEN.3.7+GAN.3.8+GEN.3.8"))
-        #expect(reference.bookUSFM == "GEN")
+        #expect(reference.bookId == "GEN")
         #expect(reference.chapter == 3)
         #expect(reference.verseStart == 7)
         #expect(reference.verseEnd == 8)

--- a/Tests/YouVersionPlatformCoreTests/URLBuilderTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/URLBuilderTests.swift
@@ -31,7 +31,7 @@ struct URLBuilderTests {
         #expect(versions.absoluteString == "https://api.youversion.com/v1/bibles?language_ranges%5B%5D=en&page_size=99")
 
         // Test /v1/bibles/{versionId}/passages endpoints
-        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
         let passage = try #require(URLBuilder.passageURL(reference: reference))
         #expect(passage.absoluteString == "https://api.youversion.com/v1/bibles/1/passages/GEN.1?format=text&include_notes=true&include_headings=true")
 

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
@@ -199,9 +199,9 @@ let previousChapterCases: [PreviousChapterCase] = [
     @Test(arguments: [false, true])
     func goToNextChapterWithoutLoadedVersionDoesNothing(_ showIntro: Bool) {
         let vm = BibleReaderViewModel(
-            reference: BibleReference(versionId: Self.versionId, bookUSFM: "GEN", chapter: 2)
+            reference: BibleReference(versionId: Self.versionId, bookId: "GEN", chapter: 2)
         )
-        let selectedReference = BibleReference(versionId: Self.versionId, bookUSFM: "GEN", chapter: 2, verse: 1)
+        let selectedReference = BibleReference(versionId: Self.versionId, bookId: "GEN", chapter: 2, verse: 1)
         vm.showBookIntro = showIntro
         // currentVersion is nil by default — the "no loaded version" state.
         vm.isChangingChapter = false
@@ -212,7 +212,7 @@ let previousChapterCases: [PreviousChapterCase] = [
 
         vm.goToNextChapter()
 
-        #expect(vm.reference == BibleReference(versionId: Self.versionId, bookUSFM: "GEN", chapter: 2))
+        #expect(vm.reference == BibleReference(versionId: Self.versionId, bookId: "GEN", chapter: 2))
         #expect(vm.showBookIntro == showIntro)
         #expect(vm.isChangingChapter == false)
         #expect(vm.lastScrollOffset == 123)
@@ -224,9 +224,9 @@ let previousChapterCases: [PreviousChapterCase] = [
     @Test(arguments: [false, true])
     func goToPreviousChapterWithoutLoadedVersionDoesNothing(_ showIntro: Bool) {
         let vm = BibleReaderViewModel(
-            reference: BibleReference(versionId: Self.versionId, bookUSFM: "GEN", chapter: 2)
+            reference: BibleReference(versionId: Self.versionId, bookId: "GEN", chapter: 2)
         )
-        let selectedReference = BibleReference(versionId: Self.versionId, bookUSFM: "GEN", chapter: 2, verse: 1)
+        let selectedReference = BibleReference(versionId: Self.versionId, bookId: "GEN", chapter: 2, verse: 1)
         vm.showBookIntro = showIntro
         // currentVersion is nil by default — the "no loaded version" state.
         vm.isChangingChapter = false
@@ -237,7 +237,7 @@ let previousChapterCases: [PreviousChapterCase] = [
 
         vm.goToPreviousChapter()
 
-        #expect(vm.reference == BibleReference(versionId: Self.versionId, bookUSFM: "GEN", chapter: 2))
+        #expect(vm.reference == BibleReference(versionId: Self.versionId, bookId: "GEN", chapter: 2))
         #expect(vm.showBookIntro == showIntro)
         #expect(vm.isChangingChapter == false)
         #expect(vm.lastScrollOffset == 123)
@@ -266,7 +266,7 @@ let previousChapterCases: [PreviousChapterCase] = [
 
         vm.goToPreviousChapter()
 
-        #expect(vm.reference == BibleReference(versionId: Self.versionId, bookUSFM: firstBook.id, chapter: 1))
+        #expect(vm.reference == BibleReference(versionId: Self.versionId, bookId: firstBook.id, chapter: 1))
         #expect(vm.showBookIntro == expectedShowBookIntro)
         assertNavigationSideEffects(on: vm)
     }
@@ -285,7 +285,7 @@ let previousChapterCases: [PreviousChapterCase] = [
 
         vm.goToNextChapter()
 
-        #expect(vm.reference == BibleReference(versionId: Self.versionId, bookUSFM: onlyBook.id, chapter: onlyBook.chapterCount))
+        #expect(vm.reference == BibleReference(versionId: Self.versionId, bookId: onlyBook.id, chapter: onlyBook.chapterCount))
         #expect(vm.showBookIntro == false)
         assertNavigationSideEffects(on: vm)
     }
@@ -301,7 +301,7 @@ let previousChapterCases: [PreviousChapterCase] = [
         let expectedBookIds = testCase.books.map(\.id)
         let actualBookIds = vm.version?.books?.compactMap { $0.id } ?? []
         #expect(actualBookIds == expectedBookIds, Comment("Case: \(testCase.name)"))
-        #expect(vm.reference.bookUSFM == testCase.referenceBook, Comment("Case: \(testCase.name)"))
+        #expect(vm.reference.bookId == testCase.referenceBook, Comment("Case: \(testCase.name)"))
         #expect(vm.reference.chapter == testCase.referenceChapter, Comment("Case: \(testCase.name)"))
 
         vm.goToNextChapter()
@@ -309,7 +309,7 @@ let previousChapterCases: [PreviousChapterCase] = [
         #expect(
             vm.reference == BibleReference(
                 versionId: Self.versionId,
-                bookUSFM: testCase.expectedBook,
+                bookId: testCase.expectedBook,
                 chapter: testCase.expectedChapter
             ),
             Comment("Case: \(testCase.name)")
@@ -329,7 +329,7 @@ let previousChapterCases: [PreviousChapterCase] = [
         let expectedBookIds = testCase.books.map(\.id)
         let actualBookIds = vm.version?.books?.compactMap { $0.id } ?? []
         #expect(actualBookIds == expectedBookIds, Comment("Case: \(testCase.name)"))
-        #expect(vm.reference.bookUSFM == testCase.referenceBook, Comment("Case: \(testCase.name)"))
+        #expect(vm.reference.bookId == testCase.referenceBook, Comment("Case: \(testCase.name)"))
         #expect(vm.reference.chapter == testCase.referenceChapter, Comment("Case: \(testCase.name)"))
 
         vm.goToPreviousChapter()
@@ -337,7 +337,7 @@ let previousChapterCases: [PreviousChapterCase] = [
         #expect(
             vm.reference == BibleReference(
                 versionId: Self.versionId,
-                bookUSFM: testCase.expectedBook,
+                bookId: testCase.expectedBook,
                 chapter: testCase.expectedChapter
             ),
             Comment("Case: \(testCase.name)")
@@ -360,9 +360,9 @@ let previousChapterCases: [PreviousChapterCase] = [
         referenceChapter: Int,
         showBookIntro: Bool
     ) -> BibleReaderViewModel {
-        let reference = BibleReference(versionId: Self.versionId, bookUSFM: referenceBook, chapter: referenceChapter)
+        let reference = BibleReference(versionId: Self.versionId, bookId: referenceBook, chapter: referenceChapter)
         let vm = BibleReaderViewModel(reference: reference)
-        let selectedReference = BibleReference(versionId: Self.versionId, bookUSFM: referenceBook, chapter: referenceChapter, verse: 1)
+        let selectedReference = BibleReference(versionId: Self.versionId, bookId: referenceBook, chapter: referenceChapter, verse: 1)
         vm.versionsViewModel.switchToVersion(makeVersion(with: books))
         vm.showBookIntro = showBookIntro
         vm.isChangingChapter = false

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
@@ -45,7 +45,7 @@ import Testing
     @Test
     func handleVerseTapWithFootnoteActionShowsFootnotes() {
         let viewModel = Support.makeViewModel()
-        let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        let reference = BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 3, verse: 16)
         let footnote = BibleFootnote(text: BibleAttributedString("Footnote"), reference: reference, id: "one")
 
         viewModel.handleVerseTap(
@@ -60,7 +60,7 @@ import Testing
 
     @Test
     func handleVerseTapUsesCustomVerseTapHandlerBeforeSelection() {
-        let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        let reference = BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 3, verse: 16)
         var tappedReference: BibleReference?
         let viewModel = Support.makeViewModel(onVerseTap: { tappedReference = $0 })
 
@@ -75,7 +75,7 @@ import Testing
     func handleVerseTapTogglesSelectionWhenSignedIn() {
         Support.clearReaderDefaults()
         let viewModel = Support.makeViewModel(isSignedIn: true)
-        let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        let reference = BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 3, verse: 16)
 
         viewModel.handleVerseTap(reference: reference, actionType: "", footnotes: [])
 
@@ -92,7 +92,7 @@ import Testing
     func removeVerseSelectionClearsSelectionAndHidesDrawer() {
         let viewModel = Support.makeViewModel()
         viewModel.selectedVerses = [
-            BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16),
+            BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 3, verse: 16),
         ]
         viewModel.showingVerseActionsDrawer = true
 
@@ -107,8 +107,8 @@ import Testing
         Support.clearReaderDefaults()
         let highlightsRepository = MockBibleHighlightsRepository()
         let viewModel = Support.makeViewModel(highlightsRepository: highlightsRepository)
-        let firstReference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
-        let secondReference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 17)
+        let firstReference = BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 3, verse: 16)
+        let secondReference = BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 3, verse: 17)
         let color = Color(hex: "#DDAAFF")
         viewModel.selectedVerses = [firstReference, secondReference]
 
@@ -146,7 +146,7 @@ import Testing
         Support.clearReaderDefaults()
         let highlightsRepository = MockBibleHighlightsRepository()
         let viewModel = Support.makeViewModel(highlightsRepository: highlightsRepository)
-        let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        let reference = BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 3, verse: 16)
         let color = Color(hex: "#DDAAFF")
         viewModel.selectedVerses = [reference]
         viewModel.highlightsViewModel.addHighlights(references: [reference], color: "DDAAFF")
@@ -170,8 +170,8 @@ import Testing
         let version = Support.makeBibleVersion(id: Support.versionId)
         viewModel.versionsViewModel.switchToVersion(version)
         viewModel.selectedVerses = [
-            BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 17),
-            BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16),
+            BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 3, verse: 17),
+            BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 3, verse: 16),
         ]
 
         let result = try #require(viewModel.shareableURLAndTitleForSelection)

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelNavigationStateTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelNavigationStateTests.swift
@@ -11,13 +11,13 @@ import Testing
         let repository = MockBibleVersionRepository()
         let viewModel = Support.makeViewModel(versionRepository: repository)
         viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
-        let selectedReference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1, verse: 1)
+        let selectedReference = BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 1, verse: 1)
         viewModel.selectedVerses = [selectedReference]
         viewModel.showingVerseActionsDrawer = true
         viewModel.showChrome = false
         viewModel.lastScrollOffset = -100
 
-        let newReference = BibleReference(versionId: 111, bookUSFM: "JHN", chapter: 3)
+        let newReference = BibleReference(versionId: 111, bookId: "JHN", chapter: 3)
         await viewModel.onHeaderSelectionChange(newReference, showIntro: true)
 
         #expect(viewModel.reference == newReference)
@@ -36,11 +36,11 @@ import Testing
     func onHeaderSelectionChangeDoesNotMutateStateWhenRepositoryThrows() async {
         let repository = MockBibleVersionRepository()
         await repository.setThrownError(TestError())
-        let originalReference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1)
+        let originalReference = BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 1)
         let viewModel = Support.makeViewModel(reference: originalReference, versionRepository: repository)
         viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
 
-        await viewModel.onHeaderSelectionChange(BibleReference(versionId: 111, bookUSFM: "JHN", chapter: 3), showIntro: true)
+        await viewModel.onHeaderSelectionChange(BibleReference(versionId: 111, bookId: "JHN", chapter: 3), showIntro: true)
 
         #expect(viewModel.reference == originalReference)
         #expect(viewModel.showBookIntro == false)
@@ -50,14 +50,14 @@ import Testing
     @Test
     func handleVersionPickedNoOpsWhenVersionIsUnchanged() async {
         let viewModel = Support.makeViewModel()
-        let selectedReference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1, verse: 1)
+        let selectedReference = BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 1, verse: 1)
         viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
         viewModel.selectedVerses = [selectedReference]
         viewModel.showingVerseActionsDrawer = true
 
         await viewModel.handleVersionPicked(Support.makeBibleVersion(id: Support.versionId))
 
-        #expect(viewModel.reference == BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1))
+        #expect(viewModel.reference == BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 1))
         #expect(viewModel.selectedVerses == [selectedReference])
         #expect(viewModel.showingVerseActionsDrawer)
     }
@@ -69,7 +69,7 @@ import Testing
 
         await viewModel.handleVersionPicked(Support.makeBibleVersion(id: 111))
 
-        #expect(viewModel.reference == BibleReference(versionId: 111, bookUSFM: "JHN", chapter: 1))
+        #expect(viewModel.reference == BibleReference(versionId: 111, bookId: "JHN", chapter: 1))
         #expect(viewModel.versionsViewModel.currentVersion == Support.makeBibleVersion(id: 111))
         #expect(await repository.requestedIds() == [111])
     }

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelPersistenceTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelPersistenceTests.swift
@@ -12,21 +12,21 @@ import Testing
     func initWithExplicitReferenceUsesReferenceAndHidesIntro() {
         Support.clearReaderDefaults()
         UserDefaults.standard.set(true, forKey: Support.displayIntroKey)
-        let savedReference = BibleReference(versionId: 111, bookUSFM: "EXO", chapter: 3)
+        let savedReference = BibleReference(versionId: 111, bookId: "EXO", chapter: 3)
         UserDefaults.standard.set(try? JSONEncoder().encode(savedReference), forKey: Support.referenceKey)
 
         let viewModel = Support.makeViewModel(
-            reference: BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1)
+            reference: BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 1)
         )
 
-        #expect(viewModel.reference == BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1))
+        #expect(viewModel.reference == BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 1))
         #expect(viewModel.showBookIntro == false)
     }
 
     @Test
     func initWithoutExplicitReferenceRestoresSavedReferenceAndIntroState() {
         Support.clearReaderDefaults()
-        let savedReference = BibleReference(versionId: 111, bookUSFM: "EXO", chapter: 3)
+        let savedReference = BibleReference(versionId: 111, bookId: "EXO", chapter: 3)
         UserDefaults.standard.set(try? JSONEncoder().encode(savedReference), forKey: Support.referenceKey)
         UserDefaults.standard.set(true, forKey: Support.displayIntroKey)
 
@@ -42,7 +42,7 @@ import Testing
 
         let viewModel = Support.makeViewModel(reference: nil)
 
-        #expect(viewModel.reference == BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1))
+        #expect(viewModel.reference == BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 1))
         #expect(viewModel.showBookIntro == false)
     }
 
@@ -50,10 +50,10 @@ import Testing
     func referenceAndShowBookIntroPersistWhenChanged() {
         Support.clearReaderDefaults()
         let viewModel = Support.makeViewModel(
-            reference: BibleReference(versionId: Support.versionId, bookUSFM: "GEN", chapter: 1)
+            reference: BibleReference(versionId: Support.versionId, bookId: "GEN", chapter: 1)
         )
 
-        let newReference = BibleReference(versionId: Support.versionId, bookUSFM: "ROM", chapter: 8)
+        let newReference = BibleReference(versionId: Support.versionId, bookId: "ROM", chapter: 8)
         viewModel.reference = newReference
         viewModel.showBookIntro = true
 

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelSignInTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelSignInTests.swift
@@ -13,7 +13,7 @@ import Testing
         let viewModel = Support.makeViewModel(isSignedIn: false)
 
         viewModel.handleVerseTap(
-            reference: BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16),
+            reference: BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 3, verse: 16),
             actionType: "",
             footnotes: []
         )
@@ -29,7 +29,7 @@ import Testing
         let viewModel = Support.makeViewModel(isSignedIn: false)
 
         viewModel.handleVerseTap(
-            reference: BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16),
+            reference: BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 3, verse: 16),
             actionType: "",
             footnotes: []
         )
@@ -62,7 +62,7 @@ import Testing
         let viewModel = Support.makeViewModel(isSignedIn: true) {
             didSignOut = true
         }
-        let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        let reference = BibleReference(versionId: Support.versionId, bookId: "JHN", chapter: 3, verse: 16)
         viewModel.highlightsViewModel.addHighlights(references: [reference], color: "DDAAFF")
 
         #expect(viewModel.isSignedIn)

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
@@ -63,7 +63,7 @@ enum BibleReaderViewModelTestSupport {
 
     @MainActor
     static func makeViewModel(
-        reference: BibleReference? = BibleReference(versionId: versionId, bookUSFM: "JHN", chapter: 1),
+        reference: BibleReference? = BibleReference(versionId: versionId, bookId: "JHN", chapter: 1),
         highlightsRepository: MockBibleHighlightsRepository = MockBibleHighlightsRepository(),
         versionRepository: any BibleVersionRepositoryProtocol = MockBibleVersionRepository(),
         onVerseTap: ((BibleReference) -> Void)? = nil,

--- a/Tests/YouVersionPlatformUITests/BibleVersionRenderingTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionRenderingTests.swift
@@ -60,7 +60,7 @@ import Testing
         </div>
         """
 
-        let reference = BibleReference(versionId: defaultVersionId, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 10)
+        let reference = BibleReference(versionId: defaultVersionId, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 10)
 
         let blocks = try await renderBlocks(html: html, reference: reference)
         #expect(hasHeaderContaining(blocks, text: "The List"))
@@ -82,7 +82,7 @@ import Testing
         </div>
         """
 
-        let reference = BibleReference(versionId: defaultVersionId, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
+        let reference = BibleReference(versionId: defaultVersionId, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
 
         let blocks = try await renderBlocks(html: html, reference: reference)
         #expect(hasHeaderContaining(blocks, text: "Mid-Verse Header"))
@@ -103,7 +103,7 @@ import Testing
         </div>
         """
 
-        let reference = BibleReference(versionId: defaultVersionId, bookUSFM: "MAT", chapter: 5, verseStart: 2, verseEnd: 2)
+        let reference = BibleReference(versionId: defaultVersionId, bookId: "MAT", chapter: 5, verseStart: 2, verseEnd: 2)
 
         let blocks = try await renderBlocks(html: html, reference: reference)
         #expect(hasHeaderContaining(blocks, text: "The Beatitudes"))
@@ -128,7 +128,7 @@ import Testing
         </div>
         """
 
-        let reference = BibleReference(versionId: defaultVersionId, bookUSFM: "MAT", chapter: 5, verseStart: 1, verseEnd: 2)
+        let reference = BibleReference(versionId: defaultVersionId, bookId: "MAT", chapter: 5, verseStart: 1, verseEnd: 2)
 
         let blocks = try await renderBlocks(html: html, reference: reference)
         #expect(hasHeaderContaining(blocks, text: "Introduction to the Sermon on the Mount"))
@@ -154,7 +154,7 @@ import Testing
         </div>
         """
 
-        let reference = BibleReference(versionId: defaultVersionId, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
+        let reference = BibleReference(versionId: defaultVersionId, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
 
         let blocks = try await renderBlocks(html: html, reference: reference)
         #expect(hasScriptureContaining(blocks, text: "Fifth verse text."))
@@ -181,7 +181,7 @@ import Testing
         </div>
         """
 
-        let reference = BibleReference(versionId: defaultVersionId, bookUSFM: "GEN", chapter: 2, verseStart: 1, verseEnd: 3)
+        let reference = BibleReference(versionId: defaultVersionId, bookId: "GEN", chapter: 2, verseStart: 1, verseEnd: 3)
 
         let blocks = try await renderBlocks(html: html, reference: reference)
         #expect(hasScriptureContaining(blocks, text: "Thus the heavens and the earth were completed"))
@@ -206,7 +206,7 @@ import Testing
         </div>
         """
 
-        let reference = BibleReference(versionId: defaultVersionId, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 10)
+        let reference = BibleReference(versionId: defaultVersionId, bookId: "GEN", chapter: 1, verseStart: 5, verseEnd: 10)
 
         let blocks = try await renderBlocks(html: html, reference: reference)
         #expect(!hasHeaderContaining(blocks, text: "Early Section"))
@@ -226,7 +226,7 @@ import Testing
         </div>
         """
 
-        let reference = BibleReference(versionId: defaultVersionId, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
+        let reference = BibleReference(versionId: defaultVersionId, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
 
         let blocks = try await renderBlocks(html: html, reference: reference, renderHeadlines: false)
         #expect(!hasHeaderContaining(blocks, text: "Visible Header"))

--- a/Tests/YouVersionPlatformUITests/BibleVersionShareUrlTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionShareUrlTests.swift
@@ -35,7 +35,7 @@ import Testing
     
     @Test func testShareUrl_SingleVerse() {
         let version = createBibleVersion(id: 111, abbreviation: "NIV")
-        let reference = BibleReference(versionId: 111, bookUSFM: "1SA", chapter: 3, verse: 10)
+        let reference = BibleReference(versionId: 111, bookId: "1SA", chapter: 3, verse: 10)
         
         let url = version.shareUrl(reference: reference)
         
@@ -44,7 +44,7 @@ import Testing
     
     @Test func testShareUrl_SingleVerseWithLocalizedAbbreviation() {
         let version = createBibleVersion(id: 111, abbreviation: "NIV", localizedAbbreviation: "NVI")
-        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 111, bookId: "GEN", chapter: 1, verse: 1)
         
         let url = version.shareUrl(reference: reference)
         
@@ -53,7 +53,7 @@ import Testing
     
     @Test func testShareUrl_SingleVerseNoAbbreviation() {
         let version = createBibleVersion(id: 999)
-        let reference = BibleReference(versionId: 999, bookUSFM: "PSA", chapter: 23, verse: 1)
+        let reference = BibleReference(versionId: 999, bookId: "PSA", chapter: 23, verse: 1)
         
         let url = version.shareUrl(reference: reference)
         
@@ -64,7 +64,7 @@ import Testing
     
     @Test func testShareUrl_VerseRange() {
         let version = createBibleVersion(id: 111, abbreviation: "NIV")
-        let reference = BibleReference(versionId: 111, bookUSFM: "1SA", chapter: 3, verseStart: 10, verseEnd: 15)
+        let reference = BibleReference(versionId: 111, bookId: "1SA", chapter: 3, verseStart: 10, verseEnd: 15)
         
         let url = version.shareUrl(reference: reference)
         
@@ -73,7 +73,7 @@ import Testing
     
     @Test func testShareUrl_VerseRangeWithLocalizedAbbreviation() {
         let version = createBibleVersion(id: 111, abbreviation: "NIV", localizedAbbreviation: "NVI")
-        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
+        let reference = BibleReference(versionId: 111, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
         
         let url = version.shareUrl(reference: reference)
         
@@ -83,7 +83,7 @@ import Testing
     @Test func testShareUrl_VerseRangeSameStartAndEnd() {
         // This should be treated as a single verse, not a range
         let version = createBibleVersion(id: 111, abbreviation: "NIV")
-        let reference = BibleReference(versionId: 111, bookUSFM: "1SA", chapter: 3, verseStart: 10, verseEnd: 10)
+        let reference = BibleReference(versionId: 111, bookId: "1SA", chapter: 3, verseStart: 10, verseEnd: 10)
         
         let url = version.shareUrl(reference: reference)
         
@@ -94,7 +94,7 @@ import Testing
     
     @Test func testShareUrl_ChapterOnly() {
         let version = createBibleVersion(id: 111, abbreviation: "NIV")
-        let reference = BibleReference(versionId: 111, bookUSFM: "1SA", chapter: 3)
+        let reference = BibleReference(versionId: 111, bookId: "1SA", chapter: 3)
         
         let url = version.shareUrl(reference: reference)
         
@@ -103,7 +103,7 @@ import Testing
     
     @Test func testShareUrl_ChapterOnlyWithLocalizedAbbreviation() {
         let version = createBibleVersion(id: 111, abbreviation: "NIV", localizedAbbreviation: "NVI")
-        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1)
+        let reference = BibleReference(versionId: 111, bookId: "GEN", chapter: 1)
         
         let url = version.shareUrl(reference: reference)
         
@@ -112,7 +112,7 @@ import Testing
     
     @Test func testShareUrl_ChapterOnlyNoAbbreviation() {
         let version = createBibleVersion(id: 999)
-        let reference = BibleReference(versionId: 999, bookUSFM: "PSA", chapter: 23)
+        let reference = BibleReference(versionId: 999, bookId: "PSA", chapter: 23)
         
         let url = version.shareUrl(reference: reference)
         
@@ -126,7 +126,7 @@ import Testing
         let version2 = createBibleVersion(id: 111, abbreviation: "NIV")
         let version3 = createBibleVersion(id: 999, abbreviation: "ESV")
         
-        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 111, bookId: "GEN", chapter: 1, verse: 1)
         
         let url1 = version1.shareUrl(reference: reference)
         let url2 = version2.shareUrl(reference: reference)
@@ -137,15 +137,15 @@ import Testing
         #expect(url3?.absoluteString == "https://www.bible.com/bible/999/GEN.1.1.ESV")
     }
     
-    // MARK: - Book USFM Tests
+    // MARK: - Book ID Tests
     
-    @Test func testShareUrl_DifferentBookUSFMs() {
+    @Test func testShareUrl_DifferentBookIds() {
         let version = createBibleVersion(id: 111, abbreviation: "NIV")
         
-        let ref1 = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verse: 1)
-        let ref2 = BibleReference(versionId: 111, bookUSFM: "EXO", chapter: 2, verse: 3)
-        let ref3 = BibleReference(versionId: 111, bookUSFM: "PSA", chapter: 23, verse: 1)
-        let ref4 = BibleReference(versionId: 111, bookUSFM: "1SA", chapter: 3, verse: 10)
+        let ref1 = BibleReference(versionId: 111, bookId: "GEN", chapter: 1, verse: 1)
+        let ref2 = BibleReference(versionId: 111, bookId: "EXO", chapter: 2, verse: 3)
+        let ref3 = BibleReference(versionId: 111, bookId: "PSA", chapter: 23, verse: 1)
+        let ref4 = BibleReference(versionId: 111, bookId: "1SA", chapter: 3, verse: 10)
         
         let url1 = version.shareUrl(reference: ref1)
         let url2 = version.shareUrl(reference: ref2)
@@ -162,7 +162,7 @@ import Testing
     
     @Test func testShareUrl_DifferentChapterNumbers() {
         let version = createBibleVersion(id: 111, abbreviation: "NIV")
-        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 50, verse: 20)
+        let reference = BibleReference(versionId: 111, bookId: "GEN", chapter: 50, verse: 20)
         
         let url = version.shareUrl(reference: reference)
         
@@ -179,7 +179,7 @@ import Testing
         // Create a reference with verseStart nil but verseEnd not nil
         // This would require creating a BibleReference directly with these values
         // Since the initializers don't allow this, we'll test the logic path
-        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1)
+        let reference = BibleReference(versionId: 111, bookId: "GEN", chapter: 1)
         
         let url = version.shareUrl(reference: reference)
         
@@ -188,7 +188,7 @@ import Testing
     
     @Test func testShareUrl_LargeVerseNumbers() {
         let version = createBibleVersion(id: 111, abbreviation: "NIV")
-        let reference = BibleReference(versionId: 111, bookUSFM: "PSA", chapter: 119, verse: 176)
+        let reference = BibleReference(versionId: 111, bookId: "PSA", chapter: 119, verse: 176)
         
         let url = version.shareUrl(reference: reference)
         
@@ -197,7 +197,7 @@ import Testing
     
     @Test func testShareUrl_LargeVerseRange() {
         let version = createBibleVersion(id: 111, abbreviation: "NIV")
-        let reference = BibleReference(versionId: 111, bookUSFM: "PSA", chapter: 119, verseStart: 1, verseEnd: 176)
+        let reference = BibleReference(versionId: 111, bookId: "PSA", chapter: 119, verseStart: 1, verseEnd: 176)
         
         let url = version.shareUrl(reference: reference)
         
@@ -206,7 +206,7 @@ import Testing
     
     @Test func testShareUrl_EmptyAbbreviation() {
         let version = createBibleVersion(id: 111, abbreviation: "")
-        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 111, bookId: "GEN", chapter: 1, verse: 1)
         
         let url = version.shareUrl(reference: reference)
         
@@ -215,7 +215,7 @@ import Testing
     
     @Test func testShareUrl_EmptyLocalizedAbbreviation() {
         let version = createBibleVersion(id: 111, abbreviation: "NIV", localizedAbbreviation: "")
-        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 111, bookId: "GEN", chapter: 1, verse: 1)
         
         let url = version.shareUrl(reference: reference)
         
@@ -226,7 +226,7 @@ import Testing
     
     @Test func testShareUrl_ReturnsValidURL() {
         let version = createBibleVersion(id: 111, abbreviation: "NIV")
-        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let reference = BibleReference(versionId: 111, bookId: "GEN", chapter: 1, verse: 1)
         
         let url = version.shareUrl(reference: reference)
         
@@ -240,13 +240,13 @@ import Testing
         let version = createBibleVersion(id: 111, abbreviation: "NIV", localizedAbbreviation: "NVI")
         
         let scenarios: [BibleReference] = [
-            BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1),
-            BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verse: 1),
-            BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 5),
-            BibleReference(versionId: 111, bookUSFM: "PSA", chapter: 23, verse: 1),
-            BibleReference(versionId: 111, bookUSFM: "PSA", chapter: 23, verseStart: 1, verseEnd: 6),
-            BibleReference(versionId: 111, bookUSFM: "1SA", chapter: 3, verse: 10),
-            BibleReference(versionId: 111, bookUSFM: "1SA", chapter: 3, verseStart: 10, verseEnd: 15)
+            BibleReference(versionId: 111, bookId: "GEN", chapter: 1),
+            BibleReference(versionId: 111, bookId: "GEN", chapter: 1, verse: 1),
+            BibleReference(versionId: 111, bookId: "GEN", chapter: 1, verseStart: 1, verseEnd: 5),
+            BibleReference(versionId: 111, bookId: "PSA", chapter: 23, verse: 1),
+            BibleReference(versionId: 111, bookId: "PSA", chapter: 23, verseStart: 1, verseEnd: 6),
+            BibleReference(versionId: 111, bookId: "1SA", chapter: 3, verse: 10),
+            BibleReference(versionId: 111, bookId: "1SA", chapter: 3, verseStart: 10, verseEnd: 15)
         ]
         
         for reference in scenarios {


### PR DESCRIPTION
## Summary
- Renames the esoteric (and imprecisely used) `usfm`/`USFM` vocabulary to `passageId`/`bookId` across the SDK's public surface and internals.
- Source-compatible: every renamed public symbol keeps a `@available(*, deprecated, renamed:)` forwarder. `BibleReference`'s `CodingKeys` are made explicit so the JSON wire format (`"bookUSFM"`, etc.) is preserved.
- Sweeps tests, `Examples/SampleApp`, and `README.md` to use the new names.

### Public-API renames (with deprecated forwarders kept)
- `BibleReference.bookUSFM` → `bookId` (stored)
- `BibleReference.init(versionId:bookUSFM:chapter:verse:)` → `…:bookId:…`
- `BibleReference.init(versionId:bookUSFM:chapter:verseStart:verseEnd:)` → `…:bookId:…`
- `BibleReference.asUSFM` → `passageId`
- `BibleReference.chapterUSFM` → `chapterPassageId`
- `BibleVersion.bookUSFMs` → `bookIds`

### Internal renames
- `BibleContentStorage.chapter(versionId:usfm:)` → `(versionId:passageId:)`
- Internal locals/params (`bookUSFM`, `usfm`, `chapterUSFM`, `asUSFM`, `subUSFMs`, `StateIn.bookUSFM`, `StateUp.bookUSFM`, etc.) updated to match the new vocabulary throughout `ChapterRepository`, `HighlightsCache`, `HighlightsRepository`, `HighlightsViewModel`, `URLBuilder`, `BibleVersionRendering`, `BibleAttributedString`, `BibleCardView`, `BibleTextView`, `BibleVersion+Additions`, and the Reader view models / header / intro views.

## Test plan
- [x] `swift build` — clean
- [x] `swift test` — 365 tests passing
- [x] `scripts/check-api-stability.sh check` — PASSED (additive only; no breaking changes)
- [x] `swiftlint --strict` — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames Bible reference terminology across the SDK. The main changes are:

- Public `BibleReference` APIs now use `bookId`, `passageId`, and `chapterPassageId`.
- Deprecated forwarders preserve source compatibility for the old `bookUSFM`, `asUSFM`, and `chapterUSFM` names.
- `BibleReference` keeps the existing `bookUSFM` JSON wire key through explicit coding keys.
- Reader, UI, cache, highlight, sample app, README, and test code were updated to the new names.

<h3>Confidence Score: 5/5</h3>

The rename is source-compatible and preserves the existing JSON wire format.

The changes are broad but mechanical, with deprecated forwarders retained and the reported validation covering build, tests, API stability, and linting.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted a swift build from detached worktrees for the requested commits, but the build exited with code 127 before any Swift code could run.
- The before/after artifacts captured the exact commands, commits, and selected test files, and confirmed the blocker Exit code 127 (Swift binary not found).
- The docs-sample before/after evidence shows USFM/bookId counts and confirms the build blocker due to the Swift executable not being found.

<a href="https://app.greptile.com/trex/runs/12463677/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into bdm/rename-usfm..."](https://github.com/youversion/platform-sdk-swift/commit/21be645399178966e32975dfd385ac1f3f855dd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32385136)</sub>

<!-- /greptile_comment -->