### PR TITLE
refactor(reader): split BibleReaderView into ReaderContent + ReaderMainScroller

### DIFF
--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -4,23 +4,17 @@ import YouVersionPlatformCore
 import YouVersionPlatformUI
 
 public struct BibleReaderView: View {
-    @State private var viewModel: BibleReaderViewModel
-#if !os(tvOS)
-    @State private var contextProvider = ContextProvider()
-#endif
+    @State private var viewModel: BibleReaderViewModel?
 
-    @Environment(\.openURL) private var openURL
-    @Environment(\.colorScheme) private var colorScheme
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
-    private let fontSettingsDetent = PresentationDetent.height(360)
-    private let fontListDetent = PresentationDetent.height(480)
-    @State private var selectedDetent: PresentationDetent
-    @State private var detents: Set<PresentationDetent>
-    private var externalSelectedVerses: Binding<Set<BibleReference>>?
-    private var audioActiveReference: BibleReference?
-    @State private var lastScrolledVerse: Int?
-    @State private var verseAnchors: [Int] = []
+    private let initialReference: BibleReference?
+    private let verseSelectionStyle: VerseSelectionStyle
+    private let onVerseTap: ((BibleReference) -> VerseTapResponse)?
+    private let onNoteIndicatorTap: ((BibleReference) -> Void)?
+    private let onReferenceChange: ((BibleReference) -> Void)?
+    private let onChapterComplete: ((BibleReference) -> Void)?
+    private let audioActiveIndicatorColor: Color?
+    private let externalSelectedVerses: Binding<Set<BibleReference>>?
+    private let audioActiveReference: BibleReference?
 
     /// Creates a Bible reader view.
     ///
@@ -75,11 +69,15 @@ public struct BibleReaderView: View {
             onVerseTap != nil || YouVersionPlatformConfiguration.isSignInEnabled,
             "onVerseTap must be provided OR YouVersion sign-in must be enabled"
         )
+        self.initialReference = reference
         self.externalSelectedVerses = selectedVerses
+        self.verseSelectionStyle = verseSelectionStyle
+        self.onVerseTap = onVerseTap
+        self.onNoteIndicatorTap = onNoteIndicatorTap
+        self.onReferenceChange = onReferenceChange
+        self.onChapterComplete = onChapterComplete
         self.audioActiveReference = audioActiveReference
-        viewModel = BibleReaderViewModel(reference: reference, verseSelectionStyle: verseSelectionStyle, audioActiveIndicatorColor: audioActiveIndicatorColor, onVerseTap: onVerseTap, onNoteIndicatorTap: onNoteIndicatorTap, onReferenceChange: onReferenceChange, onChapterComplete: onChapterComplete)
-        detents = [fontSettingsDetent, fontListDetent]
-        selectedDetent = fontSettingsDetent
+        self.audioActiveIndicatorColor = audioActiveIndicatorColor
     }
 
     /// Creates a Bible reader view with sign-in configuration.
@@ -102,6 +100,51 @@ public struct BibleReaderView: View {
     }
 
     public var body: some View {
+        Group {
+            if let viewModel {
+                ReaderContent(
+                    viewModel: viewModel,
+                    externalSelectedVerses: externalSelectedVerses,
+                    audioActiveReference: audioActiveReference
+                )
+            } else {
+                Color.clear
+            }
+        }
+        .task {
+            if viewModel == nil {
+                viewModel = BibleReaderViewModel(
+                    reference: initialReference,
+                    verseSelectionStyle: verseSelectionStyle,
+                    audioActiveIndicatorColor: audioActiveIndicatorColor,
+                    onVerseTap: onVerseTap,
+                    onNoteIndicatorTap: onNoteIndicatorTap,
+                    onReferenceChange: onReferenceChange,
+                    onChapterComplete: onChapterComplete
+                )
+            }
+        }
+    }
+}
+
+private struct ReaderContent: View {
+    @Bindable var viewModel: BibleReaderViewModel
+    let externalSelectedVerses: Binding<Set<BibleReference>>?
+    let audioActiveReference: BibleReference?
+
+#if !os(tvOS)
+    @State private var contextProvider = ContextProvider()
+#endif
+
+    @Environment(\.openURL) private var openURL
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private let fontSettingsDetent = PresentationDetent.height(360)
+    private let fontListDetent = PresentationDetent.height(480)
+    @State private var selectedDetent = PresentationDetent.height(360)
+    @State private var detents: Set<PresentationDetent> = [.height(360), .height(480)]
+
+    var body: some View {
         VStack(spacing: 0) {
             header
             Spacer()
@@ -110,7 +153,12 @@ public struct BibleReaderView: View {
                 .frame(height: 1)
             ZStack {
                 VStack {
-                    mainScroller
+                    ReaderMainScroller(
+                        viewModel: viewModel,
+                        audioActiveReference: audioActiveReference
+                    ) {
+                        bibleCopyrightBlock
+                    }
                     Spacer(minLength: 0)
                 }
                 BibleReaderNavButtons()
@@ -184,13 +232,9 @@ public struct BibleReaderView: View {
             viewModel.isReduceMotionEnabled = newValue
         }
         .onAppear {
-            verseAnchors = []
-            lastScrolledVerse = nil
             viewModel.resetChapterCompleteTracking()
         }
         .onChange(of: viewModel.reference) { _, newReference in
-            verseAnchors = []
-            lastScrolledVerse = nil
             viewModel.resetChapterCompleteTracking()
             viewModel.onReferenceChange?(newReference)
         }
@@ -294,101 +338,6 @@ public struct BibleReaderView: View {
         }
     }
 
-    private var mainScroller: some View {
-        ScrollViewReader { scrollProxy in
-            ScrollView {
-                if viewModel.version != nil {
-                    VStack(alignment: .leading) {
-                        if viewModel.showBookIntro {
-                            BibleReaderIntroView()
-                        } else {
-                            BibleTextView(
-                                viewModel.reference,
-                                textOptions: viewModel.textOptions,
-                                selectedVerses: $viewModel.selectedVerses,
-                                onVerseTap: { reference, actionType, footnotes, footnoteId in
-                                    viewModel.handleVerseTap(reference: reference, actionType: actionType, footnotes: footnotes)
-                                },
-                                onAnchorsChanged: { anchors in
-                                    verseAnchors = anchors
-                                },
-                                audioActiveVerse: audioActiveReference?.verseStart
-                            )
-                        }
-                        bibleCopyrightBlock
-                    }
-                    .frame(maxWidth: viewModel.readerMaxWidth)
-                    .padding(.vertical)
-                    .padding(.horizontal, 30)
-                    .id("topOfContent")
-                    .onGeometryChange(for: CGRect.self) { proxy in
-                        proxy.frame(in: .named("scrollView"))
-                    } action: { newFrame in
-                        viewModel.handleScroll(offset: newFrame.minY, contentHeight: newFrame.height)
-                    }
-                } else {
-                    ProgressView()
-                        .tint(viewModel.readerTextMutedColor)
-                        .padding(.vertical, 48)
-                }
-            }
-            .coordinateSpace(.named("scrollView"))
-            .background(
-                GeometryReader { geo in
-                    Color.clear
-                        .onAppear { viewModel.scrollViewHeight = geo.size.height }
-                        .onChange(of: geo.size.height) { _, newHeight in
-                            viewModel.scrollViewHeight = newHeight
-                        }
-                }
-            )
-            .onPreferenceChange(VerseAnchorsPreferenceKey.self) { verseAnchors = $0 }
-            .onChange(of: viewModel.scrollToTop) { _, shouldScroll in
-                if shouldScroll {
-                    scrollProxy.scrollTo("topOfContent", anchor: .top)
-                    viewModel.scrollToTop = false
-                    lastScrolledVerse = nil
-                    // Wait for scroll animation before clearing the flag.
-                    Task { @MainActor in
-                        // swiftlint:disable:next common_debug_statements
-                        try? await Task.sleep(for: .seconds(0.5))
-                        viewModel.isChangingChapter = false
-                    }
-                }
-            }
-            .onChange(of: audioActiveReference) { _, _ in
-                applyAudioScrollIfNeeded(scrollProxy: scrollProxy)
-            }
-            .onChange(of: verseAnchors) { _, _ in
-                applyAudioScrollIfNeeded(scrollProxy: scrollProxy)
-            }
-        }
-    }
-
-    private func applyAudioScrollIfNeeded(scrollProxy: ScrollViewProxy) {
-        guard let audioRef = audioActiveReference,
-              let verse = audioRef.verseStart,
-              audioRef.chapter == viewModel.reference.chapter,
-              audioRef.bookUSFM.uppercased() == viewModel.reference.bookUSFM.uppercased(),
-              !viewModel.isChangingChapter else {
-            return
-        }
-        guard let anchorVerse = verseAnchors.last(where: { $0 <= verse }) else {
-            return
-        }
-        guard anchorVerse != lastScrolledVerse else {
-            return
-        }
-        lastScrolledVerse = anchorVerse
-        let anchorId = "ch\(viewModel.reference.chapter)v\(anchorVerse)"
-        Task { @MainActor in
-            let animation: Animation? = reduceMotion ? nil : .easeInOut(duration: 0.3)
-            withAnimation(animation) {
-                scrollProxy.scrollTo(anchorId, anchor: .center)
-            }
-        }
-    }
-
 #if !os(tvOS)
     class ContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
         func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
@@ -419,14 +368,13 @@ public struct BibleReaderView: View {
                 )
                 dump(result)
 #endif
-                
+
                 await viewModel.updateSignInState()
             } catch {
                 YouVersionPlatformLogger.error("Sign-in error: \(error)", category: "BibleReader")
             }
         }
     }
-
 }
 
 #Preview {

--- a/Sources/YouVersionPlatformReader/ReaderMainScroller.swift
+++ b/Sources/YouVersionPlatformReader/ReaderMainScroller.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+import YouVersionPlatformCore
+import YouVersionPlatformUI
+
+struct ReaderMainScroller<Footer: View>: View {
+    @Bindable var viewModel: BibleReaderViewModel
+    let audioActiveReference: BibleReference?
+    let bibleCopyrightBlock: Footer
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var verseAnchors: [Int] = []
+    @State private var lastScrolledVerse: Int?
+
+    init(
+        viewModel: BibleReaderViewModel,
+        audioActiveReference: BibleReference?,
+        @ViewBuilder bibleCopyrightBlock: () -> Footer
+    ) {
+        self.viewModel = viewModel
+        self.audioActiveReference = audioActiveReference
+        self.bibleCopyrightBlock = bibleCopyrightBlock()
+    }
+
+    var body: some View {
+        ScrollViewReader { scrollProxy in
+            ScrollView {
+                if viewModel.version != nil {
+                    VStack(alignment: .leading) {
+                        if viewModel.showBookIntro {
+                            BibleReaderIntroView()
+                        } else {
+                            BibleTextView(
+                                viewModel.reference,
+                                textOptions: viewModel.textOptions,
+                                selectedVerses: $viewModel.selectedVerses,
+                                onVerseTap: { reference, actionType, footnotes, footnoteId in
+                                    viewModel.handleVerseTap(reference: reference, actionType: actionType, footnotes: footnotes)
+                                },
+                                onAnchorsChanged: { anchors in
+                                    verseAnchors = anchors
+                                },
+                                audioActiveVerse: audioActiveReference?.verseStart
+                            )
+                        }
+                        bibleCopyrightBlock
+                    }
+                    .frame(maxWidth: viewModel.readerMaxWidth)
+                    .padding(.vertical)
+                    .padding(.horizontal, 30)
+                    .id("topOfContent")
+                    .onGeometryChange(for: CGRect.self) { proxy in
+                        proxy.frame(in: .named("scrollView"))
+                    } action: { newFrame in
+                        viewModel.handleScroll(offset: newFrame.minY, contentHeight: newFrame.height)
+                    }
+                } else {
+                    ProgressView()
+                        .tint(viewModel.readerTextMutedColor)
+                        .padding(.vertical, 48)
+                }
+            }
+            .coordinateSpace(.named("scrollView"))
+            .background(
+                GeometryReader { geo in
+                    Color.clear
+                        .onAppear { viewModel.scrollViewHeight = geo.size.height }
+                        .onChange(of: geo.size.height) { _, newHeight in
+                            viewModel.scrollViewHeight = newHeight
+                        }
+                }
+            )
+            .onPreferenceChange(VerseAnchorsPreferenceKey.self) { verseAnchors = $0 }
+            .onChange(of: viewModel.scrollToTop) { _, shouldScroll in
+                if shouldScroll {
+                    scrollProxy.scrollTo("topOfContent", anchor: .top)
+                    viewModel.scrollToTop = false
+                    lastScrolledVerse = nil
+                    // Wait for scroll animation before clearing the flag.
+                    Task { @MainActor in
+                        // swiftlint:disable:next common_debug_statements
+                        try? await Task.sleep(for: .seconds(0.5))
+                        viewModel.isChangingChapter = false
+                    }
+                }
+            }
+            .onChange(of: viewModel.reference) {
+                verseAnchors = []
+                lastScrolledVerse = nil
+            }
+            .onChange(of: audioActiveReference) { _, _ in
+                applyAudioScrollIfNeeded(scrollProxy: scrollProxy)
+            }
+            .onChange(of: verseAnchors) { _, _ in
+                applyAudioScrollIfNeeded(scrollProxy: scrollProxy)
+            }
+        }
+    }
+
+    private func applyAudioScrollIfNeeded(scrollProxy: ScrollViewProxy) {
+        guard let audioRef = audioActiveReference,
+              let verse = audioRef.verseStart,
+              audioRef.chapter == viewModel.reference.chapter,
+              audioRef.bookUSFM.uppercased() == viewModel.reference.bookUSFM.uppercased(),
+              !viewModel.isChangingChapter else {
+            return
+        }
+        guard let anchorVerse = verseAnchors.last(where: { $0 <= verse }) else {
+            return
+        }
+        guard anchorVerse != lastScrolledVerse else {
+            return
+        }
+        lastScrolledVerse = anchorVerse
+        let anchorId = "ch\(viewModel.reference.chapter)v\(anchorVerse)"
+        Task { @MainActor in
+            let animation: Animation? = reduceMotion ? nil : .easeInOut(duration: 0.3)
+            withAnimation(animation) {
+                scrollProxy.scrollTo(anchorId, anchor: .center)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Reshapes [BibleReaderView.swift](Sources/YouVersionPlatformReader/BibleReaderView.swift) to match main's #122 lazy-VM structure and extracts audio-scroll bookkeeping into a new [ReaderMainScroller.swift](Sources/YouVersionPlatformReader/ReaderMainScroller.swift). Goal: shrink the shared surface area with `main` so future merges into the long-running `feat/bible-loop` branch encounter smaller conflict zones.

- `BibleReaderView` becomes a thin wrapper that constructs the view model once in `.task` and forwards init params to a private `ReaderContent` struct (mirrors main's [8dad856](https://github.com/youversion/platform-sdk-swift/commit/8dad856) shape).
- `ReaderMainScroller` owns `verseAnchors`, `lastScrolledVerse`, and `applyAudioScrollIfNeeded` — audio-scroll state no longer threads through the top-level view.

## Conflict-reduction verification

`git merge origin/main --no-ff --no-commit` before vs after:

| | Conflict regions | Largest region |
|---|---|---|
| Before (on `feat/bible-loop`) | 2 | One block subsumed ~220 lines (entire `ReaderContent` body main introduced) |
| After (this branch) | 5 | All small (2–8 lines each), mechanical: branch added N params/props vs main added 0–1 |

The mega-conflict is gone; remaining conflicts are trivially resolvable.

## What I didn't do

Skipped splitting `BibleReaderViewModel.swift` into more extensions. The branch-added VM content is mostly stored properties (`versionsInLanguage`, chapter-complete state, etc.) which Swift doesn't allow in class extensions; the function-only chapter-complete logic already lives in `BibleReaderViewModel+Navigation.swift`. The remaining theoretical win (moving `textOptions` out) would require widening private font properties — not worth it.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 348 tests pass (one flaky cross-test pollution failure on first run is pre-existing, unrelated)
- [x] `swiftlint --strict` — 0 violations
- [x] `scripts/check-api-stability.sh check` — no breaking changes
- [ ] Manual smoke test of the Bible reader in the sample app (recommend before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors `BibleReaderView` into a thin public shell + a private `ReaderContent`, and extracts audio-scroll bookkeeping into a new `ReaderMainScroller` struct — explicitly to shrink the conflict surface with the `main` branch.

- `BibleReaderView` now defers `BibleReaderViewModel` construction to a `.task` modifier (lazy-VM pattern), storing init params as plain `let` properties until needed.
- `ReaderMainScroller` is a new generic view that owns `verseAnchors`, `lastScrolledVerse`, and `applyAudioScrollIfNeeded`, accepting the copyright footer via a `@ViewBuilder` closure evaluated eagerly in its `init`.
- `ReaderContent` holds all sheet, alert, and sign-in plumbing previously on the top-level view; font-detent state is now initialized inline rather than via a separate `@State` + `init` assignment.

<h3>Confidence Score: 4/5</h3>

Safe to merge after a quick manual smoke-test of the Bible reader in the sample app to verify the first-render transition looks clean.

The refactoring faithfully moves logic into new types without removing any behavioral paths. The `@State viewModel?` + `.task` lazy-init pattern is a deliberate structural change that introduces a one-frame `Color.clear` placeholder; while nearly imperceptible, it's the main thing worth exercising manually before merging.

Both changed files are worth a quick skim for the lazy-VM transition, but `BibleReaderView.swift` is the higher-priority one since it touches the public API surface and the new `Color.clear` initial state.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Thin wrapper shell + private ReaderContent extraction; viewModel is now lazily created via .task with a Color.clear placeholder on first render; font-detent state and sign-in logic correctly moved into ReaderContent. |
| Sources/YouVersionPlatformReader/ReaderMainScroller.swift | New file housing scroll bookkeeping (verseAnchors, lastScrolledVerse, applyAudioScrollIfNeeded); generic Footer @ViewBuilder pattern evaluated eagerly in init; reference-change observer correctly resets local scroll state. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["BibleReaderView (public)\n@State viewModel: BibleReaderViewModel?"] -->|".task { init VM }"| B["BibleReaderViewModel\n(created lazily)"]
    A -->|"viewModel != nil"| C["ReaderContent (private)\n@Bindable viewModel\nexternalSelectedVerses\naudioActiveReference"]
    A -->|"viewModel == nil"| D["Color.clear\n(initial render)"]
    C --> E["ReaderMainScroller\n@Bindable viewModel\n@State verseAnchors: [Int]\n@State lastScrolledVerse: Int?"]
    C --> F["Header / Sheets / Drawers\nSign-in, Font settings, Footnotes"]
    E --> G["ScrollViewReader + ScrollView"]
    G -->|"version != nil"| H["BibleTextView / BibleReaderIntroView"]
    G -->|"version == nil"| I["ProgressView"]
    E -->|"@ViewBuilder Footer"| J["bibleCopyrightBlock"]
    E -->|"applyAudioScrollIfNeeded"| K["ScrollViewProxy.scrollTo"]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformReader%2FBibleReaderView.swift%3A114-126%0AThe%20%60.task%60%20guard%20%60if%20viewModel%20%3D%3D%20nil%60%20is%20redundant%3A%20SwiftUI's%20%60.task%60%20modifier%20fires%20exactly%20once%20per%20appearance%20and%20is%20automatically%20cancelled%20on%20disappearance%2C%20so%20a%20second%20init%20is%20not%20possible%20through%20this%20path.%20Removing%20it%20keeps%20the%20intent%20clearer%20and%20avoids%20a%20reader%20wondering%20whether%20there's%20a%20re-entrancy%20scenario%20being%20defended%20against.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.task%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20viewModel%20%3D%20BibleReaderViewModel%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reference%3A%20initialReference%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20verseSelectionStyle%3A%20verseSelectionStyle%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20audioActiveIndicatorColor%3A%20audioActiveIndicatorColor%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onVerseTap%3A%20onVerseTap%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onNoteIndicatorTap%3A%20onNoteIndicatorTap%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onReferenceChange%3A%20onReferenceChange%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onChapterComplete%3A%20onChapterComplete%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformReader%2FBibleReaderView.swift%3A102-127%0A**%60Color.clear%60%20placeholder%20on%20first%20render**%0A%0ABecause%20%60viewModel%60%20starts%20as%20%60nil%60%2C%20the%20very%20first%20layout%20pass%20renders%20%60Color.clear%60%20instead%20of%20%60ReaderContent%60.%20%60BibleReaderViewModel.init%60%20is%20synchronous%20and%20fast%2C%20so%20the%20flash%20should%20be%20imperceptible%20in%20practice%20%E2%80%94%20but%20it%20does%20mean%20the%20outer%20container%20gets%20a%20zero-content%20frame%20for%20one%20render%20cycle%20before%20the%20real%20content%20appears.%20If%20any%20parent%20ever%20constrains%20or%20animates%20based%20on%20the%20reader's%20initial%20size%20this%20could%20cause%20a%20brief%20jump.%20This%20is%20intentional%20%28mirrors%20%60main%60's%20lazy-VM%20shape%29%2C%20so%20it's%20worth%20a%20quick%20smoke-test%20with%20the%20sample%20app%20to%20confirm%20the%20transition%20is%20visually%20seamless.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=141&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformReader%2FBibleReaderView.swift%3A114-126%0AThe%20%60.task%60%20guard%20%60if%20viewModel%20%3D%3D%20nil%60%20is%20redundant%3A%20SwiftUI's%20%60.task%60%20modifier%20fires%20exactly%20once%20per%20appearance%20and%20is%20automatically%20cancelled%20on%20disappearance%2C%20so%20a%20second%20init%20is%20not%20possible%20through%20this%20path.%20Removing%20it%20keeps%20the%20intent%20clearer%20and%20avoids%20a%20reader%20wondering%20whether%20there's%20a%20re-entrancy%20scenario%20being%20defended%20against.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.task%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20viewModel%20%3D%20BibleReaderViewModel%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reference%3A%20initialReference%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20verseSelectionStyle%3A%20verseSelectionStyle%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20audioActiveIndicatorColor%3A%20audioActiveIndicatorColor%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onVerseTap%3A%20onVerseTap%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onNoteIndicatorTap%3A%20onNoteIndicatorTap%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onReferenceChange%3A%20onReferenceChange%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onChapterComplete%3A%20onChapterComplete%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformReader%2FBibleReaderView.swift%3A102-127%0A**%60Color.clear%60%20placeholder%20on%20first%20render**%0A%0ABecause%20%60viewModel%60%20starts%20as%20%60nil%60%2C%20the%20very%20first%20layout%20pass%20renders%20%60Color.clear%60%20instead%20of%20%60ReaderContent%60.%20%60BibleReaderViewModel.init%60%20is%20synchronous%20and%20fast%2C%20so%20the%20flash%20should%20be%20imperceptible%20in%20practice%20%E2%80%94%20but%20it%20does%20mean%20the%20outer%20container%20gets%20a%20zero-content%20frame%20for%20one%20render%20cycle%20before%20the%20real%20content%20appears.%20If%20any%20parent%20ever%20constrains%20or%20animates%20based%20on%20the%20reader's%20initial%20size%20this%20could%20cause%20a%20brief%20jump.%20This%20is%20intentional%20%28mirrors%20%60main%60's%20lazy-VM%20shape%29%2C%20so%20it's%20worth%20a%20quick%20smoke-test%20with%20the%20sample%20app%20to%20confirm%20the%20transition%20is%20visually%20seamless.%0A%0A&pr=141&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
Sources/YouVersionPlatformReader/BibleReaderView.swift:114-126
The `.task` guard `if viewModel == nil` is redundant: SwiftUI's `.task` modifier fires exactly once per appearance and is automatically cancelled on disappearance, so a second init is not possible through this path. Removing it keeps the intent clearer and avoids a reader wondering whether there's a re-entrancy scenario being defended against.

```suggestion
        .task {
            viewModel = BibleReaderViewModel(
                reference: initialReference,
                verseSelectionStyle: verseSelectionStyle,
                audioActiveIndicatorColor: audioActiveIndicatorColor,
                onVerseTap: onVerseTap,
                onNoteIndicatorTap: onNoteIndicatorTap,
                onReferenceChange: onReferenceChange,
                onChapterComplete: onChapterComplete
            )
        }
```

### Issue 2 of 2
Sources/YouVersionPlatformReader/BibleReaderView.swift:102-127
**`Color.clear` placeholder on first render**

Because `viewModel` starts as `nil`, the very first layout pass renders `Color.clear` instead of `ReaderContent`. `BibleReaderViewModel.init` is synchronous and fast, so the flash should be imperceptible in practice — but it does mean the outer container gets a zero-content frame for one render cycle before the real content appears. If any parent ever constrains or animates based on the reader's initial size this could cause a brief jump. This is intentional (mirrors `main`'s lazy-VM shape), so it's worth a quick smoke-test with the sample app to confirm the transition is visually seamless.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(reader): split BibleReaderView ..."](https://github.com/youversion/platform-sdk-swift/commit/09630f28a8ff5532ac58f63ad2da44b8edd015a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34036363)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->