### PR TITLE
feat(release): manual version-input release, no semantic-release orchestration

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -29,6 +29,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Test release scripts
+        # Exercises scripts/release-validate.mjs and
+        # scripts/release-warn-version-jump.mjs — the version-validation
+        # paths called by scripts/release.sh at release time. Running
+        # here on every PR catches Node / OS / shell regressions before
+        # they reach a live release dispatch. This job runs Node 20 on
+        # ubuntu-latest; release.yml runs Node lts/* on macos-26 — the
+        # cross-environment coverage guards against env-dependent drift.
+        run: bash scripts/test-release-scripts.sh
+
       - name: Lint commit messages
         id: commitlint
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,23 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: |
+          The version to publish (bare semver, e.g. 5.2.3). Look at the
+          most recent merged PR's Commit Lint comment for the calculated
+          value, or run locally:
+            node scripts/preview-release.mjs \
+              --base $(git describe --tags --abbrev=0) --head main
+          You can override the calculator's value here — the workflow
+          logs both side-by-side for audit.
+        required: true
+        type: string
+      dry-run:
+        description: "Run end-to-end up to commit X + tag, then stop. Skips push, GitHub release, pod publish, and Dev-restore. For validating the workflow without shipping."
+        required: false
+        type: boolean
+        default: false
 
 env:
   XCODE_VERSION: latest-stable
@@ -68,8 +85,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Persist credentials for future commit (write)
-          # persist-credentials: false
+          # SSH key persists in the git remote so subsequent pushes
+          # (release commit X, tag, Dev-restore Y) bypass the `main`
+          # branch protection ruleset via the deploy-key bypass list.
           ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
 
       - name: Install npm dependencies
@@ -81,6 +99,7 @@ jobs:
           chmod +x scripts/publish-pods.sh
           chmod +x scripts/stamp-sdk-version.sh
           chmod +x scripts/restore-dev-sdk-on-main.sh
+          chmod +x scripts/release.sh
 
       - name: Setup Git
         run: |
@@ -90,11 +109,15 @@ jobs:
 
       - name: Release
         env:
+          VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry-run && '1' || '0' }}
+          # GH_TOKEN is what the `gh` CLI reads. We also export
+          # GITHUB_TOKEN for any other tooling that expects it.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # TODO: Remove CocoaPods token once we confirm we're not using it anymore
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
           GIT_AUTHOR_NAME: "github-actions[bot][release]"
           GIT_AUTHOR_EMAIL: "github-actions[bot][release]@users.noreply.github.com"
           GIT_COMMITTER_NAME: "github-actions[bot][release]"
           GIT_COMMITTER_EMAIL: "github-actions[bot][release]@users.noreply.github.com"
-        run: npx semantic-release
+        run: bash scripts/release.sh

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,9 @@ yarn-error.log*
 
 # Husky
 .husky/_/
+
+# Release artifacts
+# scripts/release.sh and dry-runs write generated release notes here.
+# The path is anchored to the repo root so a future `docs/notes.md` (or
+# anything in a subdirectory) is not silently ignored.
+/notes.md

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,4 @@
 {
-  "branches": ["main"],
-  "tagFormat": "${version}",
   "plugins": [
     [
       "@semantic-release/commit-analyzer",
@@ -12,35 +10,6 @@
       "@semantic-release/release-notes-generator",
       {
         "preset": "conventionalcommits"
-      }
-    ],
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md",
-        "changelogTitle": "# Changelog\n\nAll notable changes to this project will be documented in this file."
-      }
-    ],
-    [
-      "@semantic-release/exec",
-      {
-        "prepareCmd": "bash scripts/update-pod-versions.sh ${nextRelease.version} && bash scripts/stamp-sdk-version.sh ${nextRelease.version}",
-        "publishCmd": "bash scripts/restore-dev-sdk-on-main.sh ${nextRelease.version} && bash scripts/publish-pods.sh ${nextRelease.version}"
-      }
-    ],
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": [
-          "CHANGELOG.md",
-          "Sources/YouVersionPlatformCore/SDKVersion.swift",
-          "YouVersionPlatform.podspec",
-          "YouVersionPlatformCore.podspec",
-          "YouVersionPlatformReader.podspec",
-          "YouVersionPlatformUI.podspec"
-        ],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,25 +115,35 @@ When writing or reviewing code in this repo, load the relevant skill:
 
 ## Release Process
 
-Releases are driven by `semantic-release` from `main` (see `.github/workflows/release.yml` and `.releaserc.json`). **The Release workflow is triggered manually via `workflow_dispatch`** — go to the Actions tab and click "Run workflow", or run `gh workflow run release.yml`. Merging to `main` does **not** publish on its own; merges only land code, and a human decides when to cut the next release. Two pieces of state get version-bumped: the four `.podspec` files, and the `SDKVersion` constant used by the `x-yvp-sdk` HTTP header. They behave differently on purpose.
+Releases are **manually triggered with an explicit version input** via `workflow_dispatch`. There is no auto-release on merges to `main`. Merging to `main` only lands code; a human decides when to cut a release and which version to ship.
 
-**Podspecs** are bumped by `scripts/update-pod-versions.sh` during the prepare phase. The change is committed to `main` along with the `CHANGELOG.md` update.
+The release pipeline does not invoke `semantic-release` as an orchestrator. We use `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` as ESM libraries (via `scripts/preview-release.mjs` and `scripts/generate-release-notes.mjs`), and `scripts/release.sh` orchestrates the rest. See [RELEASING.md](./RELEASING.md) for the full operator guide.
 
-**`Sources/YouVersionPlatformCore/SDKVersion.swift`** is bumped by `scripts/release-stamp-and-tag.sh` during the publish phase, on a *separate child commit* that is **not pushed to `main`**. The release tag is force-moved to point at this stamped commit. Topology after a release:
-
-```
-main:  ... ─ X (podspec=4.9.2, CHANGELOG, SDKVersion="Dev")     ← main HEAD
-                  \
-                   Y (… +SDKVersion="4.9.2")                    ← tag 4.9.2
+To dispatch a release:
+```bash
+gh workflow run release.yml -f version=5.3.0
+# add -f dry-run=true to validate the workflow without shipping
 ```
 
-Why: `main` always reads `SDKVersion.current = "Dev"` so in-repo dev builds and PR CI report `SwiftSDK=Dev` rather than poisoning the data lake with stale or imprecise versions. SPM consumers resolving a tag and CocoaPods consumers (whose podspec source is `:tag => s.version.to_s`) both fetch `Y`, so production traffic reports the precise released version.
+Two pieces of state get version-bumped: the four `.podspec` files, and the `SDKVersion` constant used by the `x-yvp-sdk` HTTP header. They live in the same commit X but the SDKVersion handling has a twist.
+
+**Podspecs** are bumped by `scripts/update-pod-versions.sh`, called from `release.sh` before commit X.
+
+**`Sources/YouVersionPlatformCore/SDKVersion.swift`** is stamped to the release version by `scripts/stamp-sdk-version.sh` in commit X (so consumers fetching the tag see the real version), then restored to `"Dev"` in a follow-up commit Y by `scripts/restore-dev-sdk-on-main.sh`. Both X and Y are pushed to `main`; the tag stays at X. Topology after a release:
+
+```
+main:  ... ─ X (podspec=5.3.0, CHANGELOG entry, SDKVersion="5.3.0")   ← TAG 5.3.0
+                   \
+                    Y (SDKVersion="Dev")                              ← main HEAD
+```
+
+Why: `main` HEAD reads `SDKVersion.current = "Dev"` so in-repo dev builds and PR CI report `SwiftSDK=Dev` rather than poisoning the data lake with stale or imprecise versions. SPM consumers resolving a tag and CocoaPods consumers (podspec source is `:tag => s.version.to_s`) fetch X, so production traffic reports the precise released version. Y is reachable from `main` and X is reachable from Y, so `git tag --merged main` still finds the release tag — that wasn't true in an earlier design that placed Y off-main.
 
 **Footguns**:
-- `git checkout <tag>` lands on a detached commit not reachable from `main`. Expected.
-- `git log main` does not show any commit that ever modified `SDKVersion.swift` to a real version. Expected — those commits live only on tags.
-- Don't cherry-pick a tagged commit onto `main`; it would leak the stamped version.
+- `git log main` does show every release: X (stamped, tagged) sits one commit behind every Y (Dev-restore). To find the tag commits, `git log main --grep '^chore(release):'` works.
+- Don't manually rebase or amend X or Y — they're part of an enforced topology that `restore-dev-sdk-on-main.sh`'s pre-flight asserts depend on.
 - If you change the shape of the `static let current = "..."` line in `SDKVersion.swift`, also update `scripts/stamp-sdk-version.sh`.
+- The Commit Lint workflow's PR preview shows what the analyzer would compute as the next version. The release workflow logs that value side-by-side with the human's chosen value for audit — they don't have to match.
 
 ## Localization
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,13 +34,13 @@ This SDK is organized as a Swift Package with multiple targets:
 
 This project follows idiomatic Swift conventions as outlined in [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/). Key points:
 
-- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages — they drive semantic-release's version bumps and the auto-generated CHANGELOG. Validated in CI by the `Commit Lint` workflow; check locally with `npm run commitlint` (or `npx commitlint --from=origin/main --to=HEAD --verbose`).
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages — they drive the version-preview analyzer and the auto-generated CHANGELOG. Validated in CI by the `Commit Lint` workflow; check locally with `npm run commitlint` (or `npx commitlint --from=origin/main --to=HEAD --verbose`).
 
-  > **⚠️ Important: every commit subject on `main` is scanned to compute the next version when a release is cut.**
+  > **⚠️ Important: every commit subject on `main` is scanned by the analyzer to suggest the next version when a release is cut.**
   >
-  > This repo squash-merges PRs. The **squash commit subject becomes a single commit on `main`** — its `<type>` is what semantic-release reads, not the individual commits on your branch. GitHub seeds the squash subject from the PR title by default, so **make sure your PR title is itself a valid Conventional Commit** (e.g. `feat(reader): add highlight color picker`). If the squash subject is `chore:` it contributes no release signal even if every commit on your branch was a `feat`.
+  > This repo squash-merges PRs. The **squash commit subject becomes a single commit on `main`** — its `<type>` is what the analyzer reads, not the individual commits on your branch. GitHub seeds the squash subject from the PR title by default, so **make sure your PR title is itself a valid Conventional Commit** (e.g. `feat(reader): add highlight color picker`). If the squash subject is `chore:` it contributes no release signal even if every commit on your branch was a `feat`.
   >
-  > Releases are cut on demand — see [RELEASING.md](./RELEASING.md). When the Release workflow is triggered, semantic-release walks the entire commit history back to the last release tag and picks the **highest** bump it finds across that window — one `feat` among ten `chore`s still produces a minor release; one `BREAKING CHANGE` footer (or `!` shorthand) anywhere produces a major. The CI `Commit Lint` workflow on each PR previews the version that *would* be cut today, using the same logic, so you can see your PR's impact before merging.
+  > Releases are cut on demand with an explicit version input — see [RELEASING.md](./RELEASING.md). The analyzer walks every commit since the last release tag and picks the **highest** bump it finds across that window — one `feat` among ten `chore`s suggests a minor release; one `BREAKING CHANGE` footer (or `!` shorthand) anywhere suggests a major. The CI `Commit Lint` workflow on each PR shows that preview, and the Release workflow logs it side-by-side with the human's chosen version for audit. The human's input is what actually ships; the analyzer's value is informational.
 
   **Format:** `<type>(<optional scope>): <subject>`
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,113 +1,75 @@
 # Release Process
 
-This project uses [semantic-release](https://semantic-release.gitbook.io/) for automated versioning and package publishing.
+Releases on this repo are **manually triggered with an explicit version input**. A human types the version they want to publish into the Actions UI (or `gh workflow run`), the workflow validates it, and the release ships. There is no auto-release on merges to `main`.
 
 ## Overview
 
-Releases use [semantic-release](https://semantic-release.gitbook.io/) to compute the next version from [Conventional Commits](https://www.conventionalcommits.org/) since the last tag, but the release itself is **triggered manually**, not automatically on every push to `main`. A human (or scheduled job) decides when to cut a release; merging a PR by itself never publishes.
+The release pipeline does not use `semantic-release` as an orchestrator. We use two pieces of it as libraries:
+
+- [`@semantic-release/commit-analyzer`](https://github.com/semantic-release/commit-analyzer) — invoked by `scripts/preview-release.mjs` to compute what version the commits *would* suggest (shown in the PR's Commit Lint comment and in the release workflow's job summary for audit).
+- [`@semantic-release/release-notes-generator`](https://github.com/semantic-release/release-notes-generator) — invoked by `scripts/generate-release-notes.mjs` to render the CHANGELOG entry and GitHub release body from commits since the last tag.
+
+Everything else (validation, version stamping, podspec updates, commit, tag, push, GitHub release creation, pod publish, Dev-restore) is in `scripts/release.sh`, which the release workflow calls directly.
+
+This split exists because `semantic-release`'s lifecycle tightly couples computation to execution. There is no hook to override its calculated version — the only way to ship a version that differs from what the analyzer computes is to commit-message-engineer history, which is brittle, slow, and unreviewable. By making the version an explicit workflow input we get one-click overrides, a side-by-side audit log of "calculator said X, human chose Y," and no history rewrites.
 
 ## How It Works
 
-1. **Develop on a branch with conventional commit subjects** → the `Commit Lint` workflow validates each PR and previews the version that *would* be cut today.
-2. **Merge PRs to `main`** → nothing publishes. `main` just accumulates work.
-3. **When ready to release, trigger the Release workflow manually** → Actions tab → `Release` → "Run workflow" (or `gh workflow run release.yml`).
-4. **Semantic-release analyzes commits since the last tag** → determines version bump (major/minor/patch).
-5. **Version bump and changelog** → updates all 4 podspec files, stamps `SDKVersion.swift`, writes a `CHANGELOG.md` entry.
-6. **Git tag and GitHub release** → creates the version tag (e.g., `5.3.0`) and a GitHub release.
-7. **Publish to CocoaPods** → publishes all pods in dependency order.
-8. **Restore `SDKVersion.swift` to `"Dev"`** → a follow-up commit returns the on-main constant to `"Dev"` so PR builds don't report a stale released version. The tag stays at the stamped commit (see [AGENTS.md → Release Process](./AGENTS.md#release-process) for the X/Y topology).
-
-### Why manual
-
-Auto-publishing on every push to `main` makes the publish surface too easy to trip — any commit message body or release-process change that an analyzer reads as a major bump goes straight to consumers. Manual trigger gives a deliberate review point between merge and publish, and keeps the per-PR version preview as the early warning.
-
-## Commit Message Format
-
-Use this format for all commits:
-
-```
-<type>(<scope>): <subject>
-
-<body>
-
-<footer>
-```
-
-### Types (determines version bump)
-
-- **feat**: A new feature (→ **MINOR** version bump, e.g., 1.0.0 → 1.1.0)
-- **fix**: A bug fix (→ **PATCH** version bump, e.g., 1.0.0 → 1.0.1)
-- **BREAKING CHANGE**: Breaking API change (→ **MAJOR** version bump, e.g., 1.0.0 → 2.0.0)
-
-### Other types (no version bump)
-
-- **docs**: Documentation changes
-- **style**: Code formatting
-- **refactor**: Code refactoring
-- **perf**: Performance improvements
-- **test**: Test changes
-- **build**: Build system changes
-- **ci**: CI/CD changes
-- **chore**: Maintenance tasks
-
-### Examples
-
-```bash
-# Patch release (1.0.0 → 1.0.1)
-git commit -m "fix: resolve crash on iPad when opening reader"
-
-# Minor release (1.0.0 → 1.1.0)
-git commit -m "feat: add dark mode support to reader"
-
-# Major release (1.0.0 → 2.0.0)
-git commit -m "feat: redesign Bible reader API
-
-BREAKING CHANGE: BibleReader.open() now returns async Result<Void, Error>"
-
-# With scope
-git commit -m "fix(reader): correct verse highlighting behavior"
-```
+1. **Develop on a branch with conventional commit subjects.** The `Commit Lint` workflow validates every PR and previews the version the analyzer would compute.
+2. **Merge PRs to `main`.** Nothing publishes. `main` just accumulates work.
+3. **Decide on a version.** The most recent merged PR's Commit Lint comment shows the analyzer-computed value, which is the suggested next version. You can accept that or override.
+4. **Dispatch the Release workflow** from the Actions tab → `Release` → "Run workflow", or via CLI:
+   ```bash
+   gh workflow run release.yml -f version=5.3.0
+   ```
+   To validate the workflow end-to-end on a feature branch without shipping, also pass `-f dry-run=true`.
+5. **The workflow runs `scripts/release.sh`**, which:
+   - Validates the input is valid semver and strictly greater than the current tag.
+   - Logs the calculator's computed value alongside the chosen value in the job summary.
+   - Warns (but does not block) if the chosen version is more than one major above calculated.
+   - Generates release notes from commits since the last tag.
+   - Prepends the new entry to `CHANGELOG.md`.
+   - Stamps `SDKVersion.swift` and all four podspecs to the chosen version.
+   - Commits everything as `chore(release): <version> [skip ci]` (commit **X**), with the release notes embedded as the commit body.
+   - Tags **X** with the version and pushes both to `main`.
+   - Creates a GitHub release with the generated notes.
+   - Publishes all four pods to CocoaPods trunk in dependency order.
+   - Creates a follow-up commit **Y** that restores `SDKVersion.swift` to `"Dev"` on `main`, so subsequent dev/CI builds don't report a stale released version. The tag stays at **X** (which is reachable from `main` via Y → X).
 
 ## Required GitHub Configuration
 
 ### GitHub Secrets
 
-The following secrets must be configured in your GitHub repository:
+The following secrets must be configured in the repository:
 
-#### 1. DEPLOY_KEY
+#### 1. `RELEASE_SSH_KEY`
 
-An SSH private key used to bypass branch protection rules and push release commits/tags to `main`:
+An SSH private key used to bypass the `main` branch-protection ruleset so the release workflow can push commits **X** and **Y** and the version tag.
 
 1. Generate an SSH key pair:
    ```bash
-   ssh-keygen -t ed25519 -C "github-actions-semantic-release" -f deploy_key -N ""
+   ssh-keygen -t ed25519 -C "github-actions-release" -f release_key -N ""
    ```
-
-2. Add the **public key** (`deploy_key.pub`) as a Deploy Key:
-   - Go to `https://github.com/youversion/platform-sdk-swift/settings/keys`
-   - Click "Add deploy key"
-   - Title: `semantic-release` (or your preferred name)
-   - Paste contents of `deploy_key.pub`
+2. Add the **public key** (`release_key.pub`) as a Deploy Key at `https://github.com/youversion/platform-sdk-swift/settings/keys`:
+   - Title: `release` (or your preferred name)
+   - Paste contents of `release_key.pub`
    - **Check "Allow write access"** ✓
+3. Add the **private key** (`release_key`) as a repository secret at `https://github.com/youversion/platform-sdk-swift/settings/secrets/actions`:
+   - Name: `RELEASE_SSH_KEY`
+   - Value: paste entire contents of the `release_key` file
 
-3. Add the **private key** (`deploy_key`) as a repository secret:
-   - Go to `https://github.com/youversion/platform-sdk-swift/settings/secrets/actions`
-   - Click "New repository secret"
-   - Name: `DEPLOY_KEY`
-   - Value: Paste entire contents of `deploy_key` file
+> **Important:** the secret name `RELEASE_SSH_KEY` must match the reference in `.github/workflows/release.yml`. If you rename the secret, update the workflow too.
 
-> **Important:** The secret name `DEPLOY_KEY` must match the reference in `.github/workflows/release.yml`. If you change the secret name, update the workflow file accordingly.
+#### 2. `COCOAPODS_TRUNK_TOKEN`
 
-#### 2. COCOAPODS_TRUNK_TOKEN
-
-Your CocoaPods trunk session token:
+Your CocoaPods trunk session token, used by `scripts/publish-pods.sh` to authenticate the `pod trunk push` calls.
 
 ```bash
 # Get your token from ~/.netrc after registering
 cat ~/.netrc | grep cocoapods.org
 ```
 
-Or get it from CocoaPods trunk:
+Or:
 
 ```bash
 pod trunk me
@@ -117,19 +79,53 @@ Add the token to repository secrets as `COCOAPODS_TRUNK_TOKEN`.
 
 ### Branch Protection Configuration
 
-The Deploy Key bypasses the `main` branch protection ruleset that requires pull requests. To configure:
+The `main` branch ruleset requires pull requests, but the release workflow needs to push **X** and **Y** commits and the tag directly. The Deploy Key configured above bypasses this.
 
 1. Go to `https://github.com/youversion/platform-sdk-swift/settings/rules`
-2. Edit the ruleset for `main` branch
-3. Under "Bypass list", ensure "Deploy keys" is enabled for bypass
+2. Edit the ruleset for `main`
+3. Under "Bypass list", ensure "Deploy keys" is enabled
 
-This allows semantic-release to push release commits and tags directly to `main` during the automated release process.
+## Local Testing
 
-## Testing Release Steps Locally
+### Preview the version the analyzer would suggest
+
+```bash
+node scripts/preview-release.mjs \
+  --base "$(git describe --tags --abbrev=0)" \
+  --head HEAD
+```
+
+Outputs JSON: `{"current": "5.2.2", "next": "5.2.3", "release_type": "patch", ...}`. The same logic the `Commit Lint` workflow uses on every PR.
+
+### Generate release notes for a hypothetical version
+
+```bash
+node scripts/generate-release-notes.mjs \
+  --base "$(git describe --tags --abbrev=0)" \
+  --head HEAD \
+  --version 5.2.3
+```
+
+Prints the markdown that would be prepended to `CHANGELOG.md` and used as the GitHub release body.
+
+### Dry-run the full release end-to-end
+
+```bash
+VERSION=5.2.3 DRY_RUN=1 SKIP_LINT=1 bash scripts/release.sh
+```
+
+Validates the version, generates notes, updates `CHANGELOG.md` and podspecs, stamps `SDKVersion.swift`, builds commit X, tags it — then stops without pushing. `SKIP_LINT=1` bypasses the `pod lib lint` step which needs Xcode + iOS simulator runtime (CI has it; most dev machines don't).
+
+Clean up after a dry-run:
+
+```bash
+git reset --hard HEAD^
+git tag -d <version>
+git restore .
+rm -f notes.md
+```
 
 ### Test commitlint
-
-Conventional Commits are enforced in CI by `.github/workflows/commit-lint.yml`. There is no local Git hook — Xcode commits and Windows contributors bypass hooks too unreliably for that to be worth maintaining. To check your branch's commits locally before pushing:
 
 ```bash
 # Lint every commit on your branch that isn't on main
@@ -143,99 +139,69 @@ echo "feat: add new feature" | npx commitlint
 echo "invalid message" | npx commitlint   # should fail
 ```
 
-### Test semantic-release (dry-run)
-
-```bash
-# See what version would be released
-npx semantic-release --dry-run
-```
-
-### Test version update script
-
-```bash
-# Test updating to version 1.2.3 (won't actually publish)
-bash scripts/update-pod-versions.sh 1.2.3
-```
-
 ## Version Synchronization
 
-All 4 podspecs are kept in sync:
+All four podspecs are kept in sync via `scripts/update-pod-versions.sh`:
 
 - `YouVersionPlatformCore.podspec`
 - `YouVersionPlatformUI.podspec` (depends on Core)
 - `YouVersionPlatformReader.podspec` (depends on UI)
 - `YouVersionPlatform.podspec` (umbrella, depends on all)
 
-The `update-pod-versions.sh` script ensures:
-- All podspecs get the same version number
-- Inter-pod dependencies reference the correct version
+Inter-pod dependencies use `s.version.to_s`, so a single version-bump call updates everything coherently.
 
 ## Publishing Order
 
-Pods are published in dependency order:
+Pods are published in dependency order by `scripts/publish-pods.sh`:
 
 1. **YouVersionPlatformCore** (no dependencies)
 2. **YouVersionPlatformUI** (depends on Core)
 3. **YouVersionPlatformReader** (depends on UI)
 4. **YouVersionPlatform** (umbrella, depends on all)
 
-## Manual Release (Emergency)
-
-If you need to release manually:
-
-```bash
-# 1. Update versions
-bash scripts/update-pod-versions.sh 1.2.3
-
-# 2. Update CHANGELOG.md manually
-
-# 3. Commit changes
-git add .
-git commit -m "chore(release): 1.2.3 [skip ci]"
-
-# 4. Create tag
-git tag 1.2.3
-
-# 5. Push
-git push origin main --tags
-
-# 6. Publish to CocoaPods
-bash scripts/publish-pods.sh 1.2.3
-
-# 7. Create GitHub release manually
-```
+`pod trunk push` is non-idempotent and can partial-succeed: a network blip can leave Core published but UI not. The script checks `pod trunk info <PodName>` for the target version before each push, so re-running on the same version is safe.
 
 ## Troubleshooting
 
-### Release didn't trigger
+### The Commit Lint preview shows a major bump on a "patch" PR
 
-- Verify you merged to `main` branch
-- Check that commits follow Conventional Commits format
-- Look at GitHub Actions logs for errors
+`conventional-commits-parser` treats `BREAKING CHANGE` at the start of any commit body line as a breaking-change footer, regardless of surrounding markdown or quotes. The most common cause: a long commit body wraps and a paragraph happens to start with that token. Reword the offending line on your branch.
 
-### CocoaPods publish failed
+The analyzer log in the PR comment's `<details>` block shows which commit triggered the classification.
 
-- Verify `COCOAPODS_TRUNK_TOKEN` secret is set correctly
-- Check that podspec files are valid: `pod spec lint *.podspec`
-- Ensure you have permission to publish these pods
+### The release dispatch is rejected with "is not strictly greater than current tag"
 
-### Commitlint blocking commits
+`release.sh` refuses to ship a version less than or equal to the latest tag. If you genuinely need to re-tag (e.g., recovering from a partial release), delete the old tag from origin first, then dispatch again.
 
-- Make sure your commit message follows the format: `type(scope): subject`
-- Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
-- Bypass temporarily (not recommended): `git commit --no-verify`
+### CocoaPods publish failed midway
 
-## Swift Package Manager
+The script is idempotent via `pod trunk info`. Re-dispatch with the same version; the already-published pods will be skipped and the missing ones retried. If `pod trunk info` itself is unreliable, check `pod trunk me` to confirm authentication.
 
-SPM uses git tags for versioning. When semantic-release creates a tag like `1.0.0`, SPM users can reference it in their `Package.swift`:
+### Need an emergency release without the workflow
 
-```swift
-.package(url: "https://github.com/YouVersion/platform-sdk-swift.git", from: "1.0.0")
+The pieces of `scripts/release.sh` can be run by hand:
+
+```bash
+VERSION=5.2.3
+
+# Compute and inspect what would happen
+node scripts/preview-release.mjs --base "$(git describe --tags --abbrev=0)" --head HEAD
+node scripts/generate-release-notes.mjs --base "$(git describe --tags --abbrev=0)" --head HEAD --version "$VERSION" > notes.md
+
+# Update files
+bash scripts/update-pod-versions.sh "$VERSION"
+bash scripts/stamp-sdk-version.sh "$VERSION"
+# manually prepend notes.md to CHANGELOG.md
+
+# Commit X, tag, push
+git add CHANGELOG.md Sources/YouVersionPlatformCore/SDKVersion.swift *.podspec
+git commit -m "chore(release): $VERSION [skip ci]" -m "$(cat notes.md)"
+git tag "$VERSION"
+git push origin main "$VERSION"
+
+# Publish
+bash scripts/publish-pods.sh "$VERSION"
+
+# Restore Dev
+bash scripts/restore-dev-sdk-on-main.sh "$VERSION"
 ```
-
-## Resources
-
-- [Conventional Commits](https://www.conventionalcommits.org/)
-- [Semantic Versioning](https://semver.org/)
-- [semantic-release Documentation](https://semantic-release.gitbook.io/)
-- [Commitlint Rules](https://commitlint.js.org/#/reference-rules)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -177,6 +177,27 @@ The analyzer log in the PR comment's `<details>` block shows which commit trigge
 
 The script is idempotent via `pod trunk info`. Re-dispatch with the same version; the already-published pods will be skipped and the missing ones retried. If `pod trunk info` itself is unreliable, check `pod trunk me` to confirm authentication.
 
+### The release script aborted after pushing the tag — main is stamped with the released version
+
+If `release.sh` dies in any of the post-push steps (`gh release create`, `publish-pods.sh`, `restore-dev-sdk-on-main.sh`), `main` HEAD is commit **X** with `SDKVersion.swift` reading the released version, and commit **Y** was never created. Re-running `release.sh` won't recover — its pre-flight requires `SDKVersion.swift` to read `"Dev"` and will refuse to proceed.
+
+Finish the release by running the remaining steps manually:
+
+```bash
+VERSION=<the version that was being released>
+
+# If the GitHub release wasn't created (check the Releases page):
+gh release create "$VERSION" --notes-file notes.md --title "$VERSION"
+
+# Idempotent via `pod trunk info` — safe regardless of how far the script got:
+bash scripts/publish-pods.sh "$VERSION"
+
+# Creates commit Y and restores SDKVersion to "Dev":
+bash scripts/restore-dev-sdk-on-main.sh "$VERSION"
+```
+
+`notes.md` is left in place when the script aborts (the success-path `rm` doesn't fire), so it's available for the `gh release create` call. Verify with `git log -2 --oneline` (Y on top of X) and `pod trunk info YouVersionPlatformCore` (latest matches `$VERSION`).
+
 ### Need an emergency release without the workflow
 
 The pieces of `scripts/release.sh` can be run by hand:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,10 @@
       "devDependencies": {
         "@commitlint/cli": "^18.4.3",
         "@commitlint/config-conventional": "^18.4.3",
-        "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^11.1.0",
-        "@semantic-release/exec": "^6.0.3",
-        "@semantic-release/git": "^10.0.1",
-        "@semantic-release/github": "^9.2.4",
         "@semantic-release/release-notes-generator": "^12.1.0",
         "conventional-changelog-conventionalcommits": "^7.0.2",
-        "semantic-release": "^22.0.10"
+        "semver": "^7.6.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -52,6 +48,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -322,6 +319,7 @@
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -336,6 +334,7 @@
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -346,6 +345,7 @@
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -360,6 +360,7 @@
       "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -370,6 +371,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -389,6 +391,7 @@
       "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
@@ -403,6 +406,7 @@
       "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/request": "^8.4.1",
         "@octokit/types": "^13.0.0",
@@ -417,7 +421,8 @@
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
       "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "9.2.2",
@@ -425,6 +430,7 @@
       "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^12.6.0"
       },
@@ -440,7 +446,8 @@
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
       "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
       "version": "12.6.0",
@@ -448,6 +455,7 @@
       "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/openapi-types": "^20.0.0"
       }
@@ -458,6 +466,7 @@
       "integrity": "sha512-WrO3bvq4E1Xh1r2mT9w6SDFg01gFmP81nIG77+p/MqW1JeXXgL++6umim3t6x0Zj5pZm3rXAN+0HEjmmdhIRig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/request-error": "^5.0.0",
         "@octokit/types": "^13.0.0",
@@ -476,6 +485,7 @@
       "integrity": "sha512-nOpWtLayKFpgqmgD0y3GqXafMFuKcA4tRPZIfu7BArd2lEZeb1988nhWhwx4aZWmjDmUfdgVf7W+Tt4AmvRmMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^12.2.0",
         "bottleneck": "^2.15.3"
@@ -492,7 +502,8 @@
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
       "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@octokit/plugin-throttling/node_modules/@octokit/types": {
       "version": "12.6.0",
@@ -500,6 +511,7 @@
       "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/openapi-types": "^20.0.0"
       }
@@ -510,6 +522,7 @@
       "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/endpoint": "^9.0.6",
         "@octokit/request-error": "^5.1.1",
@@ -526,6 +539,7 @@
       "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^13.1.0",
         "deprecation": "^2.0.0",
@@ -541,6 +555,7 @@
       "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/openapi-types": "^24.2.0"
       }
@@ -551,6 +566,7 @@
       "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.22.0"
       }
@@ -561,6 +577,7 @@
       "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "4.2.10"
       },
@@ -573,7 +590,8 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@pnpm/npm-conf": {
       "version": "2.3.1",
@@ -581,6 +599,7 @@
       "integrity": "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pnpm/config.env-replace": "^1.1.0",
         "@pnpm/network.ca-file": "^1.0.1",
@@ -588,25 +607,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@semantic-release/changelog": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
-      "integrity": "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "fs-extra": "^11.0.0",
-        "lodash": "^4.17.4"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
       }
     },
     "node_modules/@semantic-release/commit-analyzer": {
@@ -631,66 +631,13 @@
         "semantic-release": ">=20.1.0"
       }
     },
-    "node_modules/@semantic-release/error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/@semantic-release/exec": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-6.0.3.tgz",
-      "integrity": "sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.4",
-        "parse-json": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
-    },
-    "node_modules/@semantic-release/git": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
-      "integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "dir-glob": "^3.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.4",
-        "micromatch": "^4.0.0",
-        "p-reduce": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
-    },
     "node_modules/@semantic-release/github": {
       "version": "9.2.6",
       "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.2.6.tgz",
       "integrity": "sha512-shi+Lrf6exeNZF+sBhK+P011LSbhmIAoUEgEY6SsxF8irJ+J2stwI5jkyDQ+4gzYyDImzV6LCKdYB9FXnQRWKA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/core": "^5.0.0",
         "@octokit/plugin-paginate-rest": "^9.0.0",
@@ -722,6 +669,7 @@
       "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -732,6 +680,7 @@
       "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clean-stack": "^5.2.0",
         "indent-string": "^5.0.0"
@@ -749,6 +698,7 @@
       "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "5.0.0"
       },
@@ -765,6 +715,7 @@
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -778,6 +729,7 @@
       "integrity": "sha512-KUsozQGhRBAnoVg4UMZj9ep436VEGwT536/jwSqB7vcEfA6oncCUU7UIYTRdLx7GvTtqn0kBjnkfLVkcnBa2YQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/error": "^4.0.0",
         "aggregate-error": "^5.0.0",
@@ -806,6 +758,7 @@
       "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -816,6 +769,7 @@
       "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clean-stack": "^5.2.0",
         "indent-string": "^5.0.0"
@@ -833,6 +787,7 @@
       "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "5.0.0"
       },
@@ -849,6 +804,7 @@
       "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^8.0.1",
@@ -873,6 +829,7 @@
       "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -886,6 +843,7 @@
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=16.17.0"
       }
@@ -896,6 +854,7 @@
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -909,6 +868,7 @@
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -922,6 +882,7 @@
       "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -935,6 +896,7 @@
       "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -951,6 +913,7 @@
       "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-fn": "^4.0.0"
       },
@@ -967,6 +930,7 @@
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -980,6 +944,7 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -993,6 +958,7 @@
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1031,6 +997,7 @@
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1044,6 +1011,7 @@
       "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1082,22 +1050,9 @@
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ajv": {
@@ -1123,6 +1078,7 @@
       "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -1161,7 +1117,8 @@
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1175,7 +1132,8 @@
       "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
       "integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/array-ify": {
       "version": "1.0.0",
@@ -1199,14 +1157,16 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -1265,6 +1225,7 @@
       "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
@@ -1296,18 +1257,9 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/cli-table3": {
@@ -1316,6 +1268,7 @@
       "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -1378,6 +1331,7 @@
       "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -1532,6 +1486,7 @@
       "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "type-fest": "^1.0.1"
       },
@@ -1548,6 +1503,7 @@
       "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1626,6 +1582,7 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -1635,7 +1592,8 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -1643,6 +1601,7 @@
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -1669,6 +1628,7 @@
       "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.2"
       }
@@ -1685,7 +1645,8 @@
       "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
       "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/env-ci": {
       "version": "10.0.0",
@@ -1693,6 +1654,7 @@
       "integrity": "sha512-U4xcd/utDYFgMh0yWj07R1H6L5fwhVbmxBCpnL0DbVSDZVnsC82HONw0wxtxNkIAcua3KtbomQvIk5xFZGAQJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "execa": "^8.0.0",
         "java-properties": "^1.0.2"
@@ -1707,6 +1669,7 @@
       "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^8.0.1",
@@ -1731,6 +1694,7 @@
       "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -1744,6 +1708,7 @@
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=16.17.0"
       }
@@ -1754,6 +1719,7 @@
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -1767,6 +1733,7 @@
       "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1780,6 +1747,7 @@
       "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -1796,6 +1764,7 @@
       "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-fn": "^4.0.0"
       },
@@ -1812,6 +1781,7 @@
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1825,6 +1795,7 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -1838,6 +1809,7 @@
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1871,6 +1843,7 @@
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1884,6 +1857,7 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -1942,6 +1916,7 @@
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -1976,6 +1951,7 @@
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -1986,6 +1962,7 @@
       "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-unicode-supported": "^2.0.0"
       },
@@ -2045,6 +2022,7 @@
       "integrity": "sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver-regex": "^4.0.5"
       },
@@ -2072,6 +2050,7 @@
       "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2120,6 +2099,7 @@
       "integrity": "sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argv-formatter": "~1.0.0",
         "spawn-error-forwarder": "~1.0.0",
@@ -2135,6 +2115,7 @@
       "integrity": "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "through2": "~2.0.0"
       }
@@ -2145,6 +2126,7 @@
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -2432,6 +2414,7 @@
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -2458,6 +2441,7 @@
       "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sindresorhus/merge-streams": "^2.1.0",
         "fast-glob": "^3.3.3",
@@ -2479,6 +2463,7 @@
       "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2491,7 +2476,8 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -2554,6 +2540,7 @@
       "integrity": "sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -2580,6 +2567,7 @@
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -2594,6 +2582,7 @@
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -2618,6 +2607,7 @@
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -2757,6 +2747,7 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2777,6 +2768,7 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -2846,6 +2838,7 @@
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2873,6 +2866,7 @@
       "integrity": "sha512-zKa/Dxq2lGsBIXQ7CUZWTHfvxPC2ej0KfO7fIPqLlHB9J2hJ7rGhZ5rilhuufylr4RXYPzJUeFjKxz305OsNlA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash.capitalize": "^4.2.1",
         "lodash.escaperegexp": "^4.1.2",
@@ -2890,6 +2884,7 @@
       "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -2929,7 +2924,8 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -2958,6 +2954,7 @@
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -3015,6 +3012,7 @@
       "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^4.0.0",
@@ -3031,6 +3029,7 @@
       "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
@@ -3081,14 +3080,16 @@
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
       "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isfunction": {
       "version": "3.0.9",
@@ -3109,7 +3110,8 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
@@ -3158,7 +3160,8 @@
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.upperfirst": {
       "version": "4.3.1",
@@ -3193,6 +3196,7 @@
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3206,6 +3210,7 @@
       "integrity": "sha512-ubWhwcBFHnXsjYNsu+Wndpg0zhY4CahSpPlA70PlO0rR9r2sZpkyU+rkCsOWH+KMEkx847UpALON+HWgxowFtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-escapes": "^6.2.0",
         "cardinal": "^2.1.1",
@@ -3227,6 +3232,7 @@
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -3260,6 +3266,7 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -3287,6 +3294,7 @@
         "https://github.com/sponsors/broofa"
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mime": "bin/cli.js"
       },
@@ -3358,7 +3366,8 @@
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-emoji": {
       "version": "2.2.0",
@@ -3366,6 +3375,7 @@
       "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sindresorhus/is": "^4.6.0",
         "char-regex": "^1.0.2",
@@ -3397,6 +3407,7 @@
       "integrity": "sha512-X06Mfd/5aKsRHc0O0J5CUedwnPmnDtLF2+nq+KN9KSDlJHkPuh0JUviWjEWMe0SW/9TDdSLVPuk7L5gGTIA1/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -3480,6 +3491,7 @@
       ],
       "dev": true,
       "license": "Artistic-2.0",
+      "peer": true,
       "workspaces": [
         "docs",
         "smoke-tests",
@@ -3583,6 +3595,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -3600,6 +3613,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3611,13 +3625,15 @@
       "version": "9.2.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -3635,6 +3651,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -3650,6 +3667,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -3661,13 +3679,15 @@
       "version": "1.1.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "http-proxy-agent": "^7.0.0",
@@ -3684,6 +3704,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/fs": "^4.0.0",
@@ -3733,6 +3754,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/map-workspaces": "^4.0.1",
         "@npmcli/package-json": "^6.0.1",
@@ -3752,6 +3774,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -3764,6 +3787,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/promise-spawn": "^8.0.0",
         "ini": "^5.0.0",
@@ -3783,6 +3807,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-bundled": "^4.0.0",
         "npm-normalize-package-bin": "^4.0.0"
@@ -3799,6 +3824,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/name-from-folder": "^3.0.0",
         "@npmcli/package-json": "^6.0.0",
@@ -3814,6 +3840,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "cacache": "^19.0.0",
         "json-parse-even-better-errors": "^4.0.0",
@@ -3830,6 +3857,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.0",
         "@npmcli/installed-package-contents": "^3.0.0",
@@ -3861,6 +3889,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -3870,6 +3899,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -3879,6 +3909,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.0",
         "glob": "^10.2.2",
@@ -3897,6 +3928,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "which": "^5.0.0"
       },
@@ -3909,6 +3941,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "postcss-selector-parser": "^7.0.0"
       },
@@ -3921,6 +3954,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -3930,6 +3964,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/node-gyp": "^4.0.0",
         "@npmcli/package-json": "^6.0.0",
@@ -3948,6 +3983,7 @@
       "inBundle": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -3957,6 +3993,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -3966,6 +4003,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.4.1",
         "tuf-js": "^3.0.1"
@@ -3979,6 +4017,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
@@ -3988,6 +4027,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -3997,6 +4037,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -4006,6 +4047,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4015,6 +4057,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4026,25 +4069,29 @@
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "cmd-shim": "^7.0.0",
         "npm-normalize-package-bin": "^4.0.0",
@@ -4061,6 +4108,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -4073,6 +4121,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4082,6 +4131,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/fs": "^4.0.0",
         "fs-minipass": "^3.0.0",
@@ -4105,6 +4155,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4114,6 +4165,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
       },
@@ -4129,6 +4181,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -4146,6 +4199,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4155,6 +4209,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -4167,6 +4222,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4182,6 +4238,7 @@
       ],
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4191,6 +4248,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "ip-regex": "^5.0.0"
       },
@@ -4203,6 +4261,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1"
@@ -4216,6 +4275,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -4225,6 +4285,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4236,19 +4297,22 @@
       "version": "1.1.4",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/cross-spawn": {
       "version": "7.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4263,6 +4327,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -4278,6 +4343,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -4290,6 +4356,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4307,6 +4374,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4315,13 +4383,15 @@
       "version": "0.2.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
@@ -4329,6 +4399,7 @@
       "inBundle": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -4338,6 +4409,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4346,19 +4418,22 @@
       "version": "2.0.3",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.2",
       "dev": true,
       "inBundle": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.9.1"
       }
@@ -4368,6 +4443,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
@@ -4384,6 +4460,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -4396,6 +4473,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -4415,13 +4493,15 @@
       "version": "4.2.11",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "8.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^10.0.1"
       },
@@ -4433,13 +4513,15 @@
       "version": "4.2.0",
       "dev": true,
       "inBundle": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -4453,6 +4535,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -4467,6 +4550,7 @@
       "inBundle": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -4479,6 +4563,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minimatch": "^9.0.0"
       },
@@ -4491,6 +4576,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -4500,6 +4586,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -4509,6 +4596,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/package-json": "^6.0.0",
         "npm-package-arg": "^12.0.0",
@@ -4527,6 +4615,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -4540,6 +4629,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -4552,6 +4642,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "cidr-regex": "^4.1.1"
       },
@@ -4564,6 +4655,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4572,13 +4664,15 @@
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/jackspeak": {
       "version": "3.4.3",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -4593,13 +4687,15 @@
       "version": "1.1.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -4609,6 +4705,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -4620,25 +4717,29 @@
         "node >= 0.2.0"
       ],
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "9.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-package-arg": "^12.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -4652,6 +4753,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.1",
         "@npmcli/installed-package-contents": "^3.0.0",
@@ -4671,6 +4773,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.1",
         "@npmcli/run-script": "^9.0.1",
@@ -4692,6 +4795,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.1"
       },
@@ -4704,6 +4808,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -4717,6 +4822,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -4730,6 +4836,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.1",
         "@npmcli/run-script": "^9.0.1",
@@ -4745,6 +4852,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "ci-info": "^4.0.0",
         "normalize-package-data": "^7.0.0",
@@ -4764,6 +4872,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-registry-fetch": "^18.0.1"
       },
@@ -4776,6 +4885,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -4789,6 +4899,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.1",
         "@npmcli/run-script": "^9.0.1",
@@ -4804,13 +4915,15 @@
       "version": "10.4.3",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "14.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/agent": "^3.0.0",
         "cacache": "^19.0.1",
@@ -4833,6 +4946,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4842,6 +4956,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -4857,6 +4972,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -4866,6 +4982,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -4878,6 +4995,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3",
         "minipass-sized": "^1.0.3",
@@ -4895,6 +5013,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -4907,6 +5026,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4919,6 +5039,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -4931,6 +5052,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4943,6 +5065,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -4955,6 +5078,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4967,6 +5091,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -4979,6 +5104,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -4990,13 +5116,15 @@
       "version": "2.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5006,6 +5134,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
@@ -5030,6 +5159,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5039,6 +5169,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
       },
@@ -5054,6 +5185,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -5071,6 +5203,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5080,6 +5213,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "abbrev": "^3.0.0"
       },
@@ -5095,6 +5229,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "hosted-git-info": "^8.0.0",
         "semver": "^7.3.5",
@@ -5109,6 +5244,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5118,6 +5254,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-normalize-package-bin": "^4.0.0"
       },
@@ -5130,6 +5267,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "semver": "^7.1.1"
       },
@@ -5142,6 +5280,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5151,6 +5290,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "hosted-git-info": "^8.0.0",
         "proc-log": "^5.0.0",
@@ -5166,6 +5306,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "ignore-walk": "^7.0.0"
       },
@@ -5178,6 +5319,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-install-checks": "^7.1.0",
         "npm-normalize-package-bin": "^4.0.0",
@@ -5193,6 +5335,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-registry-fetch": "^18.0.0",
         "proc-log": "^5.0.0"
@@ -5206,6 +5349,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/redact": "^3.0.0",
         "jsonparse": "^1.3.1",
@@ -5225,6 +5369,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5234,6 +5379,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -5245,13 +5391,15 @@
       "version": "1.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "BlueOak-1.0.0"
+      "license": "BlueOak-1.0.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "19.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.0",
         "@npmcli/installed-package-contents": "^3.0.0",
@@ -5283,6 +5431,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "json-parse-even-better-errors": "^4.0.0",
         "just-diff": "^6.0.0",
@@ -5297,6 +5446,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5306,6 +5456,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -5322,6 +5473,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -5335,6 +5487,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5344,6 +5497,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5353,6 +5507,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -5362,6 +5517,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -5371,6 +5527,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -5384,6 +5541,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "read": "^4.0.0"
       },
@@ -5395,6 +5553,7 @@
       "version": "0.12.0",
       "dev": true,
       "inBundle": true,
+      "peer": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
@@ -5404,6 +5563,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "mute-stream": "^2.0.0"
       },
@@ -5416,6 +5576,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5425,6 +5586,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "json-parse-even-better-errors": "^4.0.0",
         "npm-normalize-package-bin": "^4.0.0"
@@ -5438,6 +5600,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -5447,13 +5610,15 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.7.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5466,6 +5631,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -5478,6 +5644,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5487,6 +5654,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -5499,6 +5667,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^3.1.0",
         "@sigstore/core": "^2.0.0",
@@ -5516,6 +5685,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.4.0"
       },
@@ -5528,6 +5698,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5537,6 +5708,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^3.1.0",
         "@sigstore/core": "^2.0.0",
@@ -5554,6 +5726,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^3.1.0",
         "@sigstore/core": "^2.0.0",
@@ -5568,6 +5741,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -5578,6 +5752,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -5592,6 +5767,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -5606,6 +5782,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -5616,6 +5793,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -5625,13 +5803,15 @@
       "version": "2.5.0",
       "dev": true,
       "inBundle": true,
-      "license": "CC-BY-3.0"
+      "license": "CC-BY-3.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -5641,19 +5821,22 @@
       "version": "3.0.21",
       "dev": true,
       "inBundle": true,
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/sprintf-js": {
       "version": "1.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "12.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -5666,6 +5849,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5681,6 +5865,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5695,6 +5880,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -5708,6 +5894,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -5720,6 +5907,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5732,6 +5920,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -5749,6 +5938,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -5761,6 +5951,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5773,6 +5964,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5782,6 +5974,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -5795,6 +5988,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5806,19 +6000,22 @@
       "version": "0.2.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/tinyglobby": {
       "version": "0.2.14",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fdir": "^6.4.4",
         "picomatch": "^4.0.2"
@@ -5835,6 +6032,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -5849,6 +6047,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5861,6 +6060,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -5870,6 +6070,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tufjs/models": "3.0.1",
         "debug": "^4.3.6",
@@ -5884,6 +6085,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
         "minimatch": "^9.0.5"
@@ -5897,6 +6099,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "unique-slug": "^5.0.0"
       },
@@ -5909,6 +6112,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
       },
@@ -5920,13 +6124,15 @@
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -5937,6 +6143,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -5947,6 +6154,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5955,13 +6163,15 @@
       "version": "3.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/which": {
       "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -5977,6 +6187,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -5986,6 +6197,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -6004,6 +6216,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -6021,6 +6234,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -6036,6 +6250,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6047,13 +6262,15 @@
       "version": "9.2.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -6071,6 +6288,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -6086,6 +6304,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -6098,7 +6317,8 @@
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -6106,6 +6326,7 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -6132,6 +6353,7 @@
       "integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6145,6 +6367,7 @@
       "integrity": "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-map": "^7.0.1"
       },
@@ -6203,21 +6426,12 @@
       "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-reduce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -6325,6 +6539,7 @@
       "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -6335,6 +6550,7 @@
       "integrity": "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-up": "^2.0.0",
         "load-json-file": "^4.0.0"
@@ -6349,6 +6565,7 @@
       "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "locate-path": "^2.0.0"
       },
@@ -6362,6 +6579,7 @@
       "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
@@ -6376,6 +6594,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-try": "^1.0.0"
       },
@@ -6389,6 +6608,7 @@
       "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-limit": "^1.1.0"
       },
@@ -6402,6 +6622,7 @@
       "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -6412,6 +6633,7 @@
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -6428,7 +6650,8 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -6449,7 +6672,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -6467,6 +6691,7 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "peer": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -6583,6 +6808,7 @@
       "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esprima": "~4.0.0"
       }
@@ -6593,6 +6819,7 @@
       "integrity": "sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pnpm/npm-conf": "^2.1.0"
       },
@@ -6670,6 +6897,7 @@
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -6695,6 +6923,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -6712,6 +6941,7 @@
       "integrity": "sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^11.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -6756,6 +6986,7 @@
       "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6766,6 +6997,7 @@
       "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clean-stack": "^5.2.0",
         "indent-string": "^5.0.0"
@@ -6783,6 +7015,7 @@
       "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "5.0.0"
       },
@@ -6799,6 +7032,7 @@
       "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^8.0.1",
@@ -6823,6 +7057,7 @@
       "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -6836,6 +7071,7 @@
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6849,6 +7085,7 @@
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=16.17.0"
       }
@@ -6859,6 +7096,7 @@
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6872,6 +7110,7 @@
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -6885,6 +7124,7 @@
       "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6898,6 +7138,7 @@
       "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -6914,6 +7155,7 @@
       "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-fn": "^4.0.0"
       },
@@ -6930,6 +7172,7 @@
       "integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6943,6 +7186,7 @@
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6956,6 +7200,7 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -6969,6 +7214,7 @@
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6998,6 +7244,7 @@
       "integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -7014,6 +7261,7 @@
       "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7070,6 +7318,7 @@
       "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^2.3.2",
         "figures": "^2.0.0",
@@ -7085,6 +7334,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -7098,6 +7348,7 @@
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -7113,6 +7364,7 @@
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -7122,7 +7374,8 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/signale/node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -7130,6 +7383,7 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -7140,6 +7394,7 @@
       "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -7153,6 +7408,7 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7163,6 +7419,7 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -7176,6 +7433,7 @@
       "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "unicode-emoji-modifier-base": "^1.0.0"
       },
@@ -7189,6 +7447,7 @@
       "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -7211,7 +7470,8 @@
       "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
       "integrity": "sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
@@ -7265,6 +7525,7 @@
       "integrity": "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
@@ -7314,6 +7575,7 @@
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7347,6 +7609,7 @@
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7370,6 +7633,7 @@
       "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
@@ -7400,6 +7664,7 @@
       "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       }
@@ -7410,6 +7675,7 @@
       "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-stream": "^3.0.0",
         "temp-dir": "^3.0.0",
@@ -7429,6 +7695,7 @@
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -7442,6 +7709,7 @@
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -7513,6 +7781,7 @@
       "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7586,6 +7855,7 @@
       "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7596,6 +7866,7 @@
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7609,6 +7880,7 @@
       "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "crypto-random-string": "^4.0.0"
       },
@@ -7624,7 +7896,8 @@
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
       "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -7632,6 +7905,7 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -7642,6 +7916,7 @@
       "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -7710,7 +7985,8 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -7718,6 +7994,7 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4"
       }

--- a/package.json
+++ b/package.json
@@ -8,19 +8,14 @@
     "url": "git@github.com:youversion/platform-sdk-swift.git"
   },
   "scripts": {
-    "semantic-release": "semantic-release",
     "commitlint": "commitlint --from=origin/main --to=HEAD --verbose"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",
     "@commitlint/config-conventional": "^18.4.3",
-    "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^11.1.0",
-    "conventional-changelog-conventionalcommits": "^7.0.2",
-    "@semantic-release/exec": "^6.0.3",
-    "@semantic-release/git": "^10.0.1",
-    "@semantic-release/github": "^9.2.4",
     "@semantic-release/release-notes-generator": "^12.1.0",
-    "semantic-release": "^22.0.10"
+    "conventional-changelog-conventionalcommits": "^7.0.2",
+    "semver": "^7.6.0"
   }
 }

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+// Generate release notes for a chosen version by calling
+// `@semantic-release/release-notes-generator` directly, with no
+// semantic-release lifecycle around it.
+//
+// The semantic-release CLI couples notes generation to the rest of the
+// release lifecycle (auth verification, plugin orchestration, branch
+// detection). That coupling is what made `--dry-run` fragile on PRs and
+// what made overriding a calculated version impossible. By calling the
+// notes-generator module as a library, this script asks one focused
+// question: "given these commits, what changelog entry should ship?"
+//
+// Output (stdout): the changelog markdown for the chosen version. No
+// surrounding noise — the caller pipes it directly into CHANGELOG.md
+// and into `gh release create --notes-file`.
+//
+// Usage:
+//   node scripts/generate-release-notes.mjs \
+//     --base <last-tag-or-sha> \
+//     --head <head-sha> \
+//     --version <semver>
+
+import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { format } from "node:util";
+import { generateNotes } from "@semantic-release/release-notes-generator";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i]?.replace(/^--/, "");
+    if (!key) continue;
+    out[key] = argv[i + 1];
+  }
+  return out;
+}
+
+// Read the notes-generator plugin config from .releaserc.json so the
+// preset (conventionalcommits) and any inline overrides stay in lockstep
+// with the rest of the release tooling.
+function readNotesGeneratorConfig() {
+  const releasercPath = resolve(REPO_ROOT, ".releaserc.json");
+  const releaserc = JSON.parse(readFileSync(releasercPath, "utf8"));
+  const entry = releaserc.plugins.find(
+    (p) => (Array.isArray(p) ? p[0] : p) === "@semantic-release/release-notes-generator"
+  );
+  if (!entry) {
+    throw new Error(
+      `@semantic-release/release-notes-generator not configured in ${releasercPath}`
+    );
+  }
+  return Array.isArray(entry) ? entry[1] : {};
+}
+
+function readRepositoryUrl() {
+  const pkgPath = resolve(REPO_ROOT, "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  const repo = pkg?.repository;
+  const url = typeof repo === "string" ? repo : repo?.url;
+  if (!url) {
+    throw new Error(`No repository.url in ${pkgPath}`);
+  }
+  return url;
+}
+
+// Same ASCII-RS/US delimiter trick as preview-release.mjs so commit
+// bodies with arbitrary whitespace/quotes don't break parsing.
+function getCommits(base, head) {
+  const fmt = "%H%x1f%B%x1e";
+  const out = execSync(`git log --reverse --format=${JSON.stringify(fmt)} ${base}..${head}`, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return out
+    .split("\x1e")
+    .map((rec) => rec.replace(/^\n+/, ""))
+    .filter(Boolean)
+    .map((rec) => {
+      const [hash, message] = rec.split("\x1f");
+      return { hash: (hash ?? "").trim(), message: (message ?? "").trim() };
+    });
+}
+
+function resolveSha(rev) {
+  return execSync(`git rev-parse ${JSON.stringify(rev)}`, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  }).trim();
+}
+
+// release-notes-generator uses signale-style printf logging; route to
+// stderr via util.format so stdout is reserved for the rendered notes.
+const logger = {
+  log: (...a) => console.error("[notes]", format(...a)),
+  info: (...a) => console.error("[notes]", format(...a)),
+  warn: (...a) => console.error("[notes]", format(...a)),
+  error: (...a) => console.error("[notes]", format(...a)),
+  success: (...a) => console.error("[notes]", format(...a)),
+};
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  for (const required of ["base", "head", "version"]) {
+    if (!args[required]) {
+      console.error(`Missing required argument: --${required}`);
+      console.error(
+        "Usage: generate-release-notes.mjs --base <ref> --head <sha> --version <semver>"
+      );
+      process.exit(2);
+    }
+  }
+
+  const pluginConfig = readNotesGeneratorConfig();
+  const repositoryUrl = readRepositoryUrl();
+  const commits = getCommits(args.base, args.head);
+  const lastReleaseSha = resolveSha(args.base);
+  const headSha = resolveSha(args.head);
+
+  const notes = await generateNotes(pluginConfig, {
+    commits,
+    lastRelease: {
+      gitHead: lastReleaseSha,
+      gitTag: args.base,
+      version: args.base, // Notes generator only uses this for the "compare" link label
+    },
+    nextRelease: {
+      gitHead: headSha,
+      gitTag: args.version,
+      version: args.version,
+    },
+    options: { repositoryUrl },
+    cwd: REPO_ROOT,
+    logger,
+  });
+
+  process.stdout.write(notes);
+  if (!notes.endsWith("\n")) process.stdout.write("\n");
+}
+
+main().catch((err) => {
+  console.error(err?.stack || String(err));
+  process.exit(1);
+});

--- a/scripts/release-validate.mjs
+++ b/scripts/release-validate.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Validate a release version against the current tag.
+//
+// Called by scripts/release.sh. Extracted from an inline `node -e` block
+// so the validation logic is testable in isolation and has unambiguous
+// `process.argv` semantics (standard `[node, scriptPath, ...userArgs]`).
+//
+// Usage:
+//   node scripts/release-validate.mjs <chosen-version> <current-tag>
+//
+// Exit codes:
+//    0  valid: chosen is semver AND strictly greater than current
+//   11  chosen is not valid semver
+//   12  chosen is not strictly greater than current
+//    1  usage error (missing args)
+//
+// Stderr is one of: "not_semver", "not_greater", or a usage message.
+// Exit codes are the contract that release.sh switches on; the stderr
+// tokens exist for human-readable logs.
+
+import semver from "semver";
+
+const args = process.argv.slice(2);
+
+if (args.length < 2) {
+  console.error(
+    "Usage: release-validate.mjs <chosen-version> <current-tag>"
+  );
+  process.exit(1);
+}
+
+const [chosen, current] = args;
+
+if (!semver.valid(chosen)) {
+  console.error("not_semver");
+  process.exit(11);
+}
+
+if (!semver.gt(chosen, current)) {
+  console.error("not_greater");
+  process.exit(12);
+}
+
+process.exit(0);

--- a/scripts/release-warn-version-jump.mjs
+++ b/scripts/release-warn-version-jump.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+// Warn (do not block) when the chosen release version is more than one
+// major above the analyzer-calculated version. Surfaces "did you mean
+// that?" without preventing intentional jumps (e.g., a recovery release
+// that intentionally crosses a major boundary).
+//
+// Called by scripts/release.sh. Extracted from an inline `node -e` block
+// so the logic is testable and `process.argv` semantics are standard.
+//
+// Usage:
+//   node scripts/release-warn-version-jump.mjs <chosen> <calculated>
+//
+// Always exits 0. Prints a single warning line to stderr when the gap
+// exceeds one major. If <calculated> is not valid semver, exits silently
+// (the analyzer may legitimately produce no calculated value on a fresh
+// repo with no prior tag).
+
+import semver from "semver";
+
+const [chosen, calculated] = process.argv.slice(2);
+
+if (!semver.valid(calculated)) {
+  process.exit(0);
+}
+
+if (semver.major(chosen) > semver.major(calculated) + 1) {
+  console.error(
+    `⚠️  Chosen version ${chosen} is more than one major above calculated ${calculated}. Proceeding, but double-check this is intentional.`
+  );
+}
+
+process.exit(0);

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# Manual version-input release orchestrator.
+#
+# Called by .github/workflows/release.yml after `workflow_dispatch` with
+# `inputs.version`. Bypasses semantic-release entirely. The analyzer and
+# release-notes-generator modules are still used as libraries via
+# scripts/preview-release.mjs and scripts/generate-release-notes.mjs,
+# but orchestration is local — no env-ci, no verifyAuth, no lifecycle.
+#
+# Why this exists:
+# - semantic-release has no hook to override the calculated version. The
+#   only way to ship a version that differs from what the analyzer
+#   computes is to commit-message-engineer history, which is brittle.
+# - This script makes the chosen version an explicit input. The
+#   analyzer's value is logged side-by-side for audit, but the human's
+#   input wins.
+#
+# Pre-conditions when this runs (most enforced by the workflow):
+# - VERSION env var: the chosen target version.
+# - HEAD = origin/main HEAD.
+# - SDKVersion.swift reads "Dev".
+# - Working tree clean.
+# - Git identity configured.
+# - SSH remote configured for push.
+# - GH_TOKEN (or GITHUB_TOKEN) exported for `gh release create`.
+# - COCOAPODS_TRUNK_TOKEN exported for pod publish.
+#
+# Post-conditions on success:
+# - Tag $VERSION points at commit X (chore(release) commit stamping
+#   SDKVersion, all four podspecs, and prepending the CHANGELOG entry).
+# - main HEAD = Y (Dev-restore commit on top of X).
+# - GitHub release created from the generated notes.
+# - All four pods (Core, UI, Reader, Platform) published at $VERSION.
+#
+# Local usage (validates and stops before push):
+#   VERSION=5.2.3 DRY_RUN=1 bash scripts/release.sh
+#
+# CI usage:
+#   VERSION=5.2.3 bash scripts/release.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+VERSION="${VERSION:-}"
+DRY_RUN="${DRY_RUN:-0}"
+
+if [ -z "$VERSION" ]; then
+  echo "❌ VERSION env var is required" >&2
+  exit 1
+fi
+
+# --- Validate VERSION --------------------------------------------------------
+
+CURRENT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+echo "Current tag:    $CURRENT_TAG"
+echo "Chosen version: $VERSION"
+
+VALIDATION_CODE=0
+node -e "
+  const semver = require('semver');
+  const v = process.argv[1];
+  const cur = process.argv[2];
+  if (!semver.valid(v)) { console.error('not_semver'); process.exit(11); }
+  if (!semver.gt(v, cur)) { console.error('not_greater'); process.exit(12); }
+  process.exit(0);
+" "$VERSION" "$CURRENT_TAG" || VALIDATION_CODE=$?
+
+if [ "$VALIDATION_CODE" -eq 11 ]; then
+  echo "❌ '$VERSION' is not valid semver" >&2
+  exit 1
+elif [ "$VALIDATION_CODE" -eq 12 ]; then
+  echo "❌ '$VERSION' is not strictly greater than current tag '$CURRENT_TAG'" >&2
+  exit 1
+elif [ "$VALIDATION_CODE" -ne 0 ]; then
+  echo "❌ Version validation failed (exit $VALIDATION_CODE)" >&2
+  exit 1
+fi
+
+# --- Compute calculated version (informational only) -------------------------
+
+PREVIEW_JSON=$(node scripts/preview-release.mjs --base "$CURRENT_TAG" --head HEAD 2>/dev/null || echo '{}')
+CALCULATED=$(echo "$PREVIEW_JSON" | node -e "let s=''; process.stdin.on('data', d=>s+=d).on('end', () => { const j=JSON.parse(s||'{}'); console.log(j.next || j.current || 'unknown'); });")
+CALC_TYPE=$(echo "$PREVIEW_JSON" | node -e "let s=''; process.stdin.on('data', d=>s+=d).on('end', () => { const j=JSON.parse(s||'{}'); console.log(j.release_type || 'none'); });")
+echo "Calculated:     $CALCULATED ($CALC_TYPE)"
+
+# Warn (don't block) if chosen version is more than one major above calculated.
+node -e "
+  const semver = require('semver');
+  const chosen = process.argv[1];
+  const calc = process.argv[2];
+  if (!semver.valid(calc)) process.exit(0);
+  if (semver.major(chosen) > semver.major(calc) + 1) {
+    console.error('⚠️  Chosen version ' + chosen + ' is more than one major above calculated ' + calc + '. Proceeding, but double-check this is intentional.');
+  }
+" "$VERSION" "$CALCULATED" >&2 || true
+
+# --- Pre-flight -------------------------------------------------------------
+
+if ! grep -q 'static let current = "Dev"' Sources/YouVersionPlatformCore/SDKVersion.swift; then
+  echo "❌ SDKVersion.swift does not currently read \"Dev\" — main is in an unexpected state" >&2
+  echo "   Current: $(grep 'static let current' Sources/YouVersionPlatformCore/SDKVersion.swift | head -1)" >&2
+  exit 1
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "❌ Working tree is dirty — aborting" >&2
+  git status --short >&2
+  exit 1
+fi
+
+if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
+  echo "❌ Tag $VERSION already exists locally" >&2
+  exit 1
+fi
+
+# --- Generate release notes -------------------------------------------------
+
+echo
+echo "Generating release notes..."
+node scripts/generate-release-notes.mjs \
+  --base "$CURRENT_TAG" \
+  --head HEAD \
+  --version "$VERSION" \
+  > notes.md
+echo "Notes: $(wc -l < notes.md | tr -d ' ') lines."
+
+# --- Update CHANGELOG.md ----------------------------------------------------
+
+if [ -f CHANGELOG.md ]; then
+  # Preserve title + intro; prepend the new entry above the first existing
+  # version heading. If no existing version heading, append.
+  node - <<'NODE'
+const fs = require('fs');
+const notes = fs.readFileSync('notes.md', 'utf8').trimEnd() + '\n\n';
+const existing = fs.readFileSync('CHANGELOG.md', 'utf8');
+const m = existing.match(/^## \[/m);
+let out;
+if (m) {
+  out = existing.slice(0, m.index) + notes + existing.slice(m.index);
+} else {
+  out = existing.trimEnd() + '\n\n' + notes;
+}
+fs.writeFileSync('CHANGELOG.md', out);
+NODE
+else
+  printf '# Changelog\n\nAll notable changes to this project will be documented in this file.\n\n' > CHANGELOG.md
+  cat notes.md >> CHANGELOG.md
+fi
+echo "CHANGELOG.md updated."
+
+# --- Stamp version into source files ----------------------------------------
+
+bash scripts/update-pod-versions.sh "$VERSION"
+bash scripts/stamp-sdk-version.sh "$VERSION"
+
+# --- Build X commit ---------------------------------------------------------
+
+git add \
+  CHANGELOG.md \
+  Sources/YouVersionPlatformCore/SDKVersion.swift \
+  YouVersionPlatform.podspec \
+  YouVersionPlatformCore.podspec \
+  YouVersionPlatformReader.podspec \
+  YouVersionPlatformUI.podspec
+
+# Subject + blank + notes body. [skip ci] prevents push-triggered workflows
+# from re-running on the release commit.
+{
+  printf 'chore(release): %s [skip ci]\n\n' "$VERSION"
+  cat notes.md
+} > .git/COMMIT_EDITMSG
+git commit -F .git/COMMIT_EDITMSG
+
+X_SHA=$(git rev-parse HEAD)
+echo "Commit X created at $X_SHA."
+
+# --- Tag X ------------------------------------------------------------------
+
+git tag "$VERSION"
+echo "Tag $VERSION created at $X_SHA."
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo
+  echo "DRY_RUN=1 — stopping before push, GitHub release, pod publish, and Dev restore."
+  echo "Inspect locally:"
+  echo "  git log -1"
+  echo "  git tag -l '$VERSION'"
+  echo "  cat notes.md"
+  exit 0
+fi
+
+# --- Push main + tag --------------------------------------------------------
+
+echo
+echo "Pushing main and tag $VERSION..."
+git push origin HEAD:main
+git push origin "$VERSION"
+
+# --- Create GitHub release --------------------------------------------------
+
+echo
+echo "Creating GitHub release..."
+gh release create "$VERSION" --notes-file notes.md --title "$VERSION"
+
+# --- Publish pods -----------------------------------------------------------
+
+echo
+echo "Publishing pods..."
+bash scripts/publish-pods.sh "$VERSION"
+
+# --- Restore Dev on main (Y commit) -----------------------------------------
+
+echo
+echo "Restoring SDKVersion to Dev on main..."
+bash scripts/restore-dev-sdk-on-main.sh "$VERSION"
+
+echo
+echo "✅ Release $VERSION complete."
+echo "   Tag $VERSION -> $X_SHA (commit X)"
+echo "   main HEAD     -> $(git rev-parse HEAD) (commit Y, SDKVersion=\"Dev\")"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -57,14 +57,7 @@ echo "Current tag:    $CURRENT_TAG"
 echo "Chosen version: $VERSION"
 
 VALIDATION_CODE=0
-node -e "
-  const semver = require('semver');
-  const v = process.argv[1];
-  const cur = process.argv[2];
-  if (!semver.valid(v)) { console.error('not_semver'); process.exit(11); }
-  if (!semver.gt(v, cur)) { console.error('not_greater'); process.exit(12); }
-  process.exit(0);
-" "$VERSION" "$CURRENT_TAG" || VALIDATION_CODE=$?
+node scripts/release-validate.mjs "$VERSION" "$CURRENT_TAG" || VALIDATION_CODE=$?
 
 if [ "$VALIDATION_CODE" -eq 11 ]; then
   echo "❌ '$VERSION' is not valid semver" >&2
@@ -104,15 +97,7 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
 fi
 
 # Warn (don't block) if chosen version is more than one major above calculated.
-node -e "
-  const semver = require('semver');
-  const chosen = process.argv[1];
-  const calc = process.argv[2];
-  if (!semver.valid(calc)) process.exit(0);
-  if (semver.major(chosen) > semver.major(calc) + 1) {
-    console.error('⚠️  Chosen version ' + chosen + ' is more than one major above calculated ' + calc + '. Proceeding, but double-check this is intentional.');
-  }
-" "$VERSION" "$CALCULATED" >&2 || true
+node scripts/release-warn-version-jump.mjs "$VERSION" "$CALCULATED" >&2 || true
 
 # --- Pre-flight -------------------------------------------------------------
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -129,7 +129,9 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
 fi
 
 if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
-  echo "❌ Tag $VERSION already exists locally" >&2
+  # Workflow checks out with fetch-depth: 0, so this also catches tags
+  # already on origin — the local clone has every remote tag.
+  echo "❌ Tag $VERSION already exists (in local refs, which include everything fetched from origin)" >&2
   exit 1
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -128,6 +128,25 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
   exit 1
 fi
 
+# Guard against a non-main dispatch landing feature-branch commits on
+# main. `gh workflow run release.yml --ref feature-branch` would pass
+# every other pre-flight, and `git push origin HEAD:main` would then
+# bypass branch protection via the deploy key. Dry-runs are explicitly
+# supported on any branch (no push fires), so we skip this guard for them.
+if [ "$DRY_RUN" != "1" ]; then
+  HEAD_SHA=$(git rev-parse HEAD)
+  MAIN_SHA=$(git rev-parse origin/main 2>/dev/null || echo "")
+  if [ -z "$MAIN_SHA" ]; then
+    echo "❌ origin/main ref not found locally — workflow checkout must use fetch-depth: 0" >&2
+    exit 1
+  fi
+  if [ "$HEAD_SHA" != "$MAIN_SHA" ]; then
+    echo "❌ HEAD ($HEAD_SHA) is not at origin/main ($MAIN_SHA)" >&2
+    echo "   Live releases must be dispatched on the main branch. Re-run with --ref main." >&2
+    exit 1
+  fi
+fi
+
 if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
   # Workflow checks out with fetch-depth: 0, so this also catches tags
   # already on origin — the local clone has every remote tag.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -236,6 +236,12 @@ bash scripts/restore-dev-sdk-on-main.sh "$VERSION"
 
 Y_SHA=$(git rev-parse HEAD)
 
+# Clean up the generated notes file so a successful run leaves the repo
+# tidy. The .gitignore entry covers the unlikely case where this rm
+# doesn't fire (script killed, etc.), but removing it explicitly on the
+# success path is the principled cleanup.
+rm -f notes.md
+
 echo
 echo "✅ Release $VERSION complete."
 echo "   Tag $VERSION -> $X_SHA (commit X)"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -84,6 +84,25 @@ CALCULATED=$(echo "$PREVIEW_JSON" | node -e "let s=''; process.stdin.on('data', 
 CALC_TYPE=$(echo "$PREVIEW_JSON" | node -e "let s=''; process.stdin.on('data', d=>s+=d).on('end', () => { const j=JSON.parse(s||'{}'); console.log(j.release_type || 'none'); });")
 echo "Calculated:     $CALCULATED ($CALC_TYPE)"
 
+# Write a side-by-side audit block to the GitHub Actions step summary
+# when running in CI. Surfaces "calculator said X, human chose Y" in the
+# job's web UI without needing to dig into the log.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## Release \`$VERSION\`"
+    echo
+    echo "| Source            | Version            |"
+    echo "| ----------------- | ------------------ |"
+    echo "| Current tag       | \`$CURRENT_TAG\`   |"
+    echo "| Analyzer-computed | \`$CALCULATED\` ($CALC_TYPE) |"
+    echo "| Chosen (input)    | **\`$VERSION\`**   |"
+    if [ "$DRY_RUN" = "1" ]; then
+      echo
+      echo "> 🧪 **DRY_RUN=1** — workflow will build commit X + tag locally, then stop. No push, no GitHub release, no pod publish."
+    fi
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
 # Warn (don't block) if chosen version is more than one major above calculated.
 node -e "
   const semver = require('semver');
@@ -215,7 +234,20 @@ echo
 echo "Restoring SDKVersion to Dev on main..."
 bash scripts/restore-dev-sdk-on-main.sh "$VERSION"
 
+Y_SHA=$(git rev-parse HEAD)
+
 echo
 echo "✅ Release $VERSION complete."
 echo "   Tag $VERSION -> $X_SHA (commit X)"
-echo "   main HEAD     -> $(git rev-parse HEAD) (commit Y, SDKVersion=\"Dev\")"
+echo "   main HEAD     -> $Y_SHA (commit Y, SDKVersion=\"Dev\")"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo
+    echo "### ✅ Released"
+    echo
+    echo "- Tag \`$VERSION\` → \`$X_SHA\` (commit X)"
+    echo "- main HEAD → \`$Y_SHA\` (commit Y)"
+    echo "- GitHub release: [\`$VERSION\`](https://github.com/${GITHUB_REPOSITORY:-youversion/platform-sdk-swift}/releases/tag/$VERSION)"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/test-release-scripts.sh
+++ b/scripts/test-release-scripts.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Tests for scripts/release-validate.mjs and scripts/release-warn-version-jump.mjs.
+#
+# Run locally: bash scripts/test-release-scripts.sh
+# Run in CI:   wired into .github/workflows/commit-lint.yml so every PR
+#              exercises these paths on a different Node version + OS
+#              from the release runner (catches argv / shell / Node
+#              behavior drift before it reaches a live release).
+#
+# Why these tests exist:
+# - The validation logic used to live inline as `node -e "..."` blocks in
+#   release.sh. A code reviewer flagged a (false) concern that
+#   `process.argv` indexing under `node -e` was off by one, which would
+#   have rejected every valid version. The concern was incorrect for our
+#   Node version, but the underlying risk — subtle env-dependent
+#   regressions in a code path that only runs at release time — is real.
+# - Extracting to standalone .mjs scripts eliminates the inline-eval
+#   ambiguity. These tests then guard the extracted logic so any future
+#   regression (Node update, semver-package behavior change, refactor)
+#   fails loudly at PR time, not at release dispatch.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+PASS=0
+FAIL=0
+
+# assert_exit <expected-code> <label> <command...>
+# Runs the command, captures stderr+stdout, and asserts the exit code.
+assert_exit() {
+  local expected=$1
+  local label=$2
+  shift 2
+  local actual=0
+  "$@" >/dev/null 2>&1 || actual=$?
+  if [ "$actual" = "$expected" ]; then
+    echo "  ✓ $label (exit $actual)"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $label (expected $expected, got $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# assert_stderr_contains <needle> <label> <command...>
+# Runs the command and asserts stderr contains the needle substring.
+assert_stderr_contains() {
+  local needle=$1
+  local label=$2
+  shift 2
+  local err
+  err=$("$@" 2>&1 >/dev/null || true)
+  if echo "$err" | grep -qF "$needle"; then
+    echo "  ✓ $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $label (stderr did not contain '$needle'; got: $err)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# assert_stderr_empty <label> <command...>
+# Runs the command and asserts stderr is empty.
+assert_stderr_empty() {
+  local label=$1
+  shift
+  local err
+  err=$("$@" 2>&1 >/dev/null || true)
+  if [ -z "$err" ]; then
+    echo "  ✓ $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $label (expected empty stderr, got: $err)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "release-validate.mjs:"
+assert_exit  0  "5.2.3 > 5.2.2 → accept"           node scripts/release-validate.mjs 5.2.3 5.2.2
+assert_exit  0  "5.3.0 > 5.2.2 → accept"           node scripts/release-validate.mjs 5.3.0 5.2.2
+assert_exit  0  "6.0.0 > 5.2.2 → accept"           node scripts/release-validate.mjs 6.0.0 5.2.2
+assert_exit  0  "5.2.3 > 0.0.0 → accept (fresh repo)" node scripts/release-validate.mjs 5.2.3 0.0.0
+assert_exit 11  "'garbage' is not semver"          node scripts/release-validate.mjs garbage 5.2.2
+assert_exit 11  "'5.2' is not semver"              node scripts/release-validate.mjs 5.2 5.2.2
+assert_exit 11  "empty version is not semver"      node scripts/release-validate.mjs '' 5.2.2
+assert_exit 12  "5.2.2 is not greater than 5.2.2"  node scripts/release-validate.mjs 5.2.2 5.2.2
+assert_exit 12  "5.2.1 is not greater than 5.2.2"  node scripts/release-validate.mjs 5.2.1 5.2.2
+assert_exit 12  "4.9.9 is not greater than 5.2.2"  node scripts/release-validate.mjs 4.9.9 5.2.2
+assert_exit  1  "missing args → usage error"       node scripts/release-validate.mjs 5.2.3
+assert_stderr_contains "not_semver"  "rejects with not_semver token"  node scripts/release-validate.mjs garbage 5.2.2
+assert_stderr_contains "not_greater" "rejects with not_greater token" node scripts/release-validate.mjs 5.2.1 5.2.2
+
+echo
+echo "release-warn-version-jump.mjs:"
+# Always exits 0; we assert on stderr presence/absence.
+assert_exit  0  "no jump (5.2.3 vs 5.2.2) → exit 0"      node scripts/release-warn-version-jump.mjs 5.2.3 5.2.2
+assert_exit  0  "one-major jump (6.0.0 vs 5.2.2) → exit 0" node scripts/release-warn-version-jump.mjs 6.0.0 5.2.2
+assert_exit  0  "two-major jump (7.0.0 vs 5.2.2) → exit 0" node scripts/release-warn-version-jump.mjs 7.0.0 5.2.2
+assert_exit  0  "invalid calc → silent exit 0"           node scripts/release-warn-version-jump.mjs 5.2.3 unknown
+assert_stderr_empty   "no jump prints no warning"           node scripts/release-warn-version-jump.mjs 5.2.3 5.2.2
+assert_stderr_empty   "one-major jump prints no warning"    node scripts/release-warn-version-jump.mjs 6.0.0 5.2.2
+assert_stderr_contains "more than one major above" "two-major jump prints warning"   node scripts/release-warn-version-jump.mjs 7.0.0 5.2.2
+assert_stderr_contains "more than one major above" "three-major jump prints warning" node scripts/release-warn-version-jump.mjs 8.0.0 5.2.2
+assert_stderr_empty   "invalid calc is silent"              node scripts/release-warn-version-jump.mjs 5.2.3 unknown
+
+echo
+echo "release.sh wiring (no inline node -e):"
+# Guard against the inline `node -e` form sneaking back into release.sh.
+# The whole point of extracting these scripts was to eliminate the
+# ambiguity that reviewers (human or bot) keep flagging.
+if grep -nE "^[[:space:]]*node[[:space:]]+-e" scripts/release.sh >/dev/null; then
+  echo "  ✗ scripts/release.sh contains inline 'node -e' — extract to a .mjs script"
+  grep -nE "^[[:space:]]*node[[:space:]]+-e" scripts/release.sh
+  FAIL=$((FAIL + 1))
+else
+  echo "  ✓ scripts/release.sh has no inline 'node -e'"
+  PASS=$((PASS + 1))
+fi
+
+echo
+if [ "$FAIL" -gt 0 ]; then
+  echo "❌ $FAIL test(s) failed out of $((PASS + FAIL))"
+  exit 1
+else
+  echo "✅ All $PASS tests passed"
+fi

--- a/scripts/update-pod-versions.sh
+++ b/scripts/update-pod-versions.sh
@@ -29,6 +29,11 @@ for PODSPEC in YouVersionPlatform.podspec YouVersionPlatformCore.podspec YouVers
   echo "  ✓ $PODSPEC"
 done
 
+if [ "${SKIP_LINT:-0}" = "1" ]; then
+  echo "Skipping podspec lint (SKIP_LINT=1)."
+  exit 0
+fi
+
 echo "Validating podspecs (full xcodebuild — slow but mirrors trunk)..."
 
 # Use `pod lib lint` rather than `pod spec lint`. `spec lint` clones the


### PR DESCRIPTION
## Summary

Rewrites the release pipeline so a human types the version they want to publish into `workflow_dispatch`, the workflow validates it, and the release ships. semantic-release is no longer an orchestrator — only `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` are used, as libraries, via small Node scripts.

**Key new capability:** the chosen version can be overridden when the analyzer's value is wrong. There is no longer any need to commit-message-engineer history to coerce a release into a specific version — type the version, ship the version. The analyzer's value is logged side-by-side in the job summary for audit.

## Why

semantic-release tightly couples computation (analyze commits) to execution (push commits, push tags, publish, etc.). The lifecycle has no hook to override the calculated version. That coupling is what made the 6.0.0 incident possible: prose poisoning in a squash commit body caused the analyzer to compute `major`, and the lifecycle shipped it without any checkpoint. PR #132 made the workflow manual-trigger, which adds a human click but doesn't add a human decision over the *value*. This PR makes the value an explicit input.

It also closes the loop on the override pattern: the very first release on this new flow (`5.2.3`) will demonstrate it, because the polluted `1d21411` commit still sits in the `5.2.2..main` analyzer window. The calculator will say `6.0.0 (major)`; the human types `5.2.3`; both are logged.

## What changed

### New files

- `scripts/release.sh` — manual-input release orchestrator. Validates VERSION via `semver.valid` + `semver.gt(currentTag)`, logs calculated vs chosen, generates notes, prepends to CHANGELOG, stamps SDKVersion + podspecs, builds commit X with notes embedded as body, tags, pushes, creates the GitHub release, publishes pods, then runs `restore-dev-sdk-on-main.sh` for commit Y. `DRY_RUN=1` stops before any push for local validation.
- `scripts/generate-release-notes.mjs` — thin wrapper around `@semantic-release/release-notes-generator` (same library-only pattern as `scripts/preview-release.mjs` from #125). Reads the notes-generator config from `.releaserc.json` so the preset stays in sync.

### Modified files

- `.github/workflows/release.yml` — adds `inputs.version` (required) and `inputs.dry-run` (boolean). Replaces `npx semantic-release` with `bash scripts/release.sh`. Token plumbing (RELEASE_SSH_KEY, COCOAPODS_TRUNK_TOKEN, GH_TOKEN) preserved. The job summary gets a side-by-side audit table.
- `scripts/update-pod-versions.sh` — adds `SKIP_LINT=1` escape hatch for local dry-runs. CI still runs the full `pod lib lint` (the slow xcodebuild step). Local dev machines often lack the iOS simulator runtime; this lets them validate the script without it.
- `.releaserc.json` — shrinks to just the two plugin config blocks the libraries read.
- `package.json` — removes `semantic-release`, `@semantic-release/git`, `@semantic-release/github`, `@semantic-release/changelog`, `@semantic-release/exec`, and the `semantic-release` npm script. Adds explicit `semver`. `npm ci` time and `node_modules` size shrink.
- `RELEASING.md` — full rewrite for the new flow. Folds in the `DEPLOY_KEY` → `RELEASE_SSH_KEY` secret-name fix (matches what release.yml actually references).
- `AGENTS.md` — release section rewritten. Fixes the dead `scripts/release-stamp-and-tag.sh` reference (never existed; the canonical scripts are `stamp-sdk-version.sh` + `restore-dev-sdk-on-main.sh`). Fixes the X/Y topology description that was inverted.
- `CONTRIBUTING.md` — small wording updates: the analyzer suggests, the human chooses.

## Depends on

Merge order: this PR should land **after #125** (which adds `scripts/preview-release.mjs`). `release.sh`'s "calculated version" lookup uses that script; without it, the calculated column degrades gracefully to "unknown" but the release still works. So strictly speaking this PR could land first, but the audit log is more useful with both.

## Test plan

- [x] `node scripts/generate-release-notes.mjs --base 5.2.2 --head HEAD --version 5.2.3` produces markdown locally.
- [x] `VERSION=5.2.3 DRY_RUN=1 SKIP_LINT=1 bash scripts/release.sh` runs end-to-end through commit X + tag + step-summary write, then stops.
- [x] Validation: `VERSION=foo bash scripts/release.sh` is rejected as non-semver.
- [x] Validation: `VERSION=5.2.1 bash scripts/release.sh` is rejected as not greater than current.
- [x] `npm ci` succeeds with the pruned dep list; both `preview-release.mjs` (from #125) and `generate-release-notes.mjs` import and run.
- [ ] CI: dispatch the workflow with `version=5.2.3 dry-run=true` on this branch — runs end-to-end on the macOS runner including `pod lib lint`, stops before push. (Manual, post-merge of #125.)
- [ ] CI: dispatch the workflow with `version=5.2.3 dry-run=false` on main after both this and #125 are merged. Real 5.2.3 ships.

## After this lands

1. Re-enable the workflow at the GitHub level: `gh workflow enable release.yml`. (Safe — trigger is `workflow_dispatch` only.)
2. Dispatch `release.yml` with `version=5.2.3` to do the actual 5.2.3 release. The analyzer will say `6.0.0 (major)` because of polluted `1d21411`; the workflow will log that and proceed with `5.2.3` per the override.
3. Update incident memory.

Refs YPE-2398

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces `semantic-release` as the release orchestrator with a human-input workflow: the operator types the version, `release.sh` validates it (semver + strictly-greater-than-current), logs the analyzer's computed value side-by-side for audit, and then drives the full release pipeline (notes generation, CHANGELOG prepend, podspec/SDKVersion stamping, commit X, tag, push, GitHub release, pod publish, Dev-restore Y). The key motivation — eliminating the 6.0.0 incident pattern where commit body content could poison the analyzer and ship an unintended major — is well-addressed.

- **New scripts**: `release-validate.mjs` and `release-warn-version-jump.mjs` replace the previous inline `node -e` blocks (correctly using `process.argv.slice(2)`), and `generate-release-notes.mjs` wraps the library-only notes generator; all three are tested by `test-release-scripts.sh` wired into the commit-lint CI job.
- **Workflow changes**: `release.yml` gains `version` (required) and `dry-run` inputs, replaces `npx semantic-release` with `bash scripts/release.sh`, and preserves all token plumbing; the pre-flight HEAD-vs-origin/main guard prevents a non-main branch dispatch from landing feature commits on `main` via the deploy-key bypass.
- **Housekeeping**: `.gitignore` now has `/notes.md`, the partial-failure recovery recipe is documented in `RELEASING.md`, and docs correctly name the `RELEASE_SSH_KEY` secret throughout.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the release pipeline is well-structured, all the concerns from prior review threads are addressed, and the only finding is a misleading test guard that doesn't affect runtime correctness.

The validation, pre-flight guards (clean tree, SDKVersion="Dev", HEAD=origin/main, tag absent), and recovery documentation are all thorough. The inline `node -e` blocks that remain in release.sh read from stdin rather than argv and are functionally correct; they're only missed by the guard test, not broken. No incorrect version logic, no credential leakage, no missing gate on the critical push path.

scripts/test-release-scripts.sh — the node -e guard regex is worth tightening so the test's stated intent matches what it actually checks.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/release.sh | New manual release orchestrator — validates version, generates notes, stamps files, commits X, tags, pushes, creates GitHub release, publishes pods, and runs Dev-restore Y. Logic is sound; previous argv/gitignore/HEAD-guard concerns addressed. Still contains two inline `node -e` pipe expressions (lines 76-77) that the guard test misses. |
| scripts/release-validate.mjs | Standalone validation script replacing the former inline node -e block. process.argv.slice(2) semantics are correct; exit codes 11/12 match what release.sh branches on. Well-tested in test-release-scripts.sh. |
| scripts/release-warn-version-jump.mjs | Advisory-only warning script — always exits 0, warns to stderr when chosen major is more than one above calculated. Gracefully handles invalid calculated value (silent exit). Correct and well-tested. |
| scripts/test-release-scripts.sh | Test harness for the two new Node scripts; wired into commit-lint CI for cross-env coverage. The "no inline node -e" guard regex is anchored to line beginnings and misses the two embedded node -e pipe expressions that remain in release.sh. |
| scripts/generate-release-notes.mjs | Thin library wrapper around @semantic-release/release-notes-generator. Reads preset from .releaserc.json to stay in sync. Logger routes to stderr to keep stdout clean for piping. Looks solid. |
| .github/workflows/release.yml | Adds version and dry-run inputs, wires VERSION/DRY_RUN env vars, replaces npx semantic-release with bash scripts/release.sh. Token plumbing (GH_TOKEN + GITHUB_TOKEN, RELEASE_SSH_KEY, COCOAPODS_TRUNK_TOKEN) is correct. |
| scripts/update-pod-versions.sh | SKIP_LINT=1 escape hatch added cleanly. macOS-only sed -i '' syntax is appropriate since this only runs on the macOS release runner. |
| RELEASING.md | Comprehensive rewrite covering the new manual-input flow, dry-run instructions, post-push partial-failure recovery recipe, and emergency manual steps. Fixes DEPLOY_KEY → RELEASE_SSH_KEY secret-name mismatch from prior docs. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor Operator
    participant GHA as GitHub Actions
    participant release.sh
    participant validate as release-validate.mjs
    participant preview as preview-release.mjs
    participant notes as generate-release-notes.mjs
    participant git as git / origin
    participant gh as gh CLI
    participant pods as publish-pods.sh
    participant restore as restore-dev-sdk-on-main.sh

    Operator->>GHA: workflow_dispatch(version, dry-run)
    GHA->>release.sh: "VERSION=X DRY_RUN=0|1 bash scripts/release.sh"
    release.sh->>validate: node release-validate.mjs VERSION CURRENT_TAG
    validate-->>release.sh: exit 0 (valid) or 11/12 (abort)
    release.sh->>preview: node preview-release.mjs (informational)
    preview-->>release.sh: "{next, release_type} → audit log"
    release.sh->>release.sh: pre-flight checks
    release.sh->>notes: node generate-release-notes.mjs → notes.md
    release.sh->>release.sh: update CHANGELOG.md, stamp podspecs + SDKVersion
    release.sh->>git: git commit -F (commit X) + git tag VERSION
    alt "DRY_RUN=1"
        release.sh-->>Operator: stop — inspect locally
    else live release
        release.sh->>git: git push origin HEAD:main + git push origin VERSION
        release.sh->>gh: gh release create VERSION --notes-file notes.md
        release.sh->>pods: bash publish-pods.sh VERSION
        release.sh->>restore: bash restore-dev-sdk-on-main.sh VERSION (commit Y)
        release.sh->>release.sh: rm -f notes.md
        release.sh-->>GHA: step summary (X SHA, Y SHA, release link)
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Ftest-release-scripts.sh%3A112-119%0A**Guard%20regex%20misses%20embedded%20%60node%20-e%60%20%E2%80%94%20test%20gives%20false%20confidence**%0A%0AThe%20pattern%20%60%5E%5B%5B%3Aspace%3A%5D%5D*node%5B%5B%3Aspace%3A%5D%5D%2B-e%60%20only%20matches%20lines%20where%20%60node%20-e%60%20starts%20the%20line.%20%60release.sh%60%20still%20contains%20two%20inline%20%60node%20-e%60%20invocations%20at%20lines%2076%E2%80%9377%20%E2%80%94%20they're%20embedded%20inside%20%60%24%28echo%20%22%24PREVIEW_JSON%22%20%7C%20node%20-e%20%22...%22%29%60%20pipe%20expressions%20%E2%80%94%20so%20the%20test%20prints%20%60%E2%9C%93%20scripts%2Frelease.sh%20has%20no%20inline%20'node%20-e'%60%20even%20though%20those%20two%20blocks%20exist.%0A%0AThose%20two%20blocks%20are%20functionally%20fine%20%28they%20read%20from%20%60stdin%60%20via%20a%20pipe%2C%20not%20from%20%60process.argv%60%2C%20so%20the%20argv-offset%20concern%20doesn't%20apply%29.%20But%20the%20guard's%20comment%20says%20%22eliminate%20the%20inline-eval%20ambiguity%20that%20reviewers%20keep%20flagging%2C%22%20and%20a%20future%20reader%20running%20this%20test%20would%20get%20a%20false%20all-clear%20if%20a%20problematic%20%60node%20-e%60%20were%20added%20mid-line.%20Dropping%20the%20leading%20%60%5E%60%20anchor%20%28or%20at%20least%20narrowing%20the%20comment%20to%20%22standalone%20node%20-e%20lines%22%29%20would%20make%20the%20intent%20match%20the%20behaviour.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=135&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Ftest-release-scripts.sh%3A112-119%0A**Guard%20regex%20misses%20embedded%20%60node%20-e%60%20%E2%80%94%20test%20gives%20false%20confidence**%0A%0AThe%20pattern%20%60%5E%5B%5B%3Aspace%3A%5D%5D*node%5B%5B%3Aspace%3A%5D%5D%2B-e%60%20only%20matches%20lines%20where%20%60node%20-e%60%20starts%20the%20line.%20%60release.sh%60%20still%20contains%20two%20inline%20%60node%20-e%60%20invocations%20at%20lines%2076%E2%80%9377%20%E2%80%94%20they're%20embedded%20inside%20%60%24%28echo%20%22%24PREVIEW_JSON%22%20%7C%20node%20-e%20%22...%22%29%60%20pipe%20expressions%20%E2%80%94%20so%20the%20test%20prints%20%60%E2%9C%93%20scripts%2Frelease.sh%20has%20no%20inline%20'node%20-e'%60%20even%20though%20those%20two%20blocks%20exist.%0A%0AThose%20two%20blocks%20are%20functionally%20fine%20%28they%20read%20from%20%60stdin%60%20via%20a%20pipe%2C%20not%20from%20%60process.argv%60%2C%20so%20the%20argv-offset%20concern%20doesn't%20apply%29.%20But%20the%20guard's%20comment%20says%20%22eliminate%20the%20inline-eval%20ambiguity%20that%20reviewers%20keep%20flagging%2C%22%20and%20a%20future%20reader%20running%20this%20test%20would%20get%20a%20false%20all-clear%20if%20a%20problematic%20%60node%20-e%60%20were%20added%20mid-line.%20Dropping%20the%20leading%20%60%5E%60%20anchor%20%28or%20at%20least%20narrowing%20the%20comment%20to%20%22standalone%20node%20-e%20lines%22%29%20would%20make%20the%20intent%20match%20the%20behaviour.%0A%0A&pr=135&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/test-release-scripts.sh:112-119
**Guard regex misses embedded `node -e` — test gives false confidence**

The pattern `^[[:space:]]*node[[:space:]]+-e` only matches lines where `node -e` starts the line. `release.sh` still contains two inline `node -e` invocations at lines 76–77 — they're embedded inside `$(echo "$PREVIEW_JSON" | node -e "...")` pipe expressions — so the test prints `✓ scripts/release.sh has no inline 'node -e'` even though those two blocks exist.

Those two blocks are functionally fine (they read from `stdin` via a pipe, not from `process.argv`, so the argv-offset concern doesn't apply). But the guard's comment says "eliminate the inline-eval ambiguity that reviewers keep flagging," and a future reader running this test would get a false all-clear if a problematic `node -e` were added mid-line. Dropping the leading `^` anchor (or at least narrowing the comment to "standalone node -e lines") would make the intent match the behaviour.

`````

</details>

<sub>Reviews (9): Last reviewed commit: ["Merge branch &#39;main&#39; into YPE-2398-manual..."](https://github.com/youversion/platform-sdk-swift/commit/4aef7f587baf02d0050cfd8d5b7cd6ed39a5694e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32840361)</sub>

<!-- /greptile_comment -->