### PR TITLE
test: handling of 3-digit and 8-digit ARGB hex strings

### DIFF
--- a/Tests/YouVersionPlatformUITests/ColorHexTests.swift
+++ b/Tests/YouVersionPlatformUITests/ColorHexTests.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import Testing
+#if canImport(UIKit)
+import UIKit
+#endif
+@testable import YouVersionPlatformUI
+
+@Suite struct ColorHexTests {
+    @Test
+    func threeDigitHexExpandsColorComponents() throws {
+        guard let components = try colorComponents(for: Color(hex: "#FA3")) else {
+            return
+        }
+
+        #expect(components.red.isApproximatelyEqual(to: 1.0))
+        #expect(components.green.isApproximatelyEqual(to: 170.0 / 255.0))
+        #expect(components.blue.isApproximatelyEqual(to: 51.0 / 255.0))
+        #expect(components.alpha.isApproximatelyEqual(to: 1.0))
+    }
+
+    @Test
+    func eightDigitHexReadsArgbColorComponents() throws {
+        guard let components = try colorComponents(for: Color(hex: "#80DDAAFF")) else {
+            return
+        }
+
+        #expect(components.red.isApproximatelyEqual(to: 221.0 / 255.0))
+        #expect(components.green.isApproximatelyEqual(to: 170.0 / 255.0))
+        #expect(components.blue.isApproximatelyEqual(to: 255.0 / 255.0))
+        #expect(components.alpha.isApproximatelyEqual(to: 128.0 / 255.0))
+    }
+
+    private func colorComponents(for color: Color) throws -> ColorComponents? {
+#if canImport(UIKit)
+        let color = UIColor(color)
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+
+        try #require(color.getRed(&red, green: &green, blue: &blue, alpha: &alpha))
+
+        return ColorComponents(red: red, green: green, blue: blue, alpha: alpha)
+#else
+        return nil
+#endif
+    }
+}
+
+private struct ColorComponents {
+    let red: CGFloat
+    let green: CGFloat
+    let blue: CGFloat
+    let alpha: CGFloat
+}
+
+private extension CGFloat {
+    func isApproximatelyEqual(to expectedValue: CGFloat) -> Bool {
+        abs(self - expectedValue) < 0.0001
+    }
+}


### PR DESCRIPTION
### Motivation
- Validate that `Color(hex:)` correctly expands shorthand 3-digit hex values and correctly interprets 8-digit ARGB (alpha-first) hex strings so color components are produced as expected.

### Description
- Add `Tests/YouVersionPlatformUITests/ColorHexTests.swift` containing two tests: `threeDigitHexExpandsColorComponents` and `eightDigitHexReadsArgbColorComponents`, which assert RGBA components using `#expect`.
- Include a `colorComponents(for:)` helper that extracts RGBA via `UIColor` under `#if canImport(UIKit)`, a `ColorComponents` struct, and a `CGFloat` extension `isApproximatelyEqual(to:)` for approximate comparisons.

### Testing
- Added the new unit tests to the `YouVersionPlatformUITests` target and executed the test suite containing `ColorHexTests`, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b56a37e6083288200f9d38de44cc6)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two unit tests for `Color(hex:)` in `ColorHexTests.swift`, covering 3-digit shorthand expansion and 8-digit ARGB parsing. A private `colorComponents(for:)` helper wraps UIKit's `getRed(_:green:blue:alpha:)` for component extraction, and a `CGFloat.isApproximatelyEqual(to:)` utility handles floating-point comparisons.

- **3-digit test** (`#FA3`): verifies the `*17` nibble-expansion math produces the correct sRGB components (r=1.0, g=170/255, b=51/255, a=1.0).
- **8-digit test** (`#80DDAAFF`): verifies ARGB ordering — alpha byte `0x80` maps to `128/255` opacity while the RGB bytes are decoded correctly from positions 24→16→8→0.
- Helper infrastructure (`ColorComponents`, `isApproximatelyEqual`) is file-private and tightly scoped to this test file.

<h3>Confidence Score: 5/5</h3>

This is a test-only addition with no changes to production code; it is safe to merge.

The two tests correctly reflect the bit-shift arithmetic in Color+Hex.swift — the expected values for both the 3-digit nibble expansion and the 8-digit ARGB byte ordering are arithmetically verified against the implementation. The helper infrastructure is file-private and introduces no risk to the library surface. No production code is modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Tests/YouVersionPlatformUITests/ColorHexTests.swift | New test file covering 3-digit and 8-digit ARGB hex parsing; expected values are arithmetically correct against the Color+Hex.swift implementation, helper types are correctly scoped as private. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@Test func threeDigitHexExpandsColorComponents()"] --> B["Color(hex: '#FA3')"]
    C["@Test func eightDigitHexReadsArgbColorComponents()"] --> D["Color(hex: '#80DDAAFF')"]
    B --> E["colorComponents(for:)"]
    D --> E
    E --> F{canImport UIKit?}
    F -- No --> G["return nil\n(test returns, no asserts)"]
    F -- Yes --> H["UIColor(color)"]
    H --> I["getRed(_:green:blue:alpha:)"]
    I -- false --> J["#require throws → test fails"]
    I -- true --> K["ColorComponents(r,g,b,a)"]
    K --> L["#expect each component\n.isApproximatelyEqual(to:)\ntolerance < 0.0001"]
```

<sub>Reviews (4): Last reviewed commit: ["test: cover Color hex shorthand and alph..."](https://github.com/youversion/platform-sdk-swift/commit/1ef616e854c43db9fa655678d4ef2931e084df96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32674761)</sub>

<!-- /greptile_comment -->