### PR TITLE
fix(ci): switch release publishing from auto-on-push to manual workflow_dispatch trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 env:
   XCODE_VERSION: latest-stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ When writing or reviewing code in this repo, load the relevant skill:
 
 ## Release Process
 
-Releases are driven by `semantic-release` from `main` (see `.github/workflows/release.yml` and `.releaserc.json`). Two pieces of state get version-bumped: the four `.podspec` files, and the `SDKVersion` constant used by the `x-yvp-sdk` HTTP header. They behave differently on purpose.
+Releases are driven by `semantic-release` from `main` (see `.github/workflows/release.yml` and `.releaserc.json`). **The Release workflow is triggered manually via `workflow_dispatch`** — go to the Actions tab and click "Run workflow", or run `gh workflow run release.yml`. Merging to `main` does **not** publish on its own; merges only land code, and a human decides when to cut the next release. Two pieces of state get version-bumped: the four `.podspec` files, and the `SDKVersion` constant used by the `x-yvp-sdk` HTTP header. They behave differently on purpose.
 
 **Podspecs** are bumped by `scripts/update-pod-versions.sh` during the prepare phase. The change is committed to `main` along with the `CHANGELOG.md` update.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,143 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## [6.0.0](https://github.com/youversion/platform-sdk-swift/compare/5.2.2...6.0.0) (2026-05-18)
+## [5.2.3](https://github.com/youversion/platform-sdk-swift/compare/5.2.2...5.2.3) (2026-05-18)
 
 
-### ⚠ BREAKING CHANGES
+### Bug Fixes
 
-* footers.
-  - Posts a sticky PR comment (via peter-evans/find-comment +
-    create-or-update-comment) on both success and failure, with a prominent
-    warning when a major bump is detected.
-  - Treats a non-zero semantic-release dry-run as a warning only, so a release
-    config glitch never blocks unrelated PRs.
-- Add an `npm run commitlint` script for local pre-push validation.
-- Update AGENTS.md, RELEASING.md, and CONTRIBUTING.md to describe the new
-  CI-enforced flow and the local check.
+* **ci:** switch release publishing from auto-on-push to manual `workflow_dispatch` trigger. The Release workflow no longer fires on every merge to `main`; cut releases on demand from the Actions tab (or `gh workflow run release.yml`). See [RELEASING.md](./RELEASING.md).
 
-Refs YPE-2398
-
-Co-Authored-By: Craft Agent <agents-noreply@craft.do>
-
-* fix(ci): pin commit-lint actions to SHAs, catch feat! breaking changes, drop edited trigger
-
-Addresses three review comments on the commit-lint workflow:
-
-- Pin peter-evans/find-comment and peter-evans/create-or-update-comment to
-  full commit SHAs (v3.1.0 and v4.0.0 respectively). Floating major tags
-  could be silently force-pushed to a malicious SHA, and this workflow has
-  `pull-requests: write`.
-- Detect major releases via semantic-release's own log line ("complete:
-  major release" / "release type is major") instead of grepping for the
-  literal "BREAKING CHANGE" string. The previous check missed the `feat!:`
-  and `fix!:` shorthand, which produces a major bump without emitting the
-  footer keyword. Banner now fires correctly for both forms.
-- Drop the `edited` PR trigger. It re-ran the full workflow on every PR
-  title/body edit despite the workflow only validating commit-range
-  contents, not PR metadata. `synchronize` already re-runs on every new
-  commit push, which is the only event that can change what we lint.
-
-Refs YPE-2398
-
-Co-Authored-By: Craft Agent <agents-noreply@craft.do>
-
-* fix(ci): make semantic-release dry-run actually compute the next version, expand commit examples
-
-- semantic-release was logging "configured to only run on main" and bailing
-  on PR runs because HEAD is `refs/pull/N/merge`, which isn't in the
-  `branches` allowlist. The previous `--branches` override was the wrong
-  knob: that controls _which_ branch can release, not _which_ branch
-  semantic-release thinks it's on. Now we point a local branch at the PR
-  merge commit using the base ref name and let semantic-release run as if
-  the PR had already merged, which is exactly the preview we want.
-- Address review feedback on CONTRIBUTING.md: add a fuller Conventional
-  Commits section with type list, version-bump table, six worked examples
-  (feat / fix / docs / refactor / chore / breaking change with footer),
-  and a note about imperative mood and scopes. Aimed at coding agents and
-  humans who haven't internalized the spec.
-
-Refs YPE-2398
-
-Co-Authored-By: Craft Agent <agents-noreply@craft.do>
-
-* fix(ci): strip GitHub Actions env vars so semantic-release dry-run detects the right branch
-
-Previous fix moved git HEAD to a local branch named after the PR base ref,
-but semantic-release never looked at git — it relies on env-ci, which
-reads GITHUB_ACTIONS + GITHUB_REF + GITHUB_EVENT_NAME and reports the
-branch as `refs/pull/N/merge` on PR events. That ref never matches the
-configured `branches: ["main"]` allowlist, so the analyzer bails with
-"triggered on the branch refs/pull/N/merge ... won't be published"
-before computing a version. The --no-ci flag bypasses the CI auth check,
-not the env-ci branch detection.
-
-Wrap the semantic-release invocation in `env -u ...` to unset the
-GitHub Actions env vars that signal "PR in CI". env-ci then falls back
-to git-based detection and sees us on `main` (because of the local
-checkout in the previous step), so the analyzer runs end-to-end and the
-PR comment shows the real next version.
-
-GITHUB_TOKEN is preserved so the @semantic-release/github plugin's
-verifyConditions step still passes.
-
-Refs YPE-2398
-
-Co-Authored-By: Craft Agent <agents-noreply@craft.do>
-
-* docs: annotate commit examples with version bumps and call out squash-merge behavior
-
-Two pieces of contributor feedback on CONTRIBUTING.md:
-
-- Each example now shows the bump it would trigger (MINOR / PATCH /
-  NO RELEASE / MAJOR) with concrete before-and-after versions, so
-  contributors and agents can see the consequence at a glance.
-- Add an explicit callout that this repo squash-merges and that the
-  squash commit subject — seeded from the PR title — is what
-  semantic-release reads on `main`. Also state that the entire commit
-  history back to the last tag is scanned and the highest bump wins.
-  This prevents the "all my commits were `feat` but the PR was titled
-  `chore: ...` and no release happened" trap.
-
-Refs YPE-2398
-
-Co-Authored-By: Craft Agent <agents-noreply@craft.do>
-
-* refactor(ci): simplify semantic-release dry-run with --branches '**' --no-ci
-
-Replace the env-var stripping + local-branch-rename dance with the
-direct CLI override: `--branches '**' --no-ci`. `--branches '**'`
-loosens the analyzer's branch allowlist for this invocation only (the
-`.releaserc.json` config is untouched, so real releases are still
-locked to `main`), and `--no-ci` bypasses the refuse-on-PR check.
-Same dry-run output, ~10 fewer lines, no GITHUB_* env juggling.
-
-Refs YPE-2398
-
-Co-Authored-By: Craft Agent <agents-noreply@craft.do>
-
-* fix(ci): scope semantic-release dry-run --branches to the PR head ref only
-
-`--branches '**'` expanded against every branch in the repo (~13) and
-tripped semantic-release's max-3-release-branches validation:
-ERELEASEBRANCHES "The release branches are invalid". Limit the override
-to a single entry — the PR head branch — which is what env-ci already
-detects us on. That keeps the allowlist exactly one branch wide, well
-under the limit, and aligned with the detected branch so the analyzer
-runs end-to-end.
-
-The file config in `.releaserc.json` is still untouched, so real
-releases continue to ship only from `main`.
-
-Refs YPE-2398
-
-Co-Authored-By: Craft Agent <agents-noreply@craft.do>
-
-* fix(ci): unset GITHUB_ACTIONS for semantic-release dry-run (canonical workaround)
 
 ### Continuous Integration
 
-* replace Husky commit-msg hook with CI commit-lint + release preview ([#117](https://github.com/youversion/platform-sdk-swift/issues/117)) ([1d21411](https://github.com/youversion/platform-sdk-swift/commit/1d214119f6e4792d6c49607f4d37d425df1e20d4)), closes [#1886](https://github.com/youversion/platform-sdk-swift/issues/1886) [#1937](https://github.com/youversion/platform-sdk-swift/issues/1937)
+* replace Husky commit-msg hook with CI commit-lint + release preview ([#117](https://github.com/youversion/platform-sdk-swift/issues/117)) ([1d21411](https://github.com/youversion/platform-sdk-swift/commit/1d214119f6e4792d6c49607f4d37d425df1e20d4))
 
 ## [5.2.2](https://github.com/youversion/platform-sdk-swift/compare/5.2.1...5.2.2) (2026-05-15)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,11 +36,11 @@ This project follows idiomatic Swift conventions as outlined in [Swift API Desig
 
 - Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages — they drive semantic-release's version bumps and the auto-generated CHANGELOG. Validated in CI by the `Commit Lint` workflow; check locally with `npm run commitlint` (or `npx commitlint --from=origin/main --to=HEAD --verbose`).
 
-  > **⚠️ Important: every commit subject on `main` is scanned to compute the next version.**
+  > **⚠️ Important: every commit subject on `main` is scanned to compute the next version when a release is cut.**
   >
-  > This repo squash-merges PRs. The **squash commit subject becomes a single commit on `main`** — its `<type>` is what semantic-release reads, not the individual commits on your branch. GitHub seeds the squash subject from the PR title by default, so **make sure your PR title is itself a valid Conventional Commit** (e.g. `feat(reader): add highlight color picker`). If the squash subject is `chore:` you'll get no release even if every commit on your branch was a `feat`.
+  > This repo squash-merges PRs. The **squash commit subject becomes a single commit on `main`** — its `<type>` is what semantic-release reads, not the individual commits on your branch. GitHub seeds the squash subject from the PR title by default, so **make sure your PR title is itself a valid Conventional Commit** (e.g. `feat(reader): add highlight color picker`). If the squash subject is `chore:` it contributes no release signal even if every commit on your branch was a `feat`.
   >
-  > On each push to `main`, semantic-release walks the entire commit history back to the last release tag and picks the **highest** bump it finds — one `feat` among ten `chore`s still triggers a minor release; one `BREAKING CHANGE` anywhere triggers a major. The CI `Commit Lint` workflow on each PR previews the next version using the same logic.
+  > Releases are cut on demand — see [RELEASING.md](./RELEASING.md). When the Release workflow is triggered, semantic-release walks the entire commit history back to the last release tag and picks the **highest** bump it finds across that window — one `feat` among ten `chore`s still produces a minor release; one `BREAKING CHANGE` footer (or `!` shorthand) anywhere produces a major. The CI `Commit Lint` workflow on each PR previews the version that *would* be cut today, using the same logic, so you can see your PR's impact before merging.
 
   **Format:** `<type>(<optional scope>): <subject>`
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,16 +4,22 @@ This project uses [semantic-release](https://semantic-release.gitbook.io/) for a
 
 ## Overview
 
-Releases are fully automated based on commit messages following the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+Releases use [semantic-release](https://semantic-release.gitbook.io/) to compute the next version from [Conventional Commits](https://www.conventionalcommits.org/) since the last tag, but the release itself is **triggered manually**, not automatically on every push to `main`. A human (or scheduled job) decides when to cut a release; merging a PR by itself never publishes.
 
 ## How It Works
 
-1. **Commit with conventional format** → Commitlint validates your message
-2. **Merge to `main`** → GitHub Actions triggers semantic-release
-3. **Semantic-release analyzes commits** → Determines version bump (major/minor/patch)
-4. **Version bump and changelog** → Updates all 4 podspec files and CHANGELOG.md
-5. **Git tag and GitHub release** → Creates version tag (e.g., `1.0.0`) and GitHub release
-6. **Publish to CocoaPods** → Publishes all pods in dependency order
+1. **Develop on a branch with conventional commit subjects** → the `Commit Lint` workflow validates each PR and previews the version that *would* be cut today.
+2. **Merge PRs to `main`** → nothing publishes. `main` just accumulates work.
+3. **When ready to release, trigger the Release workflow manually** → Actions tab → `Release` → "Run workflow" (or `gh workflow run release.yml`).
+4. **Semantic-release analyzes commits since the last tag** → determines version bump (major/minor/patch).
+5. **Version bump and changelog** → updates all 4 podspec files, stamps `SDKVersion.swift`, writes a `CHANGELOG.md` entry.
+6. **Git tag and GitHub release** → creates the version tag (e.g., `5.3.0`) and a GitHub release.
+7. **Publish to CocoaPods** → publishes all pods in dependency order.
+8. **Restore `SDKVersion.swift` to `"Dev"`** → a follow-up commit returns the on-main constant to `"Dev"` so PR builds don't report a stale released version. The tag stays at the stamped commit (see [AGENTS.md → Release Process](./AGENTS.md#release-process) for the X/Y topology).
+
+### Why manual
+
+Auto-publishing on every push to `main` makes the publish surface too easy to trip — any commit message body or release-process change that an analyzer reads as a major bump goes straight to consumers. Manual trigger gives a deliberate review point between merge and publish, and keeps the per-PR version preview as the early warning.
 
 ## Commit Message Format
 

--- a/YouVersionPlatform.podspec
+++ b/YouVersionPlatform.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatform'
   s.module_name  = 'YouVersionPlatform'
-  s.version      = '6.0.0'
+  s.version      = '5.2.3'
   s.summary      = 'YouVersion Platform features'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatformCore.podspec
+++ b/YouVersionPlatformCore.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatformCore'
   s.module_name  = 'YouVersionPlatformCore'
-  s.version      = '6.0.0'
+  s.version      = '5.2.3'
   s.summary      = 'Core layer for YouVersion Platform'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatformReader.podspec
+++ b/YouVersionPlatformReader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatformReader'
   s.module_name  = 'YouVersionPlatformReader'
-  s.version      = '6.0.0'
+  s.version      = '5.2.3'
   s.summary      = 'YouVersion Platform Bible Reader'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatformUI.podspec
+++ b/YouVersionPlatformUI.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatformUI'
   s.module_name  = 'YouVersionPlatformUI'
-  s.version      = '6.0.0'
+  s.version      = '5.2.3'
   s.summary      = 'UI components for YouVersion Platform'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }


### PR DESCRIPTION
## Summary

Switch the Release workflow from firing on every push to main to a manual `workflow_dispatch` trigger. Releases are now deliberate clicks (or `gh workflow run release.yml`), not a side effect of merging.

## Why

Auto-publish on every main push made it easy to ship an unintended release when commit message contents lit up semantic-release's commit analyzer in an unexpected way (see the recent 6.0.0 incident). Manual trigger gives a deliberate review point between merge and publish. The per-PR commit-lint preview keeps its full value as the early warning.

## What's in this PR

- `.github/workflows/release.yml`: trigger flips to `workflow_dispatch`
- `RELEASING.md`: rewrite "How It Works" for the manual procedure; add a short "Why manual" note
- `AGENTS.md`: clarify that merge-to-main no longer publishes
- `CONTRIBUTING.md`: update the "every push to main scans history" callout
- `CHANGELOG.md`: replace the stale 6.0.0 entry (yanked, never finalized) with this 5.2.3 entry
- Podspecs: bump from 6.0.0 to 5.2.3 across all four files

## Note on the per-PR version preview

The Commit Lint workflow on this PR will likely show an inflated next-version because the commits from the rolled-back 6.0.0 attempt are still in main's history. That's expected and gets cleaned up post-merge when 5.2.3 is tagged manually — semantic-release's analyzer window then shifts past the polluted commits.

## Post-merge

After this merges:
1. Manually create the \`5.2.3\` tag at the merge commit (following the X/Y topology in AGENTS.md)
2. Coordinate pod publish for 5.2.3 with the CocoaPods trunk owner
3. Re-enable \`release.yml\` (it's currently disabled at the workflow level since the 6.0.0 cleanup)

## Test plan

- [ ] Commit Lint workflow runs and posts a sticky comment (preview version may be inflated, see note above)
- [ ] API stability check passes
- [ ] SwiftLint passes
- [ ] Unit Tests pass

Refs YPE-2398

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR switches the Release workflow from auto-triggering on every push to `main` to a manual `workflow_dispatch` trigger, preventing the kind of unintended major-version release that produced the erroneous 6.0.0. All four podspecs are rolled back from 6.0.0 to 5.2.3, and the docs (RELEASING.md, AGENTS.md, CONTRIBUTING.md) are updated to describe the new manual-trigger model.

- `.github/workflows/release.yml`: single-line trigger change from `push: branches: [main]` to `workflow_dispatch`; the rest of the workflow is unchanged.
- `CHANGELOG.md`: stale 6.0.0 entry replaced with a clean 5.2.3 patch entry; all four podspecs version-bumped down to match.
- `RELEASING.md`: Overview and How It Works sections accurately rewritten for manual trigger, though the Troubleshooting section and the Required GitHub Configuration section have minor stale references worth addressing before the next release cycle.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the workflow trigger change is a single-line swap with no logic impact, and the podspec rollback is intentional and consistent across all four specs.

The core change (trigger swap + podspec rollback) is clean and low-risk. The two findings are both in RELEASING.md documentation: the Troubleshooting section still tells maintainers to verify you merged to main for a trigger that no longer exists, and the Required GitHub Configuration section names the deploy-key secret as DEPLOY_KEY while the workflow uses RELEASE_SSH_KEY. Neither blocks the immediate release, but the stale troubleshooting step could mislead the next person who runs the manual workflow and hits an error.

RELEASING.md — Troubleshooting section and Required GitHub Configuration section have stale references that don't match the new manual-trigger model or the actual secret name used in the workflow.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Trigger swapped from `push: branches: [main]` to `workflow_dispatch`; workflow body is otherwise unchanged and looks correct. |
| RELEASING.md | Overview and How It Works sections cleanly rewritten for manual trigger, but the Troubleshooting section still references the old push-to-main trigger, and the Required GitHub Configuration section uses a mismatched secret name (`DEPLOY_KEY` vs `RELEASE_SSH_KEY` in the workflow). |
| CHANGELOG.md | 6.0.0 entry (yanked, never finalized) replaced with a clean 5.2.3 patch entry covering this CI change. |
| AGENTS.md | Release Process paragraph updated to note that `workflow_dispatch` is required; wording is accurate. |
| CONTRIBUTING.md | Callout updated from 'every push to main triggers a scan' to 'releases are cut on demand'; accurate and clear. |
| YouVersionPlatform.podspec | Version rolled back from 6.0.0 to 5.2.3; all four podspecs are in sync and inter-pod dependencies use `s.version.to_s` so they stay consistent. |
| YouVersionPlatformCore.podspec | Version bumped down to 5.2.3, consistent with sibling podspecs. |
| YouVersionPlatformReader.podspec | Version bumped down to 5.2.3, consistent with sibling podspecs. |
| YouVersionPlatformUI.podspec | Version bumped down to 5.2.3, consistent with sibling podspecs. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer merges PR to main] --> B[main accumulates commits]
    B --> C{Ready to release?}
    C -- No --> B
    C -- Yes --> D[Human triggers workflow_dispatch\nActions tab or gh workflow run release.yml]
    D --> E[Release workflow runs tests]
    E --> F[semantic-release analyzes commits\nsince last tag]
    F --> G[Computes version bump\nmajor / minor / patch]
    G --> H[Updates podspecs + CHANGELOG\nStamps SDKVersion.swift]
    H --> I[Creates git tag + GitHub Release]
    I --> J[Publishes pods to CocoaPods\nin dependency order]
    J --> K[Restores SDKVersion.swift to Dev\nfollow-up commit on main]

    subgraph OLD [Old behavior - removed]
        direction LR
        P1[Push to main] --> P2[Release workflow auto-fires]
    end

    style OLD fill:#fdd,stroke:#f00,color:#600
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `RELEASING.md`, line 211-214 ([link](https://github.com/youversion/platform-sdk-swift/blob/6500ff6eb1f7606a948177b39cefa2ce184a6459/RELEASING.md#L211-L214)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Stale troubleshooting step after trigger change**

   The "Release didn't trigger" section still says "Verify you merged to `main` branch" — but merging to `main` no longer triggers a release (that was the whole point of this PR). A maintainer hitting this section after a failed `workflow_dispatch` would follow that step, see the merge is there, and still be confused. Consider replacing the first bullet with guidance on manually triggering the workflow (e.g., "Go to Actions → Release → Run workflow, or run `gh workflow run release.yml`").

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: RELEASING.md
   Line: 211-214

   Comment:
   **Stale troubleshooting step after trigger change**

   The "Release didn't trigger" section still says "Verify you merged to `main` branch" — but merging to `main` no longer triggers a release (that was the whole point of this PR). A maintainer hitting this section after a failed `workflow_dispatch` would follow that step, see the merge is there, and still be confused. Consider replacing the first bullet with guidance on manually triggering the workflow (e.g., "Go to Actions → Release → Run workflow, or run `gh workflow run release.yml`").

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20RELEASING.md%0ALine%3A%20211-214%0A%0AComment%3A%0A**Stale%20troubleshooting%20step%20after%20trigger%20change**%0A%0AThe%20%22Release%20didn't%20trigger%22%20section%20still%20says%20%22Verify%20you%20merged%20to%20%60main%60%20branch%22%20%E2%80%94%20but%20merging%20to%20%60main%60%20no%20longer%20triggers%20a%20release%20%28that%20was%20the%20whole%20point%20of%20this%20PR%29.%20A%20maintainer%20hitting%20this%20section%20after%20a%20failed%20%60workflow_dispatch%60%20would%20follow%20that%20step%2C%20see%20the%20merge%20is%20there%2C%20and%20still%20be%20confused.%20Consider%20replacing%20the%20first%20bullet%20with%20guidance%20on%20manually%20triggering%20the%20workflow%20%28e.g.%2C%20%22Go%20to%20Actions%20%E2%86%92%20Release%20%E2%86%92%20Run%20workflow%2C%20or%20run%20%60gh%20workflow%20run%20release.yml%60%22%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=132&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20RELEASING.md%0ALine%3A%20211-214%0A%0AComment%3A%0A**Stale%20troubleshooting%20step%20after%20trigger%20change**%0A%0AThe%20%22Release%20didn't%20trigger%22%20section%20still%20says%20%22Verify%20you%20merged%20to%20%60main%60%20branch%22%20%E2%80%94%20but%20merging%20to%20%60main%60%20no%20longer%20triggers%20a%20release%20%28that%20was%20the%20whole%20point%20of%20this%20PR%29.%20A%20maintainer%20hitting%20this%20section%20after%20a%20failed%20%60workflow_dispatch%60%20would%20follow%20that%20step%2C%20see%20the%20merge%20is%20there%2C%20and%20still%20be%20confused.%20Consider%20replacing%20the%20first%20bullet%20with%20guidance%20on%20manually%20triggering%20the%20workflow%20%28e.g.%2C%20%22Go%20to%20Actions%20%E2%86%92%20Release%20%E2%86%92%20Run%20workflow%2C%20or%20run%20%60gh%20workflow%20run%20release.yml%60%22%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=132&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>


2. `RELEASING.md`, line 77-99 ([link](https://github.com/youversion/platform-sdk-swift/blob/6500ff6eb1f7606a948177b39cefa2ce184a6459/RELEASING.md#L77-L99)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Secret name mismatch between docs and workflow**

   The "Required GitHub Configuration" section documents the deploy key secret as `DEPLOY_KEY`, but `release.yml` references it as `secrets.RELEASE_SSH_KEY`. Anyone setting up the release pipeline from scratch using this guide would create the wrong secret name and the SSH authentication step would fail silently. This discrepancy predates this PR, but since RELEASING.md was edited here, it's a good opportunity to align the two.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: RELEASING.md
   Line: 77-99

   Comment:
   **Secret name mismatch between docs and workflow**

   The "Required GitHub Configuration" section documents the deploy key secret as `DEPLOY_KEY`, but `release.yml` references it as `secrets.RELEASE_SSH_KEY`. Anyone setting up the release pipeline from scratch using this guide would create the wrong secret name and the SSH authentication step would fail silently. This discrepancy predates this PR, but since RELEASING.md was edited here, it's a good opportunity to align the two.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20RELEASING.md%0ALine%3A%2077-99%0A%0AComment%3A%0A**Secret%20name%20mismatch%20between%20docs%20and%20workflow**%0A%0AThe%20%22Required%20GitHub%20Configuration%22%20section%20documents%20the%20deploy%20key%20secret%20as%20%60DEPLOY_KEY%60%2C%20but%20%60release.yml%60%20references%20it%20as%20%60secrets.RELEASE_SSH_KEY%60.%20Anyone%20setting%20up%20the%20release%20pipeline%20from%20scratch%20using%20this%20guide%20would%20create%20the%20wrong%20secret%20name%20and%20the%20SSH%20authentication%20step%20would%20fail%20silently.%20This%20discrepancy%20predates%20this%20PR%2C%20but%20since%20RELEASING.md%20was%20edited%20here%2C%20it's%20a%20good%20opportunity%20to%20align%20the%20two.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=132&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20RELEASING.md%0ALine%3A%2077-99%0A%0AComment%3A%0A**Secret%20name%20mismatch%20between%20docs%20and%20workflow**%0A%0AThe%20%22Required%20GitHub%20Configuration%22%20section%20documents%20the%20deploy%20key%20secret%20as%20%60DEPLOY_KEY%60%2C%20but%20%60release.yml%60%20references%20it%20as%20%60secrets.RELEASE_SSH_KEY%60.%20Anyone%20setting%20up%20the%20release%20pipeline%20from%20scratch%20using%20this%20guide%20would%20create%20the%20wrong%20secret%20name%20and%20the%20SSH%20authentication%20step%20would%20fail%20silently.%20This%20discrepancy%20predates%20this%20PR%2C%20but%20since%20RELEASING.md%20was%20edited%20here%2C%20it's%20a%20good%20opportunity%20to%20align%20the%20two.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=132&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ARELEASING.md%3A211-214%0A**Stale%20troubleshooting%20step%20after%20trigger%20change**%0A%0AThe%20%22Release%20didn't%20trigger%22%20section%20still%20says%20%22Verify%20you%20merged%20to%20%60main%60%20branch%22%20%E2%80%94%20but%20merging%20to%20%60main%60%20no%20longer%20triggers%20a%20release%20%28that%20was%20the%20whole%20point%20of%20this%20PR%29.%20A%20maintainer%20hitting%20this%20section%20after%20a%20failed%20%60workflow_dispatch%60%20would%20follow%20that%20step%2C%20see%20the%20merge%20is%20there%2C%20and%20still%20be%20confused.%20Consider%20replacing%20the%20first%20bullet%20with%20guidance%20on%20manually%20triggering%20the%20workflow%20%28e.g.%2C%20%22Go%20to%20Actions%20%E2%86%92%20Release%20%E2%86%92%20Run%20workflow%2C%20or%20run%20%60gh%20workflow%20run%20release.yml%60%22%29.%0A%0A%23%23%23%20Issue%202%20of%202%0ARELEASING.md%3A77-99%0A**Secret%20name%20mismatch%20between%20docs%20and%20workflow**%0A%0AThe%20%22Required%20GitHub%20Configuration%22%20section%20documents%20the%20deploy%20key%20secret%20as%20%60DEPLOY_KEY%60%2C%20but%20%60release.yml%60%20references%20it%20as%20%60secrets.RELEASE_SSH_KEY%60.%20Anyone%20setting%20up%20the%20release%20pipeline%20from%20scratch%20using%20this%20guide%20would%20create%20the%20wrong%20secret%20name%20and%20the%20SSH%20authentication%20step%20would%20fail%20silently.%20This%20discrepancy%20predates%20this%20PR%2C%20but%20since%20RELEASING.md%20was%20edited%20here%2C%20it's%20a%20good%20opportunity%20to%20align%20the%20two.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=132&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ARELEASING.md%3A211-214%0A**Stale%20troubleshooting%20step%20after%20trigger%20change**%0A%0AThe%20%22Release%20didn't%20trigger%22%20section%20still%20says%20%22Verify%20you%20merged%20to%20%60main%60%20branch%22%20%E2%80%94%20but%20merging%20to%20%60main%60%20no%20longer%20triggers%20a%20release%20%28that%20was%20the%20whole%20point%20of%20this%20PR%29.%20A%20maintainer%20hitting%20this%20section%20after%20a%20failed%20%60workflow_dispatch%60%20would%20follow%20that%20step%2C%20see%20the%20merge%20is%20there%2C%20and%20still%20be%20confused.%20Consider%20replacing%20the%20first%20bullet%20with%20guidance%20on%20manually%20triggering%20the%20workflow%20%28e.g.%2C%20%22Go%20to%20Actions%20%E2%86%92%20Release%20%E2%86%92%20Run%20workflow%2C%20or%20run%20%60gh%20workflow%20run%20release.yml%60%22%29.%0A%0A%23%23%23%20Issue%202%20of%202%0ARELEASING.md%3A77-99%0A**Secret%20name%20mismatch%20between%20docs%20and%20workflow**%0A%0AThe%20%22Required%20GitHub%20Configuration%22%20section%20documents%20the%20deploy%20key%20secret%20as%20%60DEPLOY_KEY%60%2C%20but%20%60release.yml%60%20references%20it%20as%20%60secrets.RELEASE_SSH_KEY%60.%20Anyone%20setting%20up%20the%20release%20pipeline%20from%20scratch%20using%20this%20guide%20would%20create%20the%20wrong%20secret%20name%20and%20the%20SSH%20authentication%20step%20would%20fail%20silently.%20This%20discrepancy%20predates%20this%20PR%2C%20but%20since%20RELEASING.md%20was%20edited%20here%2C%20it's%20a%20good%20opportunity%20to%20align%20the%20two.%0A%0A&pr=132&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
RELEASING.md:211-214
**Stale troubleshooting step after trigger change**

The "Release didn't trigger" section still says "Verify you merged to `main` branch" — but merging to `main` no longer triggers a release (that was the whole point of this PR). A maintainer hitting this section after a failed `workflow_dispatch` would follow that step, see the merge is there, and still be confused. Consider replacing the first bullet with guidance on manually triggering the workflow (e.g., "Go to Actions → Release → Run workflow, or run `gh workflow run release.yml`").

### Issue 2 of 2
RELEASING.md:77-99
**Secret name mismatch between docs and workflow**

The "Required GitHub Configuration" section documents the deploy key secret as `DEPLOY_KEY`, but `release.yml` references it as `secrets.RELEASE_SSH_KEY`. Anyone setting up the release pipeline from scratch using this guide would create the wrong secret name and the SSH authentication step would fail silently. This discrepancy predates this PR, but since RELEASING.md was edited here, it's a good opportunity to align the two.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): switch release publishing from ..."](https://github.com/youversion/platform-sdk-swift/commit/6500ff6eb1f7606a948177b39cefa2ce184a6459) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32697849)</sub>

<!-- /greptile_comment -->