### PR TITLE
test: add coverage for YouVersionAPI.Bible.permittedVersions

### DIFF
--- a/Tests/YouVersionPlatformCoreTests/BibleVersionsAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionsAPITests.swift
@@ -102,6 +102,9 @@ import Testing
         let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
         let queryItems = components?.queryItems ?? []
         #expect(queryItems.contains(where: { $0.name == "language_ranges[]" && $0.value == "*" }))
+        #expect(queryItems.contains(where: { $0.name == "page_size" && $0.value == "*" }))
+        #expect(queryItems.contains(where: { $0.name == "fields[]" && $0.value == "id" }))
+        #expect(queryItems.contains(where: { $0.name == "fields[]" && $0.value == "language_tag" }))
     }
 
     @MainActor
@@ -111,6 +114,21 @@ import Testing
 
         HTTPMocking.setHandler(token: token) { request in
             let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil)!
+            return (Data(), response)
+        }
+
+        await #expect(throws: YouVersionAPIError.notPermitted) {
+            _ = try await YouVersionAPI.Bible.permittedVersions(forLanguageTag: "en", accessToken: "swift-test-suite", session: session)
+        }
+    }
+
+    @MainActor
+    @Test func permittedVersionsForbiddenThrowsNotPermitted() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 403, httpVersion: nil, headerFields: nil)!
             return (Data(), response)
         }
 

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionsAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionsAPITests.swift
@@ -39,6 +39,117 @@ import Testing
     }
 
     @MainActor
+    @Test func permittedVersionsSuccessReturnsMinimalInfo() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        let json = """
+        {"data": [
+            {"id": 1, "title": "English Version", "abbreviation": "eng", "language_tag": "en"},
+            {"id": 2, "title": "German Version", "abbreviation": "deu", "language_tag": "de"}
+        ]}
+        """.data(using: .utf8)!
+        var capturedRequest: URLRequest?
+
+        HTTPMocking.setHandler(token: token) { request in
+            capturedRequest = request
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (json, response)
+        }
+
+        let versions = try await YouVersionAPI.Bible.permittedVersions(
+            forLanguageTag: "en",
+            accessToken: "swift-test-suite",
+            session: session
+        )
+
+        #expect(versions == [
+            YouVersionAPI.Bible.BibleVersionMinimalInfo(id: 1, languageTag: "en"),
+            YouVersionAPI.Bible.BibleVersionMinimalInfo(id: 2, languageTag: "de")
+        ])
+
+        let request = try #require(capturedRequest)
+        let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+        let queryItems = components?.queryItems ?? []
+        #expect(queryItems.contains(where: { $0.name == "language_ranges[]" && $0.value == "en" }))
+        #expect(queryItems.contains(where: { $0.name == "page_size" && $0.value == "*" }))
+        #expect(queryItems.contains(where: { $0.name == "fields[]" && $0.value == "id" }))
+        #expect(queryItems.contains(where: { $0.name == "fields[]" && $0.value == "language_tag" }))
+    }
+
+    @MainActor
+    @Test func permittedVersionsDefaultsToAllLanguages() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        let json = """
+        {"data": [
+            {"id": 1, "language_tag": "en"}
+        ]}
+        """.data(using: .utf8)!
+        var capturedRequest: URLRequest?
+
+        HTTPMocking.setHandler(token: token) { request in
+            capturedRequest = request
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (json, response)
+        }
+
+        let versions = try await YouVersionAPI.Bible.permittedVersions(accessToken: "swift-test-suite", session: session)
+
+        #expect(versions == [YouVersionAPI.Bible.BibleVersionMinimalInfo(id: 1, languageTag: "en")])
+        let request = try #require(capturedRequest)
+        let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+        let queryItems = components?.queryItems ?? []
+        #expect(queryItems.contains(where: { $0.name == "language_ranges[]" && $0.value == "*" }))
+    }
+
+    @MainActor
+    @Test func permittedVersionsUnauthorizedThrowsNotPermitted() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil)!
+            return (Data(), response)
+        }
+
+        await #expect(throws: YouVersionAPIError.notPermitted) {
+            _ = try await YouVersionAPI.Bible.permittedVersions(forLanguageTag: "en", accessToken: "swift-test-suite", session: session)
+        }
+    }
+
+    @MainActor
+    @Test func permittedVersionsUnexpectedStatusThrowsCannotDownload() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+            return (Data(), response)
+        }
+
+        await #expect(throws: YouVersionAPIError.cannotDownload) {
+            _ = try await YouVersionAPI.Bible.permittedVersions(forLanguageTag: "en", accessToken: "swift-test-suite", session: session)
+        }
+    }
+
+    @MainActor
+    @Test func permittedVersionsInvalidResponseThrows() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = URLResponse(url: request.url!, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+            return (Data(), response)
+        }
+
+        await #expect(throws: YouVersionAPIError.invalidResponse) {
+            _ = try await YouVersionAPI.Bible.permittedVersions(forLanguageTag: "en", accessToken: "swift-test-suite", session: session)
+        }
+    }
+
+    @MainActor
     @Test func versionsUnauthorizedThrowsNotPermitted() async throws {
         let (session, token) = HTTPMocking.makeSession()
         defer { HTTPMocking.clear(token: token) }


### PR DESCRIPTION
### Motivation
- The `permittedVersions()` helper in `Sources/YouVersionPlatformCore/APIs/Bible/BibleVersions.swift` lacked unit test coverage for its success and error paths.
- Tests should verify the minimal-field decoding and that the request uses the expected query parameters (language ranges, wildcard page size, and explicit `fields[]`).

### Description
- Add multiple unit tests to `Tests/YouVersionPlatformCoreTests/BibleVersionsAPITests.swift` that mock the server using `HTTPMocking` and exercise `YouVersionAPI.Bible.permittedVersions(...)`.
- Add a success test that asserts returned `BibleVersionMinimalInfo` values and validates the outgoing query items for `language_ranges[]`, `page_size` set to `*`, and `fields[]` including `id` and `language_tag`.
- Add a default-behavior test that ensures the function requests all languages (wildcard `language_ranges[] = *`).
- Add error-path tests for unauthorized (401 -> `YouVersionAPIError.notPermitted`), unexpected status (500 -> `YouVersionAPIError.cannotDownload`), and non-HTTP response (-> `YouVersionAPIError.invalidResponse`).

### Testing
- Ran the focused test suite with `swift test --filter BibleVersionsAPITests` and observed all tests in the suite pass.
- Ran the full test suite with `swift test` and observed the whole test run pass (268 tests in this environment).
- Ran SwiftLint with `LINUX_SOURCEKIT_LIB_PATH=... /tmp/swiftlint/swiftlint --strict` and confirmed no lint violations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b59c8972c83288a2fa3d948f5f51c)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds comprehensive unit test coverage for `YouVersionAPI.Bible.permittedVersions(...)`, exercising both the success and error paths that were previously untested.

- **Success & query-param tests**: `permittedVersionsSuccessReturnsMinimalInfo` and `permittedVersionsDefaultsToAllLanguages` verify that the correct `BibleVersionMinimalInfo` values are returned and that all three query contracts — `language_ranges[]`, `page_size=*`, and `fields[]=id,language_tag` — are honoured in the outgoing request.
- **Error-path tests**: Four new tests cover 401 → `.notPermitted`, 403 → `.notPermitted`, 500 → `.cannotDownload`, and a non-HTTP response → `.invalidResponse`, mirroring the error-path tests that already exist for `versions(...)`.
- Both previously raised review issues (missing 403 coverage and missing `page_size`/`fields[]` assertions in the default-language test) have been addressed in this revision.

<h3>Confidence Score: 5/5</h3>

Test-only change; no production code is modified and all new tests are correctly wired to the existing mock infrastructure.

The six new tests are self-contained, use the established HTTPMocking pattern, and cover every meaningful code path in permittedVersions — success decoding, wildcard vs. explicit language filtering, and all three error branches (401/403, 5xx, non-HTTP).

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Tests/YouVersionPlatformCoreTests/BibleVersionsAPITests.swift | Adds six new tests for permittedVersions covering success decoding, wildcard/specific language filtering, 401, 403, 500, and non-HTTP error paths — all consistent with existing test conventions and no logic issues found. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: address permitted versions review ..."](https://github.com/youversion/platform-sdk-swift/commit/01970494a7f5e6977fc46cae6e05ad3c3769cfb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32674772)</sub>

<!-- /greptile_comment -->