### PR TITLE
fix(ci): make commit-lint dry-run actually compute the next version (YPE-2398 follow-up)

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -73,7 +73,14 @@ jobs:
           # CI checkout (see plugin-filter step below); the version in the
           # repo is untouched, so real releases on `main` still ship with
           # the full plugin list.
-          git checkout -B "$HEAD_REF" "origin/$HEAD_REF"
+          # Fork PRs don't have their head branch on `origin` (origin is the
+          # base repo), so the first attempt silently fails on fork-originated
+          # PRs. The HEAD fallback reattaches to the merge ref still under our
+          # feet, which is enough for env-ci's git fallback to report a real
+          # symbolic ref. Non-fork PRs hit the first form and never reach the
+          # fallback.
+          git checkout -B "$HEAD_REF" "origin/$HEAD_REF" 2>/dev/null \
+            || git checkout -B "$HEAD_REF" HEAD
 
           # Capture the current released version up-front so we can always
           # report a "calculated version" — even when semantic-release
@@ -166,7 +173,7 @@ jobs:
                 echo
               fi
               if [ "${NO_BUMP:-0}" = "1" ]; then
-                echo "### 📦 Release preview: \`v$CURRENT\` → \`v$NEXT\` (no bump)"
+                echo "### 📦 Release preview: \`v$CURRENT\` (no bump)"
                 echo
                 echo 'These commits do not trigger a version bump. The published version on `main` would remain `v'"$CURRENT"'`.'
               elif [ "${IS_MAJOR:-0}" = "1" ]; then

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -78,8 +78,20 @@ jobs:
           # determines no bump is warranted, the answer is "current stays".
           CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
 
+          # Override the plugin list for the dry-run only. The repo's
+          # `.releaserc.json` includes `@semantic-release/git` and
+          # `@semantic-release/github`, whose `verifyConditions` steps run
+          # even in dry-run and try to verify push/API permissions against
+          # the repo. On a PR event the GITHUB_TOKEN doesn't have
+          # `contents: write` (and shouldn't), so the git plugin's
+          # `git push --dry-run` fails noisily with a 403 and trips
+          # EGITNOPERMISSION. For a version preview we only need the
+          # analyzer + notes generator. The actual release on `main` still
+          # uses the full plugin list from the config file unchanged.
           unset GITHUB_ACTIONS
-          npx semantic-release --dry-run --no-ci --branches "$HEAD_REF" > semrel.log 2>&1
+          npx semantic-release --dry-run --no-ci --branches "$HEAD_REF" \
+            --plugins '@semantic-release/commit-analyzer' '@semantic-release/release-notes-generator' \
+            > semrel.log 2>&1
           STATUS=$?
           cat semrel.log
 

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -83,8 +83,16 @@ jobs:
           CURRENT=$(jq -r .current preview.json)
           NEXT=$(jq -r .next preview.json)
           RELEASE_TYPE=$(jq -r .release_type preview.json)
-          IS_MAJOR=$(jq -r .is_major preview.json)
-          if [ "$RELEASE_TYPE" = "null" ]; then NO_BUMP=1; else NO_BUMP=0; fi
+          # Derive NO_BUMP / IS_MAJOR from RELEASE_TYPE rather than reading
+          # the script's `is_major` JSON field. `jq -r .is_major` would
+          # stringify the boolean as "true"/"false", but the comment-body
+          # step compares against "1"/"0" — depending on jq's output
+          # format here is a footgun. RELEASE_TYPE is canonical.
+          case "$RELEASE_TYPE" in
+            null)  NO_BUMP=1; IS_MAJOR=0 ;;
+            major) NO_BUMP=0; IS_MAJOR=1 ;;
+            *)     NO_BUMP=0; IS_MAJOR=0 ;;
+          esac
 
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -42,110 +42,55 @@ jobs:
           echo "status=$STATUS" >> "$GITHUB_OUTPUT"
           exit 0
 
-      - name: Semantic-release dry-run
-        id: semrel
+      - name: Compute release preview
+        id: preview
         if: steps.commitlint.outputs.status == '0'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          set +e
-          # Canonical workaround for running semantic-release --dry-run on a
-          # PR (see semantic-release discussions #1886 and #1937):
+          set -e
+          # Direct call to `@semantic-release/commit-analyzer` via
+          # scripts/preview-release.mjs. Skips the full
+          # `semantic-release --dry-run` lifecycle entirely.
           #
-          #   1. Reset HEAD to `origin/$HEAD_REF` (the actual PR head commit,
-          #      not the synthetic merge ref actions/checkout leaves us on).
-          #      This both gives env-ci a real symbolic ref to report (instead
-          #      of `undefined` on detached HEAD) AND keeps local == remote so
-          #      semantic-release's "local branch is behind remote" check
-          #      passes.
-          #   2. Unset GITHUB_ACTIONS. env-ci uses that flag to decide it's
-          #      on GitHub Actions and to report the branch as
-          #      `refs/pull/N/merge`. With it gone, env-ci falls back to git,
-          #      which now reports the head-ref branch.
-          #   3. Override the branches allowlist with just that head branch
-          #      — a single entry, well under semantic-release's
-          #      max-3-release-branches validation.
-          #   4. --no-ci skips the refuse-on-PR check that runs even after
-          #      branch detection passes.
+          # Why this exists: the previous dry-run approach silently
+          # failed on PR events because semantic-release's core
+          # `verifyAuth` step runs `git push --dry-run` to test push
+          # permission — and the `pull_request`-event `GITHUB_TOKEN`
+          # has `contents: read` only. That auth check aborts the
+          # whole lifecycle BEFORE `analyzeCommits` runs, producing a
+          # silent false-negative "no bump" preview (the exact
+          # fail-open class that hid the major bump on the squash of
+          # PR #117). `--no-ci` skips the CI env check, not the auth
+          # verification — there is no flag to disable it.
           #
-          # The committed `.releaserc.json` is rewritten in this throwaway
-          # CI checkout (see plugin-filter step below); the version in the
-          # repo is untouched, so real releases on `main` still ship with
-          # the full plugin list.
-          # Fork PRs don't have their head branch on `origin` (origin is the
-          # base repo), so the first attempt silently fails on fork-originated
-          # PRs. The HEAD fallback reattaches to the merge ref still under our
-          # feet, which is enough for env-ci's git fallback to report a real
-          # symbolic ref. Non-fork PRs hit the first form and never reach the
-          # fallback.
-          git checkout -B "$HEAD_REF" "origin/$HEAD_REF" 2>/dev/null \
-            || git checkout -B "$HEAD_REF" HEAD
+          # The analyzer module has no auth concerns, no env-ci, no
+          # branch-detection, no `verifyConditions`. Given a list of
+          # commits and the same plugin config production uses on
+          # `main` (read from `.releaserc.json`), it deterministically
+          # returns the release type.
+          #
+          # If the analyzer errors, this step fails (set -e). That is
+          # intentional: a broken preview should be loud, not silent.
+          node scripts/preview-release.mjs \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            > preview.json 2> analyzer.log
+          cat analyzer.log
+          cat preview.json
 
-          # Capture the current released version up-front so we can always
-          # report a "calculated version" — even when semantic-release
-          # determines no bump is warranted, the answer is "current stays".
-          CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+          CURRENT=$(jq -r .current preview.json)
+          NEXT=$(jq -r .next preview.json)
+          RELEASE_TYPE=$(jq -r .release_type preview.json)
+          IS_MAJOR=$(jq -r .is_major preview.json)
+          if [ "$RELEASE_TYPE" = "null" ]; then NO_BUMP=1; else NO_BUMP=0; fi
 
-          # Filter `.releaserc.json` in place to only the analysis plugins
-          # (commit-analyzer + release-notes-generator), preserving their
-          # inline configs — `preset: conventionalcommits` stays intact, so
-          # the preview uses the exact same semver-inference rules as the
-          # real release on `main`. The other plugins (git, github,
-          # changelog, exec) run `verifyConditions` even in --dry-run, and
-          # `@semantic-release/git` fails noisily with EGITNOPERMISSION
-          # because PR-event GITHUB_TOKEN lacks `contents: write`. Dropping
-          # them removes the noise without affecting version calculation.
-          # CI working tree is throwaway, so the in-place rewrite is safe.
-          node - <<'NODE'
-          const fs = require('fs');
-          const path = '.releaserc.json';
-          const cfg = JSON.parse(fs.readFileSync(path, 'utf8'));
-          const keep = new Set([
-            '@semantic-release/commit-analyzer',
-            '@semantic-release/release-notes-generator',
-          ]);
-          cfg.plugins = cfg.plugins.filter(p => keep.has(Array.isArray(p) ? p[0] : p));
-          fs.writeFileSync(path, JSON.stringify(cfg, null, 2));
-          NODE
-
-          unset GITHUB_ACTIONS
-          npx semantic-release --dry-run --no-ci --branches "$HEAD_REF" > semrel.log 2>&1
-          STATUS=$?
-          cat semrel.log
-
-          NEXT=$(grep -Eo "The next release version is [0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?" semrel.log | tail -1 | awk '{print $NF}')
-          # Extract semantic-release's calculated release type from its own
-          # "Analysis of N commit(s) complete: <type> release" log line.
-          RELEASE_TYPE=$(grep -Eo "Analysis of [0-9]+ commits?, complete: [a-z]+ release|complete:[[:space:]]*[a-z]+[[:space:]]+release" semrel.log \
-            | tail -1 \
-            | awk '{for(i=1;i<=NF;i++) if($i=="release") print $(i-1)}')
-
-          # When semantic-release decides no bump, NEXT is empty. The
-          # "calculated version" in that case is simply the current version
-          # — surface that explicitly so the comment is never blank.
-          if [ -z "$NEXT" ]; then
-            NEXT="$CURRENT_VERSION"
-            NO_BUMP=1
-            [ -z "$RELEASE_TYPE" ] && RELEASE_TYPE="none"
-          else
-            NO_BUMP=0
-          fi
-
-          if [ "$RELEASE_TYPE" = "major" ]; then IS_MAJOR=1; else IS_MAJOR=0; fi
-
-          # Pull any explicit BREAKING CHANGE footer text for the comment.
-          # `feat!:` commits without a footer won't have notes here, and
-          # that's fine — the banner is gated on IS_MAJOR.
-          awk '/BREAKING CHANGE:/{flag=1} flag{print; if(/^$/) flag=0}' semrel.log > breaking.txt || true
-
-          echo "current=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
           echo "release_type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
-          echo "no_bump=$NO_BUMP" >> "$GITHUB_OUTPUT"
           echo "is_major=$IS_MAJOR" >> "$GITHUB_OUTPUT"
-          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
-          exit 0
+          echo "no_bump=$NO_BUMP" >> "$GITHUB_OUTPUT"
 
       - name: Build PR comment body
         id: body
@@ -154,12 +99,11 @@ jobs:
           set -e
           MARKER='<!-- commit-lint-bot -->'
           STATUS="${{ steps.commitlint.outputs.status }}"
-          CURRENT="${{ steps.semrel.outputs.current }}"
-          NEXT="${{ steps.semrel.outputs.next }}"
-          RELEASE_TYPE="${{ steps.semrel.outputs.release_type }}"
-          NO_BUMP="${{ steps.semrel.outputs.no_bump }}"
-          IS_MAJOR="${{ steps.semrel.outputs.is_major }}"
-          SEMREL_STATUS="${{ steps.semrel.outputs.status }}"
+          CURRENT="${{ steps.preview.outputs.current }}"
+          NEXT="${{ steps.preview.outputs.next }}"
+          RELEASE_TYPE="${{ steps.preview.outputs.release_type }}"
+          NO_BUMP="${{ steps.preview.outputs.no_bump }}"
+          IS_MAJOR="${{ steps.preview.outputs.is_major }}"
 
           {
             echo "$MARKER"
@@ -168,39 +112,25 @@ jobs:
               echo
               echo 'All commit messages in this PR conform to [Conventional Commits](https://www.conventionalcommits.org/).'
               echo
-              if [ "$SEMREL_STATUS" != "0" ]; then
-                echo '> ⚠️ `semantic-release --dry-run` exited non-zero. Release preview may be incomplete. This does not block the PR.'
-                echo
-              fi
               if [ "${NO_BUMP:-0}" = "1" ]; then
                 echo "### 📦 Release preview: \`v$CURRENT\` (no bump)"
                 echo
                 echo 'These commits do not trigger a version bump. The published version on `main` would remain `v'"$CURRENT"'`.'
               elif [ "${IS_MAJOR:-0}" = "1" ]; then
-                echo "### 🚨🚨🚨 BREAKING CHANGES DETECTED — \`v$CURRENT\` → \`v$NEXT\` (MAJOR)"
+                echo "### 🚨🚨🚨 Major version bump detected — \`v$CURRENT\` → \`v$NEXT\` (MAJOR)"
                 echo
-                echo 'This PR introduces one or more breaking changes (either a `BREAKING CHANGE:` footer or a `feat!:` / `fix!:` shorthand). Merging will publish a **major** version bump.'
-                echo
-                if [ -s breaking.txt ]; then
-                  echo '<details><summary>Breaking change notes</summary>'
-                  echo
-                  echo '```'
-                  head -c 4000 breaking.txt
-                  echo
-                  echo '```'
-                  echo '</details>'
-                fi
+                echo 'The analyzer classified one or more commits as a major bump (a footer at start-of-line with the breaking-change token, or a `feat!:` / `fix!:` shorthand). If this is intentional, proceed. If this is prose accidentally tripping the parser, reword the offending commit body before merging — see the analyzer log below to identify which commit triggered the classification.'
               else
                 BUMP_LABEL="${RELEASE_TYPE:-release}"
                 echo "### 📦 Release preview: \`v$CURRENT\` → \`v$NEXT\` ($BUMP_LABEL)"
                 echo
-                echo 'Merging this PR will trigger a new release on `main`.'
+                echo 'Merging this PR will, on the next manual release dispatch, ship as the version above.'
               fi
               echo
-              echo '<details><summary>semantic-release dry-run output</summary>'
+              echo '<details><summary>Release analyzer output</summary>'
               echo
               echo '```'
-              tail -c 6000 semrel.log 2>/dev/null || true
+              tail -c 6000 analyzer.log 2>/dev/null || true
               echo
               echo '```'
               echo '</details>'

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -69,8 +69,10 @@ jobs:
           #   4. --no-ci skips the refuse-on-PR check that runs even after
           #      branch detection passes.
           #
-          # The file config (`.releaserc.json`) is untouched, so real releases
-          # still only ship from `main`.
+          # The committed `.releaserc.json` is rewritten in this throwaway
+          # CI checkout (see plugin-filter step below); the version in the
+          # repo is untouched, so real releases on `main` still ship with
+          # the full plugin list.
           git checkout -B "$HEAD_REF" "origin/$HEAD_REF"
 
           # Capture the current released version up-front so we can always
@@ -78,20 +80,30 @@ jobs:
           # determines no bump is warranted, the answer is "current stays".
           CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
 
-          # Override the plugin list for the dry-run only. The repo's
-          # `.releaserc.json` includes `@semantic-release/git` and
-          # `@semantic-release/github`, whose `verifyConditions` steps run
-          # even in dry-run and try to verify push/API permissions against
-          # the repo. On a PR event the GITHUB_TOKEN doesn't have
-          # `contents: write` (and shouldn't), so the git plugin's
-          # `git push --dry-run` fails noisily with a 403 and trips
-          # EGITNOPERMISSION. For a version preview we only need the
-          # analyzer + notes generator. The actual release on `main` still
-          # uses the full plugin list from the config file unchanged.
+          # Filter `.releaserc.json` in place to only the analysis plugins
+          # (commit-analyzer + release-notes-generator), preserving their
+          # inline configs — `preset: conventionalcommits` stays intact, so
+          # the preview uses the exact same semver-inference rules as the
+          # real release on `main`. The other plugins (git, github,
+          # changelog, exec) run `verifyConditions` even in --dry-run, and
+          # `@semantic-release/git` fails noisily with EGITNOPERMISSION
+          # because PR-event GITHUB_TOKEN lacks `contents: write`. Dropping
+          # them removes the noise without affecting version calculation.
+          # CI working tree is throwaway, so the in-place rewrite is safe.
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = '.releaserc.json';
+          const cfg = JSON.parse(fs.readFileSync(path, 'utf8'));
+          const keep = new Set([
+            '@semantic-release/commit-analyzer',
+            '@semantic-release/release-notes-generator',
+          ]);
+          cfg.plugins = cfg.plugins.filter(p => keep.has(Array.isArray(p) ? p[0] : p));
+          fs.writeFileSync(path, JSON.stringify(cfg, null, 2));
+          NODE
+
           unset GITHUB_ACTIONS
-          npx semantic-release --dry-run --no-ci --branches "$HEAD_REF" \
-            --plugins '@semantic-release/commit-analyzer' '@semantic-release/release-notes-generator' \
-            > semrel.log 2>&1
+          npx semantic-release --dry-run --no-ci --branches "$HEAD_REF" > semrel.log 2>&1
           STATUS=$?
           cat semrel.log
 

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -53,14 +53,16 @@ jobs:
           # Canonical workaround for running semantic-release --dry-run on a
           # PR (see semantic-release discussions #1886 and #1937):
           #
-          #   1. Attach HEAD to a local branch named after the PR head ref.
-          #      actions/checkout leaves us in detached-HEAD state at the PR
-          #      merge commit; without a symbolic ref, env-ci's git-based
-          #      branch detection returns `undefined` and the analyzer bails.
+          #   1. Reset HEAD to `origin/$HEAD_REF` (the actual PR head commit,
+          #      not the synthetic merge ref actions/checkout leaves us on).
+          #      This both gives env-ci a real symbolic ref to report (instead
+          #      of `undefined` on detached HEAD) AND keeps local == remote so
+          #      semantic-release's "local branch is behind remote" check
+          #      passes.
           #   2. Unset GITHUB_ACTIONS. env-ci uses that flag to decide it's
           #      on GitHub Actions and to report the branch as
           #      `refs/pull/N/merge`. With it gone, env-ci falls back to git,
-          #      which now reports the head-ref branch we just created.
+          #      which now reports the head-ref branch.
           #   3. Override the branches allowlist with just that head branch
           #      — a single entry, well under semantic-release's
           #      max-3-release-branches validation.
@@ -69,26 +71,47 @@ jobs:
           #
           # The file config (`.releaserc.json`) is untouched, so real releases
           # still only ship from `main`.
-          git checkout -B "$HEAD_REF" HEAD
+          git checkout -B "$HEAD_REF" "origin/$HEAD_REF"
+
+          # Capture the current released version up-front so we can always
+          # report a "calculated version" — even when semantic-release
+          # determines no bump is warranted, the answer is "current stays".
+          CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+
           unset GITHUB_ACTIONS
           npx semantic-release --dry-run --no-ci --branches "$HEAD_REF" > semrel.log 2>&1
           STATUS=$?
           cat semrel.log
+
           NEXT=$(grep -Eo "The next release version is [0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?" semrel.log | tail -1 | awk '{print $NF}')
-          [ -z "$NEXT" ] && NEXT="none"
-          # Detect "major" via semantic-release's own release-type log line.
-          # This catches both `BREAKING CHANGE:` footers AND the `feat!:` /
-          # `fix!:` shorthand, which doesn't emit the footer keyword.
-          if grep -qiE "complete:[[:space:]]*major[[:space:]]+release|release type[[:space:]]+is[[:space:]]+major" semrel.log; then
-            IS_MAJOR=1
+          # Extract semantic-release's calculated release type from its own
+          # "Analysis of N commit(s) complete: <type> release" log line.
+          RELEASE_TYPE=$(grep -Eo "Analysis of [0-9]+ commits?, complete: [a-z]+ release|complete:[[:space:]]*[a-z]+[[:space:]]+release" semrel.log \
+            | tail -1 \
+            | awk '{for(i=1;i<=NF;i++) if($i=="release") print $(i-1)}')
+
+          # When semantic-release decides no bump, NEXT is empty. The
+          # "calculated version" in that case is simply the current version
+          # — surface that explicitly so the comment is never blank.
+          if [ -z "$NEXT" ]; then
+            NEXT="$CURRENT_VERSION"
+            NO_BUMP=1
+            [ -z "$RELEASE_TYPE" ] && RELEASE_TYPE="none"
           else
-            IS_MAJOR=0
+            NO_BUMP=0
           fi
-          # Best-effort: pull any explicit BREAKING CHANGE footer text for the comment.
-          # `feat!:` commits without a footer won't have notes here, and that's fine —
-          # the banner is gated on IS_MAJOR, not on the presence of footer text.
+
+          if [ "$RELEASE_TYPE" = "major" ]; then IS_MAJOR=1; else IS_MAJOR=0; fi
+
+          # Pull any explicit BREAKING CHANGE footer text for the comment.
+          # `feat!:` commits without a footer won't have notes here, and
+          # that's fine — the banner is gated on IS_MAJOR.
           awk '/BREAKING CHANGE:/{flag=1} flag{print; if(/^$/) flag=0}' semrel.log > breaking.txt || true
+
+          echo "current=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "release_type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
+          echo "no_bump=$NO_BUMP" >> "$GITHUB_OUTPUT"
           echo "is_major=$IS_MAJOR" >> "$GITHUB_OUTPUT"
           echo "status=$STATUS" >> "$GITHUB_OUTPUT"
           exit 0
@@ -100,7 +123,10 @@ jobs:
           set -e
           MARKER='<!-- commit-lint-bot -->'
           STATUS="${{ steps.commitlint.outputs.status }}"
+          CURRENT="${{ steps.semrel.outputs.current }}"
           NEXT="${{ steps.semrel.outputs.next }}"
+          RELEASE_TYPE="${{ steps.semrel.outputs.release_type }}"
+          NO_BUMP="${{ steps.semrel.outputs.no_bump }}"
           IS_MAJOR="${{ steps.semrel.outputs.is_major }}"
           SEMREL_STATUS="${{ steps.semrel.outputs.status }}"
 
@@ -115,12 +141,12 @@ jobs:
                 echo '> ⚠️ `semantic-release --dry-run` exited non-zero. Release preview may be incomplete. This does not block the PR.'
                 echo
               fi
-              if [ -z "$NEXT" ] || [ "$NEXT" = "none" ]; then
-                echo '### 📦 Release preview: _no release_'
+              if [ "${NO_BUMP:-0}" = "1" ]; then
+                echo "### 📦 Release preview: \`v$CURRENT\` → \`v$NEXT\` (no bump)"
                 echo
-                echo 'These commits would not trigger a new release on `main`.'
+                echo 'These commits do not trigger a version bump. The published version on `main` would remain `v'"$CURRENT"'`.'
               elif [ "${IS_MAJOR:-0}" = "1" ]; then
-                echo "### 🚨🚨🚨 BREAKING CHANGES DETECTED — Next release: \`v$NEXT\` (MAJOR)"
+                echo "### 🚨🚨🚨 BREAKING CHANGES DETECTED — \`v$CURRENT\` → \`v$NEXT\` (MAJOR)"
                 echo
                 echo 'This PR introduces one or more breaking changes (either a `BREAKING CHANGE:` footer or a `feat!:` / `fix!:` shorthand). Merging will publish a **major** version bump.'
                 echo
@@ -134,7 +160,8 @@ jobs:
                   echo '</details>'
                 fi
               else
-                echo "### 📦 Release preview: \`v$NEXT\`"
+                BUMP_LABEL="${RELEASE_TYPE:-release}"
+                echo "### 📦 Release preview: \`v$CURRENT\` → \`v$NEXT\` ($BUMP_LABEL)"
                 echo
                 echo 'Merging this PR will trigger a new release on `main`.'
               fi

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -53,19 +53,23 @@ jobs:
           # Canonical workaround for running semantic-release --dry-run on a
           # PR (see semantic-release discussions #1886 and #1937):
           #
-          #   1. Unset GITHUB_ACTIONS. env-ci uses that flag to decide it's on
-          #      GitHub Actions and to report the branch as `refs/pull/N/merge`.
-          #      With it gone, env-ci falls back to git-based branch detection
-          #      and sees us on the PR head branch.
-          #   2. Override the branches allowlist with just that head branch.
-          #      A single entry keeps us well under semantic-release's
+          #   1. Attach HEAD to a local branch named after the PR head ref.
+          #      actions/checkout leaves us in detached-HEAD state at the PR
+          #      merge commit; without a symbolic ref, env-ci's git-based
+          #      branch detection returns `undefined` and the analyzer bails.
+          #   2. Unset GITHUB_ACTIONS. env-ci uses that flag to decide it's
+          #      on GitHub Actions and to report the branch as
+          #      `refs/pull/N/merge`. With it gone, env-ci falls back to git,
+          #      which now reports the head-ref branch we just created.
+          #   3. Override the branches allowlist with just that head branch
+          #      — a single entry, well under semantic-release's
           #      max-3-release-branches validation.
-          #   3. --no-ci skips the refuse-on-PR check that runs even after
+          #   4. --no-ci skips the refuse-on-PR check that runs even after
           #      branch detection passes.
           #
           # The file config (`.releaserc.json`) is untouched, so real releases
-          # still only ship from `main`. actions/checkout uses the merge ref
-          # by default, which is what we want analyzed.
+          # still only ship from `main`.
+          git checkout -B "$HEAD_REF" HEAD
           unset GITHUB_ACTIONS
           npx semantic-release --dry-run --no-ci --branches "$HEAD_REF" > semrel.log 2>&1
           STATUS=$?

--- a/scripts/preview-release.mjs
+++ b/scripts/preview-release.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// Compute the release type and next version for a PR by calling
+// `@semantic-release/commit-analyzer` directly. Avoids the full
+// `semantic-release --dry-run` lifecycle, which on a `pull_request` event
+// fails at the core `verifyAuth()` step (`git push --dry-run`) because the
+// PR-event `GITHUB_TOKEN` has `contents: read` only. That failure aborts
+// before the analyzer runs and produces a silent false-negative "no bump"
+// preview — the same fail-open class that hid the major bump on the squash
+// of PR #117.
+//
+// Output (stdout): one line of JSON:
+//   { current, next, release_type, is_major, commit_count }
+// `release_type` is one of `"major" | "minor" | "patch" | null`.
+//
+// Usage:
+//   node scripts/preview-release.mjs --base <sha> --head <sha>
+
+import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { format } from "node:util";
+import semver from "semver";
+import { analyzeCommits } from "@semantic-release/commit-analyzer";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i]?.replace(/^--/, "");
+    if (!key) continue;
+    out[key] = argv[i + 1];
+  }
+  return out;
+}
+
+// Read the same plugin config that production uses on `main`, so the
+// preview applies identical semver-inference rules (preset, releaseRules,
+// parserOpts, etc.). If the config shape ever changes, the preview tracks
+// it automatically.
+function readCommitAnalyzerConfig() {
+  const releasercPath = resolve(REPO_ROOT, ".releaserc.json");
+  const releaserc = JSON.parse(readFileSync(releasercPath, "utf8"));
+  const entry = releaserc.plugins.find(
+    (p) => (Array.isArray(p) ? p[0] : p) === "@semantic-release/commit-analyzer"
+  );
+  if (!entry) {
+    throw new Error(
+      `@semantic-release/commit-analyzer not configured in ${releasercPath}`
+    );
+  }
+  return Array.isArray(entry) ? entry[1] : {};
+}
+
+// Collect commits in `base..head` as `{hash, message}` records. Use ASCII
+// US (0x1f) between fields and RS (0x1e) between records so commit bodies
+// with arbitrary whitespace, quotes, and Unicode can't break parsing.
+function getCommits(base, head) {
+  const fmt = "%H%x1f%B%x1e";
+  const out = execSync(`git log --reverse --format=${JSON.stringify(fmt)} ${base}..${head}`, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return out
+    .split("\x1e")
+    .map((rec) => rec.replace(/^\n+/, ""))
+    .filter(Boolean)
+    .map((rec) => {
+      const [hash, message] = rec.split("\x1f");
+      return { hash: (hash ?? "").trim(), message: (message ?? "").trim() };
+    });
+}
+
+function getCurrentVersion() {
+  try {
+    return execSync("git describe --tags --abbrev=0", {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return "0.0.0";
+  }
+}
+
+// commit-analyzer expects a signale-shaped logger and calls methods with
+// printf-style format strings (e.g. `log("Analyzing commit: %s", msg)`).
+// Route everything through util.format so the substitutions actually
+// happen, and to stderr so stdout stays clean for the JSON payload.
+const logger = {
+  log: (...a) => console.error("[analyzer]", format(...a)),
+  info: (...a) => console.error("[analyzer]", format(...a)),
+  warn: (...a) => console.error("[analyzer]", format(...a)),
+  error: (...a) => console.error("[analyzer]", format(...a)),
+  success: (...a) => console.error("[analyzer]", format(...a)),
+};
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.base || !args.head) {
+    console.error("Usage: preview-release.mjs --base <sha> --head <sha>");
+    process.exit(2);
+  }
+
+  const pluginConfig = readCommitAnalyzerConfig();
+  const commits = getCommits(args.base, args.head);
+  const current = getCurrentVersion();
+
+  const releaseType = await analyzeCommits(pluginConfig, {
+    commits,
+    logger,
+    cwd: REPO_ROOT,
+  });
+
+  const next = releaseType ? semver.inc(current, releaseType) : current;
+
+  process.stdout.write(
+    JSON.stringify({
+      current,
+      next,
+      release_type: releaseType,
+      is_major: releaseType === "major",
+      commit_count: commits.length,
+    }) + "\n"
+  );
+}
+
+main().catch((err) => {
+  console.error(err?.stack || String(err));
+  process.exit(1);
+});

--- a/scripts/preview-release.mjs
+++ b/scripts/preview-release.mjs
@@ -75,10 +75,15 @@ function getCommits(base, head) {
 
 function getCurrentVersion() {
   try {
-    return execSync("git describe --tags --abbrev=0", {
+    const tag = execSync("git describe --tags --abbrev=0", {
       cwd: REPO_ROOT,
       encoding: "utf8",
     }).trim();
+    // Strip leading `v` so the caller always gets a bare semver string
+    // (e.g. "1.2.3"). The workflow already prepends `v` in the display
+    // strings, and semver.inc() also returns without a prefix — keeping
+    // both in sync avoids a `vv1.2.3` double-prefix in PR comments.
+    return tag.replace(/^v/, "") || "0.0.0";
   } catch {
     return "0.0.0";
   }


### PR DESCRIPTION
## Summary

Follow-up to #117. The `Commit Lint` workflow that just merged still doesn't print a real release preview on PRs — it logs `triggered on the branch undefined ... won't be published`.

**Root cause:** the canonical `unset GITHUB_ACTIONS` workaround makes env-ci fall back to git for branch detection, but `actions/checkout@v4` leaves the runner in detached-HEAD state at the PR merge commit. With no symbolic ref, git reports the branch as `undefined`, semantic-release can't match that against `--branches "$HEAD_REF"`, and it bails.

**Fix:** one line — `git checkout -B "$HEAD_REF" HEAD` before invoking semantic-release. That attaches HEAD to a local branch named after the PR head ref, so env-ci's git fallback reports the real branch name, the allowlist matches, and the analyzer runs end-to-end.

`.releaserc.json` is still `["main"]`-only — production releases are unaffected.

Jira: [YPE-2398](https://lifechurch.atlassian.net/browse/YPE-2398)

## Test plan

- [ ] CI: `Commit Lint` workflow runs on this PR and the sticky comment shows an actual `### 📦 Release preview: \`vX.Y.Z\`` line (or `_no release_` if these commits don't bump anything — they're `fix(ci):` so should produce a patch preview).
- [ ] Verify `semrel.log` no longer contains `triggered on the branch undefined` or `refs/pull/N/merge`.

🤖 Generated with [Craft Agent](https://craft.do)

[YPE-2398]: https://lifechurch.atlassian.net/browse/YPE-2398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the flawed `semantic-release --dry-run` preview with a direct call to `@semantic-release/commit-analyzer` via a new `scripts/preview-release.mjs` script, eliminating the auth-check (`git push --dry-run`) that silently aborted before the analyzer ran on PR events.

- **`scripts/preview-release.mjs`** (new): fetches commits by SHA range with `git log base..head`, reads plugin config from `.releaserc.json`, calls `analyzeCommits` directly, strips the `v` prefix from the current tag (fixing the `vv1.2.3` double-prefix surfaced in the previous review), and emits a clean JSON payload to stdout with debug output on stderr.
- **`commit-lint.yml`**: replaces the `semrel` step with a `preview` step that parses the JSON output; derives `IS_MAJOR` / `NO_BUMP` from the canonical string `RELEASE_TYPE` using a `case` statement (fixing the `\"true\"` vs `\"1\"` boolean mismatch flagged in review of #117); switches from `set+e; exit 0` to `set -e` so errors are loud rather than silently swallowed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a well-scoped CI improvement that makes the release preview reliable and fails loudly on errors.

Both previously identified issues (boolean true vs 1 for IS_MAJOR, and the vv1.2.3 double-prefix) are cleanly addressed. The new script routes only JSON to stdout, reads plugin config live from .releaserc.json, and uses set -e so any failure in the preview step surfaces as a visible CI failure rather than a silent wrong answer. No production release path is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/commit-lint.yml | Replaces the semantic-release dry-run step with a direct call to scripts/preview-release.mjs; uses a case statement to derive IS_MAJOR/NO_BUMP from the string release type (fixing the boolean-vs-1 mismatch from #117); sets set -e for loud failures; no new issues found. |
| scripts/preview-release.mjs | New script that calls @semantic-release/commit-analyzer directly with a SHA-range filtered commit list; strips leading v from the current tag to prevent the vv1.2.3 double-prefix; routes all debug output to stderr, JSON payload to stdout; no issues found. |

</details>

<sub>Reviews (9): Last reviewed commit: ["fix(ci): strip v prefix from current ver..."](https://github.com/youversion/platform-sdk-swift/commit/8320acd88ce21008ae8027561c9905f91f160dd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32664986)</sub>

<!-- /greptile_comment -->