### PR TITLE
test: add hasValidToken coverage

### DIFF
--- a/Tests/YouVersionPlatformCoreTests/YouVersionAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/YouVersionAPITests.swift
@@ -1,0 +1,116 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+@testable import YouVersionPlatformCore
+
+extension ConfigurationStateTests {
+    @Suite struct YouVersionAPITests {
+        @Test func hasValidTokenReturnsFalseWithoutStoredAuthData() async {
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+
+            let hasValidToken = await YouVersionAPI.hasValidToken()
+
+            #expect(hasValidToken == false)
+        }
+
+        @Test func hasValidTokenReturnsTrueForUnexpiredTokenWithoutRefreshing() async {
+            await YouVersionPlatformConfiguration.saveAuthData(
+                accessToken: "access-token",
+                refreshToken: "refresh-token",
+                idToken: "id-token",
+                expiryDate: Date(timeIntervalSinceNow: 3600)
+            )
+
+            let (session, token) = HTTPMocking.makeSession()
+            defer { HTTPMocking.clear(token: token) }
+
+            HTTPMocking.setHandler(token: token) { _ in
+                Issue.record("Expected hasValidToken not to refresh an unexpired token")
+                throw URLError(.badURL)
+            }
+
+            let hasValidToken = await YouVersionAPI.hasValidToken(session: session)
+
+            #expect(hasValidToken == true)
+            #expect(YouVersionPlatformConfiguration.authData?.accessToken == "access-token")
+
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+        }
+
+        @Test func hasValidTokenRefreshesExpiringTokenAndStoresResponse() async throws {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configure(appKey: "test-app")
+            await YouVersionPlatformConfiguration.saveAuthData(
+                accessToken: "old-access-token",
+                refreshToken: "old-refresh-token",
+                idToken: "id-token",
+                expiryDate: Date(timeIntervalSinceNow: 5)
+            )
+
+            let (session, token) = HTTPMocking.makeSession()
+            defer { HTTPMocking.clear(token: token) }
+
+            let responsePayload: [String: String] = [
+                "access_token": "new-access-token",
+                "expires_in": "7200",
+                "refresh_token": "new-refresh-token",
+                "scope": "ignored"
+            ]
+            let responseData = try JSONEncoder().encode(responsePayload)
+
+            HTTPMocking.setHandler(token: token) { request in
+                #expect(request.url?.path == "/auth/token")
+                #expect(request.httpMethod == "POST")
+                #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
+                let body = requestBodyString(request)
+                #expect(body.contains("grant_type=refresh_token"))
+                #expect(body.contains("client_id=test-app"))
+                #expect(body.contains("refresh_token=old-refresh-token"))
+
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (responseData, response)
+            }
+
+            let hasValidToken = await YouVersionAPI.hasValidToken(session: session)
+            let authData = YouVersionPlatformConfiguration.authData
+
+            #expect(hasValidToken == true)
+            #expect(authData?.accessToken == "new-access-token")
+            #expect(authData?.refreshToken == "new-refresh-token")
+            #expect(authData?.idToken == "id-token")
+            #expect((authData?.expiryDate?.timeIntervalSinceNow ?? 0) > 7100)
+
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+        }
+
+        @Test func hasValidTokenReturnsFalseWhenRefreshFails() async {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configure(appKey: "test-app")
+            await YouVersionPlatformConfiguration.saveAuthData(
+                accessToken: "old-access-token",
+                refreshToken: "old-refresh-token",
+                idToken: "id-token",
+                expiryDate: Date(timeIntervalSinceNow: 5)
+            )
+
+            let (session, token) = HTTPMocking.makeSession()
+            defer { HTTPMocking.clear(token: token) }
+
+            HTTPMocking.setHandler(token: token) { request in
+                let response = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+                return (Data(), response)
+            }
+
+            let hasValidToken = await YouVersionAPI.hasValidToken(session: session)
+
+            #expect(hasValidToken == false)
+            #expect(YouVersionPlatformConfiguration.authData?.accessToken == "old-access-token")
+
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+        }
+    }
+}

--- a/Tests/YouVersionPlatformCoreTests/YouVersionAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/YouVersionAPITests.swift
@@ -6,7 +6,7 @@ import Testing
 @testable import YouVersionPlatformCore
 
 extension ConfigurationStateTests {
-    @Suite struct YouVersionAPITests {
+    @Suite(.serialized) struct YouVersionAPITests {
         @Test func hasValidTokenReturnsFalseWithoutStoredAuthData() async {
             await YouVersionPlatformConfiguration.clearAuthTokens()
 
@@ -41,6 +41,14 @@ extension ConfigurationStateTests {
 
         @Test func hasValidTokenRefreshesExpiringTokenAndStoresResponse() async throws {
             let originalAppKey = YouVersionPlatformConfiguration.appKey
+            let responsePayload: [String: String] = [
+                "access_token": "new-access-token",
+                "expires_in": "7200",
+                "refresh_token": "new-refresh-token",
+                "scope": "ignored"
+            ]
+            let responseData = try JSONEncoder().encode(responsePayload)
+
             await YouVersionPlatformConfiguration.configure(appKey: "test-app")
             await YouVersionPlatformConfiguration.saveAuthData(
                 accessToken: "old-access-token",
@@ -51,14 +59,6 @@ extension ConfigurationStateTests {
 
             let (session, token) = HTTPMocking.makeSession()
             defer { HTTPMocking.clear(token: token) }
-
-            let responsePayload: [String: String] = [
-                "access_token": "new-access-token",
-                "expires_in": "7200",
-                "refresh_token": "new-refresh-token",
-                "scope": "ignored"
-            ]
-            let responseData = try JSONEncoder().encode(responsePayload)
 
             HTTPMocking.setHandler(token: token) { request in
                 #expect(request.url?.path == "/auth/token")


### PR DESCRIPTION
### Motivation
- Ensure `YouVersionAPI.hasValidToken()` behavior is covered for the key global-auth scenarios and that tests manipulate `YouVersionPlatformConfiguration` in a serialized context to avoid cross-test races.

### Description
- Add `Tests/YouVersionPlatformCoreTests/YouVersionAPITests.swift` under the existing `ConfigurationStateTests` serialized parent with tests for missing auth data, unexpired token (no refresh), expiring token (successful refresh and persisted storage), and failed refresh (returns false and leaves tokens unchanged).

### Testing
- Ran `swift test --filter YouVersionAPITests` and the new suite passed.
- Ran `swift test` and the full test run passed (all tests green).
- Ran SwiftLint with the project toolchain binary (`/tmp/swiftlint-install/swiftlint --strict`) and the linting step completed successfully for the checked files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b5959a9648328a2e146bef209497c)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `YouVersionAPITests.swift` as a nested extension of `ConfigurationStateTests`, providing test coverage for the four main `YouVersionAPI.hasValidToken()` scenarios: no stored auth data, an unexpired token (no refresh), an expiring token (successful refresh with token persistence), and a failed refresh (original tokens unchanged).

- Four `async` tests use `HTTPMocking.makeSession()` with `defer { HTTPMocking.clear(token:) }` for clean session teardown, and the suite inherits the parent's `.serialized` trait to prevent cross-test races on the shared `YouVersionPlatformConfiguration` global state.
- Each test that mutates `appKey` captures and restores `originalAppKey` at the end, and token state is cleared via `clearAuthTokens()` as the last cleanup step.

<h3>Confidence Score: 5/5</h3>

This PR only adds new tests — no production code is changed, and the tests correctly model all four token-validity paths.

The suite is properly nested under ConfigurationStateTests with .serialized on both the parent and inner suite, so tests that mutate global UserDefaults-backed state run in strict sequence. The lone try in the async throws test is placed before any state mutations. Mock sessions are scoped with defer teardown and assertions match the actual production-code logic.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Tests/YouVersionPlatformCoreTests/YouVersionAPITests.swift | New test suite covering the four key `hasValidToken()` paths. Suite structure, mock setup/teardown, and state cleanup are all correct. |

</details>

<sub>Reviews (7): Last reviewed commit: ["test: address hasValidToken review comme..."](https://github.com/youversion/platform-sdk-swift/commit/561babc83337238c97cb8607a021b3a36dd2ba39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32674587)</sub>

<!-- /greptile_comment -->