### PR TITLE
fix: Handle BibleReference verse cases in display title and enforce verseEnd invariant; add tests

### DIFF
--- a/Sources/YouVersionPlatformUI/Objects/BibleVersion+Additions.swift
+++ b/Sources/YouVersionPlatformUI/Objects/BibleVersion+Additions.swift
@@ -55,27 +55,22 @@ public extension BibleVersion {
         let bookAndChapterSeparator = hasOneChapter ? "" : " "
         let chapter = hasOneChapter ? "" : String(reference.chapter)
 
-        switch (reference.verseStart, reference.verseEnd) {
-        case (_, let verseEnd?) where verseEnd == 999:
+        if reference.verseEnd == 999 || reference.verseStart == nil {
             // Whole chapter
             return [bookName, bookAndChapterSeparator, chapter]
-            
-        case (nil, _):
-            // Whole chapter
+        }
+
+        guard let verseStart = reference.verseStart, let verseEnd = reference.verseEnd else {
+            assertionFailure("BibleReference verseEnd should be set when verseStart is set.")
             return [bookName, bookAndChapterSeparator, chapter]
-            
-        case let (verseStart?, verseEnd?):
-            if verseStart == verseEnd {
-                // Single verse
-                return [bookName, bookAndChapterSeparator, chapter, chapterSeparator, String(verseStart)]
-            } else {
-                // Verse range
-                return [bookName, bookAndChapterSeparator, chapter, chapterSeparator, String(verseStart), "-", String(verseEnd)]
-            }
-            
-        case let (verseStart?, nil):
-            // Single verse with no verseEnd
+        }
+
+        if verseStart == verseEnd {
+            // Single verse
             return [bookName, bookAndChapterSeparator, chapter, chapterSeparator, String(verseStart)]
+        } else {
+            // Verse range
+            return [bookName, bookAndChapterSeparator, chapter, chapterSeparator, String(verseStart), "-", String(verseEnd)]
         }
     }
 }

--- a/Sources/YouVersionPlatformUI/Objects/BibleVersion+Additions.swift
+++ b/Sources/YouVersionPlatformUI/Objects/BibleVersion+Additions.swift
@@ -55,12 +55,17 @@ public extension BibleVersion {
         let bookAndChapterSeparator = hasOneChapter ? "" : " "
         let chapter = hasOneChapter ? "" : String(reference.chapter)
 
-        if reference.verseEnd == 999 || reference.verseStart == nil {
+        if reference.verseEnd == 999 {
             // Whole chapter
             return [bookName, bookAndChapterSeparator, chapter]
         }
 
-        guard let verseStart = reference.verseStart, let verseEnd = reference.verseEnd else {
+        guard let verseStart = reference.verseStart else {
+            // Whole chapter
+            return [bookName, bookAndChapterSeparator, chapter]
+        }
+
+        guard let verseEnd = reference.verseEnd else {
             assertionFailure("BibleReference verseEnd should be set when verseStart is set.")
             return [bookName, bookAndChapterSeparator, chapter]
         }

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 @testable import YouVersionPlatformCore
 import Testing
 
@@ -23,6 +24,23 @@ func testInitVerseRange() {
     #expect(ref.chapter == 23)
     #expect(ref.verseStart == 1)
     #expect(ref.verseEnd == 2)
+}
+
+@Test
+func bibleReferenceConstructorsAlwaysSetVerseEndWhenVerseStartExists() throws {
+    let singleVerseReference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verse: 3)
+    let rangeReference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
+    let decodedReference = try JSONDecoder().decode(
+        BibleReference.self,
+        from: Data(#"{"versionId":111,"bookUSFM":"GEN","chapter":1,"verseStart":3}"#.utf8)
+    )
+
+    #expect(singleVerseReference.verseStart == 3)
+    #expect(singleVerseReference.verseEnd == 3)
+    #expect(rangeReference.verseStart == 3)
+    #expect(rangeReference.verseEnd == 5)
+    #expect(decodedReference.verseStart == 3)
+    #expect(decodedReference.verseEnd == 3)
 }
 
 // MARK: - Test isRange

--- a/Tests/YouVersionPlatformUITests/BibleVersionDisplayTitleTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionDisplayTitleTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+@testable import YouVersionPlatformCore
+@testable import YouVersionPlatformUI
+
+@Suite struct BibleVersionDisplayTitleTests {
+    @Test func displayTitleFallsBackToBookUSFMForInvalidBook() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "XYZ", chapter: 3)
+
+        #expect(version.displayTitle(for: reference) == "XYZ 3 NIV")
+    }
+
+    @Test func displayTitleUsesBookNameAndChapterForWholeChapterReference() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1)
+
+        #expect(version.displayTitle(for: reference) == "Genesis 1 NIV")
+    }
+
+    @Test func displayTitleUsesBookNameAndChapterForWholeChapterVerseSentinel() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 999)
+
+        #expect(version.displayTitle(for: reference) == "Genesis 1 NIV")
+    }
+
+    @Test func displayTitleOmitsChapterForWholeChapterSingleChapterBook() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "JUD", chapter: 1)
+
+        #expect(version.displayTitle(for: reference) == "Jude NIV")
+    }
+
+    @Test func displayTitleOmitsChapterForWholeChapterSentinelInSingleChapterBook() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "JUD", chapter: 1, verseStart: 1, verseEnd: 999)
+
+        #expect(version.displayTitle(for: reference) == "Jude NIV")
+    }
+
+    @Test func displayTitleIncludesSingleVerse() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verse: 3)
+
+        #expect(version.displayTitle(for: reference) == "Genesis 1:3 NIV")
+    }
+
+    @Test func displayTitleIncludesSingleVerseInSingleChapterBook() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "JUD", chapter: 1, verse: 4)
+
+        #expect(version.displayTitle(for: reference) == "Jude 4 NIV")
+    }
+
+    private func makeBibleVersion() -> BibleVersion {
+        BibleVersion(
+            id: 111,
+            abbreviation: "NIV",
+            promotionalContent: nil,
+            copyright: nil,
+            languageTag: "eng",
+            localizedAbbreviation: nil,
+            localizedTitle: nil,
+            readerFooter: nil,
+            readerFooterUrl: nil,
+            title: nil,
+            organizationId: nil,
+            bookCodes: nil,
+            books: [
+                makeBibleBook(id: "GEN", title: "Genesis", chapterCount: 50),
+                makeBibleBook(id: "JUD", title: "Jude", chapterCount: 1)
+            ],
+            textDirection: "ltr"
+        )
+    }
+
+    private func makeBibleBook(id: String, title: String, chapterCount: Int) -> BibleBook {
+        BibleBook(
+            id: id,
+            title: title,
+            fullTitle: title,
+            abbreviation: nil,
+            canon: "nt",
+            chapters: (1...chapterCount).map { chapter in
+                BibleChapter(id: String(chapter), passageId: "\(id).\(chapter)", title: String(chapter), verses: nil)
+            },
+            intro: nil
+        )
+    }
+}

--- a/Tests/YouVersionPlatformUITests/BibleVersionDisplayTitleTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionDisplayTitleTests.swift
@@ -46,6 +46,13 @@ import Testing
         #expect(version.displayTitle(for: reference) == "Genesis 1:3 NIV")
     }
 
+    @Test func displayTitleIncludesVerseRange() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
+
+        #expect(version.displayTitle(for: reference) == "Genesis 1:3-5 NIV")
+    }
+
     @Test func displayTitleIncludesSingleVerseInSingleChapterBook() {
         let version = makeBibleVersion()
         let reference = BibleReference(versionId: 111, bookUSFM: "JUD", chapter: 1, verse: 4)


### PR DESCRIPTION
### Motivation
- Ensure `BibleVersion.displayTitle(for:)` produces correct titles for whole-chapter sentinels, single-verse, and verse-range references and to avoid incorrect formatting for missing verse data. 
- Enforce the invariant that when a `BibleReference` has a `verseStart` it also has a `verseEnd` to simplify downstream display logic and catch unexpected decoding/initialization states. 

### Description
- Replace the previous `switch` logic in `titleChunks(for:)` with explicit handling where `reference.verseEnd == 999` or `reference.verseStart == nil` is treated as a whole chapter, followed by a `guard` that asserts if `verseStart` exists without `verseEnd`, and then concise single-verse / verse-range formatting. 
- Add an `assertionFailure` when a `BibleReference` has a `verseStart` but no `verseEnd` to catch invalid states during development. 
- Add tests in `YouVersionPlatformCoreTests/BibleReferenceTests.swift` to verify that constructors and decoding always set `verseEnd` when `verseStart` is present. 
- Add UI tests in `YouVersionPlatformUITests/BibleVersionDisplayTitleTests.swift` to validate `displayTitle(for:)` behavior for invalid book codes, whole-chapter references, single-chapter books, single verses, and the chapter sentinel `verseEnd == 999`, and add an `import Foundation` where needed. 

### Testing
- Ran core unit tests in `YouVersionPlatformCoreTests`, including the new `bibleReferenceConstructorsAlwaysSetVerseEndWhenVerseStartExists` test, and they passed. 
- Ran UI unit tests in `YouVersionPlatformUITests`, including the new `BibleVersionDisplayTitleTests` suite, and they passed. 
- No regressions were reported by the test suite after these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b57639234832894fb0cf3fef14736)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors `BibleVersion.titleChunks(for:)` from a `switch` to an explicit `if`/`guard` chain, adding an `assertionFailure` to enforce the invariant that `verseEnd` must always be set when `verseStart` is present. It also adds comprehensive unit tests for both the invariant and all display-title formatting branches.

- **`BibleVersion+Additions.swift`**: Replaces the `switch (verseStart, verseEnd)` with sequential guards — `verseEnd == 999` → whole chapter, missing `verseStart` → whole chapter, missing `verseEnd` (with `assertionFailure`) → whole-chapter fallback, then single-verse or range formatting.
- **`BibleReferenceTests.swift`**: Adds `import Foundation` (needed for `JSONDecoder`/`Data`) and a new test verifying all three constructors (single-verse init, range init, decoded-from-JSON) honour the `verseEnd` invariant.
- **`BibleVersionDisplayTitleTests.swift`**: New test suite covering invalid book code fallback, whole-chapter references, single-chapter book formatting, single-verse, verse range, and the `verseEnd == 999` chapter sentinel — all branches of the refactored logic are now exercised.

<h3>Confidence Score: 5/5</h3>

All changes are confined to display formatting and test additions; no data model or persistence logic is touched, and the refactored title-building logic preserves the original behaviour for every valid reference state.

The refactored titleChunks(for:) correctly handles all reachable states — verseEnd == 999 sentinel, missing verseStart, and single-verse / range paths — and new tests exercise every branch. The assertionFailure is appropriate for an unreachable invariant violation and degrades gracefully in release builds.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformUI/Objects/BibleVersion+Additions.swift | Refactors titleChunks(for:) from a switch to if/guard; adds assertionFailure for the verseStart-without-verseEnd invariant. Logic is correct and all branches are exercised by new tests. |
| Tests/YouVersionPlatformCoreTests/BibleReferenceTests.swift | Adds import Foundation and a new test verifying the verseEnd invariant across all three constructors; test expectations match the existing decoder behavior. |
| Tests/YouVersionPlatformUITests/BibleVersionDisplayTitleTests.swift | New test suite with 8 cases covering every branch of the refactored titleChunks logic, including the previously missing verse-range case and the chapter-sentinel test. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["titleChunks(for: reference)"] --> B{"verseEnd == 999?"}
    B -- Yes --> Z["Return whole-chapter chunks"]
    B -- No --> C{"verseStart == nil?"}
    C -- Yes --> Z
    C -- No --> D{"verseEnd == nil?"}
    D -- Yes --> E["assertionFailure (debug only)"]
    E --> Z
    D -- No --> F{"verseStart == verseEnd?"}
    F -- Yes --> G["Return single-verse chunks"]
    F -- No --> H["Return verse-range chunks"]
```

<sub>Reviews (2): Last reviewed commit: ["test: cover Bible reference display titl..."](https://github.com/youversion/platform-sdk-swift/commit/eb2a915fe3dd0bb38f8ecda5d5f019341c342fb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32674779)</sub>

<!-- /greptile_comment -->