### PR TITLE
chore: weekly sync main → feat/bible-loop (2026-05-26)

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -42,52 +42,63 @@ jobs:
           echo "status=$STATUS" >> "$GITHUB_OUTPUT"
           exit 0
 
-      - name: Semantic-release dry-run
-        id: semrel
+      - name: Compute release preview
+        id: preview
         if: steps.commitlint.outputs.status == '0'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          set +e
-          # Canonical workaround for running semantic-release --dry-run on a
-          # PR (see semantic-release discussions #1886 and #1937):
+          set -e
+          # Direct call to `@semantic-release/commit-analyzer` via
+          # scripts/preview-release.mjs. Skips the full
+          # `semantic-release --dry-run` lifecycle entirely.
           #
-          #   1. Unset GITHUB_ACTIONS. env-ci uses that flag to decide it's on
-          #      GitHub Actions and to report the branch as `refs/pull/N/merge`.
-          #      With it gone, env-ci falls back to git-based branch detection
-          #      and sees us on the PR head branch.
-          #   2. Override the branches allowlist with just that head branch.
-          #      A single entry keeps us well under semantic-release's
-          #      max-3-release-branches validation.
-          #   3. --no-ci skips the refuse-on-PR check that runs even after
-          #      branch detection passes.
+          # Why this exists: the previous dry-run approach silently
+          # failed on PR events because semantic-release's core
+          # `verifyAuth` step runs `git push --dry-run` to test push
+          # permission — and the `pull_request`-event `GITHUB_TOKEN`
+          # has `contents: read` only. That auth check aborts the
+          # whole lifecycle BEFORE `analyzeCommits` runs, producing a
+          # silent false-negative "no bump" preview (the exact
+          # fail-open class that hid the major bump on the squash of
+          # PR #117). `--no-ci` skips the CI env check, not the auth
+          # verification — there is no flag to disable it.
           #
-          # The file config (`.releaserc.json`) is untouched, so real releases
-          # still only ship from `main`. actions/checkout uses the merge ref
-          # by default, which is what we want analyzed.
-          unset GITHUB_ACTIONS
-          npx semantic-release --dry-run --no-ci --branches "$HEAD_REF" > semrel.log 2>&1
-          STATUS=$?
-          cat semrel.log
-          NEXT=$(grep -Eo "The next release version is [0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?" semrel.log | tail -1 | awk '{print $NF}')
-          [ -z "$NEXT" ] && NEXT="none"
-          # Detect "major" via semantic-release's own release-type log line.
-          # This catches both `BREAKING CHANGE:` footers AND the `feat!:` /
-          # `fix!:` shorthand, which doesn't emit the footer keyword.
-          if grep -qiE "complete:[[:space:]]*major[[:space:]]+release|release type[[:space:]]+is[[:space:]]+major" semrel.log; then
-            IS_MAJOR=1
-          else
-            IS_MAJOR=0
-          fi
-          # Best-effort: pull any explicit BREAKING CHANGE footer text for the comment.
-          # `feat!:` commits without a footer won't have notes here, and that's fine —
-          # the banner is gated on IS_MAJOR, not on the presence of footer text.
-          awk '/BREAKING CHANGE:/{flag=1} flag{print; if(/^$/) flag=0}' semrel.log > breaking.txt || true
+          # The analyzer module has no auth concerns, no env-ci, no
+          # branch-detection, no `verifyConditions`. Given a list of
+          # commits and the same plugin config production uses on
+          # `main` (read from `.releaserc.json`), it deterministically
+          # returns the release type.
+          #
+          # If the analyzer errors, this step fails (set -e). That is
+          # intentional: a broken preview should be loud, not silent.
+          node scripts/preview-release.mjs \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            > preview.json 2> analyzer.log
+          cat analyzer.log
+          cat preview.json
+
+          CURRENT=$(jq -r .current preview.json)
+          NEXT=$(jq -r .next preview.json)
+          RELEASE_TYPE=$(jq -r .release_type preview.json)
+          # Derive NO_BUMP / IS_MAJOR from RELEASE_TYPE rather than reading
+          # the script's `is_major` JSON field. `jq -r .is_major` would
+          # stringify the boolean as "true"/"false", but the comment-body
+          # step compares against "1"/"0" — depending on jq's output
+          # format here is a footgun. RELEASE_TYPE is canonical.
+          case "$RELEASE_TYPE" in
+            null)  NO_BUMP=1; IS_MAJOR=0 ;;
+            major) NO_BUMP=0; IS_MAJOR=1 ;;
+            *)     NO_BUMP=0; IS_MAJOR=0 ;;
+          esac
+
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "release_type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
           echo "is_major=$IS_MAJOR" >> "$GITHUB_OUTPUT"
-          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
-          exit 0
+          echo "no_bump=$NO_BUMP" >> "$GITHUB_OUTPUT"
 
       - name: Build PR comment body
         id: body
@@ -96,9 +107,11 @@ jobs:
           set -e
           MARKER='<!-- commit-lint-bot -->'
           STATUS="${{ steps.commitlint.outputs.status }}"
-          NEXT="${{ steps.semrel.outputs.next }}"
-          IS_MAJOR="${{ steps.semrel.outputs.is_major }}"
-          SEMREL_STATUS="${{ steps.semrel.outputs.status }}"
+          CURRENT="${{ steps.preview.outputs.current }}"
+          NEXT="${{ steps.preview.outputs.next }}"
+          RELEASE_TYPE="${{ steps.preview.outputs.release_type }}"
+          NO_BUMP="${{ steps.preview.outputs.no_bump }}"
+          IS_MAJOR="${{ steps.preview.outputs.is_major }}"
 
           {
             echo "$MARKER"
@@ -107,38 +120,25 @@ jobs:
               echo
               echo 'All commit messages in this PR conform to [Conventional Commits](https://www.conventionalcommits.org/).'
               echo
-              if [ "$SEMREL_STATUS" != "0" ]; then
-                echo '> ⚠️ `semantic-release --dry-run` exited non-zero. Release preview may be incomplete. This does not block the PR.'
+              if [ "${NO_BUMP:-0}" = "1" ]; then
+                echo "### 📦 Release preview: \`v$CURRENT\` (no bump)"
                 echo
-              fi
-              if [ -z "$NEXT" ] || [ "$NEXT" = "none" ]; then
-                echo '### 📦 Release preview: _no release_'
-                echo
-                echo 'These commits would not trigger a new release on `main`.'
+                echo 'These commits do not trigger a version bump. The published version on `main` would remain `v'"$CURRENT"'`.'
               elif [ "${IS_MAJOR:-0}" = "1" ]; then
-                echo "### 🚨🚨🚨 BREAKING CHANGES DETECTED — Next release: \`v$NEXT\` (MAJOR)"
+                echo "### 🚨🚨🚨 Major version bump detected — \`v$CURRENT\` → \`v$NEXT\` (MAJOR)"
                 echo
-                echo 'This PR introduces one or more breaking changes (either a `BREAKING CHANGE:` footer or a `feat!:` / `fix!:` shorthand). Merging will publish a **major** version bump.'
-                echo
-                if [ -s breaking.txt ]; then
-                  echo '<details><summary>Breaking change notes</summary>'
-                  echo
-                  echo '```'
-                  head -c 4000 breaking.txt
-                  echo
-                  echo '```'
-                  echo '</details>'
-                fi
+                echo 'The analyzer classified one or more commits as a major bump (a footer at start-of-line with the breaking-change token, or a `feat!:` / `fix!:` shorthand). If this is intentional, proceed. If this is prose accidentally tripping the parser, reword the offending commit body before merging — see the analyzer log below to identify which commit triggered the classification.'
               else
-                echo "### 📦 Release preview: \`v$NEXT\`"
+                BUMP_LABEL="${RELEASE_TYPE:-release}"
+                echo "### 📦 Release preview: \`v$CURRENT\` → \`v$NEXT\` ($BUMP_LABEL)"
                 echo
-                echo 'Merging this PR will trigger a new release on `main`.'
+                echo 'Merging this PR will, on the next manual release dispatch, ship as the version above.'
               fi
               echo
-              echo '<details><summary>semantic-release dry-run output</summary>'
+              echo '<details><summary>Release analyzer output</summary>'
               echo
               echo '```'
-              tail -c 6000 semrel.log 2>/dev/null || true
+              tail -c 6000 analyzer.log 2>/dev/null || true
               echo
               echo '```'
               echo '</details>'

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -29,6 +29,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Test release scripts
+        # Exercises scripts/release-validate.mjs and
+        # scripts/release-warn-version-jump.mjs — the version-validation
+        # paths called by scripts/release.sh at release time. Running
+        # here on every PR catches Node / OS / shell regressions before
+        # they reach a live release dispatch. This job runs Node 20 on
+        # ubuntu-latest; release.yml runs Node lts/* on macos-26 — the
+        # cross-environment coverage guards against env-dependent drift.
+        run: bash scripts/test-release-scripts.sh
+
       - name: Lint commit messages
         id: commitlint
         run: |

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,199 @@
+name: Commit Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: commit-lint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint-commits:
+    name: Lint commits & preview release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint commit messages
+        id: commitlint
+        run: |
+          set +e
+          npx commitlint \
+            --from "${{ github.event.pull_request.base.sha }}" \
+            --to "${{ github.event.pull_request.head.sha }}" \
+            --verbose > commitlint.log 2>&1
+          STATUS=$?
+          cat commitlint.log
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Semantic-release dry-run
+        id: semrel
+        if: steps.commitlint.outputs.status == '0'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set +e
+          # Canonical workaround for running semantic-release --dry-run on a
+          # PR (see semantic-release discussions #1886 and #1937):
+          #
+          #   1. Unset GITHUB_ACTIONS. env-ci uses that flag to decide it's on
+          #      GitHub Actions and to report the branch as `refs/pull/N/merge`.
+          #      With it gone, env-ci falls back to git-based branch detection
+          #      and sees us on the PR head branch.
+          #   2. Override the branches allowlist with just that head branch.
+          #      A single entry keeps us well under semantic-release's
+          #      max-3-release-branches validation.
+          #   3. --no-ci skips the refuse-on-PR check that runs even after
+          #      branch detection passes.
+          #
+          # The file config (`.releaserc.json`) is untouched, so real releases
+          # still only ship from `main`. actions/checkout uses the merge ref
+          # by default, which is what we want analyzed.
+          unset GITHUB_ACTIONS
+          npx semantic-release --dry-run --no-ci --branches "$HEAD_REF" > semrel.log 2>&1
+          STATUS=$?
+          cat semrel.log
+          NEXT=$(grep -Eo "The next release version is [0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?" semrel.log | tail -1 | awk '{print $NF}')
+          [ -z "$NEXT" ] && NEXT="none"
+          # Detect "major" via semantic-release's own release-type log line.
+          # This catches both `BREAKING CHANGE:` footers AND the `feat!:` /
+          # `fix!:` shorthand, which doesn't emit the footer keyword.
+          if grep -qiE "complete:[[:space:]]*major[[:space:]]+release|release type[[:space:]]+is[[:space:]]+major" semrel.log; then
+            IS_MAJOR=1
+          else
+            IS_MAJOR=0
+          fi
+          # Best-effort: pull any explicit BREAKING CHANGE footer text for the comment.
+          # `feat!:` commits without a footer won't have notes here, and that's fine —
+          # the banner is gated on IS_MAJOR, not on the presence of footer text.
+          awk '/BREAKING CHANGE:/{flag=1} flag{print; if(/^$/) flag=0}' semrel.log > breaking.txt || true
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "is_major=$IS_MAJOR" >> "$GITHUB_OUTPUT"
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Build PR comment body
+        id: body
+        if: always()
+        run: |
+          set -e
+          MARKER='<!-- commit-lint-bot -->'
+          STATUS="${{ steps.commitlint.outputs.status }}"
+          NEXT="${{ steps.semrel.outputs.next }}"
+          IS_MAJOR="${{ steps.semrel.outputs.is_major }}"
+          SEMREL_STATUS="${{ steps.semrel.outputs.status }}"
+
+          {
+            echo "$MARKER"
+            if [ "$STATUS" = "0" ]; then
+              echo '## ✅ Commit Lint: passed'
+              echo
+              echo 'All commit messages in this PR conform to [Conventional Commits](https://www.conventionalcommits.org/).'
+              echo
+              if [ "$SEMREL_STATUS" != "0" ]; then
+                echo '> ⚠️ `semantic-release --dry-run` exited non-zero. Release preview may be incomplete. This does not block the PR.'
+                echo
+              fi
+              if [ -z "$NEXT" ] || [ "$NEXT" = "none" ]; then
+                echo '### 📦 Release preview: _no release_'
+                echo
+                echo 'These commits would not trigger a new release on `main`.'
+              elif [ "${IS_MAJOR:-0}" = "1" ]; then
+                echo "### 🚨🚨🚨 BREAKING CHANGES DETECTED — Next release: \`v$NEXT\` (MAJOR)"
+                echo
+                echo 'This PR introduces one or more breaking changes (either a `BREAKING CHANGE:` footer or a `feat!:` / `fix!:` shorthand). Merging will publish a **major** version bump.'
+                echo
+                if [ -s breaking.txt ]; then
+                  echo '<details><summary>Breaking change notes</summary>'
+                  echo
+                  echo '```'
+                  head -c 4000 breaking.txt
+                  echo
+                  echo '```'
+                  echo '</details>'
+                fi
+              else
+                echo "### 📦 Release preview: \`v$NEXT\`"
+                echo
+                echo 'Merging this PR will trigger a new release on `main`.'
+              fi
+              echo
+              echo '<details><summary>semantic-release dry-run output</summary>'
+              echo
+              echo '```'
+              tail -c 6000 semrel.log 2>/dev/null || true
+              echo
+              echo '```'
+              echo '</details>'
+            else
+              echo '## ❌ Commit Lint: failed'
+              echo
+              echo 'One or more commit messages in this PR do not conform to [Conventional Commits](https://www.conventionalcommits.org/).'
+              echo 'This must be fixed before this PR can be merged.'
+              echo
+              echo '### commitlint output'
+              echo
+              echo '```'
+              cat commitlint.log
+              echo '```'
+              echo
+              echo '### How to fix'
+              echo
+              echo '1. Reword the offending commit(s) so the subject matches `type(scope): description`.'
+              echo '   - Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.'
+              echo '   - Breaking changes: append `!` after the type/scope, or add a `BREAKING CHANGE:` footer.'
+              echo '2. Rewrite history on your branch:'
+              echo
+              echo '   ```bash'
+              echo '   # most recent commit'
+              echo '   git commit --amend'
+              echo '   # earlier commits'
+              echo '   git rebase -i origin/${{ github.event.pull_request.base.ref }}'
+              echo '   git push --force-with-lease'
+              echo '   ```'
+              echo
+              echo 'See `commitlint.config.js` for the full ruleset.'
+            fi
+          } > comment.md
+          echo "path=$PWD/comment.md" >> "$GITHUB_OUTPUT"
+
+      - name: Find existing bot comment
+        if: always()
+        id: find_comment
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- commit-lint-bot -->'
+
+      - name: Upsert PR comment
+        if: always()
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: ${{ steps.body.outputs.path }}
+          edit-mode: replace
+
+      - name: Fail job if commitlint failed
+        if: steps.commitlint.outputs.status != '0'
+        run: |
+          echo "Commit lint failed — see PR comment for details."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 env:
   XCODE_VERSION: latest-stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,23 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: |
+          The version to publish (bare semver, e.g. 5.2.3). Look at the
+          most recent merged PR's Commit Lint comment for the calculated
+          value, or run locally:
+            node scripts/preview-release.mjs \
+              --base $(git describe --tags --abbrev=0) --head main
+          You can override the calculator's value here — the workflow
+          logs both side-by-side for audit.
+        required: true
+        type: string
+      dry-run:
+        description: "Run end-to-end up to commit X + tag, then stop. Skips push, GitHub release, pod publish, and Dev-restore. For validating the workflow without shipping."
+        required: false
+        type: boolean
+        default: false
 
 env:
   XCODE_VERSION: latest-stable
@@ -68,8 +85,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Persist credentials for future commit (write)
-          # persist-credentials: false
+          # SSH key persists in the git remote so subsequent pushes
+          # (release commit X, tag, Dev-restore Y) bypass the `main`
+          # branch protection ruleset via the deploy-key bypass list.
           ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
 
       - name: Install npm dependencies
@@ -81,6 +99,7 @@ jobs:
           chmod +x scripts/publish-pods.sh
           chmod +x scripts/stamp-sdk-version.sh
           chmod +x scripts/restore-dev-sdk-on-main.sh
+          chmod +x scripts/release.sh
 
       - name: Setup Git
         run: |
@@ -90,11 +109,15 @@ jobs:
 
       - name: Release
         env:
+          VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry-run && '1' || '0' }}
+          # GH_TOKEN is what the `gh` CLI reads. We also export
+          # GITHUB_TOKEN for any other tooling that expects it.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # TODO: Remove CocoaPods token once we confirm we're not using it anymore
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
           GIT_AUTHOR_NAME: "github-actions[bot][release]"
           GIT_AUTHOR_EMAIL: "github-actions[bot][release]@users.noreply.github.com"
           GIT_COMMITTER_NAME: "github-actions[bot][release]"
           GIT_COMMITTER_EMAIL: "github-actions[bot][release]@users.noreply.github.com"
-        run: npx semantic-release
+        run: bash scripts/release.sh

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,9 @@ yarn-error.log*
 
 # Husky
 .husky/_/
+
+# Release artifacts
+# scripts/release.sh and dry-runs write generated release notes here.
+# The path is anchored to the repo root so a future `docs/notes.md` (or
+# anything in a subdirectory) is not silently ignored.
+/notes.md

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx --no -- commitlint --edit $1

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,4 @@
 {
-  "branches": ["main"],
-  "tagFormat": "${version}",
   "plugins": [
     [
       "@semantic-release/commit-analyzer",
@@ -12,35 +10,6 @@
       "@semantic-release/release-notes-generator",
       {
         "preset": "conventionalcommits"
-      }
-    ],
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md",
-        "changelogTitle": "# Changelog\n\nAll notable changes to this project will be documented in this file."
-      }
-    ],
-    [
-      "@semantic-release/exec",
-      {
-        "prepareCmd": "bash scripts/update-pod-versions.sh ${nextRelease.version} && bash scripts/stamp-sdk-version.sh ${nextRelease.version}",
-        "publishCmd": "bash scripts/restore-dev-sdk-on-main.sh ${nextRelease.version} && bash scripts/publish-pods.sh ${nextRelease.version}"
-      }
-    ],
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": [
-          "CHANGELOG.md",
-          "Sources/YouVersionPlatformCore/SDKVersion.swift",
-          "YouVersionPlatform.podspec",
-          "YouVersionPlatformCore.podspec",
-          "YouVersionPlatformReader.podspec",
-          "YouVersionPlatformUI.podspec"
-        ],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,25 +115,35 @@ When writing or reviewing code in this repo, load the relevant skill:
 
 ## Release Process
 
-Releases are driven by `semantic-release` from `main` (see `.github/workflows/release.yml` and `.releaserc.json`). **The Release workflow is triggered manually via `workflow_dispatch`** — go to the Actions tab and click "Run workflow", or run `gh workflow run release.yml`. Merging to `main` does **not** publish on its own; merges only land code, and a human decides when to cut the next release. Two pieces of state get version-bumped: the four `.podspec` files, and the `SDKVersion` constant used by the `x-yvp-sdk` HTTP header. They behave differently on purpose.
+Releases are **manually triggered with an explicit version input** via `workflow_dispatch`. There is no auto-release on merges to `main`. Merging to `main` only lands code; a human decides when to cut a release and which version to ship.
 
-**Podspecs** are bumped by `scripts/update-pod-versions.sh` during the prepare phase. The change is committed to `main` along with the `CHANGELOG.md` update.
+The release pipeline does not invoke `semantic-release` as an orchestrator. We use `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` as ESM libraries (via `scripts/preview-release.mjs` and `scripts/generate-release-notes.mjs`), and `scripts/release.sh` orchestrates the rest. See [RELEASING.md](./RELEASING.md) for the full operator guide.
 
-**`Sources/YouVersionPlatformCore/SDKVersion.swift`** is bumped by `scripts/release-stamp-and-tag.sh` during the publish phase, on a *separate child commit* that is **not pushed to `main`**. The release tag is force-moved to point at this stamped commit. Topology after a release:
-
-```
-main:  ... ─ X (podspec=4.9.2, CHANGELOG, SDKVersion="Dev")     ← main HEAD
-                  \
-                   Y (… +SDKVersion="4.9.2")                    ← tag 4.9.2
+To dispatch a release:
+```bash
+gh workflow run release.yml -f version=5.3.0
+# add -f dry-run=true to validate the workflow without shipping
 ```
 
-Why: `main` always reads `SDKVersion.current = "Dev"` so in-repo dev builds and PR CI report `SwiftSDK=Dev` rather than poisoning the data lake with stale or imprecise versions. SPM consumers resolving a tag and CocoaPods consumers (whose podspec source is `:tag => s.version.to_s`) both fetch `Y`, so production traffic reports the precise released version.
+Two pieces of state get version-bumped: the four `.podspec` files, and the `SDKVersion` constant used by the `x-yvp-sdk` HTTP header. They live in the same commit X but the SDKVersion handling has a twist.
+
+**Podspecs** are bumped by `scripts/update-pod-versions.sh`, called from `release.sh` before commit X.
+
+**`Sources/YouVersionPlatformCore/SDKVersion.swift`** is stamped to the release version by `scripts/stamp-sdk-version.sh` in commit X (so consumers fetching the tag see the real version), then restored to `"Dev"` in a follow-up commit Y by `scripts/restore-dev-sdk-on-main.sh`. Both X and Y are pushed to `main`; the tag stays at X. Topology after a release:
+
+```
+main:  ... ─ X (podspec=5.3.0, CHANGELOG entry, SDKVersion="5.3.0")   ← TAG 5.3.0
+                   \
+                    Y (SDKVersion="Dev")                              ← main HEAD
+```
+
+Why: `main` HEAD reads `SDKVersion.current = "Dev"` so in-repo dev builds and PR CI report `SwiftSDK=Dev` rather than poisoning the data lake with stale or imprecise versions. SPM consumers resolving a tag and CocoaPods consumers (podspec source is `:tag => s.version.to_s`) fetch X, so production traffic reports the precise released version. Y is reachable from `main` and X is reachable from Y, so `git tag --merged main` still finds the release tag — that wasn't true in an earlier design that placed Y off-main.
 
 **Footguns**:
-- `git checkout <tag>` lands on a detached commit not reachable from `main`. Expected.
-- `git log main` does not show any commit that ever modified `SDKVersion.swift` to a real version. Expected — those commits live only on tags.
-- Don't cherry-pick a tagged commit onto `main`; it would leak the stamped version.
+- `git log main` does show every release: X (stamped, tagged) sits one commit behind every Y (Dev-restore). To find the tag commits, `git log main --grep '^chore(release):'` works.
+- Don't manually rebase or amend X or Y — they're part of an enforced topology that `restore-dev-sdk-on-main.sh`'s pre-flight asserts depend on.
 - If you change the shape of the `static let current = "..."` line in `SDKVersion.swift`, also update `scripts/stamp-sdk-version.sh`.
+- The Commit Lint workflow's PR preview shows what the analyzer would compute as the next version. The release workflow logs that value side-by-side with the human's chosen value for audit — they don't have to match.
 
 ## Localization
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ LINUX_SOURCEKIT_LIB_PATH=/root/.local/share/swiftly/toolchains/6.1.3/usr/lib swi
 - Unit tests for core functionality
 
 ### Code Style
-- [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) for commit messages (enforced by commitlint)
+- [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) for commit messages (enforced in CI by the `Commit Lint` workflow — no local hook required)
 - Protocol-oriented programming patterns
 - Extensive use of extensions for code organization
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ When writing or reviewing code in this repo, load the relevant skill:
 
 ## Release Process
 
-Releases are driven by `semantic-release` from `main` (see `.github/workflows/release.yml` and `.releaserc.json`). Two pieces of state get version-bumped: the four `.podspec` files, and the `SDKVersion` constant used by the `x-yvp-sdk` HTTP header. They behave differently on purpose.
+Releases are driven by `semantic-release` from `main` (see `.github/workflows/release.yml` and `.releaserc.json`). **The Release workflow is triggered manually via `workflow_dispatch`** — go to the Actions tab and click "Run workflow", or run `gh workflow run release.yml`. Merging to `main` does **not** publish on its own; merges only land code, and a human decides when to cut the next release. Two pieces of state get version-bumped: the four `.podspec` files, and the `SDKVersion` constant used by the `x-yvp-sdk` HTTP header. They behave differently on purpose.
 
 **Podspecs** are bumped by `scripts/update-pod-versions.sh` during the prepare phase. The change is committed to `main` along with the `CHANGELOG.md` update.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,144 @@
 
 All notable changes to this project will be documented in this file.
 
+## [6.0.0](https://github.com/youversion/platform-sdk-swift/compare/5.2.2...6.0.0) (2026-05-18)
+
+
+### ⚠ BREAKING CHANGES
+
+* footers.
+  - Posts a sticky PR comment (via peter-evans/find-comment +
+    create-or-update-comment) on both success and failure, with a prominent
+    warning when a major bump is detected.
+  - Treats a non-zero semantic-release dry-run as a warning only, so a release
+    config glitch never blocks unrelated PRs.
+- Add an `npm run commitlint` script for local pre-push validation.
+- Update AGENTS.md, RELEASING.md, and CONTRIBUTING.md to describe the new
+  CI-enforced flow and the local check.
+
+Refs YPE-2398
+
+Co-Authored-By: Craft Agent <agents-noreply@craft.do>
+
+* fix(ci): pin commit-lint actions to SHAs, catch feat! breaking changes, drop edited trigger
+
+Addresses three review comments on the commit-lint workflow:
+
+- Pin peter-evans/find-comment and peter-evans/create-or-update-comment to
+  full commit SHAs (v3.1.0 and v4.0.0 respectively). Floating major tags
+  could be silently force-pushed to a malicious SHA, and this workflow has
+  `pull-requests: write`.
+- Detect major releases via semantic-release's own log line ("complete:
+  major release" / "release type is major") instead of grepping for the
+  literal "BREAKING CHANGE" string. The previous check missed the `feat!:`
+  and `fix!:` shorthand, which produces a major bump without emitting the
+  footer keyword. Banner now fires correctly for both forms.
+- Drop the `edited` PR trigger. It re-ran the full workflow on every PR
+  title/body edit despite the workflow only validating commit-range
+  contents, not PR metadata. `synchronize` already re-runs on every new
+  commit push, which is the only event that can change what we lint.
+
+Refs YPE-2398
+
+Co-Authored-By: Craft Agent <agents-noreply@craft.do>
+
+* fix(ci): make semantic-release dry-run actually compute the next version, expand commit examples
+
+- semantic-release was logging "configured to only run on main" and bailing
+  on PR runs because HEAD is `refs/pull/N/merge`, which isn't in the
+  `branches` allowlist. The previous `--branches` override was the wrong
+  knob: that controls _which_ branch can release, not _which_ branch
+  semantic-release thinks it's on. Now we point a local branch at the PR
+  merge commit using the base ref name and let semantic-release run as if
+  the PR had already merged, which is exactly the preview we want.
+- Address review feedback on CONTRIBUTING.md: add a fuller Conventional
+  Commits section with type list, version-bump table, six worked examples
+  (feat / fix / docs / refactor / chore / breaking change with footer),
+  and a note about imperative mood and scopes. Aimed at coding agents and
+  humans who haven't internalized the spec.
+
+Refs YPE-2398
+
+Co-Authored-By: Craft Agent <agents-noreply@craft.do>
+
+* fix(ci): strip GitHub Actions env vars so semantic-release dry-run detects the right branch
+
+Previous fix moved git HEAD to a local branch named after the PR base ref,
+but semantic-release never looked at git — it relies on env-ci, which
+reads GITHUB_ACTIONS + GITHUB_REF + GITHUB_EVENT_NAME and reports the
+branch as `refs/pull/N/merge` on PR events. That ref never matches the
+configured `branches: ["main"]` allowlist, so the analyzer bails with
+"triggered on the branch refs/pull/N/merge ... won't be published"
+before computing a version. The --no-ci flag bypasses the CI auth check,
+not the env-ci branch detection.
+
+Wrap the semantic-release invocation in `env -u ...` to unset the
+GitHub Actions env vars that signal "PR in CI". env-ci then falls back
+to git-based detection and sees us on `main` (because of the local
+checkout in the previous step), so the analyzer runs end-to-end and the
+PR comment shows the real next version.
+
+GITHUB_TOKEN is preserved so the @semantic-release/github plugin's
+verifyConditions step still passes.
+
+Refs YPE-2398
+
+Co-Authored-By: Craft Agent <agents-noreply@craft.do>
+
+* docs: annotate commit examples with version bumps and call out squash-merge behavior
+
+Two pieces of contributor feedback on CONTRIBUTING.md:
+
+- Each example now shows the bump it would trigger (MINOR / PATCH /
+  NO RELEASE / MAJOR) with concrete before-and-after versions, so
+  contributors and agents can see the consequence at a glance.
+- Add an explicit callout that this repo squash-merges and that the
+  squash commit subject — seeded from the PR title — is what
+  semantic-release reads on `main`. Also state that the entire commit
+  history back to the last tag is scanned and the highest bump wins.
+  This prevents the "all my commits were `feat` but the PR was titled
+  `chore: ...` and no release happened" trap.
+
+Refs YPE-2398
+
+Co-Authored-By: Craft Agent <agents-noreply@craft.do>
+
+* refactor(ci): simplify semantic-release dry-run with --branches '**' --no-ci
+
+Replace the env-var stripping + local-branch-rename dance with the
+direct CLI override: `--branches '**' --no-ci`. `--branches '**'`
+loosens the analyzer's branch allowlist for this invocation only (the
+`.releaserc.json` config is untouched, so real releases are still
+locked to `main`), and `--no-ci` bypasses the refuse-on-PR check.
+Same dry-run output, ~10 fewer lines, no GITHUB_* env juggling.
+
+Refs YPE-2398
+
+Co-Authored-By: Craft Agent <agents-noreply@craft.do>
+
+* fix(ci): scope semantic-release dry-run --branches to the PR head ref only
+
+`--branches '**'` expanded against every branch in the repo (~13) and
+tripped semantic-release's max-3-release-branches validation:
+ERELEASEBRANCHES "The release branches are invalid". Limit the override
+to a single entry — the PR head branch — which is what env-ci already
+detects us on. That keeps the allowlist exactly one branch wide, well
+under the limit, and aligned with the detected branch so the analyzer
+runs end-to-end.
+
+The file config in `.releaserc.json` is still untouched, so real
+releases continue to ship only from `main`.
+
+Refs YPE-2398
+
+Co-Authored-By: Craft Agent <agents-noreply@craft.do>
+
+* fix(ci): unset GITHUB_ACTIONS for semantic-release dry-run (canonical workaround)
+
+### Continuous Integration
+
+* replace Husky commit-msg hook with CI commit-lint + release preview ([#117](https://github.com/youversion/platform-sdk-swift/issues/117)) ([1d21411](https://github.com/youversion/platform-sdk-swift/commit/1d214119f6e4792d6c49607f4d37d425df1e20d4)), closes [#1886](https://github.com/youversion/platform-sdk-swift/issues/1886) [#1937](https://github.com/youversion/platform-sdk-swift/issues/1937)
+
 ## [5.2.2](https://github.com/youversion/platform-sdk-swift/compare/5.2.1...5.2.2) (2026-05-15)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [5.2.2](https://github.com/youversion/platform-sdk-swift/compare/5.2.1...5.2.2) (2026-05-15)
+
+
+### Bug Fixes
+
+* BibleReaderViewModel created on every render ([#122](https://github.com/youversion/platform-sdk-swift/issues/122)) ([8dad856](https://github.com/youversion/platform-sdk-swift/commit/8dad8567eca81ef94d78ee1376a05903178fd76b))
+
 ## [5.2.1](https://github.com/youversion/platform-sdk-swift/compare/5.2.0...5.2.1) (2026-05-11)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,143 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## [6.0.0](https://github.com/youversion/platform-sdk-swift/compare/5.2.2...6.0.0) (2026-05-18)
+## [5.2.3](https://github.com/youversion/platform-sdk-swift/compare/5.2.2...5.2.3) (2026-05-18)
 
 
-### ⚠ BREAKING CHANGES
+### Bug Fixes
 
-* footers.
-  - Posts a sticky PR comment (via peter-evans/find-comment +
-    create-or-update-comment) on both success and failure, with a prominent
-    warning when a major bump is detected.
-  - Treats a non-zero semantic-release dry-run as a warning only, so a release
-    config glitch never blocks unrelated PRs.
-- Add an `npm run commitlint` script for local pre-push validation.
-- Update AGENTS.md, RELEASING.md, and CONTRIBUTING.md to describe the new
-  CI-enforced flow and the local check.
+* **ci:** switch release publishing from auto-on-push to manual `workflow_dispatch` trigger. The Release workflow no longer fires on every merge to `main`; cut releases on demand from the Actions tab (or `gh workflow run release.yml`). See [RELEASING.md](./RELEASING.md).
 
-Refs YPE-2398
-
-Co-Authored-By: Craft Agent <agents-noreply@craft.do>
-
-* fix(ci): pin commit-lint actions to SHAs, catch feat! breaking changes, drop edited trigger
-
-Addresses three review comments on the commit-lint workflow:
-
-- Pin peter-evans/find-comment and peter-evans/create-or-update-comment to
-  full commit SHAs (v3.1.0 and v4.0.0 respectively). Floating major tags
-  could be silently force-pushed to a malicious SHA, and this workflow has
-  `pull-requests: write`.
-- Detect major releases via semantic-release's own log line ("complete:
-  major release" / "release type is major") instead of grepping for the
-  literal "BREAKING CHANGE" string. The previous check missed the `feat!:`
-  and `fix!:` shorthand, which produces a major bump without emitting the
-  footer keyword. Banner now fires correctly for both forms.
-- Drop the `edited` PR trigger. It re-ran the full workflow on every PR
-  title/body edit despite the workflow only validating commit-range
-  contents, not PR metadata. `synchronize` already re-runs on every new
-  commit push, which is the only event that can change what we lint.
-
-Refs YPE-2398
-
-Co-Authored-By: Craft Agent <agents-noreply@craft.do>
-
-* fix(ci): make semantic-release dry-run actually compute the next version, expand commit examples
-
-- semantic-release was logging "configured to only run on main" and bailing
-  on PR runs because HEAD is `refs/pull/N/merge`, which isn't in the
-  `branches` allowlist. The previous `--branches` override was the wrong
-  knob: that controls _which_ branch can release, not _which_ branch
-  semantic-release thinks it's on. Now we point a local branch at the PR
-  merge commit using the base ref name and let semantic-release run as if
-  the PR had already merged, which is exactly the preview we want.
-- Address review feedback on CONTRIBUTING.md: add a fuller Conventional
-  Commits section with type list, version-bump table, six worked examples
-  (feat / fix / docs / refactor / chore / breaking change with footer),
-  and a note about imperative mood and scopes. Aimed at coding agents and
-  humans who haven't internalized the spec.
-
-Refs YPE-2398
-
-Co-Authored-By: Craft Agent <agents-noreply@craft.do>
-
-* fix(ci): strip GitHub Actions env vars so semantic-release dry-run detects the right branch
-
-Previous fix moved git HEAD to a local branch named after the PR base ref,
-but semantic-release never looked at git — it relies on env-ci, which
-reads GITHUB_ACTIONS + GITHUB_REF + GITHUB_EVENT_NAME and reports the
-branch as `refs/pull/N/merge` on PR events. That ref never matches the
-configured `branches: ["main"]` allowlist, so the analyzer bails with
-"triggered on the branch refs/pull/N/merge ... won't be published"
-before computing a version. The --no-ci flag bypasses the CI auth check,
-not the env-ci branch detection.
-
-Wrap the semantic-release invocation in `env -u ...` to unset the
-GitHub Actions env vars that signal "PR in CI". env-ci then falls back
-to git-based detection and sees us on `main` (because of the local
-checkout in the previous step), so the analyzer runs end-to-end and the
-PR comment shows the real next version.
-
-GITHUB_TOKEN is preserved so the @semantic-release/github plugin's
-verifyConditions step still passes.
-
-Refs YPE-2398
-
-Co-Authored-By: Craft Agent <agents-noreply@craft.do>
-
-* docs: annotate commit examples with version bumps and call out squash-merge behavior
-
-Two pieces of contributor feedback on CONTRIBUTING.md:
-
-- Each example now shows the bump it would trigger (MINOR / PATCH /
-  NO RELEASE / MAJOR) with concrete before-and-after versions, so
-  contributors and agents can see the consequence at a glance.
-- Add an explicit callout that this repo squash-merges and that the
-  squash commit subject — seeded from the PR title — is what
-  semantic-release reads on `main`. Also state that the entire commit
-  history back to the last tag is scanned and the highest bump wins.
-  This prevents the "all my commits were `feat` but the PR was titled
-  `chore: ...` and no release happened" trap.
-
-Refs YPE-2398
-
-Co-Authored-By: Craft Agent <agents-noreply@craft.do>
-
-* refactor(ci): simplify semantic-release dry-run with --branches '**' --no-ci
-
-Replace the env-var stripping + local-branch-rename dance with the
-direct CLI override: `--branches '**' --no-ci`. `--branches '**'`
-loosens the analyzer's branch allowlist for this invocation only (the
-`.releaserc.json` config is untouched, so real releases are still
-locked to `main`), and `--no-ci` bypasses the refuse-on-PR check.
-Same dry-run output, ~10 fewer lines, no GITHUB_* env juggling.
-
-Refs YPE-2398
-
-Co-Authored-By: Craft Agent <agents-noreply@craft.do>
-
-* fix(ci): scope semantic-release dry-run --branches to the PR head ref only
-
-`--branches '**'` expanded against every branch in the repo (~13) and
-tripped semantic-release's max-3-release-branches validation:
-ERELEASEBRANCHES "The release branches are invalid". Limit the override
-to a single entry — the PR head branch — which is what env-ci already
-detects us on. That keeps the allowlist exactly one branch wide, well
-under the limit, and aligned with the detected branch so the analyzer
-runs end-to-end.
-
-The file config in `.releaserc.json` is still untouched, so real
-releases continue to ship only from `main`.
-
-Refs YPE-2398
-
-Co-Authored-By: Craft Agent <agents-noreply@craft.do>
-
-* fix(ci): unset GITHUB_ACTIONS for semantic-release dry-run (canonical workaround)
 
 ### Continuous Integration
 
-* replace Husky commit-msg hook with CI commit-lint + release preview ([#117](https://github.com/youversion/platform-sdk-swift/issues/117)) ([1d21411](https://github.com/youversion/platform-sdk-swift/commit/1d214119f6e4792d6c49607f4d37d425df1e20d4)), closes [#1886](https://github.com/youversion/platform-sdk-swift/issues/1886) [#1937](https://github.com/youversion/platform-sdk-swift/issues/1937)
+* replace Husky commit-msg hook with CI commit-lint + release preview ([#117](https://github.com/youversion/platform-sdk-swift/issues/117)) ([1d21411](https://github.com/youversion/platform-sdk-swift/commit/1d214119f6e4792d6c49607f4d37d425df1e20d4))
 
 ## [5.2.2](https://github.com/youversion/platform-sdk-swift/compare/5.2.1...5.2.2) (2026-05-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [5.2.1](https://github.com/youversion/platform-sdk-swift/compare/5.2.0...5.2.1) (2026-05-11)
+
+
+### Bug Fixes
+
+* normalize bookUSFM case in overlaps/contains and fix chapter-only USFM parsing ([52b9bf5](https://github.com/youversion/platform-sdk-swift/commit/52b9bf5b6b8bfe2b68ed888a5c4b6268eb7233bf))
+
 ## [5.2.0](https://github.com/youversion/platform-sdk-swift/compare/5.1.1...5.2.0) (2026-05-08)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,11 +36,11 @@ This project follows idiomatic Swift conventions as outlined in [Swift API Desig
 
 - Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages — they drive semantic-release's version bumps and the auto-generated CHANGELOG. Validated in CI by the `Commit Lint` workflow; check locally with `npm run commitlint` (or `npx commitlint --from=origin/main --to=HEAD --verbose`).
 
-  > **⚠️ Important: every commit subject on `main` is scanned to compute the next version.**
+  > **⚠️ Important: every commit subject on `main` is scanned to compute the next version when a release is cut.**
   >
-  > This repo squash-merges PRs. The **squash commit subject becomes a single commit on `main`** — its `<type>` is what semantic-release reads, not the individual commits on your branch. GitHub seeds the squash subject from the PR title by default, so **make sure your PR title is itself a valid Conventional Commit** (e.g. `feat(reader): add highlight color picker`). If the squash subject is `chore:` you'll get no release even if every commit on your branch was a `feat`.
+  > This repo squash-merges PRs. The **squash commit subject becomes a single commit on `main`** — its `<type>` is what semantic-release reads, not the individual commits on your branch. GitHub seeds the squash subject from the PR title by default, so **make sure your PR title is itself a valid Conventional Commit** (e.g. `feat(reader): add highlight color picker`). If the squash subject is `chore:` it contributes no release signal even if every commit on your branch was a `feat`.
   >
-  > On each push to `main`, semantic-release walks the entire commit history back to the last release tag and picks the **highest** bump it finds — one `feat` among ten `chore`s still triggers a minor release; one `BREAKING CHANGE` anywhere triggers a major. The CI `Commit Lint` workflow on each PR previews the next version using the same logic.
+  > Releases are cut on demand — see [RELEASING.md](./RELEASING.md). When the Release workflow is triggered, semantic-release walks the entire commit history back to the last release tag and picks the **highest** bump it finds across that window — one `feat` among ten `chore`s still produces a minor release; one `BREAKING CHANGE` footer (or `!` shorthand) anywhere produces a major. The CI `Commit Lint` workflow on each PR previews the version that *would* be cut today, using the same logic, so you can see your PR's impact before merging.
 
   **Format:** `<type>(<optional scope>): <subject>`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,53 @@ This SDK is organized as a Swift Package with multiple targets:
 
 This project follows idiomatic Swift conventions as outlined in [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/). Key points:
 
-- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages — they drive semantic-release's version bumps and the auto-generated CHANGELOG. Validated in CI by the `Commit Lint` workflow; check locally with `npm run commitlint` (or `npx commitlint --from=origin/main --to=HEAD --verbose`).
+
+  > **⚠️ Important: every commit subject on `main` is scanned to compute the next version.**
+  >
+  > This repo squash-merges PRs. The **squash commit subject becomes a single commit on `main`** — its `<type>` is what semantic-release reads, not the individual commits on your branch. GitHub seeds the squash subject from the PR title by default, so **make sure your PR title is itself a valid Conventional Commit** (e.g. `feat(reader): add highlight color picker`). If the squash subject is `chore:` you'll get no release even if every commit on your branch was a `feat`.
+  >
+  > On each push to `main`, semantic-release walks the entire commit history back to the last release tag and picks the **highest** bump it finds — one `feat` among ten `chore`s still triggers a minor release; one `BREAKING CHANGE` anywhere triggers a major. The CI `Commit Lint` workflow on each PR previews the next version using the same logic.
+
+  **Format:** `<type>(<optional scope>): <subject>`
+
+  **Allowed types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+
+  **Version-bump behavior:**
+  - `feat:` → **minor** bump (e.g. `5.2.2` → `5.3.0`)
+  - `fix:` and `perf:` → **patch** bump (e.g. `5.2.2` → `5.2.3`)
+  - `docs`, `style`, `refactor`, `test`, `build`, `ci`, `chore`, `revert` → **no release**
+  - Any commit with `!` after the type/scope, **or** a `BREAKING CHANGE:` footer → **major** bump (e.g. `5.2.2` → `6.0.0`)
+
+  **Examples (annotated with the bump each one would trigger):**
+
+  ```text
+  feat(reader): add highlight color picker to BibleReaderView
+  # → MINOR: 5.2.2 → 5.3.0
+
+  fix(core): normalize bookUSFM case in overlaps/contains
+  # → PATCH: 5.2.2 → 5.2.3
+
+  perf(reader): cache verse layout to avoid recomputation on scroll
+  # → PATCH: 5.2.2 → 5.2.3
+
+  docs: clarify SDK installation steps in README
+  # → NO RELEASE
+
+  refactor(ui): extract VerseRow into its own SwiftUI view
+  # → NO RELEASE
+
+  chore(deps): bump SwiftLint to 0.55.1
+  # → NO RELEASE
+
+  feat(api)!: rename PlatformClient.fetch(_:) to PlatformClient.load(_:)
+
+  BREAKING CHANGE: `fetch(_:)` has been removed. Migrate to `load(_:)`,
+  which throws instead of returning an optional.
+  # → MAJOR: 5.2.2 → 6.0.0  (the `!` is enough; the footer adds CHANGELOG detail)
+  ```
+
+  Keep the subject in the imperative mood ("add", "fix", "rename" — not "added"/"fixes"). Use a `scope` (e.g. `reader`, `core`, `ui`, `api`) when the change is localized; omit it when the change is repo-wide.
 - Run `swiftlint` before submitting PRs
 - Prefer `async`/`await` over completion handlers
 - Use protocol-oriented programming patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,13 +34,13 @@ This SDK is organized as a Swift Package with multiple targets:
 
 This project follows idiomatic Swift conventions as outlined in [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/). Key points:
 
-- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages — they drive semantic-release's version bumps and the auto-generated CHANGELOG. Validated in CI by the `Commit Lint` workflow; check locally with `npm run commitlint` (or `npx commitlint --from=origin/main --to=HEAD --verbose`).
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages — they drive the version-preview analyzer and the auto-generated CHANGELOG. Validated in CI by the `Commit Lint` workflow; check locally with `npm run commitlint` (or `npx commitlint --from=origin/main --to=HEAD --verbose`).
 
-  > **⚠️ Important: every commit subject on `main` is scanned to compute the next version when a release is cut.**
+  > **⚠️ Important: every commit subject on `main` is scanned by the analyzer to suggest the next version when a release is cut.**
   >
-  > This repo squash-merges PRs. The **squash commit subject becomes a single commit on `main`** — its `<type>` is what semantic-release reads, not the individual commits on your branch. GitHub seeds the squash subject from the PR title by default, so **make sure your PR title is itself a valid Conventional Commit** (e.g. `feat(reader): add highlight color picker`). If the squash subject is `chore:` it contributes no release signal even if every commit on your branch was a `feat`.
+  > This repo squash-merges PRs. The **squash commit subject becomes a single commit on `main`** — its `<type>` is what the analyzer reads, not the individual commits on your branch. GitHub seeds the squash subject from the PR title by default, so **make sure your PR title is itself a valid Conventional Commit** (e.g. `feat(reader): add highlight color picker`). If the squash subject is `chore:` it contributes no release signal even if every commit on your branch was a `feat`.
   >
-  > Releases are cut on demand — see [RELEASING.md](./RELEASING.md). When the Release workflow is triggered, semantic-release walks the entire commit history back to the last release tag and picks the **highest** bump it finds across that window — one `feat` among ten `chore`s still produces a minor release; one `BREAKING CHANGE` footer (or `!` shorthand) anywhere produces a major. The CI `Commit Lint` workflow on each PR previews the version that *would* be cut today, using the same logic, so you can see your PR's impact before merging.
+  > Releases are cut on demand with an explicit version input — see [RELEASING.md](./RELEASING.md). The analyzer walks every commit since the last release tag and picks the **highest** bump it finds across that window — one `feat` among ten `chore`s suggests a minor release; one `BREAKING CHANGE` footer (or `!` shorthand) anywhere suggests a major. The CI `Commit Lint` workflow on each PR shows that preview, and the Release workflow logs it side-by-side with the human's chosen version for audit. The human's input is what actually ships; the analyzer's value is informational.
 
   **Format:** `<type>(<optional scope>): <subject>`
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,113 +1,75 @@
 # Release Process
 
-This project uses [semantic-release](https://semantic-release.gitbook.io/) for automated versioning and package publishing.
+Releases on this repo are **manually triggered with an explicit version input**. A human types the version they want to publish into the Actions UI (or `gh workflow run`), the workflow validates it, and the release ships. There is no auto-release on merges to `main`.
 
 ## Overview
 
-Releases use [semantic-release](https://semantic-release.gitbook.io/) to compute the next version from [Conventional Commits](https://www.conventionalcommits.org/) since the last tag, but the release itself is **triggered manually**, not automatically on every push to `main`. A human (or scheduled job) decides when to cut a release; merging a PR by itself never publishes.
+The release pipeline does not use `semantic-release` as an orchestrator. We use two pieces of it as libraries:
+
+- [`@semantic-release/commit-analyzer`](https://github.com/semantic-release/commit-analyzer) — invoked by `scripts/preview-release.mjs` to compute what version the commits *would* suggest (shown in the PR's Commit Lint comment and in the release workflow's job summary for audit).
+- [`@semantic-release/release-notes-generator`](https://github.com/semantic-release/release-notes-generator) — invoked by `scripts/generate-release-notes.mjs` to render the CHANGELOG entry and GitHub release body from commits since the last tag.
+
+Everything else (validation, version stamping, podspec updates, commit, tag, push, GitHub release creation, pod publish, Dev-restore) is in `scripts/release.sh`, which the release workflow calls directly.
+
+This split exists because `semantic-release`'s lifecycle tightly couples computation to execution. There is no hook to override its calculated version — the only way to ship a version that differs from what the analyzer computes is to commit-message-engineer history, which is brittle, slow, and unreviewable. By making the version an explicit workflow input we get one-click overrides, a side-by-side audit log of "calculator said X, human chose Y," and no history rewrites.
 
 ## How It Works
 
-1. **Develop on a branch with conventional commit subjects** → the `Commit Lint` workflow validates each PR and previews the version that *would* be cut today.
-2. **Merge PRs to `main`** → nothing publishes. `main` just accumulates work.
-3. **When ready to release, trigger the Release workflow manually** → Actions tab → `Release` → "Run workflow" (or `gh workflow run release.yml`).
-4. **Semantic-release analyzes commits since the last tag** → determines version bump (major/minor/patch).
-5. **Version bump and changelog** → updates all 4 podspec files, stamps `SDKVersion.swift`, writes a `CHANGELOG.md` entry.
-6. **Git tag and GitHub release** → creates the version tag (e.g., `5.3.0`) and a GitHub release.
-7. **Publish to CocoaPods** → publishes all pods in dependency order.
-8. **Restore `SDKVersion.swift` to `"Dev"`** → a follow-up commit returns the on-main constant to `"Dev"` so PR builds don't report a stale released version. The tag stays at the stamped commit (see [AGENTS.md → Release Process](./AGENTS.md#release-process) for the X/Y topology).
-
-### Why manual
-
-Auto-publishing on every push to `main` makes the publish surface too easy to trip — any commit message body or release-process change that an analyzer reads as a major bump goes straight to consumers. Manual trigger gives a deliberate review point between merge and publish, and keeps the per-PR version preview as the early warning.
-
-## Commit Message Format
-
-Use this format for all commits:
-
-```
-<type>(<scope>): <subject>
-
-<body>
-
-<footer>
-```
-
-### Types (determines version bump)
-
-- **feat**: A new feature (→ **MINOR** version bump, e.g., 1.0.0 → 1.1.0)
-- **fix**: A bug fix (→ **PATCH** version bump, e.g., 1.0.0 → 1.0.1)
-- **BREAKING CHANGE**: Breaking API change (→ **MAJOR** version bump, e.g., 1.0.0 → 2.0.0)
-
-### Other types (no version bump)
-
-- **docs**: Documentation changes
-- **style**: Code formatting
-- **refactor**: Code refactoring
-- **perf**: Performance improvements
-- **test**: Test changes
-- **build**: Build system changes
-- **ci**: CI/CD changes
-- **chore**: Maintenance tasks
-
-### Examples
-
-```bash
-# Patch release (1.0.0 → 1.0.1)
-git commit -m "fix: resolve crash on iPad when opening reader"
-
-# Minor release (1.0.0 → 1.1.0)
-git commit -m "feat: add dark mode support to reader"
-
-# Major release (1.0.0 → 2.0.0)
-git commit -m "feat: redesign Bible reader API
-
-BREAKING CHANGE: BibleReader.open() now returns async Result<Void, Error>"
-
-# With scope
-git commit -m "fix(reader): correct verse highlighting behavior"
-```
+1. **Develop on a branch with conventional commit subjects.** The `Commit Lint` workflow validates every PR and previews the version the analyzer would compute.
+2. **Merge PRs to `main`.** Nothing publishes. `main` just accumulates work.
+3. **Decide on a version.** The most recent merged PR's Commit Lint comment shows the analyzer-computed value, which is the suggested next version. You can accept that or override.
+4. **Dispatch the Release workflow** from the Actions tab → `Release` → "Run workflow", or via CLI:
+   ```bash
+   gh workflow run release.yml -f version=5.3.0
+   ```
+   To validate the workflow end-to-end on a feature branch without shipping, also pass `-f dry-run=true`.
+5. **The workflow runs `scripts/release.sh`**, which:
+   - Validates the input is valid semver and strictly greater than the current tag.
+   - Logs the calculator's computed value alongside the chosen value in the job summary.
+   - Warns (but does not block) if the chosen version is more than one major above calculated.
+   - Generates release notes from commits since the last tag.
+   - Prepends the new entry to `CHANGELOG.md`.
+   - Stamps `SDKVersion.swift` and all four podspecs to the chosen version.
+   - Commits everything as `chore(release): <version> [skip ci]` (commit **X**), with the release notes embedded as the commit body.
+   - Tags **X** with the version and pushes both to `main`.
+   - Creates a GitHub release with the generated notes.
+   - Publishes all four pods to CocoaPods trunk in dependency order.
+   - Creates a follow-up commit **Y** that restores `SDKVersion.swift` to `"Dev"` on `main`, so subsequent dev/CI builds don't report a stale released version. The tag stays at **X** (which is reachable from `main` via Y → X).
 
 ## Required GitHub Configuration
 
 ### GitHub Secrets
 
-The following secrets must be configured in your GitHub repository:
+The following secrets must be configured in the repository:
 
-#### 1. DEPLOY_KEY
+#### 1. `RELEASE_SSH_KEY`
 
-An SSH private key used to bypass branch protection rules and push release commits/tags to `main`:
+An SSH private key used to bypass the `main` branch-protection ruleset so the release workflow can push commits **X** and **Y** and the version tag.
 
 1. Generate an SSH key pair:
    ```bash
-   ssh-keygen -t ed25519 -C "github-actions-semantic-release" -f deploy_key -N ""
+   ssh-keygen -t ed25519 -C "github-actions-release" -f release_key -N ""
    ```
-
-2. Add the **public key** (`deploy_key.pub`) as a Deploy Key:
-   - Go to `https://github.com/youversion/platform-sdk-swift/settings/keys`
-   - Click "Add deploy key"
-   - Title: `semantic-release` (or your preferred name)
-   - Paste contents of `deploy_key.pub`
+2. Add the **public key** (`release_key.pub`) as a Deploy Key at `https://github.com/youversion/platform-sdk-swift/settings/keys`:
+   - Title: `release` (or your preferred name)
+   - Paste contents of `release_key.pub`
    - **Check "Allow write access"** ✓
+3. Add the **private key** (`release_key`) as a repository secret at `https://github.com/youversion/platform-sdk-swift/settings/secrets/actions`:
+   - Name: `RELEASE_SSH_KEY`
+   - Value: paste entire contents of the `release_key` file
 
-3. Add the **private key** (`deploy_key`) as a repository secret:
-   - Go to `https://github.com/youversion/platform-sdk-swift/settings/secrets/actions`
-   - Click "New repository secret"
-   - Name: `DEPLOY_KEY`
-   - Value: Paste entire contents of `deploy_key` file
+> **Important:** the secret name `RELEASE_SSH_KEY` must match the reference in `.github/workflows/release.yml`. If you rename the secret, update the workflow too.
 
-> **Important:** The secret name `DEPLOY_KEY` must match the reference in `.github/workflows/release.yml`. If you change the secret name, update the workflow file accordingly.
+#### 2. `COCOAPODS_TRUNK_TOKEN`
 
-#### 2. COCOAPODS_TRUNK_TOKEN
-
-Your CocoaPods trunk session token:
+Your CocoaPods trunk session token, used by `scripts/publish-pods.sh` to authenticate the `pod trunk push` calls.
 
 ```bash
 # Get your token from ~/.netrc after registering
 cat ~/.netrc | grep cocoapods.org
 ```
 
-Or get it from CocoaPods trunk:
+Or:
 
 ```bash
 pod trunk me
@@ -117,19 +79,53 @@ Add the token to repository secrets as `COCOAPODS_TRUNK_TOKEN`.
 
 ### Branch Protection Configuration
 
-The Deploy Key bypasses the `main` branch protection ruleset that requires pull requests. To configure:
+The `main` branch ruleset requires pull requests, but the release workflow needs to push **X** and **Y** commits and the tag directly. The Deploy Key configured above bypasses this.
 
 1. Go to `https://github.com/youversion/platform-sdk-swift/settings/rules`
-2. Edit the ruleset for `main` branch
-3. Under "Bypass list", ensure "Deploy keys" is enabled for bypass
+2. Edit the ruleset for `main`
+3. Under "Bypass list", ensure "Deploy keys" is enabled
 
-This allows semantic-release to push release commits and tags directly to `main` during the automated release process.
+## Local Testing
 
-## Testing Release Steps Locally
+### Preview the version the analyzer would suggest
+
+```bash
+node scripts/preview-release.mjs \
+  --base "$(git describe --tags --abbrev=0)" \
+  --head HEAD
+```
+
+Outputs JSON: `{"current": "5.2.2", "next": "5.2.3", "release_type": "patch", ...}`. The same logic the `Commit Lint` workflow uses on every PR.
+
+### Generate release notes for a hypothetical version
+
+```bash
+node scripts/generate-release-notes.mjs \
+  --base "$(git describe --tags --abbrev=0)" \
+  --head HEAD \
+  --version 5.2.3
+```
+
+Prints the markdown that would be prepended to `CHANGELOG.md` and used as the GitHub release body.
+
+### Dry-run the full release end-to-end
+
+```bash
+VERSION=5.2.3 DRY_RUN=1 SKIP_LINT=1 bash scripts/release.sh
+```
+
+Validates the version, generates notes, updates `CHANGELOG.md` and podspecs, stamps `SDKVersion.swift`, builds commit X, tags it — then stops without pushing. `SKIP_LINT=1` bypasses the `pod lib lint` step which needs Xcode + iOS simulator runtime (CI has it; most dev machines don't).
+
+Clean up after a dry-run:
+
+```bash
+git reset --hard HEAD^
+git tag -d <version>
+git restore .
+rm -f notes.md
+```
 
 ### Test commitlint
-
-Conventional Commits are enforced in CI by `.github/workflows/commit-lint.yml`. There is no local Git hook — Xcode commits and Windows contributors bypass hooks too unreliably for that to be worth maintaining. To check your branch's commits locally before pushing:
 
 ```bash
 # Lint every commit on your branch that isn't on main
@@ -143,99 +139,90 @@ echo "feat: add new feature" | npx commitlint
 echo "invalid message" | npx commitlint   # should fail
 ```
 
-### Test semantic-release (dry-run)
-
-```bash
-# See what version would be released
-npx semantic-release --dry-run
-```
-
-### Test version update script
-
-```bash
-# Test updating to version 1.2.3 (won't actually publish)
-bash scripts/update-pod-versions.sh 1.2.3
-```
-
 ## Version Synchronization
 
-All 4 podspecs are kept in sync:
+All four podspecs are kept in sync via `scripts/update-pod-versions.sh`:
 
 - `YouVersionPlatformCore.podspec`
 - `YouVersionPlatformUI.podspec` (depends on Core)
 - `YouVersionPlatformReader.podspec` (depends on UI)
 - `YouVersionPlatform.podspec` (umbrella, depends on all)
 
-The `update-pod-versions.sh` script ensures:
-- All podspecs get the same version number
-- Inter-pod dependencies reference the correct version
+Inter-pod dependencies use `s.version.to_s`, so a single version-bump call updates everything coherently.
 
 ## Publishing Order
 
-Pods are published in dependency order:
+Pods are published in dependency order by `scripts/publish-pods.sh`:
 
 1. **YouVersionPlatformCore** (no dependencies)
 2. **YouVersionPlatformUI** (depends on Core)
 3. **YouVersionPlatformReader** (depends on UI)
 4. **YouVersionPlatform** (umbrella, depends on all)
 
-## Manual Release (Emergency)
-
-If you need to release manually:
-
-```bash
-# 1. Update versions
-bash scripts/update-pod-versions.sh 1.2.3
-
-# 2. Update CHANGELOG.md manually
-
-# 3. Commit changes
-git add .
-git commit -m "chore(release): 1.2.3 [skip ci]"
-
-# 4. Create tag
-git tag 1.2.3
-
-# 5. Push
-git push origin main --tags
-
-# 6. Publish to CocoaPods
-bash scripts/publish-pods.sh 1.2.3
-
-# 7. Create GitHub release manually
-```
+`pod trunk push` is non-idempotent and can partial-succeed: a network blip can leave Core published but UI not. The script checks `pod trunk info <PodName>` for the target version before each push, so re-running on the same version is safe.
 
 ## Troubleshooting
 
-### Release didn't trigger
+### The Commit Lint preview shows a major bump on a "patch" PR
 
-- Verify you merged to `main` branch
-- Check that commits follow Conventional Commits format
-- Look at GitHub Actions logs for errors
+`conventional-commits-parser` treats `BREAKING CHANGE` at the start of any commit body line as a breaking-change footer, regardless of surrounding markdown or quotes. The most common cause: a long commit body wraps and a paragraph happens to start with that token. Reword the offending line on your branch.
 
-### CocoaPods publish failed
+The analyzer log in the PR comment's `<details>` block shows which commit triggered the classification.
 
-- Verify `COCOAPODS_TRUNK_TOKEN` secret is set correctly
-- Check that podspec files are valid: `pod spec lint *.podspec`
-- Ensure you have permission to publish these pods
+### The release dispatch is rejected with "is not strictly greater than current tag"
 
-### Commitlint blocking commits
+`release.sh` refuses to ship a version less than or equal to the latest tag. If you genuinely need to re-tag (e.g., recovering from a partial release), delete the old tag from origin first, then dispatch again.
 
-- Make sure your commit message follows the format: `type(scope): subject`
-- Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
-- Bypass temporarily (not recommended): `git commit --no-verify`
+### CocoaPods publish failed midway
 
-## Swift Package Manager
+The script is idempotent via `pod trunk info`. Re-dispatch with the same version; the already-published pods will be skipped and the missing ones retried. If `pod trunk info` itself is unreliable, check `pod trunk me` to confirm authentication.
 
-SPM uses git tags for versioning. When semantic-release creates a tag like `1.0.0`, SPM users can reference it in their `Package.swift`:
+### The release script aborted after pushing the tag — main is stamped with the released version
 
-```swift
-.package(url: "https://github.com/YouVersion/platform-sdk-swift.git", from: "1.0.0")
+If `release.sh` dies in any of the post-push steps (`gh release create`, `publish-pods.sh`, `restore-dev-sdk-on-main.sh`), `main` HEAD is commit **X** with `SDKVersion.swift` reading the released version, and commit **Y** was never created. Re-running `release.sh` won't recover — its pre-flight requires `SDKVersion.swift` to read `"Dev"` and will refuse to proceed.
+
+Finish the release by running the remaining steps manually:
+
+```bash
+VERSION=<the version that was being released>
+
+# If the GitHub release wasn't created (check the Releases page):
+gh release create "$VERSION" --notes-file notes.md --title "$VERSION"
+
+# Idempotent via `pod trunk info` — safe regardless of how far the script got:
+bash scripts/publish-pods.sh "$VERSION"
+
+# Creates commit Y and restores SDKVersion to "Dev":
+bash scripts/restore-dev-sdk-on-main.sh "$VERSION"
 ```
 
-## Resources
+`notes.md` is left in place when the script aborts (the success-path `rm` doesn't fire), so it's available for the `gh release create` call. Verify with `git log -2 --oneline` (Y on top of X) and `pod trunk info YouVersionPlatformCore` (latest matches `$VERSION`).
 
-- [Conventional Commits](https://www.conventionalcommits.org/)
-- [Semantic Versioning](https://semver.org/)
-- [semantic-release Documentation](https://semantic-release.gitbook.io/)
-- [Commitlint Rules](https://commitlint.js.org/#/reference-rules)
+### Need an emergency release without the workflow
+
+The pieces of `scripts/release.sh` can be run by hand:
+
+```bash
+VERSION=5.2.3
+
+# Compute and inspect what would happen
+node scripts/preview-release.mjs --base "$(git describe --tags --abbrev=0)" --head HEAD
+node scripts/generate-release-notes.mjs --base "$(git describe --tags --abbrev=0)" --head HEAD --version "$VERSION" > notes.md
+
+# Update files
+bash scripts/update-pod-versions.sh "$VERSION"
+bash scripts/stamp-sdk-version.sh "$VERSION"
+# manually prepend notes.md to CHANGELOG.md
+
+# Commit X, tag, push
+git add CHANGELOG.md Sources/YouVersionPlatformCore/SDKVersion.swift *.podspec
+git commit -m "chore(release): $VERSION [skip ci]" -m "$(cat notes.md)"
+git tag "$VERSION"
+git push origin main "$VERSION"
+
+# Publish
+bash scripts/publish-pods.sh "$VERSION"
+
+# Restore Dev
+bash scripts/restore-dev-sdk-on-main.sh "$VERSION"
+```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,16 +4,22 @@ This project uses [semantic-release](https://semantic-release.gitbook.io/) for a
 
 ## Overview
 
-Releases are fully automated based on commit messages following the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+Releases use [semantic-release](https://semantic-release.gitbook.io/) to compute the next version from [Conventional Commits](https://www.conventionalcommits.org/) since the last tag, but the release itself is **triggered manually**, not automatically on every push to `main`. A human (or scheduled job) decides when to cut a release; merging a PR by itself never publishes.
 
 ## How It Works
 
-1. **Commit with conventional format** → Commitlint validates your message
-2. **Merge to `main`** → GitHub Actions triggers semantic-release
-3. **Semantic-release analyzes commits** → Determines version bump (major/minor/patch)
-4. **Version bump and changelog** → Updates all 4 podspec files and CHANGELOG.md
-5. **Git tag and GitHub release** → Creates version tag (e.g., `1.0.0`) and GitHub release
-6. **Publish to CocoaPods** → Publishes all pods in dependency order
+1. **Develop on a branch with conventional commit subjects** → the `Commit Lint` workflow validates each PR and previews the version that *would* be cut today.
+2. **Merge PRs to `main`** → nothing publishes. `main` just accumulates work.
+3. **When ready to release, trigger the Release workflow manually** → Actions tab → `Release` → "Run workflow" (or `gh workflow run release.yml`).
+4. **Semantic-release analyzes commits since the last tag** → determines version bump (major/minor/patch).
+5. **Version bump and changelog** → updates all 4 podspec files, stamps `SDKVersion.swift`, writes a `CHANGELOG.md` entry.
+6. **Git tag and GitHub release** → creates the version tag (e.g., `5.3.0`) and a GitHub release.
+7. **Publish to CocoaPods** → publishes all pods in dependency order.
+8. **Restore `SDKVersion.swift` to `"Dev"`** → a follow-up commit returns the on-main constant to `"Dev"` so PR builds don't report a stale released version. The tag stays at the stamped commit (see [AGENTS.md → Release Process](./AGENTS.md#release-process) for the X/Y topology).
+
+### Why manual
+
+Auto-publishing on every push to `main` makes the publish surface too easy to trip — any commit message body or release-process change that an analyzer reads as a major bump goes straight to consumers. Manual trigger gives a deliberate review point between merge and publish, and keeps the per-PR version preview as the early warning.
 
 ## Commit Message Format
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -123,12 +123,18 @@ This allows semantic-release to push release commits and tags directly to `main`
 
 ### Test commitlint
 
-```bash
-# Valid commit message
-echo "feat: add new feature" | npx commitlint
+Conventional Commits are enforced in CI by `.github/workflows/commit-lint.yml`. There is no local Git hook — Xcode commits and Windows contributors bypass hooks too unreliably for that to be worth maintaining. To check your branch's commits locally before pushing:
 
-# Invalid commit message (should fail)
-echo "invalid message" | npx commitlint
+```bash
+# Lint every commit on your branch that isn't on main
+npx commitlint --from=origin/main --to=HEAD --verbose
+
+# Or, equivalently:
+npm run commitlint
+
+# Pipe a single message to test rule changes
+echo "feat: add new feature" | npx commitlint
+echo "invalid message" | npx commitlint   # should fail
 ```
 
 ### Test semantic-release (dry-run)

--- a/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
@@ -14,23 +14,37 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         }
         
         self.versionId = versionId
-        self.bookUSFM = bookUSFM
+        self.bookUSFM = bookUSFM.uppercased()
         self.chapter = chapter
         self.verseStart = verse
         self.verseEnd = verse
     }
-    
+
     public init(versionId: Int, bookUSFM: String, chapter: Int, verseStart: Int, verseEnd: Int) {
         assert(chapter >= 1, "Starting chapter must be greater than or equal to 1.")
         assert(verseStart >= 1, "Starting verse must be greater than or equal to 1.")
         assert(verseEnd >= 1, "Ending verse must be greater than or equal to 1.")
         assert(verseEnd >= verseStart, "Ending verse must be equal to or after starting verse.")
-        
+
         self.versionId = versionId
-        self.bookUSFM = bookUSFM
+        self.bookUSFM = bookUSFM.uppercased()
         self.chapter = chapter
         self.verseStart = verseStart
         self.verseEnd = verseEnd
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let versionId = try container.decode(Int.self, forKey: .versionId)
+        let bookUSFM = try container.decode(String.self, forKey: .bookUSFM)
+        let chapter = try container.decode(Int.self, forKey: .chapter)
+        let verseStart = try container.decodeIfPresent(Int.self, forKey: .verseStart)
+        let verseEnd = try container.decodeIfPresent(Int.self, forKey: .verseEnd)
+        if let verseStart, let verseEnd {
+            self.init(versionId: versionId, bookUSFM: bookUSFM, chapter: chapter, verseStart: verseStart, verseEnd: verseEnd)
+        } else {
+            self.init(versionId: versionId, bookUSFM: bookUSFM, chapter: chapter, verse: verseStart)
+        }
     }
 
     public var debugDescription: String {
@@ -88,30 +102,28 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
     }
 
     public var chapterUSFM: String? {
-        "\(bookUSFM.uppercased()).\(chapter)"
+        "\(bookUSFM).\(chapter)"
     }
 
     public var asUSFM: String {
-        let upperBookUSFM = bookUSFM.uppercased()
         if let verseStart {
             if let verseEnd, verseStart != verseEnd {
-                return "\(upperBookUSFM).\(chapter).\(verseStart)-\(upperBookUSFM).\(chapter).\(verseEnd)"
+                return "\(bookUSFM).\(chapter).\(verseStart)-\(bookUSFM).\(chapter).\(verseEnd)"
             } else {
-                return "\(upperBookUSFM).\(chapter).\(verseStart)"
+                return "\(bookUSFM).\(chapter).\(verseStart)"
             }
         } else {
-            return "\(upperBookUSFM).\(chapter)"
+            return "\(bookUSFM).\(chapter)"
         }
     }
 
     /// Returns whether this reference is available in the provided Bible version metadata.
     public func existsIn(version: BibleVersion) -> Bool {
-        let normalizedBookUSFM = bookUSFM.uppercased()
-        guard version.bookUSFMs.contains(where: { $0.uppercased() == normalizedBookUSFM }) else {
+        guard version.bookUSFMs.contains(where: { $0.uppercased() == bookUSFM }) else {
             return false
         }
 
-        guard let book = version.book(with: normalizedBookUSFM) else {
+        guard let book = version.book(with: bookUSFM) else {
             return true
         }
 
@@ -271,7 +283,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         if let match = usfm.wholeMatch(of: patBCVCV) {
             let (_, bText, cText, vText, _, v2Text) = match.output
             if let c = Int(cText), let v = Int(vText), let v2 = Int(v2Text) {
-                return reference(bookUSFM: bText.uppercased(), chapter: c, verseStart: v, verseEnd: v2)
+                return reference(bookUSFM: String(bText), chapter: c, verseStart: v, verseEnd: v2)
             }
             return nil
         }
@@ -284,7 +296,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
                 if String(bText) != String(b2Text) {
                     return nil
                 }
-                return reference(bookUSFM: bText.uppercased(), chapter: c, verseStart: v, verseEnd: v2)
+                return reference(bookUSFM: String(bText), chapter: c, verseStart: v, verseEnd: v2)
             }
             return nil
         }
@@ -294,7 +306,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         if let match = usfm.wholeMatch(of: patBCVV) {
             let (_, bText, cText, vText, v2Text) = match.output
             if let c = Int(cText), let v = Int(vText), let v2 = Int(v2Text) {
-                return reference(bookUSFM: bText.uppercased(), chapter: c, verseStart: v, verseEnd: v2)
+                return reference(bookUSFM: String(bText), chapter: c, verseStart: v, verseEnd: v2)
             }
             return nil
         }
@@ -304,7 +316,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         if let match = usfm.wholeMatch(of: patBCV) {
             let (_, bText, cText, vText) = match.output
             if let c = Int(cText), let v = Int(vText) {
-                return reference(bookUSFM: bText.uppercased(), chapter: c, verseStart: v, verseEnd: v)
+                return reference(bookUSFM: String(bText), chapter: c, verseStart: v, verseEnd: v)
             }
             return nil
         }
@@ -314,7 +326,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         if let match = usfm.wholeMatch(of: patBC) {
             let (_, bText, cText) = match.output
             if let c = Int(cText) {
-                return reference(bookUSFM: bText.uppercased(), chapter: c, verseStart: 1, verseEnd: 1)
+                return BibleReference(versionId: versionId, bookUSFM: String(bText), chapter: c)
             }
             return nil
         }
@@ -324,7 +336,7 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
         if let match = usfm.wholeMatch(of: patBCC) {
             let (_, bText, cText, _) = match.output
             if let c = Int(cText) {
-                return reference(bookUSFM: bText.uppercased(), chapter: c, verseStart: 1, verseEnd: 1)
+                return reference(bookUSFM: String(bText), chapter: c, verseStart: 1, verseEnd: 1)
             }
             return nil
         }

--- a/Sources/YouVersionPlatformCore/SDKVersion.swift
+++ b/Sources/YouVersionPlatformCore/SDKVersion.swift
@@ -5,5 +5,5 @@
 // in-repo and PR-CI builds report "Dev". If you change the shape of the
 // declaration below, also update scripts/stamp-sdk-version.sh.
 enum SDKVersion {
-    static let current = "Dev"
+    static let current = "6.0.0"
 }

--- a/Sources/YouVersionPlatformCore/SDKVersion.swift
+++ b/Sources/YouVersionPlatformCore/SDKVersion.swift
@@ -5,5 +5,5 @@
 // in-repo and PR-CI builds report "Dev". If you change the shape of the
 // declaration below, also update scripts/stamp-sdk-version.sh.
 enum SDKVersion {
-    static let current = "Dev"
+    static let current = "5.2.2"
 }

--- a/Sources/YouVersionPlatformCore/SDKVersion.swift
+++ b/Sources/YouVersionPlatformCore/SDKVersion.swift
@@ -5,5 +5,5 @@
 // in-repo and PR-CI builds report "Dev". If you change the shape of the
 // declaration below, also update scripts/stamp-sdk-version.sh.
 enum SDKVersion {
-    static let current = "Dev"
+    static let current = "5.2.1"
 }

--- a/Sources/YouVersionPlatformCore/SDKVersion.swift
+++ b/Sources/YouVersionPlatformCore/SDKVersion.swift
@@ -5,5 +5,5 @@
 // in-repo and PR-CI builds report "Dev". If you change the shape of the
 // declaration below, also update scripts/stamp-sdk-version.sh.
 enum SDKVersion {
-    static let current = "5.2.2"
+    static let current = "Dev"
 }

--- a/Sources/YouVersionPlatformCore/SDKVersion.swift
+++ b/Sources/YouVersionPlatformCore/SDKVersion.swift
@@ -5,5 +5,5 @@
 // in-repo and PR-CI builds report "Dev". If you change the shape of the
 // declaration below, also update scripts/stamp-sdk-version.sh.
 enum SDKVersion {
-    static let current = "5.2.1"
+    static let current = "Dev"
 }

--- a/Sources/YouVersionPlatformCore/SDKVersion.swift
+++ b/Sources/YouVersionPlatformCore/SDKVersion.swift
@@ -5,5 +5,5 @@
 // in-repo and PR-CI builds report "Dev". If you change the shape of the
 // declaration below, also update scripts/stamp-sdk-version.sh.
 enum SDKVersion {
-    static let current = "6.0.0"
+    static let current = "Dev"
 }

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -4,18 +4,11 @@ import YouVersionPlatformCore
 import YouVersionPlatformUI
 
 public struct BibleReaderView: View {
-    @State private var viewModel: BibleReaderViewModel
-#if !os(tvOS)
-    @State private var contextProvider = ContextProvider()
-#endif
+    @State private var viewModel: BibleReaderViewModel?
 
-    @Environment(\.openURL) private var openURL
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
-    private let fontSettingsDetent = PresentationDetent.height(360)
-    private let fontListDetent = PresentationDetent.height(480)
-    @State private var selectedDetent: PresentationDetent
-    @State private var detents: Set<PresentationDetent>
+    private let initialReference: BibleReference?
+    private let verseSelectionStyle: VerseSelectionStyle
+    private let onVerseTap: ((BibleReference) -> Void)?
 
     /// Creates a Bible reader view.
     ///
@@ -40,9 +33,9 @@ public struct BibleReaderView: View {
             onVerseTap != nil || YouVersionPlatformConfiguration.isSignInEnabled,
             "onVerseTap must be provided OR YouVersion sign-in must be enabled"
         )
-        viewModel = BibleReaderViewModel(reference: reference, verseSelectionStyle: verseSelectionStyle, onVerseTap: onVerseTap)
-        detents = [fontSettingsDetent, fontListDetent]
-        selectedDetent = fontSettingsDetent
+        self.initialReference = reference
+        self.verseSelectionStyle = verseSelectionStyle
+        self.onVerseTap = onVerseTap
     }
 
     /// Creates a Bible reader view with sign-in configuration.
@@ -64,6 +57,40 @@ public struct BibleReaderView: View {
     }
 
     public var body: some View {
+        Group {
+            if let viewModel {
+                ReaderContent(viewModel: viewModel)
+            } else {
+                Color.clear
+            }
+        }
+        .task {
+            if viewModel == nil {
+                viewModel = BibleReaderViewModel(
+                    reference: initialReference,
+                    verseSelectionStyle: verseSelectionStyle,
+                    onVerseTap: onVerseTap
+                )
+            }
+        }
+    }
+}
+
+private struct ReaderContent: View {
+    @Bindable var viewModel: BibleReaderViewModel
+#if !os(tvOS)
+    @State private var contextProvider = ContextProvider()
+#endif
+
+    @Environment(\.openURL) private var openURL
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private let fontSettingsDetent = PresentationDetent.height(360)
+    private let fontListDetent = PresentationDetent.height(480)
+    @State private var selectedDetent = PresentationDetent.height(360)
+    @State private var detents: Set<PresentationDetent> = [.height(360), .height(480)]
+
+    var body: some View {
         VStack(spacing: 0) {
             header
             Spacer()

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -141,8 +141,8 @@ private struct ReaderContent: View {
     @State private var selectedDetent = PresentationDetent.height(360)
     @State private var detents: Set<PresentationDetent> = [.height(360), .height(480)]
 
-    var externalSelectedVerses: Binding<Set<BibleReference>>?
-    var audioActiveReference: BibleReference?
+    private var externalSelectedVerses: Binding<Set<BibleReference>>?
+    private var audioActiveReference: BibleReference?
     @State private var lastScrolledVerse: Int?
     @State private var verseAnchors: [Int] = []
 

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift
@@ -49,7 +49,7 @@ struct BibleReaderFontListView: View {
                 let isSelected = viewModel.textOptions.fontFamily == family
                 HStack {
                     Text(family)
-                        .font(.custom(family, size: 20))
+                        .font(ReaderFonts.displayFont(familyName: family, size: 20))
                     if isSelected {
                         Image(systemName: "checkmark")
                             .font(.system(size: 18, weight: .semibold))

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift
@@ -27,7 +27,7 @@ struct BibleReaderFontSettingsView: View {
                     .foregroundStyle(viewModel.readerTextMutedColor)
                 let family = viewModel.textOptions.fontFamily
                 Text(family)
-                    .font(.custom(family, size: 22))
+                    .font(ReaderFonts.displayFont(familyName: family, size: 22))
             }
             Spacer()
             Image(systemName: "chevron.right")

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -200,13 +200,15 @@ extension BibleReaderViewModel {
         return (url, referenceTitlesJoined)
     }
 
-    func handleVerseActionCopy() {
+    @discardableResult
+    // swiftlint:disable:next var_over_func
+    func handleVerseActionCopy() -> Task<Void, Never>? {
         guard !selectedVerses.isEmpty else {
-            return
+            return nil
         }
         let references = BibleReference.referencesByMerging(references: Array(selectedVerses).sorted())
         removeVerseSelection()
-        Task {
+        return Task {
             let t = await shareableVerseText(references: references)
             if let (url, title) = shareableURLAndTitleFor(references: references) {
                 let data = "\(t)\n\(title)\n\(url.absoluteString)"

--- a/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
@@ -38,8 +38,8 @@ public enum ReaderFonts {
     static let suggestedFamilies = [
         "Untitled Serif",
         "Avenir Next",
-        // New York
-        // San Francisco
+        "New York",
+        "San Francisco",
         // Gentium Plus
         "Baskerville", "Georgia", "Helvetica Neue", "Hoefler Text", "Verdana"
         // OpenDyslexic
@@ -79,6 +79,17 @@ public enum ReaderFonts {
 
     static func isPermittedFont(_ family: String) -> Bool {
         suggestedFamilies.contains(family) || otherFamilies.contains(family)
+    }
+
+    static func displayFont(familyName: String, size: CGFloat) -> Font {
+        switch familyName {
+        case "San Francisco":
+            .system(size: size)
+        case "New York":
+            .system(size: size, design: .serif)
+        default:
+            .custom(familyName, size: size)
+        }
     }
 
     // MARK: - Font Sizes and Spacing

--- a/Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift
+++ b/Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift
@@ -37,9 +37,10 @@ public struct BibleTextFonts {
 #endif
         self.baseSize = baseSize
         verseNumBaselineOffset = baseSize * 0.3
+
         let boldFamilyName: String
         let italicFamilyName: String
-        
+
         if familyName.hasSuffix("-Regular") {
             let base = familyName.split(separator: "-").dropLast().joined(separator: "-")
             boldFamilyName = base + "-Bold"
@@ -49,22 +50,33 @@ public struct BibleTextFonts {
             italicFamilyName = familyName
         }
 
-        let larger = Font.custom(familyName, fixedSize: baseSize * 1.1)
         fonts = [
-            .textFontItalic: Font.custom(italicFamilyName, fixedSize: baseSize).italic(),
-            .textFontBold: Font.custom(boldFamilyName, fixedSize: baseSize).bold(),
-            .smallCaps: Font.custom(familyName, fixedSize: baseSize).lowercaseSmallCaps(),
-            .headerItalic: Font.custom(italicFamilyName, fixedSize: baseSize * 1.1).italic(),
-            .headerSmaller: Font.custom(boldFamilyName, fixedSize: baseSize * 0.9).weight(.medium),
-            .header2: Font.custom(boldFamilyName, fixedSize: baseSize * 1.1).weight(.bold),
-            .header3: larger,
-            .header4: larger,
-            .footnote: Font.custom(familyName, fixedSize: baseSize * 0.8),
+            .textFontItalic: Self.font(familyName: italicFamilyName, size: baseSize).italic(),
+            .textFontBold: Self.font(familyName: boldFamilyName, size: baseSize).bold(),
+            .smallCaps: Self.font(familyName: familyName, size: baseSize).lowercaseSmallCaps(),
+            .headerItalic: Self.font(familyName: italicFamilyName, size: baseSize * 1.1).italic(),
+            .headerSmaller: Self.font(familyName: boldFamilyName, size: baseSize * 0.9).weight(.medium),
+            .header2: Self.font(familyName: boldFamilyName, size: baseSize * 1.1).weight(.bold),
+            .header3: Self.font(familyName: familyName, size: baseSize * 1.1),
+            .header4: Self.font(familyName: familyName, size: baseSize * 1.1),
+            .footnote: Self.font(familyName: familyName, size: baseSize * 0.8),
             // below are validated standards:
-            .header: Font.custom(boldFamilyName, fixedSize: baseSize).bold(),
-            .headerSmallerItalic: Font.custom(italicFamilyName, fixedSize: baseSize * 0.76).italic(),
-            .textFont: Font.custom(familyName, fixedSize: baseSize),
-            .verseNumFont: Font.custom(familyName, fixedSize: baseSize * 0.65).smallCaps()
+            .header: Self.font(familyName: boldFamilyName, size: baseSize).bold(),
+            .headerSmallerItalic: Self.font(familyName: italicFamilyName, size: baseSize * 0.76).italic(),
+            .textFont: Self.font(familyName: familyName, size: baseSize),
+            .verseNumFont: Self.font(familyName: familyName, size: baseSize * 0.65).smallCaps()
         ]
+    }
+
+    private static func font(familyName: String, size: CGFloat) -> Font {
+        if familyName == "San Francisco" || familyName == "SF Pro Text" || familyName.hasPrefix("SFProText-") {
+            return Font.system(size: size)
+        }
+
+        if familyName == "New York" || familyName.hasPrefix("NewYork-") {
+            return Font.system(size: size, design: .serif)
+        }
+
+        return Font.custom(familyName, fixedSize: size)
     }
 }

--- a/Sources/YouVersionPlatformUI/Objects/BibleVersion+Additions.swift
+++ b/Sources/YouVersionPlatformUI/Objects/BibleVersion+Additions.swift
@@ -55,27 +55,27 @@ public extension BibleVersion {
         let bookAndChapterSeparator = hasOneChapter ? "" : " "
         let chapter = hasOneChapter ? "" : String(reference.chapter)
 
-        switch (reference.verseStart, reference.verseEnd) {
-        case (_, let verseEnd?) where verseEnd == 999:
+        if reference.verseEnd == 999 {
             // Whole chapter
             return [bookName, bookAndChapterSeparator, chapter]
-            
-        case (nil, _):
+        }
+
+        guard let verseStart = reference.verseStart else {
             // Whole chapter
             return [bookName, bookAndChapterSeparator, chapter]
-            
-        case let (verseStart?, verseEnd?):
-            if verseStart == verseEnd {
-                // Single verse
-                return [bookName, bookAndChapterSeparator, chapter, chapterSeparator, String(verseStart)]
-            } else {
-                // Verse range
-                return [bookName, bookAndChapterSeparator, chapter, chapterSeparator, String(verseStart), "-", String(verseEnd)]
-            }
-            
-        case let (verseStart?, nil):
-            // Single verse with no verseEnd
+        }
+
+        guard let verseEnd = reference.verseEnd else {
+            assertionFailure("BibleReference verseEnd should be set when verseStart is set.")
+            return [bookName, bookAndChapterSeparator, chapter]
+        }
+
+        if verseStart == verseEnd {
+            // Single verse
             return [bookName, bookAndChapterSeparator, chapter, chapterSeparator, String(verseStart)]
+        } else {
+            // Verse range
+            return [bookName, bookAndChapterSeparator, chapter, chapterSeparator, String(verseStart), "-", String(verseEnd)]
         }
     }
 }

--- a/Tests/YouVersionPlatformCoreTests/BibleHighlightsViewModelTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleHighlightsViewModelTests.swift
@@ -252,7 +252,7 @@ struct BibleHighlightsViewModelTests {
         viewModel.ensureHighlightsForChapterLoaded(BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 10))
         // give the async task a moment
         try? await Task.sleep(nanoseconds: 50_000_000)
-        #expect(mockRepository.highlightsCallCount >= 0)
+        #expect(mockRepository.highlightsCallCount > 0)
     }
     
     @Test

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 @testable import YouVersionPlatformCore
 import Testing
 
@@ -23,6 +24,23 @@ func testInitVerseRange() {
     #expect(ref.chapter == 23)
     #expect(ref.verseStart == 1)
     #expect(ref.verseEnd == 2)
+}
+
+@Test
+func bibleReferenceConstructorsAlwaysSetVerseEndWhenVerseStartExists() throws {
+    let singleVerseReference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verse: 3)
+    let rangeReference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
+    let decodedReference = try JSONDecoder().decode(
+        BibleReference.self,
+        from: Data(#"{"versionId":111,"bookUSFM":"GEN","chapter":1,"verseStart":3}"#.utf8)
+    )
+
+    #expect(singleVerseReference.verseStart == 3)
+    #expect(singleVerseReference.verseEnd == 3)
+    #expect(rangeReference.verseStart == 3)
+    #expect(rangeReference.verseEnd == 5)
+    #expect(decodedReference.verseStart == 3)
+    #expect(decodedReference.verseEnd == 3)
 }
 
 // MARK: - Test isRange

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_codable.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_codable.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+@testable import YouVersionPlatformCore
+
+// MARK: - Codable
+
+@Test func decodedBookUSFMIsUppercased() throws {
+    let json = """
+    {"versionId":1,"bookUSFM":"gen","chapter":1,"verseStart":1,"verseEnd":1}
+    """
+    let ref = try JSONDecoder().decode(BibleReference.self, from: Data(json.utf8))
+    #expect(ref.bookUSFM == "GEN")
+}
+
+@Test func decodedVerseReferenceRoundTrips() throws {
+    let original = BibleReference(versionId: 1, bookUSFM: "REV", chapter: 22, verse: 21)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(BibleReference.self, from: data)
+    #expect(decoded.bookUSFM == original.bookUSFM)
+    #expect(decoded.versionId == original.versionId)
+    #expect(decoded.chapter == original.chapter)
+    #expect(decoded.verseStart == original.verseStart)
+    #expect(decoded.verseEnd == original.verseEnd)
+}
+
+@Test func decodedRangeReferenceRoundTrips() throws {
+    let original = BibleReference(versionId: 2, bookUSFM: "PSA", chapter: 23, verseStart: 1, verseEnd: 6)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(BibleReference.self, from: data)
+    #expect(decoded.bookUSFM == original.bookUSFM)
+    #expect(decoded.verseStart == original.verseStart)
+    #expect(decoded.verseEnd == original.verseEnd)
+}
+
+@Test func decodedChapterReferenceRoundTrips() throws {
+    let original = BibleReference(versionId: 1, bookUSFM: "JHN", chapter: 3)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(BibleReference.self, from: data)
+    #expect(decoded.bookUSFM == original.bookUSFM)
+    #expect(decoded.chapter == original.chapter)
+    #expect(decoded.verseStart == nil)
+    #expect(decoded.verseEnd == nil)
+}
+
+@Test func decodedLowercaseBookUSFMOverlapsCorrectly() throws {
+    let json = """
+    {"versionId":1,"bookUSFM":"jhn","chapter":3,"verseStart":16,"verseEnd":16}
+    """
+    let decoded = try JSONDecoder().decode(BibleReference.self, from: Data(json.utf8))
+    let constructed = BibleReference(versionId: 1, bookUSFM: "JHN", chapter: 3, verse: 16)
+    #expect(decoded.overlaps(with: constructed))
+}

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_overlaps.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_overlaps.swift
@@ -179,12 +179,12 @@ func testOverlaps_EdgeCaseNilHandling() {
 
 @Test
 func testOverlaps_CaseSensitiveBookComparison() {
-    // Test that book comparison is case-sensitive (as implemented)
+    // Test that book comparison is case-insensitive (bookUSFM is normalized to uppercase)
     let ref1 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
     let ref2 = BibleReference(versionId: 1, bookUSFM: "gen", chapter: 1, verse: 1)
-    
-    #expect(!ref1.overlaps(with: ref2))
-    #expect(!ref2.overlaps(with: ref1))
+
+    #expect(ref1.overlaps(with: ref2))
+    #expect(ref2.overlaps(with: ref1))
 }
 
 @Test

--- a/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_unvalidatedReference.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleReferenceTests_unvalidatedReference.swift
@@ -46,8 +46,13 @@ func testUnvalidatedReference_invalidVerseOrder() {
 @Test
 func testUnvalidatedReference_chapterOnly() throws {
     let ref = try #require(BibleReference.unvalidatedReference(with: "GEN.1", versionId: 1))
-    let expected = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 1)
+    let expected = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
     #expect(ref == expected)
+    #expect(ref.verseStart == nil)
+    #expect(ref.verseEnd == nil)
+    // A chapter-level reference should overlap any verse within that chapter
+    let verse5 = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 5)
+    #expect(ref.overlaps(with: verse5))
 }
 
 

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionAPITests.swift
@@ -79,7 +79,9 @@ import Testing
         {"content":"<div>ok</div>"}
         """.data(using: .utf8)!
 
+        var capturedRequest: URLRequest?
         HTTPMocking.setHandler(token: token) { request in
+            capturedRequest = request
             let resp = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
             return (json, resp)
         }
@@ -87,6 +89,13 @@ import Testing
         let ref = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
         let html = try await YouVersionAPI.Bible.chapter(reference: ref, accessToken: "swift-test-suite", session: session)
         #expect(html == "<div>ok</div>")
+
+        let req = try #require(capturedRequest)
+        let components = URLComponents(url: req.url!, resolvingAgainstBaseURL: false)
+        let queryItems = components?.queryItems ?? []
+        #expect(queryItems.contains(where: { $0.name == "format" && $0.value == "html" }))
+        #expect(queryItems.contains(where: { $0.name == "include_notes" && $0.value == "true" }))
+        #expect(queryItems.contains(where: { $0.name == "include_headings" && $0.value == "true" }))
     }
 
     @MainActor
@@ -133,6 +142,27 @@ import Testing
 
         let ref = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
         await #expect(throws: YouVersionAPIError.invalidResponse) {
+            _ = try await YouVersionAPI.Bible.chapter(reference: ref, accessToken: "swift-test-suite", session: session)
+        }
+    }
+
+    @MainActor
+    @Test func chapterInvalidContentThrowsInvalidDownload() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        // 200 response with valid JSON but missing the "content" key
+        let json = """
+        {"other_field": "no content here"}
+        """.data(using: .utf8)!
+
+        HTTPMocking.setHandler(token: token) { request in
+            let resp = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (json, resp)
+        }
+
+        let ref = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)
+        await #expect(throws: YouVersionAPIError.invalidDownload) {
             _ = try await YouVersionAPI.Bible.chapter(reference: ref, accessToken: "swift-test-suite", session: session)
         }
     }

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionsAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionsAPITests.swift
@@ -14,8 +14,8 @@ import Testing
 
         let json = """
         {"data": [
-            {"id": 1, "title": "English Version", "abbreviation": "en", "language": "en"},
-            {"id": 2, "title": "German Version", "abbreviation": "de", "language": "de"}
+            {"id": 1, "title": "English Version", "abbreviation": "en", "language_tag": "en"},
+            {"id": 2, "title": "German Version", "abbreviation": "de", "language_tag": "de"}
         ]}
         """.data(using: .utf8)!
         var capturedRequest: URLRequest?
@@ -33,6 +33,8 @@ import Testing
 
         #expect(versions.count == 2)
         #expect(versions.first?.id == 1)
+        #expect(versions.first?.languageTag == "en")
+        #expect(versions.last?.languageTag == "de")
         let _ = try #require(capturedRequest)
     }
 
@@ -79,5 +81,46 @@ import Testing
         await #expect(throws: YouVersionAPIError.invalidResponse) {
             _ = try await YouVersionAPI.Bible.versions(forLanguageTag: "en", accessToken: "swift-test-suite", session: session)
         }
+    }
+
+    @MainActor
+    @Test func versionsPaginationCombinesBothPages() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        let page1 = """
+        {"data": [
+            {"id": 1, "title": "Version One", "language_tag": "en"}
+        ], "next_page_token": "token-abc"}
+        """.data(using: .utf8)!
+
+        let page2 = """
+        {"data": [
+            {"id": 2, "title": "Version Two", "language_tag": "en"}
+        ]}
+        """.data(using: .utf8)!
+
+        var requestCount = 0
+
+        HTTPMocking.setHandler(token: token) { request in
+            requestCount += 1
+            let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+            let queryItems = components?.queryItems ?? []
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            if requestCount == 1 {
+                #expect(!queryItems.contains(where: { $0.name == "page_token" }))
+                return (page1, response)
+            } else {
+                #expect(queryItems.contains(where: { $0.name == "page_token" && $0.value == "token-abc" }))
+                return (page2, response)
+            }
+        }
+
+        let versions = try await YouVersionAPI.Bible.versions(forLanguageTag: "en", accessToken: "swift-test-suite", session: session)
+
+        #expect(requestCount == 2)
+        #expect(versions.count == 2)
+        #expect(versions[0].id == 1)
+        #expect(versions[1].id == 2)
     }
 }

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionsAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionsAPITests.swift
@@ -39,6 +39,135 @@ import Testing
     }
 
     @MainActor
+    @Test func permittedVersionsSuccessReturnsMinimalInfo() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        let json = """
+        {"data": [
+            {"id": 1, "title": "English Version", "abbreviation": "eng", "language_tag": "en"},
+            {"id": 2, "title": "German Version", "abbreviation": "deu", "language_tag": "de"}
+        ]}
+        """.data(using: .utf8)!
+        var capturedRequest: URLRequest?
+
+        HTTPMocking.setHandler(token: token) { request in
+            capturedRequest = request
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (json, response)
+        }
+
+        let versions = try await YouVersionAPI.Bible.permittedVersions(
+            forLanguageTag: "en",
+            accessToken: "swift-test-suite",
+            session: session
+        )
+
+        #expect(versions == [
+            YouVersionAPI.Bible.BibleVersionMinimalInfo(id: 1, languageTag: "en"),
+            YouVersionAPI.Bible.BibleVersionMinimalInfo(id: 2, languageTag: "de")
+        ])
+
+        let request = try #require(capturedRequest)
+        let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+        let queryItems = components?.queryItems ?? []
+        #expect(queryItems.contains(where: { $0.name == "language_ranges[]" && $0.value == "en" }))
+        #expect(queryItems.contains(where: { $0.name == "page_size" && $0.value == "*" }))
+        #expect(queryItems.contains(where: { $0.name == "fields[]" && $0.value == "id" }))
+        #expect(queryItems.contains(where: { $0.name == "fields[]" && $0.value == "language_tag" }))
+    }
+
+    @MainActor
+    @Test func permittedVersionsDefaultsToAllLanguages() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        let json = """
+        {"data": [
+            {"id": 1, "language_tag": "en"}
+        ]}
+        """.data(using: .utf8)!
+        var capturedRequest: URLRequest?
+
+        HTTPMocking.setHandler(token: token) { request in
+            capturedRequest = request
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (json, response)
+        }
+
+        let versions = try await YouVersionAPI.Bible.permittedVersions(accessToken: "swift-test-suite", session: session)
+
+        #expect(versions == [YouVersionAPI.Bible.BibleVersionMinimalInfo(id: 1, languageTag: "en")])
+        let request = try #require(capturedRequest)
+        let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+        let queryItems = components?.queryItems ?? []
+        #expect(queryItems.contains(where: { $0.name == "language_ranges[]" && $0.value == "*" }))
+        #expect(queryItems.contains(where: { $0.name == "page_size" && $0.value == "*" }))
+        #expect(queryItems.contains(where: { $0.name == "fields[]" && $0.value == "id" }))
+        #expect(queryItems.contains(where: { $0.name == "fields[]" && $0.value == "language_tag" }))
+    }
+
+    @MainActor
+    @Test func permittedVersionsUnauthorizedThrowsNotPermitted() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil)!
+            return (Data(), response)
+        }
+
+        await #expect(throws: YouVersionAPIError.notPermitted) {
+            _ = try await YouVersionAPI.Bible.permittedVersions(forLanguageTag: "en", accessToken: "swift-test-suite", session: session)
+        }
+    }
+
+    @MainActor
+    @Test func permittedVersionsForbiddenThrowsNotPermitted() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 403, httpVersion: nil, headerFields: nil)!
+            return (Data(), response)
+        }
+
+        await #expect(throws: YouVersionAPIError.notPermitted) {
+            _ = try await YouVersionAPI.Bible.permittedVersions(forLanguageTag: "en", accessToken: "swift-test-suite", session: session)
+        }
+    }
+
+    @MainActor
+    @Test func permittedVersionsUnexpectedStatusThrowsCannotDownload() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+            return (Data(), response)
+        }
+
+        await #expect(throws: YouVersionAPIError.cannotDownload) {
+            _ = try await YouVersionAPI.Bible.permittedVersions(forLanguageTag: "en", accessToken: "swift-test-suite", session: session)
+        }
+    }
+
+    @MainActor
+    @Test func permittedVersionsInvalidResponseThrows() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = URLResponse(url: request.url!, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+            return (Data(), response)
+        }
+
+        await #expect(throws: YouVersionAPIError.invalidResponse) {
+            _ = try await YouVersionAPI.Bible.permittedVersions(forLanguageTag: "en", accessToken: "swift-test-suite", session: session)
+        }
+    }
+
+    @MainActor
     @Test func versionsUnauthorizedThrowsNotPermitted() async throws {
         let (session, token) = HTTPMocking.makeSession()
         defer { HTTPMocking.clear(token: token) }

--- a/Tests/YouVersionPlatformCoreTests/ConfigurationStateTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/ConfigurationStateTests.swift
@@ -1,0 +1,8 @@
+import Testing
+
+/// Parent suite that serializes all tests touching `YouVersionPlatformConfiguration`'s
+/// global state. `.serialized` only prevents parallelism *within* a suite, so suites
+/// that share mutable static state must be nested under a common serialized parent to
+/// prevent cross-suite races.
+@Suite(.serialized)
+struct ConfigurationStateTests {}

--- a/Tests/YouVersionPlatformCoreTests/LanguagesAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/LanguagesAPITests.swift
@@ -59,8 +59,12 @@ import Testing
         #expect(languages[1].id == "es")
         #expect(languages[1].language == "Spanish")
         #expect(languages[1].defaultBibleId == 128)
-        
-        let _ = try #require(capturedRequest)
+
+        let request = try #require(capturedRequest)
+        #expect(request.url?.path.contains("/v1/languages") == true)
+        let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+        let queryItems = components?.queryItems ?? []
+        #expect(queryItems.contains(where: { $0.name == "page_size" && $0.value == "99" }))
     }
 
     @MainActor
@@ -178,6 +182,45 @@ import Testing
 
         let languages = try await YouVersionAPI.Languages.languages(accessToken: "swift-test-suite", session: session)
         #expect(languages.isEmpty)
+    }
+
+    @MainActor
+    @Test func languagesPaginationCombinesBothPages() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        let page1Languages = [
+            LanguageOverview(id: "en", language: "English", defaultBibleId: 3034)
+        ]
+        let page2Languages = [
+            LanguageOverview(id: "es", language: "Spanish", defaultBibleId: 128)
+        ]
+
+        let page1Data = try JSONEncoder().encode(LanguagesResponse(data: page1Languages, nextPageToken: "token-xyz", totalSize: nil))
+        let page2Data = try JSONEncoder().encode(LanguagesResponse(data: page2Languages, nextPageToken: nil, totalSize: nil))
+
+        var requestCount = 0
+
+        HTTPMocking.setHandler(token: token) { request in
+            requestCount += 1
+            let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+            let queryItems = components?.queryItems ?? []
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            if requestCount == 1 {
+                #expect(!queryItems.contains(where: { $0.name == "page_token" }))
+                return (page1Data, response)
+            } else {
+                #expect(queryItems.contains(where: { $0.name == "page_token" && $0.value == "token-xyz" }))
+                return (page2Data, response)
+            }
+        }
+
+        let languages = try await YouVersionAPI.Languages.languages(accessToken: "swift-test-suite", session: session)
+
+        #expect(requestCount == 2)
+        #expect(languages.count == 2)
+        #expect(languages[0].id == "en")
+        #expect(languages[1].id == "es")
     }
 
     // Helper struct for encoding test responses

--- a/Tests/YouVersionPlatformCoreTests/URLBuilderTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/URLBuilderTests.swift
@@ -62,6 +62,17 @@ struct URLBuilderTests {
     }
 
     @Test
+    func testHighlightsDeleteURLWithHyphenatedPassageId() throws {
+        // Hyphens are valid URL path characters (RFC 3986), so a verse-range passageId like
+        // "GEN.1.3-GEN.1.5" is safe to interpolate directly into the path.
+        // Note: only URL-path-safe passageIds are supported; the source does not percent-encode
+        // the passageId before embedding it in the path segment.
+        let url = try #require(URLBuilder.highlightsDeleteURL(bibleId: 1, passageId: "GEN.1.3-GEN.1.5"))
+        #expect(url.absoluteString == "https://api.youversion.com/v1/highlights/GEN.1.3-GEN.1.5?bible_id=1")
+        #expect(url.path.contains("GEN.1.3-GEN.1.5"))
+    }
+
+    @Test
     func testLanguagesURLs() throws {
         // Configure using defaults (no host environment)
 

--- a/Tests/YouVersionPlatformCoreTests/URLRequestYouVersionTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/URLRequestYouVersionTests.swift
@@ -5,31 +5,33 @@ import FoundationNetworking
 import Testing
 @testable import YouVersionPlatformCore
 
-@Suite(.serialized) struct URLRequestYouVersionTests {
-
-    @Test func sdkVersionHeaderIsSetWhenAppKeyConfigured() async throws {
-        let originalAppKey = YouVersionPlatformConfiguration.appKey
-        await YouVersionPlatformConfiguration.configure(appKey: "test-app")
-
-        let url = try #require(URL(string: "https://api.youversion.com/v1/bibles/1"))
-        let request = URLRequest.youVersion(url)
-
-        #expect(request.value(forHTTPHeaderField: "x-yvp-app-key") == "test-app")
-        #expect(request.value(forHTTPHeaderField: "x-yvp-sdk") == "SwiftSDK=\(SDKVersion.current)")
-
-        await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
-    }
-
-    @Test func sdkVersionHeaderIsAbsentWhenAppKeyNotConfigured() async throws {
-        let originalAppKey = YouVersionPlatformConfiguration.appKey
-        await YouVersionPlatformConfiguration.configure(appKey: nil)
-
-        let url = try #require(URL(string: "https://api.youversion.com/v1/bibles/1"))
-        let request = URLRequest.youVersion(url)
-
-        #expect(request.value(forHTTPHeaderField: "x-yvp-app-key") == nil)
-        #expect(request.value(forHTTPHeaderField: "x-yvp-sdk") == nil)
-
-        await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+extension ConfigurationStateTests {
+    @Suite struct URLRequestYouVersionTests {
+        
+        @Test func sdkVersionHeaderIsSetWhenAppKeyConfigured() async throws {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configure(appKey: "test-app")
+            
+            let url = try #require(URL(string: "https://api.youversion.com/v1/bibles/1"))
+            let request = URLRequest.youVersion(url)
+            
+            #expect(request.value(forHTTPHeaderField: "x-yvp-app-key") == "test-app")
+            #expect(request.value(forHTTPHeaderField: "x-yvp-sdk") == "SwiftSDK=\(SDKVersion.current)")
+            
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+        }
+        
+        @Test func sdkVersionHeaderIsAbsentWhenAppKeyNotConfigured() async throws {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configure(appKey: nil)
+            
+            let url = try #require(URL(string: "https://api.youversion.com/v1/bibles/1"))
+            let request = URLRequest.youVersion(url)
+            
+            #expect(request.value(forHTTPHeaderField: "x-yvp-app-key") == nil)
+            #expect(request.value(forHTTPHeaderField: "x-yvp-sdk") == nil)
+            
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+        }
     }
 }

--- a/Tests/YouVersionPlatformCoreTests/UsersAuthHelpersTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/UsersAuthHelpersTests.swift
@@ -5,143 +5,145 @@ import FoundationNetworking
 import Testing
 @testable import YouVersionPlatformCore
 
-@Suite(.serialized) struct UsersAuthHelpersTests {
-
-    @Test func obtainCodeReturnsAuthorizationCode() throws {
-        let location = "youversionauth://callback?state=xyz&code=abc123&scope=bibles"
-
-        let code = try YouVersionAPI.Users.obtainCode(from: location)
-
-        #expect(code == "abc123")
-    }
-
-    @Test func obtainCodeMissingAuthorizationCodeThrows() {
-        let location = "youversionauth://callback?state=xyz"
-
-        #expect(throws: URLError.self) {
-            _ = try YouVersionAPI.Users.obtainCode(from: location)
+extension ConfigurationStateTests {
+    @Suite struct UsersAuthHelpersTests {
+        
+        @Test func obtainCodeReturnsAuthorizationCode() throws {
+            let location = "youversionauth://callback?state=xyz&code=abc123&scope=bibles"
+            
+            let code = try YouVersionAPI.Users.obtainCode(from: location)
+            
+            #expect(code == "abc123")
         }
-    }
-
-    @Test func extractResultParsesClaimsAndPermissions() throws {
-        let payload: [String: Any] = [
-            "sub": "user-123",
-            "name": "Test User",
-            "profile_picture": "https://example.com/avatar.png",
-            "email": "user@example.com",
-            "nonce": "xyz"
-        ]
-        let token = try makeTestJWT(claims: payload)
-
-        let tokens = YouVersionAPI.Users.TokenResponse(
-            accessToken: "access-token",
-            expiresIn: "3600",
-            idToken: token,
-            refreshToken: "refresh-token",
-            scope: "openid,email,profile",
-            tokenType: "Bearer"
-        )
-
-        let result = try YouVersionAPI.Users.extractSignInWithYouVersionResult(from: tokens, nonce: "xyz")
-
-        #expect(result.accessToken == "access-token")
-        #expect(result.refreshToken == "refresh-token")
-        #expect(result.idToken == token)
-        #expect(result.permissions == [.openid, .email, .profile])
-        #expect(result.yvpUserId == "user-123")
-        #expect(result.name == "Test User")
-        #expect(result.profilePicture == "https://example.com/avatar.png")
-        #expect(result.email == "user@example.com")
-    }
-
-    @Test func extractResultFailsBadNonce() throws {
-        let payload: [String: Any] = [
-            "sub": "user-123",
-            "name": "Test User",
-            "profile_picture": "https://example.com/avatar.png",
-            "email": "user@example.com",
-            "nonce": "BADVALUE"
-        ]
-        let token = try makeTestJWT(claims: payload)
-
-        let tokens = YouVersionAPI.Users.TokenResponse(
-            accessToken: "access-token",
-            expiresIn: "3600",
-            idToken: token,
-            refreshToken: "refresh-token",
-            scope: "openid,email,profile",
-            tokenType: "Bearer"
-        )
-
-        #expect(throws: URLError.self) {
-            _ = try YouVersionAPI.Users.extractSignInWithYouVersionResult(from: tokens, nonce: "xyz")
+        
+        @Test func obtainCodeMissingAuthorizationCodeThrows() {
+            let location = "youversionauth://callback?state=xyz"
+            
+            #expect(throws: URLError.self) {
+                _ = try YouVersionAPI.Users.obtainCode(from: location)
+            }
         }
-    }
-
-    @Test func refreshSignInSuccessReturnsNewTokens() async throws {
-        let originalAppKey = YouVersionPlatformConfiguration.appKey
-        await YouVersionPlatformConfiguration.configure(appKey: "test-app")
-
-        let (session, token) = HTTPMocking.makeSession()
-        defer { HTTPMocking.clear(token: token) }
-
-        let responsePayload: [String: String] = [
-            "access_token": "new-access",
-            "expires_in": "7200",
-            "refresh_token": "new-refresh",
-            "scope": "ignored"
-        ]
-        let responseData = try JSONEncoder().encode(responsePayload)
-
-        HTTPMocking.setHandler(token: token) { request in
-            #expect(request.url?.path == "/auth/token")
-            #expect(request.httpMethod == "POST")
-            #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
-            let body = requestBodyString(request)
-            #expect(body.contains("grant_type=refresh_token"))
-            #expect(body.contains("client_id=test-app"))
-            #expect(body.contains("refresh_token=refresh-token-value"))
-
-            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
-            return (responseData, response)
+        
+        @Test func extractResultParsesClaimsAndPermissions() throws {
+            let payload: [String: Any] = [
+                "sub": "user-123",
+                "name": "Test User",
+                "profile_picture": "https://example.com/avatar.png",
+                "email": "user@example.com",
+                "nonce": "xyz"
+            ]
+            let token = try makeTestJWT(claims: payload)
+            
+            let tokens = YouVersionAPI.Users.TokenResponse(
+                accessToken: "access-token",
+                expiresIn: "3600",
+                idToken: token,
+                refreshToken: "refresh-token",
+                scope: "openid,email,profile",
+                tokenType: "Bearer"
+            )
+            
+            let result = try YouVersionAPI.Users.extractSignInWithYouVersionResult(from: tokens, nonce: "xyz")
+            
+            #expect(result.accessToken == "access-token")
+            #expect(result.refreshToken == "refresh-token")
+            #expect(result.idToken == token)
+            #expect(result.permissions == [.openid, .email, .profile])
+            #expect(result.yvpUserId == "user-123")
+            #expect(result.name == "Test User")
+            #expect(result.profilePicture == "https://example.com/avatar.png")
+            #expect(result.email == "user@example.com")
         }
-
-        let result = try await YouVersionAPI.Users.refreshSignIn(
-            withToken: "refresh-token-value",
-            idToken: "id-token",
-            session: session
-        )
-
-        #expect(result.accessToken == "new-access")
-        #expect(result.refreshToken == "new-refresh")
-        #expect(result.idToken == "id-token")
-        #expect(result.permissions.isEmpty)
-        #expect(result.yvpUserId == nil)
-
-        await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
-    }
-
-    @Test func refreshSignInNon200Throws() async {
-        let originalAppKey = YouVersionPlatformConfiguration.appKey
-        await YouVersionPlatformConfiguration.configure(appKey: "test-app")
-
-        let (session, token) = HTTPMocking.makeSession()
-        defer { HTTPMocking.clear(token: token) }
-
-        HTTPMocking.setHandler(token: token) { request in
-            let response = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
-            return (Data(), response)
+        
+        @Test func extractResultFailsBadNonce() throws {
+            let payload: [String: Any] = [
+                "sub": "user-123",
+                "name": "Test User",
+                "profile_picture": "https://example.com/avatar.png",
+                "email": "user@example.com",
+                "nonce": "BADVALUE"
+            ]
+            let token = try makeTestJWT(claims: payload)
+            
+            let tokens = YouVersionAPI.Users.TokenResponse(
+                accessToken: "access-token",
+                expiresIn: "3600",
+                idToken: token,
+                refreshToken: "refresh-token",
+                scope: "openid,email,profile",
+                tokenType: "Bearer"
+            )
+            
+            #expect(throws: URLError.self) {
+                _ = try YouVersionAPI.Users.extractSignInWithYouVersionResult(from: tokens, nonce: "xyz")
+            }
         }
-
-        await #expect(throws: URLError.self) {
-            _ = try await YouVersionAPI.Users.refreshSignIn(
+        
+        @Test func refreshSignInSuccessReturnsNewTokens() async throws {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configure(appKey: "test-app")
+            
+            let (session, token) = HTTPMocking.makeSession()
+            defer { HTTPMocking.clear(token: token) }
+            
+            let responsePayload: [String: String] = [
+                "access_token": "new-access",
+                "expires_in": "7200",
+                "refresh_token": "new-refresh",
+                "scope": "ignored"
+            ]
+            let responseData = try JSONEncoder().encode(responsePayload)
+            
+            HTTPMocking.setHandler(token: token) { request in
+                #expect(request.url?.path == "/auth/token")
+                #expect(request.httpMethod == "POST")
+                #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
+                let body = requestBodyString(request)
+                #expect(body.contains("grant_type=refresh_token"))
+                #expect(body.contains("client_id=test-app"))
+                #expect(body.contains("refresh_token=refresh-token-value"))
+                
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (responseData, response)
+            }
+            
+            let result = try await YouVersionAPI.Users.refreshSignIn(
                 withToken: "refresh-token-value",
-                idToken: nil,
+                idToken: "id-token",
                 session: session
             )
+            
+            #expect(result.accessToken == "new-access")
+            #expect(result.refreshToken == "new-refresh")
+            #expect(result.idToken == "id-token")
+            #expect(result.permissions.isEmpty)
+            #expect(result.yvpUserId == nil)
+            
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
         }
-
-        await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+        
+        @Test func refreshSignInNon200Throws() async {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configure(appKey: "test-app")
+            
+            let (session, token) = HTTPMocking.makeSession()
+            defer { HTTPMocking.clear(token: token) }
+            
+            HTTPMocking.setHandler(token: token) { request in
+                let response = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+                return (Data(), response)
+            }
+            
+            await #expect(throws: URLError.self) {
+                _ = try await YouVersionAPI.Users.refreshSignIn(
+                    withToken: "refresh-token-value",
+                    idToken: nil,
+                    session: session
+                )
+            }
+            
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+        }
     }
 }
 

--- a/Tests/YouVersionPlatformCoreTests/UsersObtainTokensTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/UsersObtainTokensTests.swift
@@ -27,6 +27,7 @@ import Testing
             #expect(body.contains("code=auth-code"))
             #expect(body.contains("code_verifier=verifier"))
             #expect(body.contains("redirect_uri=youversionauth://callback"))
+            #expect(body.contains("grant_type=authorization_code"))
 
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
             return (responseData, response)
@@ -54,6 +55,48 @@ import Testing
         }
 
         await #expect(throws: URLError.self) {
+            _ = try await YouVersionAPI.Users.obtainTokens(
+                from: "auth-code",
+                codeVerifier: "verifier",
+                redirectUri: "youversionauth://callback",
+                session: session
+            )
+        }
+    }
+
+    @Test func obtainTokens400InvalidGrantThrows() async {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        let errorBody = """
+        {"error": "invalid_grant"}
+        """.data(using: .utf8)!
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 400, httpVersion: nil, headerFields: nil)!
+            return (errorBody, response)
+        }
+
+        await #expect(throws: URLError(.badServerResponse)) {
+            _ = try await YouVersionAPI.Users.obtainTokens(
+                from: "bad-code",
+                codeVerifier: "verifier",
+                redirectUri: "youversionauth://callback",
+                session: session
+            )
+        }
+    }
+
+    @Test func obtainTokens401UnauthorizedThrows() async {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil)!
+            return (Data(), response)
+        }
+
+        await #expect(throws: URLError(.badServerResponse)) {
             _ = try await YouVersionAPI.Users.obtainTokens(
                 from: "auth-code",
                 codeVerifier: "verifier",

--- a/Tests/YouVersionPlatformCoreTests/VOTDTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/VOTDTests.swift
@@ -88,7 +88,7 @@ import Testing
     }
 
     @MainActor
-    @Test func votdRequestSetsAppKeyHeader() async throws {
+    @Test func votdRequestUsesCorrectDayInURL() async throws {
         let (session, token) = HTTPMocking.makeSession()
         defer { HTTPMocking.clear(token: token) }
 
@@ -103,7 +103,7 @@ import Testing
             return (json, response)
         }
 
-        let _ = try await YouVersionAPI.VOTD.verseOfTheDay(dayOfYear: 99, accessToken: "swift-test-suite", session: session)
+        let _ = try await YouVersionAPI.VOTD.verseOfTheDay(dayOfYear: 99, accessToken: nil, session: session)
         let req = try #require(captured)
         #expect(req.url?.absoluteString.contains("/99") == true)
     }

--- a/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+@testable import YouVersionPlatformCore
+
+extension ConfigurationStateTests {
+    @Suite struct YouVersionPlatformConfigurationTests {
+        
+        // MARK: - configure
+        
+        @Test func configureStoresAppKey() async {
+            let original = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configure(appKey: "test-key")
+            #expect(YouVersionPlatformConfiguration.appKey == "test-key")
+            await YouVersionPlatformConfiguration.configure(appKey: original)
+        }
+        
+        @Test func configureNilAppKeyStoresNil() async {
+            let original = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configure(appKey: nil)
+            #expect(YouVersionPlatformConfiguration.appKey == nil)
+            await YouVersionPlatformConfiguration.configure(appKey: original)
+        }
+        
+        @Test func configureOverridesApiHost() async {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            let originalApiHost = YouVersionPlatformConfiguration.apiHost
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey, apiHost: "custom.example.com")
+            #expect(YouVersionPlatformConfiguration.apiHost == "custom.example.com")
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey, apiHost: originalApiHost)
+        }
+        
+        @Test func configureNilApiHostKeepsExistingValue() async {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            let originalApiHost = YouVersionPlatformConfiguration.apiHost
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey, apiHost: "first.example.com")
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey, apiHost: nil)
+            #expect(YouVersionPlatformConfiguration.apiHost == "first.example.com")
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey, apiHost: originalApiHost)
+        }
+        
+        @Test func configureStoresAppName() async {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey, appName: "My App")
+            #expect(YouVersionPlatformConfiguration.appName == "My App")
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+        }
+        
+        @Test func configureDisablesSignIn() async {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey, isSignInEnabled: false)
+            #expect(YouVersionPlatformConfiguration.isSignInEnabled == false)
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+        }
+        
+        @Test func configureDefaultsSignInToEnabled() async {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey, isSignInEnabled: false)
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+            #expect(YouVersionPlatformConfiguration.isSignInEnabled == true)
+        }
+        
+        @Test func configureStoresSignInPromptMessage() async {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey, signInPromptMessage: "Please sign in.")
+            #expect(YouVersionPlatformConfiguration.signInPromptMessage == "Please sign in.")
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+        }
+        
+        @Test func configureInstallIdIsNonNilAfterConfigure() async {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+            #expect(YouVersionPlatformConfiguration.installId != nil)
+        }
+        
+        @Test func configureInstallIdIsStableAcrossSubsequentCalls() async {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+            let firstId = YouVersionPlatformConfiguration.installId
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+            #expect(YouVersionPlatformConfiguration.installId == firstId)
+        }
+        
+        // MARK: - configureSignIn
+        
+        @Test func configureSignInSetsAppName() async {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configureSignIn(appName: "Sign In App")
+            #expect(YouVersionPlatformConfiguration.appName == "Sign In App")
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+        }
+        
+        @Test func configureSignInForcesSignInEnabled() async {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey, isSignInEnabled: false)
+            await YouVersionPlatformConfiguration.configureSignIn(appName: "My App")
+            #expect(YouVersionPlatformConfiguration.isSignInEnabled == true)
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+        }
+        
+        @Test func configureSignInSetsPromptMessage() async {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configureSignIn(appName: "My App", signInPromptMessage: "Sign in to see your highlights.")
+            #expect(YouVersionPlatformConfiguration.signInPromptMessage == "Sign in to see your highlights.")
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+        }
+        
+        @Test func configureSignInNilPromptMessageClearsMessage() async {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            await YouVersionPlatformConfiguration.configureSignIn(appName: "My App", signInPromptMessage: "Initial message")
+            await YouVersionPlatformConfiguration.configureSignIn(appName: "My App", signInPromptMessage: nil)
+            #expect(YouVersionPlatformConfiguration.signInPromptMessage == nil)
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+        }
+        
+        // MARK: - saveAuthData / accessToken / authData / clearAuthTokens
+        
+        @Test func saveAuthDataPersistsAccessToken() async {
+            let expiry = Date(timeIntervalSinceNow: 3600)
+            await YouVersionPlatformConfiguration.saveAuthData(accessToken: "token-abc", refreshToken: "refresh-xyz", idToken: nil, expiryDate: expiry)
+            #expect(YouVersionPlatformConfiguration.accessToken == "token-abc")
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+        }
+        
+        @Test func authDataReturnsFullResultWhenAllTokensPresent() async {
+            let expiry = Date(timeIntervalSinceNow: 3600)
+            await YouVersionPlatformConfiguration.saveAuthData(
+                accessToken: "access-1",
+                refreshToken: "refresh-1",
+                idToken: "id-1",
+                expiryDate: expiry
+            )
+            let data = YouVersionPlatformConfiguration.authData
+            #expect(data?.accessToken == "access-1")
+            #expect(data?.refreshToken == "refresh-1")
+            #expect(data?.idToken == "id-1")
+            #expect(data?.expiryDate != nil)
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+        }
+        
+        @Test func authDataIncludesNilIdTokenWhenNotStored() async {
+            let expiry = Date(timeIntervalSinceNow: 3600)
+            await YouVersionPlatformConfiguration.saveAuthData(accessToken: "access-1", refreshToken: "refresh-1", idToken: nil, expiryDate: expiry)
+            let data = YouVersionPlatformConfiguration.authData
+            #expect(data != nil)
+            #expect(data?.idToken == nil)
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+        }
+        
+        @Test func authDataReturnsNilWhenAccessTokenMissing() async {
+            let expiry = Date(timeIntervalSinceNow: 3600)
+            await YouVersionPlatformConfiguration.saveAuthData(accessToken: nil, refreshToken: "refresh-1", idToken: nil, expiryDate: expiry)
+            #expect(YouVersionPlatformConfiguration.authData == nil)
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+        }
+        
+        @Test func authDataReturnsNilWhenRefreshTokenMissing() async {
+            let expiry = Date(timeIntervalSinceNow: 3600)
+            await YouVersionPlatformConfiguration.saveAuthData(accessToken: "access-1", refreshToken: nil, idToken: nil, expiryDate: expiry)
+            #expect(YouVersionPlatformConfiguration.authData == nil)
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+        }
+        
+        @Test func authDataReturnsNilWhenExpiryDateMissing() async {
+            await YouVersionPlatformConfiguration.saveAuthData(accessToken: "access-1", refreshToken: "refresh-1", idToken: nil, expiryDate: nil)
+            #expect(YouVersionPlatformConfiguration.authData == nil)
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+        }
+        
+        @Test func clearAuthTokensMakesAuthDataNil() async {
+            let expiry = Date(timeIntervalSinceNow: 3600)
+            await YouVersionPlatformConfiguration.saveAuthData(accessToken: "access-1", refreshToken: "refresh-1", idToken: "id-1", expiryDate: expiry)
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+            #expect(YouVersionPlatformConfiguration.authData == nil)
+            #expect(YouVersionPlatformConfiguration.accessToken == nil)
+        }
+        
+        // MARK: - Top-level configure function
+        
+        @Test func topLevelConfigureFunctionSetsAppKey() async {
+            let original = YouVersionPlatformConfiguration.appKey
+            await configure(appKey: "top-level-key")
+            #expect(YouVersionPlatformConfiguration.appKey == "top-level-key")
+            await YouVersionPlatformConfiguration.configure(appKey: original)
+        }
+    }
+}

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
@@ -1,6 +1,8 @@
+import SwiftUI
 import Testing
 @testable import YouVersionPlatformCore
 @testable import YouVersionPlatformReader
+@testable import YouVersionPlatformUI
 
 struct BookFixture: Sendable {
     let id: String
@@ -194,6 +196,7 @@ let previousChapterCases: [PreviousChapterCase] = [
 
 @MainActor
 @Suite struct BibleReaderViewModelNavigationTests {
+    private static var nextGeneratedVersionId = 909_000
     private static let versionId = 3034
 
     @Test(arguments: [false, true])
@@ -346,12 +349,133 @@ let previousChapterCases: [PreviousChapterCase] = [
         assertNavigationSideEffects(on: vm)
     }
 
+#if canImport(UIKit)
+    @Test
+    func selectedVerseColorPresenceMatchesHexCaseInsensitivelyAndIgnoresHashPrefix() {
+        let viewModel = BibleReaderViewModelTestSupport.makeViewModel(
+            highlightsRepository: MockBibleHighlightsRepository()
+        )
+        let firstReference = BibleReference(versionId: Self.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        let secondReference = BibleReference(versionId: Self.versionId, bookUSFM: "JHN", chapter: 3, verse: 17)
+        let unselectedReference = BibleReference(versionId: Self.versionId, bookUSFM: "JHN", chapter: 3, verse: 18)
+        let selectedColor = Color(hex: "#DDAAFF")
+        viewModel.selectedVerses = [firstReference, secondReference]
+        viewModel.highlightsViewModel.addHighlights(references: [firstReference], color: "#ddaaff")
+        viewModel.highlightsViewModel.addHighlights(references: [unselectedReference], color: "DDAAFF")
+
+        #expect(viewModel.isColorPresentOnAnySelectedVerses(selectedColor))
+        #expect(viewModel.isColorPresentOnAllSelectedVerses(selectedColor) == false)
+
+        viewModel.highlightsViewModel.addHighlights(references: [secondReference], color: "ddaaff")
+
+        #expect(viewModel.isColorPresentOnAnySelectedVerses(selectedColor))
+        #expect(viewModel.isColorPresentOnAllSelectedVerses(selectedColor))
+    }
+
+    @Test
+    func removeVerseColorRemovesMatchingHighlightsForSelectedVersesOnly() {
+        let viewModel = BibleReaderViewModelTestSupport.makeViewModel(
+            highlightsRepository: MockBibleHighlightsRepository()
+        )
+        let matchingReference = BibleReference(versionId: Self.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        let nonmatchingReference = BibleReference(versionId: Self.versionId, bookUSFM: "JHN", chapter: 3, verse: 17)
+        let unselectedReference = BibleReference(versionId: Self.versionId, bookUSFM: "JHN", chapter: 3, verse: 18)
+        let selectedColor = Color(hex: "#DDAAFF")
+        viewModel.selectedVerses = [matchingReference, nonmatchingReference]
+        viewModel.showingVerseActionsDrawer = true
+        viewModel.highlightsViewModel.addHighlights(references: [matchingReference], color: "#ddaaff")
+        viewModel.highlightsViewModel.addHighlights(references: [nonmatchingReference], color: "00FF00")
+        viewModel.highlightsViewModel.addHighlights(references: [unselectedReference], color: "DDAAFF")
+
+        viewModel.removeVerseColor(selectedColor)
+
+        #expect(viewModel.selectedVerses.isEmpty)
+        #expect(viewModel.showingVerseActionsDrawer == false)
+        #expect(viewModel.highlightsViewModel.highlights(for: matchingReference).isEmpty)
+        #expect(viewModel.highlightsViewModel.highlights(for: nonmatchingReference) == [
+            BibleHighlight(nonmatchingReference, color: "00FF00"),
+        ])
+        #expect(viewModel.highlightsViewModel.highlights(for: unselectedReference) == [
+            BibleHighlight(unselectedReference, color: "DDAAFF"),
+        ])
+    }
+#endif
+
+    @Test
+    func shareableVerseTextRendersCachedChapterTextForReferences() async throws {
+        let versionId = Self.generatedVersionId()
+        let chapterReference = BibleReference(versionId: versionId, bookUSFM: "JHN", chapter: 3)
+        let verseReference = BibleReference(versionId: versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        let html = """
+        <div>
+            <div class="p">
+                <span class="yv-v" v="16"></span><span class="yv-vlbl">16</span>
+                For God so loved the world.
+            </div>
+        </div>
+        """
+        let storage = BibleContentStorage(storageKind: .cache)
+        let chapterUSFM = try #require(chapterReference.chapterUSFM)
+        try storage.writeString(
+            html,
+            to: .chapter(versionId: versionId, usfm: chapterUSFM)
+        )
+        let viewModel = BibleReaderViewModel(reference: chapterReference)
+
+        let text = await viewModel.shareableVerseText(references: [verseReference])
+
+        #expect(text.contains("For God so loved the world."))
+        await BibleChapterRepository.shared.removeVersion(withId: versionId)
+    }
+
+    @Test
+    func handleVerseActionCopyWithSelectedVersesClearsSelectionAndHidesDrawer() async throws {
+        let versionId = Self.generatedVersionId()
+        let chapterReference = BibleReference(versionId: versionId, bookUSFM: "JHN", chapter: 3)
+        let selectedReferences = [
+            BibleReference(versionId: versionId, bookUSFM: "JHN", chapter: 3, verse: 16),
+            BibleReference(versionId: versionId, bookUSFM: "JHN", chapter: 3, verse: 17),
+        ]
+        let html = """
+        <div>
+            <div class="p">
+                <span class="yv-v" v="16"></span><span class="yv-vlbl">16</span>Verse sixteen.
+                <span class="yv-v" v="17"></span><span class="yv-vlbl">17</span>Verse seventeen.
+            </div>
+        </div>
+        """
+        let storage = BibleContentStorage(storageKind: .cache)
+        let chapterUSFM = try #require(chapterReference.chapterUSFM)
+        try storage.writeString(
+            html,
+            to: .chapter(versionId: versionId, usfm: chapterUSFM)
+        )
+        let viewModel = BibleReaderViewModelTestSupport.makeViewModel(reference: chapterReference)
+        viewModel.versionsViewModel.switchToVersion(
+            BibleReaderViewModelTestSupport.makeBibleVersion(id: versionId)
+        )
+        viewModel.selectedVerses = Set(selectedReferences)
+        viewModel.showingVerseActionsDrawer = true
+
+        let copyTask = try #require(viewModel.handleVerseActionCopy())
+
+        #expect(viewModel.selectedVerses.isEmpty)
+        #expect(viewModel.showingVerseActionsDrawer == false)
+        await copyTask.value
+        await BibleChapterRepository.shared.removeVersion(withId: versionId)
+    }
+
     private func assertNavigationSideEffects(on vm: BibleReaderViewModel) {
         #expect(vm.isChangingChapter == true)
         #expect(vm.lastScrollOffset == 0)
         #expect(vm.scrollToTop == true)
         #expect(vm.selectedVerses.isEmpty)
         #expect(vm.showingVerseActionsDrawer == false)
+    }
+
+    private static func generatedVersionId() -> Int {
+        nextGeneratedVersionId += 1
+        return nextGeneratedVersionId
     }
 
     private func makeViewModel(

--- a/Tests/YouVersionPlatformReaderTests/ReaderFontsTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/ReaderFontsTests.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import Testing
 @testable import YouVersionPlatformReader
 
@@ -5,6 +6,8 @@ struct ReaderFontsTests {
     @Test
     func isPermittedFontAcceptsSuggestedAndOtherFamilies() {
         #expect(ReaderFonts.isPermittedFont("Untitled Serif"))
+        #expect(ReaderFonts.isPermittedFont("New York"))
+        #expect(ReaderFonts.isPermittedFont("San Francisco"))
         #expect(ReaderFonts.isPermittedFont("Georgia"))
         #expect(ReaderFonts.isPermittedFont("Arial"))
         #expect(ReaderFonts.isPermittedFont("Times New Roman"))
@@ -15,6 +18,25 @@ struct ReaderFontsTests {
         #expect(ReaderFonts.isPermittedFont("") == false)
         #expect(ReaderFonts.isPermittedFont("Definitely Not A Reader Font") == false)
         #expect(ReaderFonts.isPermittedFont("georgia") == false)
+    }
+
+    @Test
+    func displayFontUsesSystemProviderForSystemFontFamilies() {
+        let sanFranciscoDescription = debugDescription(
+            of: ReaderFonts.displayFont(familyName: "San Francisco", size: 20)
+        )
+        #expect(sanFranciscoDescription.contains("SwiftUI.Font.SystemProvider"))
+        #expect(sanFranciscoDescription.contains("size: 20.0"))
+        #expect(sanFranciscoDescription.contains("design: nil"))
+        #expect(sanFranciscoDescription.contains("SwiftUI.Font.NamedProvider") == false)
+
+        let newYorkDescription = debugDescription(
+            of: ReaderFonts.displayFont(familyName: "New York", size: 20)
+        )
+        #expect(newYorkDescription.contains("SwiftUI.Font.SystemProvider"))
+        #expect(newYorkDescription.contains("size: 20.0"))
+        #expect(newYorkDescription.contains("SwiftUI.Font.Design.serif"))
+        #expect(newYorkDescription.contains("SwiftUI.Font.NamedProvider") == false)
     }
 
     @Test
@@ -40,4 +62,10 @@ struct ReaderFontsTests {
         #expect(ReaderFonts.nextLineSpacing(currentSpacing: 18) == 6)
         #expect(ReaderFonts.nextLineSpacing(currentSpacing: 100) == 6)
     }
+}
+
+private func debugDescription(of font: Font) -> String {
+    var output = ""
+    dump(font, to: &output)
+    return output
 }

--- a/Tests/YouVersionPlatformUITests/BibleVersionDisplayTitleTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionDisplayTitleTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+@testable import YouVersionPlatformCore
+@testable import YouVersionPlatformUI
+
+@Suite struct BibleVersionDisplayTitleTests {
+    @Test func displayTitleFallsBackToBookUSFMForInvalidBook() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "XYZ", chapter: 3)
+
+        #expect(version.displayTitle(for: reference) == "XYZ 3 NIV")
+    }
+
+    @Test func displayTitleUsesBookNameAndChapterForWholeChapterReference() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1)
+
+        #expect(version.displayTitle(for: reference) == "Genesis 1 NIV")
+    }
+
+    @Test func displayTitleUsesBookNameAndChapterForWholeChapterVerseSentinel() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 999)
+
+        #expect(version.displayTitle(for: reference) == "Genesis 1 NIV")
+    }
+
+    @Test func displayTitleOmitsChapterForWholeChapterSingleChapterBook() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "JUD", chapter: 1)
+
+        #expect(version.displayTitle(for: reference) == "Jude NIV")
+    }
+
+    @Test func displayTitleOmitsChapterForWholeChapterSentinelInSingleChapterBook() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "JUD", chapter: 1, verseStart: 1, verseEnd: 999)
+
+        #expect(version.displayTitle(for: reference) == "Jude NIV")
+    }
+
+    @Test func displayTitleIncludesSingleVerse() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verse: 3)
+
+        #expect(version.displayTitle(for: reference) == "Genesis 1:3 NIV")
+    }
+
+    @Test func displayTitleIncludesVerseRange() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "GEN", chapter: 1, verseStart: 3, verseEnd: 5)
+
+        #expect(version.displayTitle(for: reference) == "Genesis 1:3-5 NIV")
+    }
+
+    @Test func displayTitleIncludesSingleVerseInSingleChapterBook() {
+        let version = makeBibleVersion()
+        let reference = BibleReference(versionId: 111, bookUSFM: "JUD", chapter: 1, verse: 4)
+
+        #expect(version.displayTitle(for: reference) == "Jude 4 NIV")
+    }
+
+    private func makeBibleVersion() -> BibleVersion {
+        BibleVersion(
+            id: 111,
+            abbreviation: "NIV",
+            promotionalContent: nil,
+            copyright: nil,
+            languageTag: "eng",
+            localizedAbbreviation: nil,
+            localizedTitle: nil,
+            readerFooter: nil,
+            readerFooterUrl: nil,
+            title: nil,
+            organizationId: nil,
+            bookCodes: nil,
+            books: [
+                makeBibleBook(id: "GEN", title: "Genesis", chapterCount: 50),
+                makeBibleBook(id: "JUD", title: "Jude", chapterCount: 1)
+            ],
+            textDirection: "ltr"
+        )
+    }
+
+    private func makeBibleBook(id: String, title: String, chapterCount: Int) -> BibleBook {
+        BibleBook(
+            id: id,
+            title: title,
+            fullTitle: title,
+            abbreviation: nil,
+            canon: "nt",
+            chapters: (1...chapterCount).map { chapter in
+                BibleChapter(id: String(chapter), passageId: "\(id).\(chapter)", title: String(chapter), verses: nil)
+            },
+            intro: nil
+        )
+    }
+}

--- a/Tests/YouVersionPlatformUITests/ColorHexTests.swift
+++ b/Tests/YouVersionPlatformUITests/ColorHexTests.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import Testing
+#if canImport(UIKit)
+import UIKit
+#endif
+@testable import YouVersionPlatformUI
+
+@Suite struct ColorHexTests {
+    @Test
+    func threeDigitHexExpandsColorComponents() throws {
+        guard let components = try colorComponents(for: Color(hex: "#FA3")) else {
+            return
+        }
+
+        #expect(components.red.isApproximatelyEqual(to: 1.0))
+        #expect(components.green.isApproximatelyEqual(to: 170.0 / 255.0))
+        #expect(components.blue.isApproximatelyEqual(to: 51.0 / 255.0))
+        #expect(components.alpha.isApproximatelyEqual(to: 1.0))
+    }
+
+    @Test
+    func eightDigitHexReadsArgbColorComponents() throws {
+        guard let components = try colorComponents(for: Color(hex: "#80DDAAFF")) else {
+            return
+        }
+
+        #expect(components.red.isApproximatelyEqual(to: 221.0 / 255.0))
+        #expect(components.green.isApproximatelyEqual(to: 170.0 / 255.0))
+        #expect(components.blue.isApproximatelyEqual(to: 255.0 / 255.0))
+        #expect(components.alpha.isApproximatelyEqual(to: 128.0 / 255.0))
+    }
+
+    private func colorComponents(for color: Color) throws -> ColorComponents? {
+#if canImport(UIKit)
+        let color = UIColor(color)
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+
+        try #require(color.getRed(&red, green: &green, blue: &blue, alpha: &alpha))
+
+        return ColorComponents(red: red, green: green, blue: blue, alpha: alpha)
+#else
+        return nil
+#endif
+    }
+}
+
+private struct ColorComponents {
+    let red: CGFloat
+    let green: CGFloat
+    let blue: CGFloat
+    let alpha: CGFloat
+}
+
+private extension CGFloat {
+    func isApproximatelyEqual(to expectedValue: CGFloat) -> Bool {
+        abs(self - expectedValue) < 0.0001
+    }
+}

--- a/YouVersionPlatform.podspec
+++ b/YouVersionPlatform.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatform'
   s.module_name  = 'YouVersionPlatform'
-  s.version      = '5.2.1'
+  s.version      = '5.2.2'
   s.summary      = 'YouVersion Platform features'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatform.podspec
+++ b/YouVersionPlatform.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatform'
   s.module_name  = 'YouVersionPlatform'
-  s.version      = '6.0.0'
+  s.version      = '5.2.3'
   s.summary      = 'YouVersion Platform features'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatform.podspec
+++ b/YouVersionPlatform.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatform'
   s.module_name  = 'YouVersionPlatform'
-  s.version      = '5.2.0'
+  s.version      = '5.2.1'
   s.summary      = 'YouVersion Platform features'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatform.podspec
+++ b/YouVersionPlatform.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatform'
   s.module_name  = 'YouVersionPlatform'
-  s.version      = '5.2.2'
+  s.version      = '6.0.0'
   s.summary      = 'YouVersion Platform features'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatformCore.podspec
+++ b/YouVersionPlatformCore.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatformCore'
   s.module_name  = 'YouVersionPlatformCore'
-  s.version      = '5.2.0'
+  s.version      = '5.2.1'
   s.summary      = 'Core layer for YouVersion Platform'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatformCore.podspec
+++ b/YouVersionPlatformCore.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatformCore'
   s.module_name  = 'YouVersionPlatformCore'
-  s.version      = '5.2.1'
+  s.version      = '5.2.2'
   s.summary      = 'Core layer for YouVersion Platform'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatformCore.podspec
+++ b/YouVersionPlatformCore.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatformCore'
   s.module_name  = 'YouVersionPlatformCore'
-  s.version      = '5.2.2'
+  s.version      = '6.0.0'
   s.summary      = 'Core layer for YouVersion Platform'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatformCore.podspec
+++ b/YouVersionPlatformCore.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatformCore'
   s.module_name  = 'YouVersionPlatformCore'
-  s.version      = '6.0.0'
+  s.version      = '5.2.3'
   s.summary      = 'Core layer for YouVersion Platform'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatformReader.podspec
+++ b/YouVersionPlatformReader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatformReader'
   s.module_name  = 'YouVersionPlatformReader'
-  s.version      = '5.2.1'
+  s.version      = '5.2.2'
   s.summary      = 'YouVersion Platform Bible Reader'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatformReader.podspec
+++ b/YouVersionPlatformReader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatformReader'
   s.module_name  = 'YouVersionPlatformReader'
-  s.version      = '5.2.0'
+  s.version      = '5.2.1'
   s.summary      = 'YouVersion Platform Bible Reader'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatformReader.podspec
+++ b/YouVersionPlatformReader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatformReader'
   s.module_name  = 'YouVersionPlatformReader'
-  s.version      = '5.2.2'
+  s.version      = '6.0.0'
   s.summary      = 'YouVersion Platform Bible Reader'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatformReader.podspec
+++ b/YouVersionPlatformReader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatformReader'
   s.module_name  = 'YouVersionPlatformReader'
-  s.version      = '6.0.0'
+  s.version      = '5.2.3'
   s.summary      = 'YouVersion Platform Bible Reader'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatformUI.podspec
+++ b/YouVersionPlatformUI.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatformUI'
   s.module_name  = 'YouVersionPlatformUI'
-  s.version      = '6.0.0'
+  s.version      = '5.2.3'
   s.summary      = 'UI components for YouVersion Platform'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatformUI.podspec
+++ b/YouVersionPlatformUI.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatformUI'
   s.module_name  = 'YouVersionPlatformUI'
-  s.version      = '5.2.1'
+  s.version      = '5.2.2'
   s.summary      = 'UI components for YouVersion Platform'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatformUI.podspec
+++ b/YouVersionPlatformUI.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatformUI'
   s.module_name  = 'YouVersionPlatformUI'
-  s.version      = '5.2.0'
+  s.version      = '5.2.1'
   s.summary      = 'UI components for YouVersion Platform'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/YouVersionPlatformUI.podspec
+++ b/YouVersionPlatformUI.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YouVersionPlatformUI'
   s.module_name  = 'YouVersionPlatformUI'
-  s.version      = '5.2.2'
+  s.version      = '6.0.0'
   s.summary      = 'UI components for YouVersion Platform'
   s.homepage     = 'https://github.com/youversion/platform-sdk-swift'
   s.license      = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@semantic-release/github": "^9.2.4",
         "@semantic-release/release-notes-generator": "^12.1.0",
         "conventional-changelog-conventionalcommits": "^7.0.2",
-        "husky": "^8.0.3",
         "semantic-release": "^22.0.10"
       }
     },
@@ -371,7 +370,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -1474,7 +1472,6 @@
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -2615,22 +2612,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
-      }
-    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -3212,7 +3193,6 @@
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -5869,7 +5849,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6733,7 +6712,6 @@
       "integrity": "sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^11.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -7599,7 +7577,8 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,10 @@
       "devDependencies": {
         "@commitlint/cli": "^18.4.3",
         "@commitlint/config-conventional": "^18.4.3",
-        "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^11.1.0",
-        "@semantic-release/exec": "^6.0.3",
-        "@semantic-release/git": "^10.0.1",
-        "@semantic-release/github": "^9.2.4",
         "@semantic-release/release-notes-generator": "^12.1.0",
         "conventional-changelog-conventionalcommits": "^7.0.2",
-        "semantic-release": "^22.0.10"
+        "semver": "^7.6.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -52,6 +48,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -322,6 +319,7 @@
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -336,6 +334,7 @@
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -346,6 +345,7 @@
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -360,6 +360,7 @@
       "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -370,6 +371,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -389,6 +391,7 @@
       "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
@@ -403,6 +406,7 @@
       "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/request": "^8.4.1",
         "@octokit/types": "^13.0.0",
@@ -417,7 +421,8 @@
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
       "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "9.2.2",
@@ -425,6 +430,7 @@
       "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^12.6.0"
       },
@@ -440,7 +446,8 @@
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
       "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
       "version": "12.6.0",
@@ -448,6 +455,7 @@
       "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/openapi-types": "^20.0.0"
       }
@@ -458,6 +466,7 @@
       "integrity": "sha512-WrO3bvq4E1Xh1r2mT9w6SDFg01gFmP81nIG77+p/MqW1JeXXgL++6umim3t6x0Zj5pZm3rXAN+0HEjmmdhIRig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/request-error": "^5.0.0",
         "@octokit/types": "^13.0.0",
@@ -476,6 +485,7 @@
       "integrity": "sha512-nOpWtLayKFpgqmgD0y3GqXafMFuKcA4tRPZIfu7BArd2lEZeb1988nhWhwx4aZWmjDmUfdgVf7W+Tt4AmvRmMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^12.2.0",
         "bottleneck": "^2.15.3"
@@ -492,7 +502,8 @@
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
       "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@octokit/plugin-throttling/node_modules/@octokit/types": {
       "version": "12.6.0",
@@ -500,6 +511,7 @@
       "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/openapi-types": "^20.0.0"
       }
@@ -510,6 +522,7 @@
       "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/endpoint": "^9.0.6",
         "@octokit/request-error": "^5.1.1",
@@ -526,6 +539,7 @@
       "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^13.1.0",
         "deprecation": "^2.0.0",
@@ -541,6 +555,7 @@
       "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/openapi-types": "^24.2.0"
       }
@@ -551,6 +566,7 @@
       "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.22.0"
       }
@@ -561,6 +577,7 @@
       "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "4.2.10"
       },
@@ -573,7 +590,8 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@pnpm/npm-conf": {
       "version": "2.3.1",
@@ -581,6 +599,7 @@
       "integrity": "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pnpm/config.env-replace": "^1.1.0",
         "@pnpm/network.ca-file": "^1.0.1",
@@ -588,25 +607,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@semantic-release/changelog": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
-      "integrity": "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "fs-extra": "^11.0.0",
-        "lodash": "^4.17.4"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
       }
     },
     "node_modules/@semantic-release/commit-analyzer": {
@@ -631,66 +631,13 @@
         "semantic-release": ">=20.1.0"
       }
     },
-    "node_modules/@semantic-release/error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/@semantic-release/exec": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-6.0.3.tgz",
-      "integrity": "sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.4",
-        "parse-json": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
-    },
-    "node_modules/@semantic-release/git": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
-      "integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "dir-glob": "^3.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.4",
-        "micromatch": "^4.0.0",
-        "p-reduce": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
-    },
     "node_modules/@semantic-release/github": {
       "version": "9.2.6",
       "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.2.6.tgz",
       "integrity": "sha512-shi+Lrf6exeNZF+sBhK+P011LSbhmIAoUEgEY6SsxF8irJ+J2stwI5jkyDQ+4gzYyDImzV6LCKdYB9FXnQRWKA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/core": "^5.0.0",
         "@octokit/plugin-paginate-rest": "^9.0.0",
@@ -722,6 +669,7 @@
       "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -732,6 +680,7 @@
       "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clean-stack": "^5.2.0",
         "indent-string": "^5.0.0"
@@ -749,6 +698,7 @@
       "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "5.0.0"
       },
@@ -765,6 +715,7 @@
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -778,6 +729,7 @@
       "integrity": "sha512-KUsozQGhRBAnoVg4UMZj9ep436VEGwT536/jwSqB7vcEfA6oncCUU7UIYTRdLx7GvTtqn0kBjnkfLVkcnBa2YQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/error": "^4.0.0",
         "aggregate-error": "^5.0.0",
@@ -806,6 +758,7 @@
       "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -816,6 +769,7 @@
       "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clean-stack": "^5.2.0",
         "indent-string": "^5.0.0"
@@ -833,6 +787,7 @@
       "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "5.0.0"
       },
@@ -849,6 +804,7 @@
       "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^8.0.1",
@@ -873,6 +829,7 @@
       "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -886,6 +843,7 @@
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=16.17.0"
       }
@@ -896,6 +854,7 @@
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -909,6 +868,7 @@
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -922,6 +882,7 @@
       "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -935,6 +896,7 @@
       "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -951,6 +913,7 @@
       "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-fn": "^4.0.0"
       },
@@ -967,6 +930,7 @@
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -980,6 +944,7 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -993,6 +958,7 @@
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1031,6 +997,7 @@
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1044,6 +1011,7 @@
       "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1082,22 +1050,9 @@
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ajv": {
@@ -1123,6 +1078,7 @@
       "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -1161,7 +1117,8 @@
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1175,7 +1132,8 @@
       "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
       "integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/array-ify": {
       "version": "1.0.0",
@@ -1199,14 +1157,16 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -1265,6 +1225,7 @@
       "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
@@ -1296,18 +1257,9 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/cli-table3": {
@@ -1316,6 +1268,7 @@
       "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -1378,6 +1331,7 @@
       "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -1532,6 +1486,7 @@
       "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "type-fest": "^1.0.1"
       },
@@ -1548,6 +1503,7 @@
       "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1626,6 +1582,7 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -1635,7 +1592,8 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -1643,6 +1601,7 @@
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -1669,6 +1628,7 @@
       "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.2"
       }
@@ -1685,7 +1645,8 @@
       "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
       "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/env-ci": {
       "version": "10.0.0",
@@ -1693,6 +1654,7 @@
       "integrity": "sha512-U4xcd/utDYFgMh0yWj07R1H6L5fwhVbmxBCpnL0DbVSDZVnsC82HONw0wxtxNkIAcua3KtbomQvIk5xFZGAQJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "execa": "^8.0.0",
         "java-properties": "^1.0.2"
@@ -1707,6 +1669,7 @@
       "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^8.0.1",
@@ -1731,6 +1694,7 @@
       "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -1744,6 +1708,7 @@
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=16.17.0"
       }
@@ -1754,6 +1719,7 @@
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -1767,6 +1733,7 @@
       "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1780,6 +1747,7 @@
       "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -1796,6 +1764,7 @@
       "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-fn": "^4.0.0"
       },
@@ -1812,6 +1781,7 @@
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1825,6 +1795,7 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -1838,6 +1809,7 @@
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1871,6 +1843,7 @@
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1884,6 +1857,7 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -1942,6 +1916,7 @@
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -1976,6 +1951,7 @@
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -1986,6 +1962,7 @@
       "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-unicode-supported": "^2.0.0"
       },
@@ -2045,6 +2022,7 @@
       "integrity": "sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver-regex": "^4.0.5"
       },
@@ -2072,6 +2050,7 @@
       "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2120,6 +2099,7 @@
       "integrity": "sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argv-formatter": "~1.0.0",
         "spawn-error-forwarder": "~1.0.0",
@@ -2135,6 +2115,7 @@
       "integrity": "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "through2": "~2.0.0"
       }
@@ -2145,6 +2126,7 @@
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -2432,6 +2414,7 @@
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -2458,6 +2441,7 @@
       "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sindresorhus/merge-streams": "^2.1.0",
         "fast-glob": "^3.3.3",
@@ -2479,6 +2463,7 @@
       "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2491,7 +2476,8 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -2554,6 +2540,7 @@
       "integrity": "sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -2580,6 +2567,7 @@
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -2594,6 +2582,7 @@
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -2618,6 +2607,7 @@
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -2757,6 +2747,7 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2777,6 +2768,7 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -2846,6 +2838,7 @@
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2873,6 +2866,7 @@
       "integrity": "sha512-zKa/Dxq2lGsBIXQ7CUZWTHfvxPC2ej0KfO7fIPqLlHB9J2hJ7rGhZ5rilhuufylr4RXYPzJUeFjKxz305OsNlA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash.capitalize": "^4.2.1",
         "lodash.escaperegexp": "^4.1.2",
@@ -2890,6 +2884,7 @@
       "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -2929,7 +2924,8 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -2958,6 +2954,7 @@
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -3015,6 +3012,7 @@
       "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^4.0.0",
@@ -3031,6 +3029,7 @@
       "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
@@ -3081,14 +3080,16 @@
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
       "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isfunction": {
       "version": "3.0.9",
@@ -3109,7 +3110,8 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
@@ -3158,7 +3160,8 @@
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.upperfirst": {
       "version": "4.3.1",
@@ -3193,6 +3196,7 @@
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3206,6 +3210,7 @@
       "integrity": "sha512-ubWhwcBFHnXsjYNsu+Wndpg0zhY4CahSpPlA70PlO0rR9r2sZpkyU+rkCsOWH+KMEkx847UpALON+HWgxowFtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-escapes": "^6.2.0",
         "cardinal": "^2.1.1",
@@ -3227,6 +3232,7 @@
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -3260,6 +3266,7 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -3287,6 +3294,7 @@
         "https://github.com/sponsors/broofa"
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mime": "bin/cli.js"
       },
@@ -3358,7 +3366,8 @@
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-emoji": {
       "version": "2.2.0",
@@ -3366,6 +3375,7 @@
       "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sindresorhus/is": "^4.6.0",
         "char-regex": "^1.0.2",
@@ -3397,6 +3407,7 @@
       "integrity": "sha512-X06Mfd/5aKsRHc0O0J5CUedwnPmnDtLF2+nq+KN9KSDlJHkPuh0JUviWjEWMe0SW/9TDdSLVPuk7L5gGTIA1/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -3480,6 +3491,7 @@
       ],
       "dev": true,
       "license": "Artistic-2.0",
+      "peer": true,
       "workspaces": [
         "docs",
         "smoke-tests",
@@ -3583,6 +3595,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -3600,6 +3613,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3611,13 +3625,15 @@
       "version": "9.2.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -3635,6 +3651,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -3650,6 +3667,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -3661,13 +3679,15 @@
       "version": "1.1.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "http-proxy-agent": "^7.0.0",
@@ -3684,6 +3704,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/fs": "^4.0.0",
@@ -3733,6 +3754,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/map-workspaces": "^4.0.1",
         "@npmcli/package-json": "^6.0.1",
@@ -3752,6 +3774,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -3764,6 +3787,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/promise-spawn": "^8.0.0",
         "ini": "^5.0.0",
@@ -3783,6 +3807,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-bundled": "^4.0.0",
         "npm-normalize-package-bin": "^4.0.0"
@@ -3799,6 +3824,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/name-from-folder": "^3.0.0",
         "@npmcli/package-json": "^6.0.0",
@@ -3814,6 +3840,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "cacache": "^19.0.0",
         "json-parse-even-better-errors": "^4.0.0",
@@ -3830,6 +3857,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.0",
         "@npmcli/installed-package-contents": "^3.0.0",
@@ -3861,6 +3889,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -3870,6 +3899,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -3879,6 +3909,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.0",
         "glob": "^10.2.2",
@@ -3897,6 +3928,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "which": "^5.0.0"
       },
@@ -3909,6 +3941,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "postcss-selector-parser": "^7.0.0"
       },
@@ -3921,6 +3954,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -3930,6 +3964,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/node-gyp": "^4.0.0",
         "@npmcli/package-json": "^6.0.0",
@@ -3948,6 +3983,7 @@
       "inBundle": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -3957,6 +3993,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -3966,6 +4003,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.4.1",
         "tuf-js": "^3.0.1"
@@ -3979,6 +4017,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
@@ -3988,6 +4027,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -3997,6 +4037,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -4006,6 +4047,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4015,6 +4057,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4026,25 +4069,29 @@
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "cmd-shim": "^7.0.0",
         "npm-normalize-package-bin": "^4.0.0",
@@ -4061,6 +4108,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -4073,6 +4121,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4082,6 +4131,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/fs": "^4.0.0",
         "fs-minipass": "^3.0.0",
@@ -4105,6 +4155,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4114,6 +4165,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
       },
@@ -4129,6 +4181,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -4146,6 +4199,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4155,6 +4209,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -4167,6 +4222,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4182,6 +4238,7 @@
       ],
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4191,6 +4248,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "ip-regex": "^5.0.0"
       },
@@ -4203,6 +4261,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1"
@@ -4216,6 +4275,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -4225,6 +4285,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4236,19 +4297,22 @@
       "version": "1.1.4",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/cross-spawn": {
       "version": "7.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4263,6 +4327,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -4278,6 +4343,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -4290,6 +4356,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4307,6 +4374,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4315,13 +4383,15 @@
       "version": "0.2.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
@@ -4329,6 +4399,7 @@
       "inBundle": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -4338,6 +4409,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4346,19 +4418,22 @@
       "version": "2.0.3",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.2",
       "dev": true,
       "inBundle": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.9.1"
       }
@@ -4368,6 +4443,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
@@ -4384,6 +4460,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -4396,6 +4473,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -4415,13 +4493,15 @@
       "version": "4.2.11",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "8.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^10.0.1"
       },
@@ -4433,13 +4513,15 @@
       "version": "4.2.0",
       "dev": true,
       "inBundle": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -4453,6 +4535,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -4467,6 +4550,7 @@
       "inBundle": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -4479,6 +4563,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minimatch": "^9.0.0"
       },
@@ -4491,6 +4576,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -4500,6 +4586,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -4509,6 +4596,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/package-json": "^6.0.0",
         "npm-package-arg": "^12.0.0",
@@ -4527,6 +4615,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -4540,6 +4629,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -4552,6 +4642,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "cidr-regex": "^4.1.1"
       },
@@ -4564,6 +4655,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4572,13 +4664,15 @@
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/jackspeak": {
       "version": "3.4.3",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -4593,13 +4687,15 @@
       "version": "1.1.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -4609,6 +4705,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -4620,25 +4717,29 @@
         "node >= 0.2.0"
       ],
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "9.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-package-arg": "^12.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -4652,6 +4753,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.1",
         "@npmcli/installed-package-contents": "^3.0.0",
@@ -4671,6 +4773,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.1",
         "@npmcli/run-script": "^9.0.1",
@@ -4692,6 +4795,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.1"
       },
@@ -4704,6 +4808,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -4717,6 +4822,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -4730,6 +4836,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.1",
         "@npmcli/run-script": "^9.0.1",
@@ -4745,6 +4852,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "ci-info": "^4.0.0",
         "normalize-package-data": "^7.0.0",
@@ -4764,6 +4872,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-registry-fetch": "^18.0.1"
       },
@@ -4776,6 +4885,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -4789,6 +4899,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.1",
         "@npmcli/run-script": "^9.0.1",
@@ -4804,13 +4915,15 @@
       "version": "10.4.3",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "14.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/agent": "^3.0.0",
         "cacache": "^19.0.1",
@@ -4833,6 +4946,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4842,6 +4956,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -4857,6 +4972,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -4866,6 +4982,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -4878,6 +4995,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3",
         "minipass-sized": "^1.0.3",
@@ -4895,6 +5013,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -4907,6 +5026,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4919,6 +5039,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -4931,6 +5052,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4943,6 +5065,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -4955,6 +5078,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4967,6 +5091,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -4979,6 +5104,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -4990,13 +5116,15 @@
       "version": "2.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5006,6 +5134,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
@@ -5030,6 +5159,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5039,6 +5169,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
       },
@@ -5054,6 +5185,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -5071,6 +5203,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5080,6 +5213,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "abbrev": "^3.0.0"
       },
@@ -5095,6 +5229,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "hosted-git-info": "^8.0.0",
         "semver": "^7.3.5",
@@ -5109,6 +5244,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5118,6 +5254,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-normalize-package-bin": "^4.0.0"
       },
@@ -5130,6 +5267,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "semver": "^7.1.1"
       },
@@ -5142,6 +5280,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5151,6 +5290,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "hosted-git-info": "^8.0.0",
         "proc-log": "^5.0.0",
@@ -5166,6 +5306,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "ignore-walk": "^7.0.0"
       },
@@ -5178,6 +5319,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-install-checks": "^7.1.0",
         "npm-normalize-package-bin": "^4.0.0",
@@ -5193,6 +5335,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-registry-fetch": "^18.0.0",
         "proc-log": "^5.0.0"
@@ -5206,6 +5349,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/redact": "^3.0.0",
         "jsonparse": "^1.3.1",
@@ -5225,6 +5369,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5234,6 +5379,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -5245,13 +5391,15 @@
       "version": "1.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "BlueOak-1.0.0"
+      "license": "BlueOak-1.0.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "19.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.0",
         "@npmcli/installed-package-contents": "^3.0.0",
@@ -5283,6 +5431,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "json-parse-even-better-errors": "^4.0.0",
         "just-diff": "^6.0.0",
@@ -5297,6 +5446,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5306,6 +5456,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -5322,6 +5473,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -5335,6 +5487,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5344,6 +5497,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5353,6 +5507,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -5362,6 +5517,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -5371,6 +5527,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -5384,6 +5541,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "read": "^4.0.0"
       },
@@ -5395,6 +5553,7 @@
       "version": "0.12.0",
       "dev": true,
       "inBundle": true,
+      "peer": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
@@ -5404,6 +5563,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "mute-stream": "^2.0.0"
       },
@@ -5416,6 +5576,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5425,6 +5586,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "json-parse-even-better-errors": "^4.0.0",
         "npm-normalize-package-bin": "^4.0.0"
@@ -5438,6 +5600,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -5447,13 +5610,15 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.7.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5466,6 +5631,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -5478,6 +5644,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5487,6 +5654,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -5499,6 +5667,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^3.1.0",
         "@sigstore/core": "^2.0.0",
@@ -5516,6 +5685,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.4.0"
       },
@@ -5528,6 +5698,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5537,6 +5708,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^3.1.0",
         "@sigstore/core": "^2.0.0",
@@ -5554,6 +5726,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^3.1.0",
         "@sigstore/core": "^2.0.0",
@@ -5568,6 +5741,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -5578,6 +5752,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -5592,6 +5767,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -5606,6 +5782,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -5616,6 +5793,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -5625,13 +5803,15 @@
       "version": "2.5.0",
       "dev": true,
       "inBundle": true,
-      "license": "CC-BY-3.0"
+      "license": "CC-BY-3.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -5641,19 +5821,22 @@
       "version": "3.0.21",
       "dev": true,
       "inBundle": true,
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/sprintf-js": {
       "version": "1.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "12.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -5666,6 +5849,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5681,6 +5865,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5695,6 +5880,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -5708,6 +5894,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -5720,6 +5907,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5732,6 +5920,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -5749,6 +5938,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -5761,6 +5951,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5773,6 +5964,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5782,6 +5974,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -5795,6 +5988,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5806,19 +6000,22 @@
       "version": "0.2.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/tinyglobby": {
       "version": "0.2.14",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fdir": "^6.4.4",
         "picomatch": "^4.0.2"
@@ -5835,6 +6032,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -5849,6 +6047,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5861,6 +6060,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -5870,6 +6070,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tufjs/models": "3.0.1",
         "debug": "^4.3.6",
@@ -5884,6 +6085,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
         "minimatch": "^9.0.5"
@@ -5897,6 +6099,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "unique-slug": "^5.0.0"
       },
@@ -5909,6 +6112,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
       },
@@ -5920,13 +6124,15 @@
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -5937,6 +6143,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -5947,6 +6154,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5955,13 +6163,15 @@
       "version": "3.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/which": {
       "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -5977,6 +6187,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -5986,6 +6197,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -6004,6 +6216,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -6021,6 +6234,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -6036,6 +6250,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6047,13 +6262,15 @@
       "version": "9.2.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -6071,6 +6288,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -6086,6 +6304,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -6098,7 +6317,8 @@
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -6106,6 +6326,7 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -6132,6 +6353,7 @@
       "integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6145,6 +6367,7 @@
       "integrity": "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-map": "^7.0.1"
       },
@@ -6203,21 +6426,12 @@
       "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-reduce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -6325,6 +6539,7 @@
       "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -6335,6 +6550,7 @@
       "integrity": "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-up": "^2.0.0",
         "load-json-file": "^4.0.0"
@@ -6349,6 +6565,7 @@
       "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "locate-path": "^2.0.0"
       },
@@ -6362,6 +6579,7 @@
       "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
@@ -6376,6 +6594,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-try": "^1.0.0"
       },
@@ -6389,6 +6608,7 @@
       "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-limit": "^1.1.0"
       },
@@ -6402,6 +6622,7 @@
       "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -6412,6 +6633,7 @@
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -6428,7 +6650,8 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -6449,7 +6672,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -6467,6 +6691,7 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "peer": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -6583,6 +6808,7 @@
       "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esprima": "~4.0.0"
       }
@@ -6593,6 +6819,7 @@
       "integrity": "sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pnpm/npm-conf": "^2.1.0"
       },
@@ -6670,6 +6897,7 @@
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -6695,6 +6923,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -6712,6 +6941,7 @@
       "integrity": "sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^11.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -6756,6 +6986,7 @@
       "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6766,6 +6997,7 @@
       "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clean-stack": "^5.2.0",
         "indent-string": "^5.0.0"
@@ -6783,6 +7015,7 @@
       "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "5.0.0"
       },
@@ -6799,6 +7032,7 @@
       "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^8.0.1",
@@ -6823,6 +7057,7 @@
       "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -6836,6 +7071,7 @@
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6849,6 +7085,7 @@
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=16.17.0"
       }
@@ -6859,6 +7096,7 @@
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6872,6 +7110,7 @@
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -6885,6 +7124,7 @@
       "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6898,6 +7138,7 @@
       "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -6914,6 +7155,7 @@
       "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-fn": "^4.0.0"
       },
@@ -6930,6 +7172,7 @@
       "integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6943,6 +7186,7 @@
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6956,6 +7200,7 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -6969,6 +7214,7 @@
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6998,6 +7244,7 @@
       "integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -7014,6 +7261,7 @@
       "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7070,6 +7318,7 @@
       "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^2.3.2",
         "figures": "^2.0.0",
@@ -7085,6 +7334,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -7098,6 +7348,7 @@
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -7113,6 +7364,7 @@
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -7122,7 +7374,8 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/signale/node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -7130,6 +7383,7 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -7140,6 +7394,7 @@
       "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -7153,6 +7408,7 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7163,6 +7419,7 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -7176,6 +7433,7 @@
       "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "unicode-emoji-modifier-base": "^1.0.0"
       },
@@ -7189,6 +7447,7 @@
       "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -7211,7 +7470,8 @@
       "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
       "integrity": "sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
@@ -7265,6 +7525,7 @@
       "integrity": "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
@@ -7314,6 +7575,7 @@
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7347,6 +7609,7 @@
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7370,6 +7633,7 @@
       "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
@@ -7400,6 +7664,7 @@
       "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       }
@@ -7410,6 +7675,7 @@
       "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-stream": "^3.0.0",
         "temp-dir": "^3.0.0",
@@ -7429,6 +7695,7 @@
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -7442,6 +7709,7 @@
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -7513,6 +7781,7 @@
       "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7586,6 +7855,7 @@
       "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7596,6 +7866,7 @@
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7609,6 +7880,7 @@
       "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "crypto-random-string": "^4.0.0"
       },
@@ -7624,7 +7896,8 @@
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
       "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -7632,6 +7905,7 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -7642,6 +7916,7 @@
       "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -7710,7 +7985,8 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -7718,6 +7994,7 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "semantic-release": "semantic-release",
-    "prepare": "husky"
+    "commitlint": "commitlint --from=origin/main --to=HEAD --verbose"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",
@@ -21,7 +21,6 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^9.2.4",
     "@semantic-release/release-notes-generator": "^12.1.0",
-    "husky": "^8.0.3",
     "semantic-release": "^22.0.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,19 +8,14 @@
     "url": "git@github.com:youversion/platform-sdk-swift.git"
   },
   "scripts": {
-    "semantic-release": "semantic-release",
     "commitlint": "commitlint --from=origin/main --to=HEAD --verbose"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",
     "@commitlint/config-conventional": "^18.4.3",
-    "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^11.1.0",
-    "conventional-changelog-conventionalcommits": "^7.0.2",
-    "@semantic-release/exec": "^6.0.3",
-    "@semantic-release/git": "^10.0.1",
-    "@semantic-release/github": "^9.2.4",
     "@semantic-release/release-notes-generator": "^12.1.0",
-    "semantic-release": "^22.0.10"
+    "conventional-changelog-conventionalcommits": "^7.0.2",
+    "semver": "^7.6.0"
   }
 }

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+// Generate release notes for a chosen version by calling
+// `@semantic-release/release-notes-generator` directly, with no
+// semantic-release lifecycle around it.
+//
+// The semantic-release CLI couples notes generation to the rest of the
+// release lifecycle (auth verification, plugin orchestration, branch
+// detection). That coupling is what made `--dry-run` fragile on PRs and
+// what made overriding a calculated version impossible. By calling the
+// notes-generator module as a library, this script asks one focused
+// question: "given these commits, what changelog entry should ship?"
+//
+// Output (stdout): the changelog markdown for the chosen version. No
+// surrounding noise — the caller pipes it directly into CHANGELOG.md
+// and into `gh release create --notes-file`.
+//
+// Usage:
+//   node scripts/generate-release-notes.mjs \
+//     --base <last-tag-or-sha> \
+//     --head <head-sha> \
+//     --version <semver>
+
+import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { format } from "node:util";
+import { generateNotes } from "@semantic-release/release-notes-generator";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i]?.replace(/^--/, "");
+    if (!key) continue;
+    out[key] = argv[i + 1];
+  }
+  return out;
+}
+
+// Read the notes-generator plugin config from .releaserc.json so the
+// preset (conventionalcommits) and any inline overrides stay in lockstep
+// with the rest of the release tooling.
+function readNotesGeneratorConfig() {
+  const releasercPath = resolve(REPO_ROOT, ".releaserc.json");
+  const releaserc = JSON.parse(readFileSync(releasercPath, "utf8"));
+  const entry = releaserc.plugins.find(
+    (p) => (Array.isArray(p) ? p[0] : p) === "@semantic-release/release-notes-generator"
+  );
+  if (!entry) {
+    throw new Error(
+      `@semantic-release/release-notes-generator not configured in ${releasercPath}`
+    );
+  }
+  return Array.isArray(entry) ? entry[1] : {};
+}
+
+function readRepositoryUrl() {
+  const pkgPath = resolve(REPO_ROOT, "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  const repo = pkg?.repository;
+  const url = typeof repo === "string" ? repo : repo?.url;
+  if (!url) {
+    throw new Error(`No repository.url in ${pkgPath}`);
+  }
+  return url;
+}
+
+// Same ASCII-RS/US delimiter trick as preview-release.mjs so commit
+// bodies with arbitrary whitespace/quotes don't break parsing.
+function getCommits(base, head) {
+  const fmt = "%H%x1f%B%x1e";
+  const out = execSync(`git log --reverse --format=${JSON.stringify(fmt)} ${base}..${head}`, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return out
+    .split("\x1e")
+    .map((rec) => rec.replace(/^\n+/, ""))
+    .filter(Boolean)
+    .map((rec) => {
+      const [hash, message] = rec.split("\x1f");
+      return { hash: (hash ?? "").trim(), message: (message ?? "").trim() };
+    });
+}
+
+function resolveSha(rev) {
+  return execSync(`git rev-parse ${JSON.stringify(rev)}`, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  }).trim();
+}
+
+// release-notes-generator uses signale-style printf logging; route to
+// stderr via util.format so stdout is reserved for the rendered notes.
+const logger = {
+  log: (...a) => console.error("[notes]", format(...a)),
+  info: (...a) => console.error("[notes]", format(...a)),
+  warn: (...a) => console.error("[notes]", format(...a)),
+  error: (...a) => console.error("[notes]", format(...a)),
+  success: (...a) => console.error("[notes]", format(...a)),
+};
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  for (const required of ["base", "head", "version"]) {
+    if (!args[required]) {
+      console.error(`Missing required argument: --${required}`);
+      console.error(
+        "Usage: generate-release-notes.mjs --base <ref> --head <sha> --version <semver>"
+      );
+      process.exit(2);
+    }
+  }
+
+  const pluginConfig = readNotesGeneratorConfig();
+  const repositoryUrl = readRepositoryUrl();
+  const commits = getCommits(args.base, args.head);
+  const lastReleaseSha = resolveSha(args.base);
+  const headSha = resolveSha(args.head);
+
+  const notes = await generateNotes(pluginConfig, {
+    commits,
+    lastRelease: {
+      gitHead: lastReleaseSha,
+      gitTag: args.base,
+      version: args.base, // Notes generator only uses this for the "compare" link label
+    },
+    nextRelease: {
+      gitHead: headSha,
+      gitTag: args.version,
+      version: args.version,
+    },
+    options: { repositoryUrl },
+    cwd: REPO_ROOT,
+    logger,
+  });
+
+  process.stdout.write(notes);
+  if (!notes.endsWith("\n")) process.stdout.write("\n");
+}
+
+main().catch((err) => {
+  console.error(err?.stack || String(err));
+  process.exit(1);
+});

--- a/scripts/preview-release.mjs
+++ b/scripts/preview-release.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// Compute the release type and next version for a PR by calling
+// `@semantic-release/commit-analyzer` directly. Avoids the full
+// `semantic-release --dry-run` lifecycle, which on a `pull_request` event
+// fails at the core `verifyAuth()` step (`git push --dry-run`) because the
+// PR-event `GITHUB_TOKEN` has `contents: read` only. That failure aborts
+// before the analyzer runs and produces a silent false-negative "no bump"
+// preview — the same fail-open class that hid the major bump on the squash
+// of PR #117.
+//
+// Output (stdout): one line of JSON:
+//   { current, next, release_type, is_major, commit_count }
+// `release_type` is one of `"major" | "minor" | "patch" | null`.
+//
+// Usage:
+//   node scripts/preview-release.mjs --base <sha> --head <sha>
+
+import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { format } from "node:util";
+import semver from "semver";
+import { analyzeCommits } from "@semantic-release/commit-analyzer";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i]?.replace(/^--/, "");
+    if (!key) continue;
+    out[key] = argv[i + 1];
+  }
+  return out;
+}
+
+// Read the same plugin config that production uses on `main`, so the
+// preview applies identical semver-inference rules (preset, releaseRules,
+// parserOpts, etc.). If the config shape ever changes, the preview tracks
+// it automatically.
+function readCommitAnalyzerConfig() {
+  const releasercPath = resolve(REPO_ROOT, ".releaserc.json");
+  const releaserc = JSON.parse(readFileSync(releasercPath, "utf8"));
+  const entry = releaserc.plugins.find(
+    (p) => (Array.isArray(p) ? p[0] : p) === "@semantic-release/commit-analyzer"
+  );
+  if (!entry) {
+    throw new Error(
+      `@semantic-release/commit-analyzer not configured in ${releasercPath}`
+    );
+  }
+  return Array.isArray(entry) ? entry[1] : {};
+}
+
+// Collect commits in `base..head` as `{hash, message}` records. Use ASCII
+// US (0x1f) between fields and RS (0x1e) between records so commit bodies
+// with arbitrary whitespace, quotes, and Unicode can't break parsing.
+function getCommits(base, head) {
+  const fmt = "%H%x1f%B%x1e";
+  const out = execSync(`git log --reverse --format=${JSON.stringify(fmt)} ${base}..${head}`, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return out
+    .split("\x1e")
+    .map((rec) => rec.replace(/^\n+/, ""))
+    .filter(Boolean)
+    .map((rec) => {
+      const [hash, message] = rec.split("\x1f");
+      return { hash: (hash ?? "").trim(), message: (message ?? "").trim() };
+    });
+}
+
+function getCurrentVersion() {
+  try {
+    const tag = execSync("git describe --tags --abbrev=0", {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    }).trim();
+    // Strip leading `v` so the caller always gets a bare semver string
+    // (e.g. "1.2.3"). The workflow already prepends `v` in the display
+    // strings, and semver.inc() also returns without a prefix — keeping
+    // both in sync avoids a `vv1.2.3` double-prefix in PR comments.
+    return tag.replace(/^v/, "") || "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+// commit-analyzer expects a signale-shaped logger and calls methods with
+// printf-style format strings (e.g. `log("Analyzing commit: %s", msg)`).
+// Route everything through util.format so the substitutions actually
+// happen, and to stderr so stdout stays clean for the JSON payload.
+const logger = {
+  log: (...a) => console.error("[analyzer]", format(...a)),
+  info: (...a) => console.error("[analyzer]", format(...a)),
+  warn: (...a) => console.error("[analyzer]", format(...a)),
+  error: (...a) => console.error("[analyzer]", format(...a)),
+  success: (...a) => console.error("[analyzer]", format(...a)),
+};
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.base || !args.head) {
+    console.error("Usage: preview-release.mjs --base <sha> --head <sha>");
+    process.exit(2);
+  }
+
+  const pluginConfig = readCommitAnalyzerConfig();
+  const commits = getCommits(args.base, args.head);
+  const current = getCurrentVersion();
+
+  const releaseType = await analyzeCommits(pluginConfig, {
+    commits,
+    logger,
+    cwd: REPO_ROOT,
+  });
+
+  const next = releaseType ? semver.inc(current, releaseType) : current;
+
+  process.stdout.write(
+    JSON.stringify({
+      current,
+      next,
+      release_type: releaseType,
+      is_major: releaseType === "major",
+      commit_count: commits.length,
+    }) + "\n"
+  );
+}
+
+main().catch((err) => {
+  console.error(err?.stack || String(err));
+  process.exit(1);
+});

--- a/scripts/release-validate.mjs
+++ b/scripts/release-validate.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Validate a release version against the current tag.
+//
+// Called by scripts/release.sh. Extracted from an inline `node -e` block
+// so the validation logic is testable in isolation and has unambiguous
+// `process.argv` semantics (standard `[node, scriptPath, ...userArgs]`).
+//
+// Usage:
+//   node scripts/release-validate.mjs <chosen-version> <current-tag>
+//
+// Exit codes:
+//    0  valid: chosen is semver AND strictly greater than current
+//   11  chosen is not valid semver
+//   12  chosen is not strictly greater than current
+//    1  usage error (missing args)
+//
+// Stderr is one of: "not_semver", "not_greater", or a usage message.
+// Exit codes are the contract that release.sh switches on; the stderr
+// tokens exist for human-readable logs.
+
+import semver from "semver";
+
+const args = process.argv.slice(2);
+
+if (args.length < 2) {
+  console.error(
+    "Usage: release-validate.mjs <chosen-version> <current-tag>"
+  );
+  process.exit(1);
+}
+
+const [chosen, current] = args;
+
+if (!semver.valid(chosen)) {
+  console.error("not_semver");
+  process.exit(11);
+}
+
+if (!semver.gt(chosen, current)) {
+  console.error("not_greater");
+  process.exit(12);
+}
+
+process.exit(0);

--- a/scripts/release-warn-version-jump.mjs
+++ b/scripts/release-warn-version-jump.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+// Warn (do not block) when the chosen release version is more than one
+// major above the analyzer-calculated version. Surfaces "did you mean
+// that?" without preventing intentional jumps (e.g., a recovery release
+// that intentionally crosses a major boundary).
+//
+// Called by scripts/release.sh. Extracted from an inline `node -e` block
+// so the logic is testable and `process.argv` semantics are standard.
+//
+// Usage:
+//   node scripts/release-warn-version-jump.mjs <chosen> <calculated>
+//
+// Always exits 0. Prints a single warning line to stderr when the gap
+// exceeds one major. If <calculated> is not valid semver, exits silently
+// (the analyzer may legitimately produce no calculated value on a fresh
+// repo with no prior tag).
+
+import semver from "semver";
+
+const [chosen, calculated] = process.argv.slice(2);
+
+if (!semver.valid(calculated)) {
+  process.exit(0);
+}
+
+if (semver.major(chosen) > semver.major(calculated) + 1) {
+  console.error(
+    `⚠️  Chosen version ${chosen} is more than one major above calculated ${calculated}. Proceeding, but double-check this is intentional.`
+  );
+}
+
+process.exit(0);

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,265 @@
+#!/bin/bash
+# Manual version-input release orchestrator.
+#
+# Called by .github/workflows/release.yml after `workflow_dispatch` with
+# `inputs.version`. Bypasses semantic-release entirely. The analyzer and
+# release-notes-generator modules are still used as libraries via
+# scripts/preview-release.mjs and scripts/generate-release-notes.mjs,
+# but orchestration is local — no env-ci, no verifyAuth, no lifecycle.
+#
+# Why this exists:
+# - semantic-release has no hook to override the calculated version. The
+#   only way to ship a version that differs from what the analyzer
+#   computes is to commit-message-engineer history, which is brittle.
+# - This script makes the chosen version an explicit input. The
+#   analyzer's value is logged side-by-side for audit, but the human's
+#   input wins.
+#
+# Pre-conditions when this runs (most enforced by the workflow):
+# - VERSION env var: the chosen target version.
+# - HEAD = origin/main HEAD.
+# - SDKVersion.swift reads "Dev".
+# - Working tree clean.
+# - Git identity configured.
+# - SSH remote configured for push.
+# - GH_TOKEN (or GITHUB_TOKEN) exported for `gh release create`.
+# - COCOAPODS_TRUNK_TOKEN exported for pod publish.
+#
+# Post-conditions on success:
+# - Tag $VERSION points at commit X (chore(release) commit stamping
+#   SDKVersion, all four podspecs, and prepending the CHANGELOG entry).
+# - main HEAD = Y (Dev-restore commit on top of X).
+# - GitHub release created from the generated notes.
+# - All four pods (Core, UI, Reader, Platform) published at $VERSION.
+#
+# Local usage (validates and stops before push):
+#   VERSION=5.2.3 DRY_RUN=1 bash scripts/release.sh
+#
+# CI usage:
+#   VERSION=5.2.3 bash scripts/release.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+VERSION="${VERSION:-}"
+DRY_RUN="${DRY_RUN:-0}"
+
+if [ -z "$VERSION" ]; then
+  echo "❌ VERSION env var is required" >&2
+  exit 1
+fi
+
+# --- Validate VERSION --------------------------------------------------------
+
+CURRENT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+echo "Current tag:    $CURRENT_TAG"
+echo "Chosen version: $VERSION"
+
+VALIDATION_CODE=0
+node scripts/release-validate.mjs "$VERSION" "$CURRENT_TAG" || VALIDATION_CODE=$?
+
+if [ "$VALIDATION_CODE" -eq 11 ]; then
+  echo "❌ '$VERSION' is not valid semver" >&2
+  exit 1
+elif [ "$VALIDATION_CODE" -eq 12 ]; then
+  echo "❌ '$VERSION' is not strictly greater than current tag '$CURRENT_TAG'" >&2
+  exit 1
+elif [ "$VALIDATION_CODE" -ne 0 ]; then
+  echo "❌ Version validation failed (exit $VALIDATION_CODE)" >&2
+  exit 1
+fi
+
+# --- Compute calculated version (informational only) -------------------------
+
+PREVIEW_JSON=$(node scripts/preview-release.mjs --base "$CURRENT_TAG" --head HEAD 2>/dev/null || echo '{}')
+CALCULATED=$(echo "$PREVIEW_JSON" | node -e "let s=''; process.stdin.on('data', d=>s+=d).on('end', () => { const j=JSON.parse(s||'{}'); console.log(j.next || j.current || 'unknown'); });")
+CALC_TYPE=$(echo "$PREVIEW_JSON" | node -e "let s=''; process.stdin.on('data', d=>s+=d).on('end', () => { const j=JSON.parse(s||'{}'); console.log(j.release_type || 'none'); });")
+echo "Calculated:     $CALCULATED ($CALC_TYPE)"
+
+# Write a side-by-side audit block to the GitHub Actions step summary
+# when running in CI. Surfaces "calculator said X, human chose Y" in the
+# job's web UI without needing to dig into the log.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## Release \`$VERSION\`"
+    echo
+    echo "| Source            | Version            |"
+    echo "| ----------------- | ------------------ |"
+    echo "| Current tag       | \`$CURRENT_TAG\`   |"
+    echo "| Analyzer-computed | \`$CALCULATED\` ($CALC_TYPE) |"
+    echo "| Chosen (input)    | **\`$VERSION\`**   |"
+    if [ "$DRY_RUN" = "1" ]; then
+      echo
+      echo "> 🧪 **DRY_RUN=1** — workflow will build commit X + tag locally, then stop. No push, no GitHub release, no pod publish."
+    fi
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+# Warn (don't block) if chosen version is more than one major above calculated.
+node scripts/release-warn-version-jump.mjs "$VERSION" "$CALCULATED" >&2 || true
+
+# --- Pre-flight -------------------------------------------------------------
+
+if ! grep -q 'static let current = "Dev"' Sources/YouVersionPlatformCore/SDKVersion.swift; then
+  echo "❌ SDKVersion.swift does not currently read \"Dev\" — main is in an unexpected state" >&2
+  echo "   Current: $(grep 'static let current' Sources/YouVersionPlatformCore/SDKVersion.swift | head -1)" >&2
+  exit 1
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "❌ Working tree is dirty — aborting" >&2
+  git status --short >&2
+  exit 1
+fi
+
+# Guard against a non-main dispatch landing feature-branch commits on
+# main. `gh workflow run release.yml --ref feature-branch` would pass
+# every other pre-flight, and `git push origin HEAD:main` would then
+# bypass branch protection via the deploy key. Dry-runs are explicitly
+# supported on any branch (no push fires), so we skip this guard for them.
+if [ "$DRY_RUN" != "1" ]; then
+  HEAD_SHA=$(git rev-parse HEAD)
+  MAIN_SHA=$(git rev-parse origin/main 2>/dev/null || echo "")
+  if [ -z "$MAIN_SHA" ]; then
+    echo "❌ origin/main ref not found locally — workflow checkout must use fetch-depth: 0" >&2
+    exit 1
+  fi
+  if [ "$HEAD_SHA" != "$MAIN_SHA" ]; then
+    echo "❌ HEAD ($HEAD_SHA) is not at origin/main ($MAIN_SHA)" >&2
+    echo "   Live releases must be dispatched on the main branch. Re-run with --ref main." >&2
+    exit 1
+  fi
+fi
+
+if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
+  # Workflow checks out with fetch-depth: 0, so this also catches tags
+  # already on origin — the local clone has every remote tag.
+  echo "❌ Tag $VERSION already exists (in local refs, which include everything fetched from origin)" >&2
+  exit 1
+fi
+
+# --- Generate release notes -------------------------------------------------
+
+echo
+echo "Generating release notes..."
+node scripts/generate-release-notes.mjs \
+  --base "$CURRENT_TAG" \
+  --head HEAD \
+  --version "$VERSION" \
+  > notes.md
+echo "Notes: $(wc -l < notes.md | tr -d ' ') lines."
+
+# --- Update CHANGELOG.md ----------------------------------------------------
+
+if [ -f CHANGELOG.md ]; then
+  # Preserve title + intro; prepend the new entry above the first existing
+  # version heading. If no existing version heading, append.
+  node - <<'NODE'
+const fs = require('fs');
+const notes = fs.readFileSync('notes.md', 'utf8').trimEnd() + '\n\n';
+const existing = fs.readFileSync('CHANGELOG.md', 'utf8');
+const m = existing.match(/^## \[/m);
+let out;
+if (m) {
+  out = existing.slice(0, m.index) + notes + existing.slice(m.index);
+} else {
+  out = existing.trimEnd() + '\n\n' + notes;
+}
+fs.writeFileSync('CHANGELOG.md', out);
+NODE
+else
+  printf '# Changelog\n\nAll notable changes to this project will be documented in this file.\n\n' > CHANGELOG.md
+  cat notes.md >> CHANGELOG.md
+fi
+echo "CHANGELOG.md updated."
+
+# --- Stamp version into source files ----------------------------------------
+
+bash scripts/update-pod-versions.sh "$VERSION"
+bash scripts/stamp-sdk-version.sh "$VERSION"
+
+# --- Build X commit ---------------------------------------------------------
+
+git add \
+  CHANGELOG.md \
+  Sources/YouVersionPlatformCore/SDKVersion.swift \
+  YouVersionPlatform.podspec \
+  YouVersionPlatformCore.podspec \
+  YouVersionPlatformReader.podspec \
+  YouVersionPlatformUI.podspec
+
+# Subject + blank + notes body. [skip ci] prevents push-triggered workflows
+# from re-running on the release commit.
+{
+  printf 'chore(release): %s [skip ci]\n\n' "$VERSION"
+  cat notes.md
+} > .git/COMMIT_EDITMSG
+git commit -F .git/COMMIT_EDITMSG
+
+X_SHA=$(git rev-parse HEAD)
+echo "Commit X created at $X_SHA."
+
+# --- Tag X ------------------------------------------------------------------
+
+git tag "$VERSION"
+echo "Tag $VERSION created at $X_SHA."
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo
+  echo "DRY_RUN=1 — stopping before push, GitHub release, pod publish, and Dev restore."
+  echo "Inspect locally:"
+  echo "  git log -1"
+  echo "  git tag -l '$VERSION'"
+  echo "  cat notes.md"
+  exit 0
+fi
+
+# --- Push main + tag --------------------------------------------------------
+
+echo
+echo "Pushing main and tag $VERSION..."
+git push origin HEAD:main
+git push origin "$VERSION"
+
+# --- Create GitHub release --------------------------------------------------
+
+echo
+echo "Creating GitHub release..."
+gh release create "$VERSION" --notes-file notes.md --title "$VERSION"
+
+# --- Publish pods -----------------------------------------------------------
+
+echo
+echo "Publishing pods..."
+bash scripts/publish-pods.sh "$VERSION"
+
+# --- Restore Dev on main (Y commit) -----------------------------------------
+
+echo
+echo "Restoring SDKVersion to Dev on main..."
+bash scripts/restore-dev-sdk-on-main.sh "$VERSION"
+
+Y_SHA=$(git rev-parse HEAD)
+
+# Clean up the generated notes file so a successful run leaves the repo
+# tidy. The .gitignore entry covers the unlikely case where this rm
+# doesn't fire (script killed, etc.), but removing it explicitly on the
+# success path is the principled cleanup.
+rm -f notes.md
+
+echo
+echo "✅ Release $VERSION complete."
+echo "   Tag $VERSION -> $X_SHA (commit X)"
+echo "   main HEAD     -> $Y_SHA (commit Y, SDKVersion=\"Dev\")"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo
+    echo "### ✅ Released"
+    echo
+    echo "- Tag \`$VERSION\` → \`$X_SHA\` (commit X)"
+    echo "- main HEAD → \`$Y_SHA\` (commit Y)"
+    echo "- GitHub release: [\`$VERSION\`](https://github.com/${GITHUB_REPOSITORY:-youversion/platform-sdk-swift}/releases/tag/$VERSION)"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/test-release-scripts.sh
+++ b/scripts/test-release-scripts.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Tests for scripts/release-validate.mjs and scripts/release-warn-version-jump.mjs.
+#
+# Run locally: bash scripts/test-release-scripts.sh
+# Run in CI:   wired into .github/workflows/commit-lint.yml so every PR
+#              exercises these paths on a different Node version + OS
+#              from the release runner (catches argv / shell / Node
+#              behavior drift before it reaches a live release).
+#
+# Why these tests exist:
+# - The validation logic used to live inline as `node -e "..."` blocks in
+#   release.sh. A code reviewer flagged a (false) concern that
+#   `process.argv` indexing under `node -e` was off by one, which would
+#   have rejected every valid version. The concern was incorrect for our
+#   Node version, but the underlying risk — subtle env-dependent
+#   regressions in a code path that only runs at release time — is real.
+# - Extracting to standalone .mjs scripts eliminates the inline-eval
+#   ambiguity. These tests then guard the extracted logic so any future
+#   regression (Node update, semver-package behavior change, refactor)
+#   fails loudly at PR time, not at release dispatch.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+PASS=0
+FAIL=0
+
+# assert_exit <expected-code> <label> <command...>
+# Runs the command, captures stderr+stdout, and asserts the exit code.
+assert_exit() {
+  local expected=$1
+  local label=$2
+  shift 2
+  local actual=0
+  "$@" >/dev/null 2>&1 || actual=$?
+  if [ "$actual" = "$expected" ]; then
+    echo "  ✓ $label (exit $actual)"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $label (expected $expected, got $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# assert_stderr_contains <needle> <label> <command...>
+# Runs the command and asserts stderr contains the needle substring.
+assert_stderr_contains() {
+  local needle=$1
+  local label=$2
+  shift 2
+  local err
+  err=$("$@" 2>&1 >/dev/null || true)
+  if echo "$err" | grep -qF "$needle"; then
+    echo "  ✓ $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $label (stderr did not contain '$needle'; got: $err)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# assert_stderr_empty <label> <command...>
+# Runs the command and asserts stderr is empty.
+assert_stderr_empty() {
+  local label=$1
+  shift
+  local err
+  err=$("$@" 2>&1 >/dev/null || true)
+  if [ -z "$err" ]; then
+    echo "  ✓ $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $label (expected empty stderr, got: $err)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "release-validate.mjs:"
+assert_exit  0  "5.2.3 > 5.2.2 → accept"           node scripts/release-validate.mjs 5.2.3 5.2.2
+assert_exit  0  "5.3.0 > 5.2.2 → accept"           node scripts/release-validate.mjs 5.3.0 5.2.2
+assert_exit  0  "6.0.0 > 5.2.2 → accept"           node scripts/release-validate.mjs 6.0.0 5.2.2
+assert_exit  0  "5.2.3 > 0.0.0 → accept (fresh repo)" node scripts/release-validate.mjs 5.2.3 0.0.0
+assert_exit 11  "'garbage' is not semver"          node scripts/release-validate.mjs garbage 5.2.2
+assert_exit 11  "'5.2' is not semver"              node scripts/release-validate.mjs 5.2 5.2.2
+assert_exit 11  "empty version is not semver"      node scripts/release-validate.mjs '' 5.2.2
+assert_exit 12  "5.2.2 is not greater than 5.2.2"  node scripts/release-validate.mjs 5.2.2 5.2.2
+assert_exit 12  "5.2.1 is not greater than 5.2.2"  node scripts/release-validate.mjs 5.2.1 5.2.2
+assert_exit 12  "4.9.9 is not greater than 5.2.2"  node scripts/release-validate.mjs 4.9.9 5.2.2
+assert_exit  1  "missing args → usage error"       node scripts/release-validate.mjs 5.2.3
+assert_stderr_contains "not_semver"  "rejects with not_semver token"  node scripts/release-validate.mjs garbage 5.2.2
+assert_stderr_contains "not_greater" "rejects with not_greater token" node scripts/release-validate.mjs 5.2.1 5.2.2
+
+echo
+echo "release-warn-version-jump.mjs:"
+# Always exits 0; we assert on stderr presence/absence.
+assert_exit  0  "no jump (5.2.3 vs 5.2.2) → exit 0"      node scripts/release-warn-version-jump.mjs 5.2.3 5.2.2
+assert_exit  0  "one-major jump (6.0.0 vs 5.2.2) → exit 0" node scripts/release-warn-version-jump.mjs 6.0.0 5.2.2
+assert_exit  0  "two-major jump (7.0.0 vs 5.2.2) → exit 0" node scripts/release-warn-version-jump.mjs 7.0.0 5.2.2
+assert_exit  0  "invalid calc → silent exit 0"           node scripts/release-warn-version-jump.mjs 5.2.3 unknown
+assert_stderr_empty   "no jump prints no warning"           node scripts/release-warn-version-jump.mjs 5.2.3 5.2.2
+assert_stderr_empty   "one-major jump prints no warning"    node scripts/release-warn-version-jump.mjs 6.0.0 5.2.2
+assert_stderr_contains "more than one major above" "two-major jump prints warning"   node scripts/release-warn-version-jump.mjs 7.0.0 5.2.2
+assert_stderr_contains "more than one major above" "three-major jump prints warning" node scripts/release-warn-version-jump.mjs 8.0.0 5.2.2
+assert_stderr_empty   "invalid calc is silent"              node scripts/release-warn-version-jump.mjs 5.2.3 unknown
+
+echo
+echo "release.sh wiring (no inline node -e):"
+# Guard against the inline `node -e` form sneaking back into release.sh.
+# The whole point of extracting these scripts was to eliminate the
+# ambiguity that reviewers (human or bot) keep flagging.
+if grep -nE "^[[:space:]]*node[[:space:]]+-e" scripts/release.sh >/dev/null; then
+  echo "  ✗ scripts/release.sh contains inline 'node -e' — extract to a .mjs script"
+  grep -nE "^[[:space:]]*node[[:space:]]+-e" scripts/release.sh
+  FAIL=$((FAIL + 1))
+else
+  echo "  ✓ scripts/release.sh has no inline 'node -e'"
+  PASS=$((PASS + 1))
+fi
+
+echo
+if [ "$FAIL" -gt 0 ]; then
+  echo "❌ $FAIL test(s) failed out of $((PASS + FAIL))"
+  exit 1
+else
+  echo "✅ All $PASS tests passed"
+fi

--- a/scripts/update-pod-versions.sh
+++ b/scripts/update-pod-versions.sh
@@ -29,6 +29,11 @@ for PODSPEC in YouVersionPlatform.podspec YouVersionPlatformCore.podspec YouVers
   echo "  ✓ $PODSPEC"
 done
 
+if [ "${SKIP_LINT:-0}" = "1" ]; then
+  echo "Skipping podspec lint (SKIP_LINT=1)."
+  exit 0
+fi
+
 echo "Validating podspecs (full xcodebuild — slow but mirrors trunk)..."
 
 # Use `pod lib lint` rather than `pod spec lint`. `spec lint` clones the


### PR DESCRIPTION
## Weekly sync: main → feat/bible-loop

Brings in commits from main since the last sync.

> **Merge style:** This PR must be merged with `--no-ff` (merge commit). Do NOT squash or rebase.

## Commits included

```
9918d19 feat(release): manual version-input release, no semantic-release orchestration (#135)
4be5cac test: cover Bible reader navigation actions
1ada5a2 fix: support system font families in Bible text
29ec4d0 test: handling of 3-digit and 8-digit ARGB hex strings
dbb7132 test: add coverage for YouVersionAPI.Bible.permittedVersions
cbec1c1 fix: Handle BibleReference verse cases in display title, and enforce verseEnd invariant
c6ebd45 fix(ci): make commit-lint dry-run actually compute the next version (YPE-2398 follow-up) (#125)
9bd318a fix(ci): switch release publishing from auto-on-push to manual workflow_dispatch trigger (#132)
0f3e2d2 chore(release): restore SDKVersion to Dev after 6.0.0 [skip ci]
5e83e05 chore(release): 6.0.0 [skip ci]
1d21411 ci: replace Husky commit-msg hook with CI commit-lint + release preview (#117)
0d86009 chore(release): restore SDKVersion to Dev after 5.2.2 [skip ci]
17083b8 chore(release): 5.2.2 [skip ci]
8dad856 fix: BibleReaderViewModel created on every render (#122)
ca5cc5e chore(release): restore SDKVersion to Dev after 5.2.1 [skip ci]
7bb8a58 chore(release): 5.2.1 [skip ci]
52b9bf5 fix: normalize bookUSFM case in overlaps/contains and fix chapter-only USFM parsing
05c1a7e test: fix vacuous assertion
b71462f test: fix fixture JSON, add pagination and missing API error coverage
1a58ec2 test: add YouVersionPlatformConfiguration coverage
```

## Conflicts

The following files had conflicts that were auto-resolved. Please review carefully:

- `Sources/YouVersionPlatformReader/BibleReaderView.swift` — `main` refactored `BibleReaderView` into a thin lazy-init wrapper delegating to a private `ReaderContent` struct, while `feat/bible-loop` had kept all state in `BibleReaderView` and extended its `init` with new parameters (`selectedVerses`, `onNoteIndicatorTap`, `onReferenceChange`, `onChapterComplete`, `audioActiveReference`, `audioActiveIndicatorColor`, `VerseTapResponse`). Resolution: adopted `main`'s thin-wrapper structure, stored all new `feat/bible-loop` parameters as stored properties on `BibleReaderView`, passed them into `BibleReaderViewModel` in the `.task` lazy-init block, and moved the `feat/bible-loop`-added state (`externalSelectedVerses`, `audioActiveReference`, `lastScrolledVerse`, `verseAnchors`) into `ReaderContent` where the UI logic lives.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This weekly sync merges a batch of `main` commits into `feat/bible-loop`, with the most significant work being the conflict-resolution of `BibleReaderView.swift` into a thin lazy-init wrapper delegating to a private `ReaderContent` struct.

- **`BibleReaderView` refactor**: outer struct stores init parameters as `let` properties and creates `BibleReaderViewModel` once inside a `.task` block; all SwiftUI state and environment reads move into the private `ReaderContent` struct. Conflict-resolution correctly carries `feat/bible-loop`'s `externalSelectedVerses`, `audioActiveReference`, `lastScrolledVerse`, and `verseAnchors` into `ReaderContent`.
- **`BibleReference` hardening**: `bookUSFM` is now uppercased at storage time across all `init` paths (including a new custom `Decodable` init that enforces the `verseEnd == verseStart` invariant when only `verseStart` appears in JSON), backed by a new `BibleReferenceTests_codable.swift` test suite.
- **System font support**: `ReaderFonts.displayFont` and `BibleTextFonts.font` now route \"San Francisco\" and \"New York\" family names to `Font.system` instead of `Font.custom`, fixing rendering for those two built-in families.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed code paths are exercised by new tests and the conflict resolution is well-structured.

The `BibleReference` changes are guarded by a thorough new Codable test suite. The `BibleReaderView` refactor is clean, with no state dropped during the thin-wrapper migration. The system-font routing is straightforward and tested via `ReaderFontsTests`. No runtime regressions were identified.

No files require special attention beyond the two style notes already left inline.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Refactored into thin `BibleReaderView` wrapper with lazy ViewModel init via `.task`, delegating all rendering to a new private `ReaderContent` struct; conflict resolution correctly migrated feat/bible-loop state into `ReaderContent`. |
| Sources/YouVersionPlatformCore/Bible/BibleReference.swift | Normalizes `bookUSFM` to uppercase at construction time (both inits) and adds a custom `Decodable` init that enforces the `verseEnd == verseStart` invariant when only `verseStart` is present in JSON; USFM parsing sites simplified by removing redundant `.uppercased()` calls. |
| Sources/YouVersionPlatformUI/Objects/BibleVersion+Additions.swift | Rewrote `displayTitle` parts array with guard-based early returns; adds `assertionFailure` to document the invariant that `verseEnd` must be set whenever `verseStart` is set, then falls back to chapter-only display in release builds. |
| Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift | Adds a `font(familyName:size:)` helper that routes "San Francisco" and "New York" names to `Font.system` (with `.serif` design for New York) instead of `Font.custom`, fixing rendering for those two built-in families. |
| Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift | Unblocks "New York" and "San Francisco" in `suggestedFamilies`; adds `displayFont(familyName:size:)` mirroring `BibleTextFonts.font` for use in the font picker UI. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift | Makes `handleVerseActionCopy()` return the inner `Task` (marked `@discardableResult`) so tests can await its completion; no logic changes to the copy flow itself. |
| Tests/YouVersionPlatformCoreTests/BibleReferenceTests_codable.swift | New file with round-trip Codable tests confirming uppercase normalization on decode, chapter-only / verse / range round-trips, and correct overlap comparison after lowercase decode. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift | Adds tests for highlight color presence/removal, `shareableVerseText`, and the new `@discardableResult` copy action; uses a per-suite `generatedVersionId()` counter to avoid cache collisions between tests. |
| scripts/release.sh | New manual release orchestrator that replaces semantic-release; reads `VERSION` and `DRY_RUN` env vars, logs the calculator's suggestion for audit, and drives commit/tag/pod-publish steps. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["BibleReaderView.init(...)"] --> B["Store params as let/var properties\n(initialReference, callbacks, audioActiveReference, ...)"]
    B --> C["body computed"]
    C --> D{"viewModel == nil?"}
    D -- "Yes (first render)" --> E["Render Color.clear"]
    E --> F[".task fires on appear"]
    F --> G["Create BibleReaderViewModel\nwith stored params"]
    G --> H["@State viewModel set → re-render"]
    H --> D
    D -- "No (subsequent renders)" --> I["Render ReaderContent\n(viewModel, externalSelectedVerses, audioActiveReference)"]
    I --> J["ReaderContent.body\n@Bindable viewModel\n@State lastScrolledVerse, verseAnchors\n.onChange / .onAppear logic"]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformReader%2FBibleReaderView.swift%3A414-418%0ASince%20%60BibleReference%60%20now%20always%20stores%20%60bookUSFM%60%20as%20uppercase%20at%20construction%20time%2C%20both%20%60.uppercased%28%29%60%20calls%20here%20are%20no-ops.%20Removing%20them%20makes%20the%20intent%20of%20the%20comparison%20clearer%20and%20removes%20the%20%28now%20incorrect%29%20implication%20that%20either%20side%20might%20be%20in%20mixed%20case.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20guard%20let%20audioRef%20%3D%20audioActiveReference%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20verse%20%3D%20audioRef.verseStart%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20audioRef.chapter%20%3D%3D%20viewModel.reference.chapter%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20audioRef.bookUSFM%20%3D%3D%20viewModel.reference.bookUSFM%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20!viewModel.isChangingChapter%20else%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformCore%2FBible%2FBibleReference.swift%3A43-47%0A**Silent%20drop%20when%20%60verseEnd%60%20is%20present%20without%20%60verseStart%60**%0A%0AThe%20%60else%60%20branch%20handles%20three%20cases%3A%20both%20nil%20%28chapter-only%20%E2%80%94%20correct%29%2C%20%60verseStart%60%20present%20%2B%20%60verseEnd%60%20nil%20%28treated%20as%20a%20single%20verse%20%E2%80%94%20correct%29%2C%20and%20%60verseStart%60%20nil%20%2B%20%60verseEnd%60%20present.%20In%20that%20last%20case%20%60verseEnd%60%20is%20silently%20discarded%20and%20a%20chapter-only%20reference%20is%20returned.%20In%20practice%20the%20API%20shouldn't%20produce%20this%20shape%2C%20but%20it's%20worth%20a%20comment%20or%20a%20debug-guarded%20check%20so%20the%20invalid%20input%20is%20visible%20during%20development.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=140&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformReader%2FBibleReaderView.swift%3A414-418%0ASince%20%60BibleReference%60%20now%20always%20stores%20%60bookUSFM%60%20as%20uppercase%20at%20construction%20time%2C%20both%20%60.uppercased%28%29%60%20calls%20here%20are%20no-ops.%20Removing%20them%20makes%20the%20intent%20of%20the%20comparison%20clearer%20and%20removes%20the%20%28now%20incorrect%29%20implication%20that%20either%20side%20might%20be%20in%20mixed%20case.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20guard%20let%20audioRef%20%3D%20audioActiveReference%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20verse%20%3D%20audioRef.verseStart%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20audioRef.chapter%20%3D%3D%20viewModel.reference.chapter%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20audioRef.bookUSFM%20%3D%3D%20viewModel.reference.bookUSFM%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20!viewModel.isChangingChapter%20else%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformCore%2FBible%2FBibleReference.swift%3A43-47%0A**Silent%20drop%20when%20%60verseEnd%60%20is%20present%20without%20%60verseStart%60**%0A%0AThe%20%60else%60%20branch%20handles%20three%20cases%3A%20both%20nil%20%28chapter-only%20%E2%80%94%20correct%29%2C%20%60verseStart%60%20present%20%2B%20%60verseEnd%60%20nil%20%28treated%20as%20a%20single%20verse%20%E2%80%94%20correct%29%2C%20and%20%60verseStart%60%20nil%20%2B%20%60verseEnd%60%20present.%20In%20that%20last%20case%20%60verseEnd%60%20is%20silently%20discarded%20and%20a%20chapter-only%20reference%20is%20returned.%20In%20practice%20the%20API%20shouldn't%20produce%20this%20shape%2C%20but%20it's%20worth%20a%20comment%20or%20a%20debug-guarded%20check%20so%20the%20invalid%20input%20is%20visible%20during%20development.%0A%0A&pr=140&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
Sources/YouVersionPlatformReader/BibleReaderView.swift:414-418
Since `BibleReference` now always stores `bookUSFM` as uppercase at construction time, both `.uppercased()` calls here are no-ops. Removing them makes the intent of the comparison clearer and removes the (now incorrect) implication that either side might be in mixed case.

```suggestion
        guard let audioRef = audioActiveReference,
              let verse = audioRef.verseStart,
              audioRef.chapter == viewModel.reference.chapter,
              audioRef.bookUSFM == viewModel.reference.bookUSFM,
              !viewModel.isChangingChapter else {
```

### Issue 2 of 2
Sources/YouVersionPlatformCore/Bible/BibleReference.swift:43-47
**Silent drop when `verseEnd` is present without `verseStart`**

The `else` branch handles three cases: both nil (chapter-only — correct), `verseStart` present + `verseEnd` nil (treated as a single verse — correct), and `verseStart` nil + `verseEnd` present. In that last case `verseEnd` is silently discarded and a chapter-only reference is returned. In practice the API shouldn't produce this shape, but it's worth a comment or a debug-guarded check so the invalid input is visible during development.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: mark ReaderContent stored propertie..."](https://github.com/youversion/platform-sdk-swift/commit/bc698ef65a57edf979158285f222dc288c2a8bf7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34025873)</sub>

<!-- /greptile_comment -->