### PR TITLE
fix: support system fonts in Bible text

### DIFF
--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift
@@ -49,7 +49,7 @@ struct BibleReaderFontListView: View {
                 let isSelected = viewModel.textOptions.fontFamily == family
                 HStack {
                     Text(family)
-                        .font(.custom(family, size: 20))
+                        .font(ReaderFonts.displayFont(familyName: family, size: 20))
                     if isSelected {
                         Image(systemName: "checkmark")
                             .font(.system(size: 18, weight: .semibold))

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift
@@ -27,7 +27,7 @@ struct BibleReaderFontSettingsView: View {
                     .foregroundStyle(viewModel.readerTextMutedColor)
                 let family = viewModel.textOptions.fontFamily
                 Text(family)
-                    .font(.custom(family, size: 22))
+                    .font(ReaderFonts.displayFont(familyName: family, size: 22))
             }
             Spacer()
             Image(systemName: "chevron.right")

--- a/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
@@ -38,8 +38,8 @@ public enum ReaderFonts {
     static let suggestedFamilies = [
         "Untitled Serif",
         "Avenir Next",
-        // New York
-        // San Francisco
+        "New York",
+        "San Francisco",
         // Gentium Plus
         "Baskerville", "Georgia", "Helvetica Neue", "Hoefler Text", "Verdana"
         // OpenDyslexic
@@ -79,6 +79,18 @@ public enum ReaderFonts {
 
     static func isPermittedFont(_ family: String) -> Bool {
         suggestedFamilies.contains(family) || otherFamilies.contains(family)
+    }
+
+    static func displayFont(familyName: String, size: CGFloat) -> Font {
+        if familyName == "San Francisco" {
+            return Font.system(size: size)
+        }
+
+        if familyName == "New York" {
+            return Font.system(size: size, design: .serif)
+        }
+
+        return Font.custom(familyName, size: size)
     }
 
     // MARK: - Font Sizes and Spacing

--- a/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
@@ -82,15 +82,14 @@ public enum ReaderFonts {
     }
 
     static func displayFont(familyName: String, size: CGFloat) -> Font {
-        if familyName == "San Francisco" {
-            return Font.system(size: size)
+        switch familyName {
+        case "San Francisco":
+            .system(size: size)
+        case "New York":
+            .system(size: size, design: .serif)
+        default:
+            .custom(familyName, size: size)
         }
-
-        if familyName == "New York" {
-            return Font.system(size: size, design: .serif)
-        }
-
-        return Font.custom(familyName, size: size)
     }
 
     // MARK: - Font Sizes and Spacing

--- a/Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift
+++ b/Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift
@@ -37,9 +37,10 @@ public struct BibleTextFonts {
 #endif
         self.baseSize = baseSize
         verseNumBaselineOffset = baseSize * 0.3
+
         let boldFamilyName: String
         let italicFamilyName: String
-        
+
         if familyName.hasSuffix("-Regular") {
             let base = familyName.split(separator: "-").dropLast().joined(separator: "-")
             boldFamilyName = base + "-Bold"
@@ -49,22 +50,33 @@ public struct BibleTextFonts {
             italicFamilyName = familyName
         }
 
-        let larger = Font.custom(familyName, fixedSize: baseSize * 1.1)
         fonts = [
-            .textFontItalic: Font.custom(italicFamilyName, fixedSize: baseSize).italic(),
-            .textFontBold: Font.custom(boldFamilyName, fixedSize: baseSize).bold(),
-            .smallCaps: Font.custom(familyName, fixedSize: baseSize).lowercaseSmallCaps(),
-            .headerItalic: Font.custom(italicFamilyName, fixedSize: baseSize * 1.1).italic(),
-            .headerSmaller: Font.custom(boldFamilyName, fixedSize: baseSize * 0.9).weight(.medium),
-            .header2: Font.custom(boldFamilyName, fixedSize: baseSize * 1.1).weight(.bold),
-            .header3: larger,
-            .header4: larger,
-            .footnote: Font.custom(familyName, fixedSize: baseSize * 0.8),
+            .textFontItalic: Self.font(familyName: italicFamilyName, size: baseSize).italic(),
+            .textFontBold: Self.font(familyName: boldFamilyName, size: baseSize).bold(),
+            .smallCaps: Self.font(familyName: familyName, size: baseSize).lowercaseSmallCaps(),
+            .headerItalic: Self.font(familyName: italicFamilyName, size: baseSize * 1.1).italic(),
+            .headerSmaller: Self.font(familyName: boldFamilyName, size: baseSize * 0.9).weight(.medium),
+            .header2: Self.font(familyName: boldFamilyName, size: baseSize * 1.1).weight(.bold),
+            .header3: Self.font(familyName: familyName, size: baseSize * 1.1),
+            .header4: Self.font(familyName: familyName, size: baseSize * 1.1),
+            .footnote: Self.font(familyName: familyName, size: baseSize * 0.8),
             // below are validated standards:
-            .header: Font.custom(boldFamilyName, fixedSize: baseSize).bold(),
-            .headerSmallerItalic: Font.custom(italicFamilyName, fixedSize: baseSize * 0.76).italic(),
-            .textFont: Font.custom(familyName, fixedSize: baseSize),
-            .verseNumFont: Font.custom(familyName, fixedSize: baseSize * 0.65).smallCaps()
+            .header: Self.font(familyName: boldFamilyName, size: baseSize).bold(),
+            .headerSmallerItalic: Self.font(familyName: italicFamilyName, size: baseSize * 0.76).italic(),
+            .textFont: Self.font(familyName: familyName, size: baseSize),
+            .verseNumFont: Self.font(familyName: familyName, size: baseSize * 0.65).smallCaps()
         ]
+    }
+
+    private static func font(familyName: String, size: CGFloat) -> Font {
+        if familyName == "San Francisco" || familyName == "SF Pro Text" || familyName.hasPrefix("SFProText-") {
+            return Font.system(size: size)
+        }
+
+        if familyName == "New York" || familyName.hasPrefix("NewYork-") {
+            return Font.system(size: size, design: .serif)
+        }
+
+        return Font.custom(familyName, fixedSize: size)
     }
 }

--- a/Tests/YouVersionPlatformReaderTests/ReaderFontsTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/ReaderFontsTests.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import Testing
 @testable import YouVersionPlatformReader
 
@@ -17,6 +18,25 @@ struct ReaderFontsTests {
         #expect(ReaderFonts.isPermittedFont("") == false)
         #expect(ReaderFonts.isPermittedFont("Definitely Not A Reader Font") == false)
         #expect(ReaderFonts.isPermittedFont("georgia") == false)
+    }
+
+    @Test
+    func displayFontUsesSystemProviderForSystemFontFamilies() {
+        let sanFranciscoDescription = debugDescription(
+            of: ReaderFonts.displayFont(familyName: "San Francisco", size: 20)
+        )
+        #expect(sanFranciscoDescription.contains("SwiftUI.Font.SystemProvider"))
+        #expect(sanFranciscoDescription.contains("size: 20.0"))
+        #expect(sanFranciscoDescription.contains("design: nil"))
+        #expect(sanFranciscoDescription.contains("SwiftUI.Font.NamedProvider") == false)
+
+        let newYorkDescription = debugDescription(
+            of: ReaderFonts.displayFont(familyName: "New York", size: 20)
+        )
+        #expect(newYorkDescription.contains("SwiftUI.Font.SystemProvider"))
+        #expect(newYorkDescription.contains("size: 20.0"))
+        #expect(newYorkDescription.contains("SwiftUI.Font.Design.serif"))
+        #expect(newYorkDescription.contains("SwiftUI.Font.NamedProvider") == false)
     }
 
     @Test
@@ -42,4 +62,10 @@ struct ReaderFontsTests {
         #expect(ReaderFonts.nextLineSpacing(currentSpacing: 18) == 6)
         #expect(ReaderFonts.nextLineSpacing(currentSpacing: 100) == 6)
     }
+}
+
+private func debugDescription(of font: Font) -> String {
+    var output = ""
+    dump(font, to: &output)
+    return output
 }

--- a/Tests/YouVersionPlatformReaderTests/ReaderFontsTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/ReaderFontsTests.swift
@@ -5,6 +5,8 @@ struct ReaderFontsTests {
     @Test
     func isPermittedFontAcceptsSuggestedAndOtherFamilies() {
         #expect(ReaderFonts.isPermittedFont("Untitled Serif"))
+        #expect(ReaderFonts.isPermittedFont("New York"))
+        #expect(ReaderFonts.isPermittedFont("San Francisco"))
         #expect(ReaderFonts.isPermittedFont("Georgia"))
         #expect(ReaderFonts.isPermittedFont("Arial"))
         #expect(ReaderFonts.isPermittedFont("Times New Roman"))


### PR DESCRIPTION
## Summary

- route San Francisco/SF Pro and New York font selections through SwiftUI system font APIs
- add New York and San Francisco to the Reader font picker
- render Reader font picker previews with the same system-font-aware helper

## Why

SF Pro and New York are Apple system fonts and do not resolve correctly through `Font.custom`. Using the system font APIs preserves Bible passage heading size and weight styling when those families are selected.

## Validation

- `swift test`
- `swiftlint --strict`
- built and launched the SampleApp in the iPhone 17 simulator for manual validation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly routes SF Pro ("San Francisco") and New York font selections through SwiftUI's system font APIs rather than `Font.custom`, fixing heading size and weight rendering for those families. The approach is well-scoped: a new `BibleTextFonts.font` private helper and a `ReaderFonts.displayFont` helper each map the special family names to `Font.system(…)`, and both preview sites are updated to use the new helper.

- **`BibleTextFonts.swift`**: Replaces all `Font.custom(…, fixedSize:)` calls with a new `private static func font(familyName:size:)` that intercepts SF Pro/New York names and dispatches to `Font.system`.
- **`ReaderFonts.swift`**: Adds `displayFont(familyName:size:)` for UI preview rendering; adds "New York" and "San Francisco" to `suggestedFamilies`.
- **`ReaderFontsTests.swift`**: Adds `isPermittedFont` assertions for the new families and a new `displayFontUsesSystemProviderForSystemFontFamilies` test that validates internal `Font` provider routing via `dump()`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the system-font routing fix is well-contained and the two new font options integrate cleanly with existing infrastructure.

The change correctly addresses a real rendering defect for SF Pro and New York fonts with no regressions to other font families. Both dispatch paths (Bible text rendering and preview UI) have been updated consistently, and new tests verify the routing. The two observations raised (test fragility and Dynamic Type asymmetry) are known SwiftUI API limitations rather than bugs introduced by this PR.

No files require special attention; the test assertions in ReaderFontsTests.swift rely on SwiftUI internal names that could drift on future OS updates, but this does not affect production behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift | Introduces private `font(familyName:size:)` helper that correctly dispatches San Francisco/SF Pro Text/New York to `Font.system`; all font dictionary entries updated to use it. Minor: system fonts now follow Dynamic Type while custom fonts remain fixed-size. |
| Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift | Adds `displayFont` helper and promotes "New York"/"San Francisco" into `suggestedFamilies`. Logic is correct and symmetric with `BibleTextFonts.font` for the two system-font names. |
| Tests/YouVersionPlatformReaderTests/ReaderFontsTests.swift | Good coverage added for both `isPermittedFont` and `displayFont` routing; the `displayFont` test uses `dump()` on internal SwiftUI types, which could be fragile across OS updates. |
| Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift | Single-line change correctly replaces `Font.custom` preview with `ReaderFonts.displayFont`. |
| Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift | Single-line change correctly replaces `Font.custom` preview with `ReaderFonts.displayFont`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Font family name selected"] --> B{Is system font?}
    B -- "San Francisco / SF Pro Text / SFProText-*" --> C["Font.system(size:)\n(responds to Dynamic Type)"]
    B -- "New York / NewYork-*" --> D["Font.system(size:, design: .serif)\n(responds to Dynamic Type)"]
    B -- "Any other family" --> E["Font.custom(familyName, fixedSize:)\n(fixed, ignores Dynamic Type)"]
    C --> F["BibleTextFonts.font() → used in Bible text rendering"]
    D --> F
    E --> F
    C --> G["ReaderFonts.displayFont() → used in font picker previews"]
    D --> G
    E2["Font.custom(familyName, size:)\n(responds to Dynamic Type)"] --> G
    B -- "San Francisco" --> G
    B -- "New York" --> G
    B -- "Any other family" --> E2
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ATests%2FYouVersionPlatformReaderTests%2FReaderFontsTests.swift%3A28-39%0A**Test%20relies%20on%20private%20SwiftUI%20internal%20names**%0A%0A%60dump%28%29%60%20produces%20output%20derived%20from%20SwiftUI's%20private%20type%20names%20%28%60SwiftUI.Font.SystemProvider%60%2C%20%60SwiftUI.Font.NamedProvider%60%2C%20%60SwiftUI.Font.Design.serif%60%29.%20Apple%20treats%20these%20as%20implementation%20details%20with%20no%20stability%20guarantee%2C%20so%20any%20OS%20update%20that%20renames%20or%20restructures%20%60Font%60's%20internals%20could%20silently%20break%20these%20assertions%20without%20any%20functional%20regression%20in%20the%20actual%20font%20rendering.%20Consider%20wrapping%20these%20assertions%20in%20a%20comment%20that%20acknowledges%20the%20fragility%2C%20or%20structuring%20the%20test%20around%20observable%20behavior%20%28e.g.%20creating%20a%20%60UIFont%60%20from%20the%20resolved%20font%20and%20inspecting%20its%20%60familyName%60%29.%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformUI%2FObjects%2FBibleTextFonts.swift%3A71-81%0A**System%20fonts%20now%20respond%20to%20Dynamic%20Type%3B%20custom%20fonts%20stay%20fixed-size**%0A%0AFor%20custom%20fonts%20%60Font.custom%28familyName%2C%20fixedSize%3A%20size%29%60%20is%20returned%2C%20which%20ignores%20the%20user's%20Dynamic%20Type%20accessibility%20setting.%20For%20system%20fonts%20%28%60Font.system%28size%3A%29%60%29%20the%20size%20does%20respond%20to%20Dynamic%20Type%2C%20because%20SwiftUI%20offers%20no%20%60fixedSize%3A%60%20equivalent%20on%20%60Font.system%60.%20If%20a%20user%20has%20Dynamic%20Type%20set%20to%20a%20large%20accessibility%20size%20and%20selects%20%22San%20Francisco%22%20or%20%22New%20York%22%2C%20the%20Bible%20text%20could%20grow%20beyond%20the%20app's%20own%20size-picker%20selection%2C%20while%20any%20other%20custom%20font%20would%20remain%20fixed.%20This%20is%20an%20inherent%20SwiftUI%20API%20limitation%2C%20so%20the%20current%20approach%20is%20likely%20the%20best%20option%20%E2%80%94%20worth%20documenting%20with%20an%20inline%20comment%20so%20future%20maintainers%20understand%20the%20intentional%20asymmetry.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=137&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ATests%2FYouVersionPlatformReaderTests%2FReaderFontsTests.swift%3A28-39%0A**Test%20relies%20on%20private%20SwiftUI%20internal%20names**%0A%0A%60dump%28%29%60%20produces%20output%20derived%20from%20SwiftUI's%20private%20type%20names%20%28%60SwiftUI.Font.SystemProvider%60%2C%20%60SwiftUI.Font.NamedProvider%60%2C%20%60SwiftUI.Font.Design.serif%60%29.%20Apple%20treats%20these%20as%20implementation%20details%20with%20no%20stability%20guarantee%2C%20so%20any%20OS%20update%20that%20renames%20or%20restructures%20%60Font%60's%20internals%20could%20silently%20break%20these%20assertions%20without%20any%20functional%20regression%20in%20the%20actual%20font%20rendering.%20Consider%20wrapping%20these%20assertions%20in%20a%20comment%20that%20acknowledges%20the%20fragility%2C%20or%20structuring%20the%20test%20around%20observable%20behavior%20%28e.g.%20creating%20a%20%60UIFont%60%20from%20the%20resolved%20font%20and%20inspecting%20its%20%60familyName%60%29.%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformUI%2FObjects%2FBibleTextFonts.swift%3A71-81%0A**System%20fonts%20now%20respond%20to%20Dynamic%20Type%3B%20custom%20fonts%20stay%20fixed-size**%0A%0AFor%20custom%20fonts%20%60Font.custom%28familyName%2C%20fixedSize%3A%20size%29%60%20is%20returned%2C%20which%20ignores%20the%20user's%20Dynamic%20Type%20accessibility%20setting.%20For%20system%20fonts%20%28%60Font.system%28size%3A%29%60%29%20the%20size%20does%20respond%20to%20Dynamic%20Type%2C%20because%20SwiftUI%20offers%20no%20%60fixedSize%3A%60%20equivalent%20on%20%60Font.system%60.%20If%20a%20user%20has%20Dynamic%20Type%20set%20to%20a%20large%20accessibility%20size%20and%20selects%20%22San%20Francisco%22%20or%20%22New%20York%22%2C%20the%20Bible%20text%20could%20grow%20beyond%20the%20app's%20own%20size-picker%20selection%2C%20while%20any%20other%20custom%20font%20would%20remain%20fixed.%20This%20is%20an%20inherent%20SwiftUI%20API%20limitation%2C%20so%20the%20current%20approach%20is%20likely%20the%20best%20option%20%E2%80%94%20worth%20documenting%20with%20an%20inline%20comment%20so%20future%20maintainers%20understand%20the%20intentional%20asymmetry.%0A%0A&pr=137&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
Tests/YouVersionPlatformReaderTests/ReaderFontsTests.swift:28-39
**Test relies on private SwiftUI internal names**

`dump()` produces output derived from SwiftUI's private type names (`SwiftUI.Font.SystemProvider`, `SwiftUI.Font.NamedProvider`, `SwiftUI.Font.Design.serif`). Apple treats these as implementation details with no stability guarantee, so any OS update that renames or restructures `Font`'s internals could silently break these assertions without any functional regression in the actual font rendering. Consider wrapping these assertions in a comment that acknowledges the fragility, or structuring the test around observable behavior (e.g. creating a `UIFont` from the resolved font and inspecting its `familyName`).

### Issue 2 of 2
Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift:71-81
**System fonts now respond to Dynamic Type; custom fonts stay fixed-size**

For custom fonts `Font.custom(familyName, fixedSize: size)` is returned, which ignores the user's Dynamic Type accessibility setting. For system fonts (`Font.system(size:)`) the size does respond to Dynamic Type, because SwiftUI offers no `fixedSize:` equivalent on `Font.system`. If a user has Dynamic Type set to a large accessibility size and selects "San Francisco" or "New York", the Bible text could grow beyond the app's own size-picker selection, while any other custom font would remain fixed. This is an inherent SwiftUI API limitation, so the current approach is likely the best option — worth documenting with an inline comment so future maintainers understand the intentional asymmetry.

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;main&#39; into YPE-2564-system..."](https://github.com/youversion/platform-sdk-swift/commit/eb2d1a73cc896a23294768da9f467fca9c9db6af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33119530)</sub>

<!-- /greptile_comment -->