### PR TITLE
perf: improve reader and versions list scrolling performance

### DIFF
--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -188,6 +188,9 @@ public struct BibleReaderView: View {
             lastScrolledVerse = nil
             viewModel.resetChapterCompleteTracking()
         }
+        .task {
+            await viewModel.onAppear()
+        }
         .onChange(of: viewModel.reference) { _, newReference in
             verseAnchors = []
             lastScrolledVerse = nil

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -91,7 +91,6 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         reference: BibleReference? = nil,
         highlightsViewModel: BibleHighlightsViewModel? = nil,
         verseSelectionStyle: VerseSelectionStyle = .solid,
-        versionsViewModel: BibleVersionsViewModel? = nil,
         audioActiveIndicatorColor: Color? = nil,
         onVerseTap: ((BibleReference) -> VerseTapResponse)? = nil,
         onNoteIndicatorTap: ((BibleReference) -> Void)? = nil,
@@ -125,8 +124,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         self.authentication = authentication
         self.isSignedIn = authentication.isSignedIn
         self.highlightsViewModel = highlightsViewModel ?? BibleHighlightsViewModel()
-        let shouldLoadVersionsViewModel = versionsViewModel == nil
-        self.versionsViewModel = versionsViewModel ?? BibleVersionsViewModel()
+        self.versionsViewModel = BibleVersionsViewModel()
         self.versionsViewModel.onSignInRequired = { [weak self] in
             self?.onSignInRequired()
         }
@@ -136,14 +134,11 @@ final class BibleReaderViewModel: ReaderThemeProviding {
 
         ReaderFonts.installFontsIfNeeded()
 
-        if shouldLoadVersionsViewModel {
-            let initialVersionId = self.reference.versionId
-            Task { [weak self] in
-                await self?.versionsViewModel.loadInitialState(initialVersionId: initialVersionId)
-            }
-        }
-
         observeCurrentVersion()
+    }
+
+    func onAppear() async {
+        await versionsViewModel.loadInitialState(initialVersionId: reference.versionId)
     }
 
     // Reacts to BibleVersionsViewModel.currentVersion changes by updating

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -70,6 +70,12 @@ public final class BibleVersionsViewModel {
         }
         hasLoadedInitialState = true
 
+        defer {
+            if Task.isCancelled {
+                hasLoadedInitialState = false
+            }
+        }
+
         // Grab the saved data first, because initializing myVersions clears the saved data.
         let savedIds = Set(UserDefaults.standard.array(forKey: userDefaultsKeyForMyVersions) as? [Int] ?? [])
 


### PR DESCRIPTION
## Description

This change improves performance of scrolling in the Reader, and Versions List view.

`BibleReaderView`'s `@State` re-evaluates `BibleReaderViewModel(...)` on every parent body call. The old init launched a `Task` that ran `loadInitialState`, which wrote to observable properties, which invalidated the reader and forced it to re-compare every `Text` in the chapter on every scroll frame.

Moving the load to `.task` makes it fire once when the view appears instead of on every struct rebuild. No more spurious invalidations during scroll.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [ ] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [x] `perf:` Performance improvement
- [ ] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] All commit messages follow [conventional commits](https://www.conventionalcommits.org/) format

## Additional Context

| Before | After |
|---|---|
|<video src="https://github.com/user-attachments/assets/fed214da-a7e4-4cbc-8f28-6a8a0f8ddab5" />|<video src="https://github.com/user-attachments/assets/640c4d88-6d1c-4a07-9ea0-3cbedb497aa9" />|
|<img width="368" height="215" alt="B" src="https://github.com/user-attachments/assets/40c4c2fd-f0d3-498b-8445-bf6d35151ed1" />|<img width="367" height="202" alt="A" src="https://github.com/user-attachments/assets/68a76c87-b479-46de-8668-7cb29735df8e" />|

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR eliminates the scrolling jank caused by `BibleReaderViewModel.init` launching an unstructured `Task` that wrote to `@Observable` properties on every parent body re-evaluation, invalidating the entire reader hierarchy on each scroll frame. Moving the load to a SwiftUI `.task` modifier ensures it fires exactly once per view appearance and is properly lifecycle-scoped.

- **`BibleReaderViewModel`**: The async load is removed from `init` and extracted into a new `onAppear()` method called by `.task`; the external `versionsViewModel` injection parameter is removed since loading is now tied to the view lifecycle.
- **`BibleVersionsViewModel`**: A `defer` block resets `hasLoadedInitialState` when the enclosing task is cancelled, addressing the potential spinner-forever case where a brief navigation away would leave the flag permanently `true` and block future loads.
- **`BibleReaderView`**: A single `.task` modifier wires the load to view appearance with no other structural changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the approach is idiomatic SwiftUI and the cancellation guard added to `BibleVersionsViewModel` correctly prevents the spinner-forever regression.

The core change (moving async work from `init` to `.task`) is straightforward and well-motivated by the before/after profiling. The `defer` block in `BibleVersionsViewModel` is a sound answer to the task-cancellation hazard identified in the prior review. The only remaining nuance is a minor double-load possibility when cooperative cancellation lets work complete after the task is marked cancelled, but `handleVersionPicked`'s version-equality guard prevents any visible chapter reload in that case.

`BibleVersionsViewModel.swift` — the `defer` reset condition is the only area that warrants a second look, specifically the edge case where the task is cancelled after all async work has already finished.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Adds `.task { await viewModel.onAppear() }` modifier to trigger the initial version load once on view appearance instead of inside the struct initialiser; no issues found. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Removes the unstructured `Task` launch and external `versionsViewModel` injection from `init`; delegates initial load to the new `onAppear()` async method called via `.task`. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift | Adds a `defer` block in `loadInitialState` to reset `hasLoadedInitialState` when the enclosing task is cancelled; addresses the spinner-forever regression, with a minor edge case where completed-but-cancelled runs also reset the flag. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Parent as Parent View
    participant BRV as BibleReaderView
    participant VM as BibleReaderViewModel
    participant VVM as BibleVersionsViewModel
    participant API as Network / Cache

    Parent->>BRV: body (re-renders on scroll)
    Note over BRV: @State ignores re-init after first use
    BRV->>BRV: .task fires once on first appear
    BRV->>VM: onAppear()
    VM->>VVM: loadInitialState(initialVersionId:)
    VVM->>VVM: guard hasLoadedInitialState → set true
    par Concurrent fetches
        VVM->>API: loadVersion(versionId:)
        VVM->>API: restoreMyVersions(savedIds:)
        VVM->>API: loadSuggestedLanguages()
    end
    API-->>VVM: results
    VVM->>API: removeUnpermittedVersions(initialVersionId:)
    API-->>VVM: permitted version list
    VVM->>VVM: setCurrentVersion(_:)
    Note over VVM: defer: reset flag if cancelled & currentVersion == nil
    VVM-->>VM: currentVersion observed (withObservationTracking)
    VM->>VM: handleVersionPicked(_:)
    VM-->>BRV: reference updated → reader renders content
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%3A73-77%0AThe%20%60defer%60%20correctly%20handles%20the%20case%20where%20cancellation%20happens%20before%20async%20work%20completes%20%E2%80%94%20great%20fix%20for%20the%20spinner-forever%20scenario.%20There's%20one%20small%20edge%20case%20worth%20knowing%20about%3A%20if%20the%20view%20disappears%20*while*%20async%20work%20is%20still%20in%20flight%20%28cooperative%20cancellation%20means%20the%20network%20calls%20may%20not%20stop%20immediately%29%2C%20%60loadInitialState%60%20can%20run%20to%20completion%20with%20%60currentVersion%60%20fully%20set%2C%20yet%20%60Task.isCancelled%60%20is%20still%20%60true%60%20when%20the%20%60defer%60%20fires.%20In%20that%20situation%2C%20%60hasLoadedInitialState%60%20gets%20reset%20to%20%60false%60%20and%20the%20whole%20load%20repeats%20on%20the%20next%20appearance.%20The%20redundant%20load%20is%20harmless%20in%20practice%20%E2%80%94%20%60handleVersionPicked%60%20guards%20against%20reloading%20the%20same%20version%20%E2%80%94%20but%20a%20narrower%20reset%20condition%20avoids%20the%20extra%20work.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20defer%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20Task.isCancelled%20%26%26%20currentVersion%20%3D%3D%20nil%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20hasLoadedInitialState%20%3D%20false%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=134&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%3A73-77%0AThe%20%60defer%60%20correctly%20handles%20the%20case%20where%20cancellation%20happens%20before%20async%20work%20completes%20%E2%80%94%20great%20fix%20for%20the%20spinner-forever%20scenario.%20There's%20one%20small%20edge%20case%20worth%20knowing%20about%3A%20if%20the%20view%20disappears%20*while*%20async%20work%20is%20still%20in%20flight%20%28cooperative%20cancellation%20means%20the%20network%20calls%20may%20not%20stop%20immediately%29%2C%20%60loadInitialState%60%20can%20run%20to%20completion%20with%20%60currentVersion%60%20fully%20set%2C%20yet%20%60Task.isCancelled%60%20is%20still%20%60true%60%20when%20the%20%60defer%60%20fires.%20In%20that%20situation%2C%20%60hasLoadedInitialState%60%20gets%20reset%20to%20%60false%60%20and%20the%20whole%20load%20repeats%20on%20the%20next%20appearance.%20The%20redundant%20load%20is%20harmless%20in%20practice%20%E2%80%94%20%60handleVersionPicked%60%20guards%20against%20reloading%20the%20same%20version%20%E2%80%94%20but%20a%20narrower%20reset%20condition%20avoids%20the%20extra%20work.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20defer%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20Task.isCancelled%20%26%26%20currentVersion%20%3D%3D%20nil%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20hasLoadedInitialState%20%3D%20false%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=134&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift:73-77
The `defer` correctly handles the case where cancellation happens before async work completes — great fix for the spinner-forever scenario. There's one small edge case worth knowing about: if the view disappears *while* async work is still in flight (cooperative cancellation means the network calls may not stop immediately), `loadInitialState` can run to completion with `currentVersion` fully set, yet `Task.isCancelled` is still `true` when the `defer` fires. In that situation, `hasLoadedInitialState` gets reset to `false` and the whole load repeats on the next appearance. The redundant load is harmless in practice — `handleVersionPicked` guards against reloading the same version — but a narrower reset condition avoids the extra work.

```suggestion
        defer {
            if Task.isCancelled && currentVersion == nil {
                hasLoadedInitialState = false
            }
        }
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: refresh loadInitialState on Task ca..."](https://github.com/youversion/platform-sdk-swift/commit/275f230812f327e3c669b4b4f26ff7d8a7a95462) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32827924)</sub>

<!-- /greptile_comment -->