### PR TITLE
ci(release): gate breaking-change PRs behind a human signoff comment (YPE-2521)

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -138,6 +138,8 @@ jobs:
                 echo "### 🚨🚨🚨 Major version bump detected — \`v$CURRENT\` → \`v$NEXT\` (MAJOR)"
                 echo
                 echo 'The analyzer classified one or more commits as a major bump (a footer at start-of-line with the breaking-change token, or a `feat!:` / `fix!:` shorthand). If this is intentional, proceed. If this is prose accidentally tripping the parser, reword the offending commit body before merging — see the analyzer log below to identify which commit triggered the classification.'
+                echo
+                echo 'Because this PR introduces a breaking change, merging is **blocked by the `major-release-signoff` check** until a write-access collaborator comments with the precise version and a 🚀. See [RELEASING.md](./RELEASING.md#major-release-signoff) for the signoff format.'
               else
                 BUMP_LABEL="${RELEASE_TYPE:-release}"
                 echo "### 📦 Release preview: \`v$CURRENT\` → \`v$NEXT\` ($BUMP_LABEL)"

--- a/.github/workflows/major-release-signoff.yml
+++ b/.github/workflows/major-release-signoff.yml
@@ -1,0 +1,278 @@
+name: Major Release Signoff
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+concurrency:
+  group: major-release-signoff-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+env:
+  STATUS_CONTEXT: major-release-signoff
+
+jobs:
+  signoff:
+    # issue_comment fires for issues AND PRs across the repo. Skip non-PR
+    # issues so we don't waste a run when someone comments on a plain issue.
+    if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request != null }}
+    name: Major release signoff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR context
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR_NUMBER=${{ github.event.pull_request.number }}
+            BASE_SHA=${{ github.event.pull_request.base.sha }}
+            HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          else
+            PR_NUMBER=${{ github.event.issue.number }}
+            # issue_comment payload has no head/base info — look it up so
+            # we evaluate the PR's *current* head, not a stale snapshot.
+            PR_JSON=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER)
+            BASE_SHA=$(jq -r .base.sha <<<"$PR_JSON")
+            HEAD_SHA=$(jq -r .head.sha <<<"$PR_JSON")
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compute release preview
+        id: preview
+        env:
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          set -e
+          # Same analyzer call commit-lint.yml uses, so the two checks stay
+          # in lock-step: if commit-lint says MAJOR, we do too.
+          node scripts/preview-release.mjs --base "$BASE_SHA" --head "$HEAD_SHA" > preview.json
+          cat preview.json
+          RELEASE_TYPE=$(jq -r .release_type preview.json)
+          NEXT=$(jq -r .next preview.json)
+          case "$RELEASE_TYPE" in
+            major) IS_MAJOR=1 ;;
+            *)     IS_MAJOR=0 ;;
+          esac
+          echo "is_major=$IS_MAJOR" >> "$GITHUB_OUTPUT"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "release_type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
+
+      - name: Mark PRs without a breaking change as success and exit
+        if: steps.preview.outputs.is_major != '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RELEASE_TYPE: ${{ steps.preview.outputs.release_type }}
+        run: |
+          set -e
+          gh api repos/${{ github.repository }}/statuses/$HEAD_SHA \
+            -f state=success \
+            -f context="$STATUS_CONTEXT" \
+            -f description="No breaking change (${RELEASE_TYPE:-no bump}); signoff not required." \
+            -f target_url="$RUN_URL"
+
+      - name: Search PR comments for valid approver signoff
+        id: signoff
+        if: steps.preview.outputs.is_major == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          NEXT_VERSION: ${{ steps.preview.outputs.next }}
+        run: |
+          set -e
+          # Escape dots in the version so the bash regex literal-matches
+          # them. NEXT_VERSION looks like "6.0.0"; an unescaped dot would
+          # match any single char.
+          ESCAPED_VERSION=${NEXT_VERSION//./\\.}
+          # Accept both `6.0.0` and `v6.0.0`. Word-boundary character
+          # classes prevent matching `6.0.00` or `vv6.0.0`.
+          VERSION_RE="(^|[^0-9A-Za-z])v?${ESCAPED_VERSION}([^0-9A-Za-z]|$)"
+          # Rocket: literal emoji or :rocket: shortcode.
+          ROCKET_RE='(🚀|:rocket:)'
+          # Acceptance criterion (1): the approver must quote the bot's
+          # template phrase verbatim. Kept on a single line so GitHub's
+          # "Quote reply" produces a comment containing this substring
+          # after a leading `> ` prefix — which we strip during normalize
+          # below. Any deviation (typo, paraphrase, dropped word) fails
+          # the match, which is the strict AC reading.
+          TEMPLATE_PHRASE='Please respond with the precise version number to be released and add the :rocket: emojii BOTH in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides'
+
+          # Normalize: drop `>` quote markers and collapse all whitespace
+          # (incl. newlines) to a single space. This way "Quote reply"
+          # output, hard-wrapped lines, and CRLF-vs-LF all match.
+          normalize() {
+            printf '%s' "$1" | tr -d '>' | tr -s '[:space:]' ' '
+          }
+          NORM_TEMPLATE=$(normalize "$TEMPLATE_PHRASE")
+
+          COMMENTS=$(gh api --paginate \
+            "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            --jq '[.[] | {login: .user.login, type: .user.type, body: .body, html_url: .html_url}]')
+
+          # Cache permission lookups so a chatty approver doesn't cost us
+          # one API call per comment.
+          declare -A PERM_CACHE
+          MATCH_LOGIN=""
+          MATCH_URL=""
+          while IFS= read -r row; do
+            LOGIN=$(jq -r .login <<<"$row")
+            BODY=$(jq -r .body <<<"$row")
+            URL=$(jq -r .html_url <<<"$row")
+            USER_TYPE=$(jq -r .type <<<"$row")
+            # Skip bot accounts entirely — github-actions[bot] etc. can't
+            # be signing off.
+            if [ "$USER_TYPE" = "Bot" ]; then
+              continue
+            fi
+            # Content match first: cheap, and most comments won't qualify.
+            # All three AC items must be present in the same comment:
+            #   (1) verbatim template phrase, (2) precise version, (3) 🚀.
+            NORM_BODY=$(normalize "$BODY")
+            if [[ "$NORM_BODY" != *"$NORM_TEMPLATE"* ]]; then
+              continue
+            fi
+            if ! [[ "$BODY" =~ $VERSION_RE ]] || ! [[ "$BODY" =~ $ROCKET_RE ]]; then
+              continue
+            fi
+            # Then verify the author has write+ permission on this repo.
+            # GITHUB_TOKEN can read this endpoint without extra scope.
+            PERM="${PERM_CACHE[$LOGIN]:-}"
+            if [ -z "$PERM" ]; then
+              PERM=$(gh api "repos/${{ github.repository }}/collaborators/$LOGIN/permission" \
+                --jq '.permission' 2>/dev/null || echo "none")
+              PERM_CACHE[$LOGIN]="$PERM"
+            fi
+            case "$PERM" in
+              admin|maintain|write)
+                MATCH_LOGIN="$LOGIN"
+                MATCH_URL="$URL"
+                break
+                ;;
+            esac
+          done < <(jq -c '.[]' <<<"$COMMENTS")
+
+          if [ -n "$MATCH_LOGIN" ]; then
+            echo "signed_off=1" >> "$GITHUB_OUTPUT"
+            echo "approver=$MATCH_LOGIN" >> "$GITHUB_OUTPUT"
+            echo "signoff_url=$MATCH_URL" >> "$GITHUB_OUTPUT"
+            echo "Signoff found: $MATCH_LOGIN ($MATCH_URL)"
+          else
+            echo "signed_off=0" >> "$GITHUB_OUTPUT"
+            echo "No qualifying signoff found yet."
+          fi
+
+      - name: Post success status when signoff present
+        if: steps.preview.outputs.is_major == '1' && steps.signoff.outputs.signed_off == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          APPROVER: ${{ steps.signoff.outputs.approver }}
+          NEXT_VERSION: ${{ steps.preview.outputs.next }}
+        run: |
+          set -e
+          gh api repos/${{ github.repository }}/statuses/$HEAD_SHA \
+            -f state=success \
+            -f context="$STATUS_CONTEXT" \
+            -f description="Major v${NEXT_VERSION} signed off by ${APPROVER}." \
+            -f target_url="$RUN_URL"
+
+      - name: Upsert blocking comment when signoff missing
+        if: steps.preview.outputs.is_major == '1' && steps.signoff.outputs.signed_off != '1' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          NEXT_VERSION: ${{ steps.preview.outputs.next }}
+        run: |
+          set -e
+          MARKER='<!-- major-signoff-required -->'
+          # Build the comment body with echo-per-line. A heredoc here would
+          # introduce un-indented lines that confuse the YAML block-scalar
+          # parser; commit-lint.yml uses this same pattern.
+          {
+            echo "$MARKER"
+            echo "## 🚨 Breaking change detected — signoff required for \`v$NEXT_VERSION\`"
+            echo
+            echo "One or more commits on this PR introduce a **breaking change** (a \`BREAKING CHANGE\` footer or a \`!\` in the type, e.g. \`feat!:\`), which would ship as a major version bump (\`v$NEXT_VERSION\`). Merging is blocked until a repo collaborator with write access comments on this PR with all three of:"
+            echo
+            echo "1. The verbatim acknowledgment phrase below,"
+            echo "2. The precise next version (\`v$NEXT_VERSION\` or \`$NEXT_VERSION\`), and"
+            echo "3. A 🚀 (\`:rocket:\`) emoji."
+            echo
+            echo "Please respond with the precise version number to be released and add the :rocket: emojii BOTH in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides"
+            echo
+            echo "**Copy-paste-ready reply:**"
+            echo
+            echo '```'
+            echo "Please respond with the precise version number to be released and add the :rocket: emojii BOTH in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides"
+            echo
+            echo "v$NEXT_VERSION 🚀"
+            echo '```'
+            echo
+            echo "The check re-runs automatically when a qualifying comment is posted or edited."
+          } > comment.md
+
+          # Look for an existing marker comment so we upsert rather than
+          # spam a new one on every push.
+          EXISTING=$(gh api --paginate \
+            "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            --jq "[.[] | select(.body | contains(\"$MARKER\"))] | .[0].id // empty")
+
+          # Send as a JSON payload via --input — the body has newlines and
+          # backticks that don't survive -f string-encoding.
+          jq -Rs '{body: .}' < comment.md > comment.json
+          if [ -n "$EXISTING" ]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$EXISTING" --input comment.json > /dev/null
+            echo "Updated existing blocking comment ($EXISTING)."
+          else
+            gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --input comment.json > /dev/null
+            echo "Posted new blocking comment."
+          fi
+
+      - name: Post failure status when signoff missing
+        if: steps.preview.outputs.is_major == '1' && steps.signoff.outputs.signed_off != '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          NEXT_VERSION: ${{ steps.preview.outputs.next }}
+        run: |
+          set -e
+          gh api repos/${{ github.repository }}/statuses/$HEAD_SHA \
+            -f state=failure \
+            -f context="$STATUS_CONTEXT" \
+            -f description="Breaking change detected; awaiting v${NEXT_VERSION} + 🚀 signoff from a write-access collaborator." \
+            -f target_url="$RUN_URL"
+
+      - name: Fail the job so the gate is loud in the PR UI
+        if: steps.preview.outputs.is_major == '1' && steps.signoff.outputs.signed_off != '1'
+        run: |
+          echo "Breaking change detected; awaiting write-access collaborator signoff."
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,8 @@ This project follows idiomatic Swift conventions as outlined in [Swift API Desig
   - `docs`, `style`, `refactor`, `test`, `build`, `ci`, `chore`, `revert` → **no release**
   - Any commit with `!` after the type/scope, **or** a `BREAKING CHANGE:` footer → **major** bump (e.g. `5.2.2` → `6.0.0`)
 
+  > **PRs that introduce a breaking change require an explicit human signoff before merge.** When any commit on the PR carries a `BREAKING CHANGE:` footer or a `!` after the type/scope, the `major-release-signoff` status check blocks merging until any repo collaborator with `write` (or higher) permission posts a single comment containing the verbatim acknowledgment phrase from the bot's blocking comment, the precise next version (e.g. `v6.0.0`), and a 🚀. See [RELEASING.md → Major Release Signoff](./RELEASING.md#major-release-signoff) for the exact comment format.
+
   **Examples (annotated with the bump each one would trigger):**
 
   ```text

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,6 +36,35 @@ This split exists because `semantic-release`'s lifecycle tightly couples computa
    - Publishes all four pods to CocoaPods trunk in dependency order.
    - Creates a follow-up commit **Y** that restores `SDKVersion.swift` to `"Dev"` on `main`, so subsequent dev/CI builds don't report a stale released version. The tag stays at **X** (which is reachable from `main` via Y → X).
 
+## Major Release Signoff
+
+PRs that **introduce a breaking change** are gated by a required PR status check named `major-release-signoff`. The check runs on every PR via `.github/workflows/major-release-signoff.yml` and is a no-op for any PR that doesn't introduce a breaking change (i.e. anything the analyzer scores as `patch`, `minor`, or no bump).
+
+A "breaking change" is detected the same way `@semantic-release/commit-analyzer` detects it — either a `BREAKING CHANGE:` body/footer token on any commit, or a `!` after the conventional-commit type (`feat!:`, `fix!:`, etc.). When that's present, the analyzer scores the PR as a major bump, and this check posts a blocking comment and stays in a `failure` state until any repo collaborator with `write`, `maintain`, or `admin` permission posts a single comment containing **all three** of:
+
+1. The verbatim acknowledgment phrase:
+
+   > Please respond with the precise version number to be released and add the :rocket: emojii BOTH in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides
+
+2. The precise next version string (e.g. `v6.0.0` or `6.0.0`), and
+3. A 🚀 (`:rocket:`) emoji.
+
+A copy-paste-ready example (assuming the next version is `6.0.0`):
+
+```
+Please respond with the precise version number to be released and add the :rocket: emojii BOTH in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides
+
+v6.0.0 🚀
+```
+
+The matcher normalizes whitespace and strips Markdown blockquote markers (`>`), so using GitHub's "Quote reply" button on the bot's blocking comment also satisfies item (1) as long as the version and 🚀 are added in the same reply.
+
+The check re-runs automatically when a qualifying comment is posted or edited; once it sees a comment from a write-access collaborator containing both tokens, it flips to `success` and merging is unblocked. The approver's comment lives in PR history as the audit record — no extra log is required.
+
+Permission is verified via `GET /repos/{owner}/{repo}/collaborators/{username}/permission` against the workflow-default `GITHUB_TOKEN`, so signoff authorization piggybacks on the same access list GitHub already uses for merge permissions — no separate allowlist file or org-scoped token to keep in sync.
+
+If the PR doesn't actually contain a breaking change (e.g. the trigger is prose accidentally matching the `BREAKING CHANGE` token), the fix is in the commit messages, not the signoff: reword the offending commit subject/body so the analyzer no longer detects a breaking change (see the `Commit Lint` PR comment for which commit triggered it), force-push, and the gate will go green on its own.
+
 ## Required GitHub Configuration
 
 ### GitHub Secrets
@@ -84,6 +113,7 @@ The `main` branch ruleset requires pull requests, but the release workflow needs
 1. Go to `https://github.com/youversion/platform-sdk-swift/settings/rules`
 2. Edit the ruleset for `main`
 3. Under "Bypass list", ensure "Deploy keys" is enabled
+4. Under "Require status checks to pass", add `major-release-signoff` to the required checks list so the gate actually blocks merges on major PRs (without this the workflow runs but the failure won't block the merge button).
 
 ## Local Testing
 


### PR DESCRIPTION
Closes YPE-2521.

Adds a `major-release-signoff` required PR status check that blocks merging when the analyzer detects a breaking change (a `BREAKING CHANGE` footer or a `!` after the type/scope). The check passes once a write-access collaborator posts a comment containing the verbatim acknowledgment phrase, the precise next version, and a 🚀.

**Follow-up (admin):** add `major-release-signoff` to the required status checks list in the `main` ruleset — without that step the workflow runs but the failure won't actually block the merge button.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `major-release-signoff` GitHub Actions workflow that gates breaking-change PRs behind an explicit human acknowledgment before merging, complemented by documentation updates in `CONTRIBUTING.md` and `RELEASING.md`.

- The new workflow (`major-release-signoff.yml`) runs on every PR push and on `issue_comment` events, reuses the same `preview-release.mjs` analyzer as `commit-lint.yml`, and only activates when the PR is classified as a major bump. It posts a blocking commit status and a bot comment with a copy-paste-ready acknowledgment template, and clears to `success` once a write-access collaborator comments with the required phrase, the precise next version, and a 🚀.
- The `commit-lint.yml` major-bump branch is updated to mention the new gate with a link to `RELEASING.md`, keeping user-facing messaging consistent across both checks.
- **Admin follow-up still required:** as noted in the PR description and `RELEASING.md`, the `major-release-signoff` check must be added to the `main` branch ruleset's required-status-checks list before the gate will actually block the merge button.

<h3>Confidence Score: 3/5</h3>

The workflow logic is correct for the happy path, but the gate can be cleared by the PR author themselves if they have write access, which undermines the intent of requiring a second reviewer for breaking changes.

The workflow correctly detects major bumps, posts blocking statuses, and verifies write-access permissions. The real concern is that there is no check preventing a PR author from self-approving their own breaking-change PR — on an internal repo where most contributors have write access, any author can post the required signoff comment themselves. The typo in the acknowledgment phrase ('emojii') is present in three places (workflow template, blocking comment body, and docs); while the two runtime copies match today, any future single-site correction will silently break signoff matching for all open PRs.

`major-release-signoff.yml` — specifically the permission check block and the acknowledgment phrase string.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/major-release-signoff.yml | New 278-line workflow gating major-release PRs behind a write-access human signoff; logic is sound but has a typo in the required acknowledgment phrase and allows PR author self-signoff |
| .github/workflows/commit-lint.yml | Minor addition: informs PR authors about the new major-release-signoff block when a breaking change is detected; messaging is clear and consistent with the new workflow |
| CONTRIBUTING.md | One-paragraph addition documenting the new signoff requirement; accurate and links to RELEASING.md for the exact format |
| RELEASING.md | New 'Major Release Signoff' section added; clearly documents the 3-part acknowledgment requirement, matching behavior, and the required admin follow-up to add the status check to the branch ruleset |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([PR opened / push / comment]) --> B{Event type?}
    B -->|pull_request| C[Resolve PR context\nfrom event payload]
    B -->|issue_comment| D[Fetch PR head SHA\nvia GitHub API]
    C --> E[Checkout PR head\nRun preview-release.mjs]
    D --> E
    E --> F{Is breaking\nchange / major?}
    F -->|No| G[POST commit status: success\n'No breaking change']
    F -->|Yes| H[Scan all PR comments\nfor valid signoff]
    H --> I{Found comment\nfrom write-access\ncollaborator with\nphrase + version + rocket?}
    I -->|Yes| J[POST commit status: success\n'Signed off by approver']
    I -->|No| K{Event is\npull_request?}
    K -->|Yes| L[Upsert blocking comment\non PR with copy-paste template]
    K -->|No| M[skip comment upsert]
    L --> N[POST commit status: failure]
    M --> N
    N --> O[exit 1 — job fails visibly]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0A.github%2Fworkflows%2Fmajor-release-signoff.yml%3A125%0AThe%20acknowledgment%20phrase%20contains%20a%20typo%20%E2%80%94%20%22emojii%22%20uses%20a%20double%20'i'.%20Because%20the%20%60TEMPLATE_PHRASE%60%20variable%20and%20the%20bot's%20blocking%20comment%20both%20use%20the%20same%20string%2C%20the%20match%20still%20works%20today.%20However%2C%20the%20typo%20is%20visible%20to%20every%20approver%20who%20reads%20or%20copy-pastes%20the%20phrase%2C%20and%20any%20future%20edit%20that%20fixes%20the%20spelling%20in%20one%20place%20%28but%20not%20the%20other%29%20will%20silently%20break%20all%20signoff%20matching.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20TEMPLATE_PHRASE%3D'Please%20respond%20with%20the%20precise%20version%20number%20to%20be%20released%20and%20add%20the%20%3Arocket%3A%20emoji%20in%20order%20to%20continue%20merging.%20For%20more%20information%20about%20how%20releases%20are%20calculated%2C%20read%20our%20CONTRIBUTING%20and%20RELEASING%20guides'%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0A.github%2Fworkflows%2Fmajor-release-signoff.yml%3A172-178%0A**PR%20author%20can%20self-approve%20their%20own%20breaking%20change**%0A%0AThe%20permission%20check%20%28%60admin%7Cmaintain%7Cwrite%60%29%20does%20not%20exclude%20the%20PR%20author.%20On%20an%20internal%20repo%20where%20most%20contributors%20have%20write%20access%2C%20the%20author%20of%20the%20breaking-change%20PR%20can%20post%20the%20signoff%20comment%20themselves%20and%20clear%20the%20gate%20%E2%80%94%20which%20defeats%20the%20intent%20of%20requiring%20a%20second%20set%20of%20eyes.%20Consider%20fetching%20the%20PR%20author%20login%20from%20the%20API%20during%20the%20%60Resolve%20PR%20context%60%20step%20%28it's%20already%20in%20the%20%60pulls%60%20response%29%20and%20skipping%20any%20comment%20whose%20%60login%60%20matches%20the%20PR%20author.%0A%0A%23%23%23%20Issue%203%20of%204%0ARELEASING.md%3A47%0AThe%20phrase%20shown%20in%20the%20documentation%20also%20carries%20the%20%22emojii%22%20typo.%20If%20the%20acknowledgment%20phrase%20is%20corrected%20in%20the%20workflow%2C%20this%20documentation%20block%20should%20be%20updated%20to%20match%20%E2%80%94%20otherwise%20approvers%20who%20copy%20from%20the%20docs%20rather%20than%20the%20bot%20comment%20will%20post%20a%20comment%20that%20fails%20the%20content%20check.%0A%0A%60%60%60suggestion%0A%20%20%20%3E%20Please%20respond%20with%20the%20precise%20version%20number%20to%20be%20released%20and%20add%20the%20%3Arocket%3A%20emoji%20in%20order%20to%20continue%20merging.%20For%20more%20information%20about%20how%20releases%20are%20calculated%2C%20read%20our%20CONTRIBUTING%20and%20RELEASING%20guides%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0ARELEASING.md%3A55-57%0AThe%20copy-paste%20block%20in%20the%20documentation%20should%20match%20the%20corrected%20phrase%20to%20keep%20docs%20and%20the%20bot%20comment%20in%20sync.%0A%0A%60%60%60suggestion%0APlease%20respond%20with%20the%20precise%20version%20number%20to%20be%20released%20and%20add%20the%20%3Arocket%3A%20emoji%20in%20order%20to%20continue%20merging.%20For%20more%20information%20about%20how%20releases%20are%20calculated%2C%20read%20our%20CONTRIBUTING%20and%20RELEASING%20guides%0A%0Av6.0.0%20%F0%9F%9A%80%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=143&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0A.github%2Fworkflows%2Fmajor-release-signoff.yml%3A125%0AThe%20acknowledgment%20phrase%20contains%20a%20typo%20%E2%80%94%20%22emojii%22%20uses%20a%20double%20'i'.%20Because%20the%20%60TEMPLATE_PHRASE%60%20variable%20and%20the%20bot's%20blocking%20comment%20both%20use%20the%20same%20string%2C%20the%20match%20still%20works%20today.%20However%2C%20the%20typo%20is%20visible%20to%20every%20approver%20who%20reads%20or%20copy-pastes%20the%20phrase%2C%20and%20any%20future%20edit%20that%20fixes%20the%20spelling%20in%20one%20place%20%28but%20not%20the%20other%29%20will%20silently%20break%20all%20signoff%20matching.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20TEMPLATE_PHRASE%3D'Please%20respond%20with%20the%20precise%20version%20number%20to%20be%20released%20and%20add%20the%20%3Arocket%3A%20emoji%20in%20order%20to%20continue%20merging.%20For%20more%20information%20about%20how%20releases%20are%20calculated%2C%20read%20our%20CONTRIBUTING%20and%20RELEASING%20guides'%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0A.github%2Fworkflows%2Fmajor-release-signoff.yml%3A172-178%0A**PR%20author%20can%20self-approve%20their%20own%20breaking%20change**%0A%0AThe%20permission%20check%20%28%60admin%7Cmaintain%7Cwrite%60%29%20does%20not%20exclude%20the%20PR%20author.%20On%20an%20internal%20repo%20where%20most%20contributors%20have%20write%20access%2C%20the%20author%20of%20the%20breaking-change%20PR%20can%20post%20the%20signoff%20comment%20themselves%20and%20clear%20the%20gate%20%E2%80%94%20which%20defeats%20the%20intent%20of%20requiring%20a%20second%20set%20of%20eyes.%20Consider%20fetching%20the%20PR%20author%20login%20from%20the%20API%20during%20the%20%60Resolve%20PR%20context%60%20step%20%28it's%20already%20in%20the%20%60pulls%60%20response%29%20and%20skipping%20any%20comment%20whose%20%60login%60%20matches%20the%20PR%20author.%0A%0A%23%23%23%20Issue%203%20of%204%0ARELEASING.md%3A47%0AThe%20phrase%20shown%20in%20the%20documentation%20also%20carries%20the%20%22emojii%22%20typo.%20If%20the%20acknowledgment%20phrase%20is%20corrected%20in%20the%20workflow%2C%20this%20documentation%20block%20should%20be%20updated%20to%20match%20%E2%80%94%20otherwise%20approvers%20who%20copy%20from%20the%20docs%20rather%20than%20the%20bot%20comment%20will%20post%20a%20comment%20that%20fails%20the%20content%20check.%0A%0A%60%60%60suggestion%0A%20%20%20%3E%20Please%20respond%20with%20the%20precise%20version%20number%20to%20be%20released%20and%20add%20the%20%3Arocket%3A%20emoji%20in%20order%20to%20continue%20merging.%20For%20more%20information%20about%20how%20releases%20are%20calculated%2C%20read%20our%20CONTRIBUTING%20and%20RELEASING%20guides%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0ARELEASING.md%3A55-57%0AThe%20copy-paste%20block%20in%20the%20documentation%20should%20match%20the%20corrected%20phrase%20to%20keep%20docs%20and%20the%20bot%20comment%20in%20sync.%0A%0A%60%60%60suggestion%0APlease%20respond%20with%20the%20precise%20version%20number%20to%20be%20released%20and%20add%20the%20%3Arocket%3A%20emoji%20in%20order%20to%20continue%20merging.%20For%20more%20information%20about%20how%20releases%20are%20calculated%2C%20read%20our%20CONTRIBUTING%20and%20RELEASING%20guides%0A%0Av6.0.0%20%F0%9F%9A%80%0A%60%60%60%0A%0A&pr=143&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
.github/workflows/major-release-signoff.yml:125
The acknowledgment phrase contains a typo — "emojii" uses a double 'i'. Because the `TEMPLATE_PHRASE` variable and the bot's blocking comment both use the same string, the match still works today. However, the typo is visible to every approver who reads or copy-pastes the phrase, and any future edit that fixes the spelling in one place (but not the other) will silently break all signoff matching.

```suggestion
          TEMPLATE_PHRASE='Please respond with the precise version number to be released and add the :rocket: emoji in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides'
```

### Issue 2 of 4
.github/workflows/major-release-signoff.yml:172-178
**PR author can self-approve their own breaking change**

The permission check (`admin|maintain|write`) does not exclude the PR author. On an internal repo where most contributors have write access, the author of the breaking-change PR can post the signoff comment themselves and clear the gate — which defeats the intent of requiring a second set of eyes. Consider fetching the PR author login from the API during the `Resolve PR context` step (it's already in the `pulls` response) and skipping any comment whose `login` matches the PR author.

### Issue 3 of 4
RELEASING.md:47
The phrase shown in the documentation also carries the "emojii" typo. If the acknowledgment phrase is corrected in the workflow, this documentation block should be updated to match — otherwise approvers who copy from the docs rather than the bot comment will post a comment that fails the content check.

```suggestion
   > Please respond with the precise version number to be released and add the :rocket: emoji in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides
```

### Issue 4 of 4
RELEASING.md:55-57
The copy-paste block in the documentation should match the corrected phrase to keep docs and the bot comment in sync.

```suggestion
Please respond with the precise version number to be released and add the :rocket: emoji in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides

v6.0.0 🚀
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(release): gate breaking-change PRs be..."](https://github.com/youversion/platform-sdk-swift/commit/74e406ea9575ec5f1a9e6892f4d6021521a64d54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34612280)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->