### PR TITLE
ci(release): gate breaking-change PRs behind a human signoff comment (YPE-2521)

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -138,6 +138,8 @@ jobs:
                 echo "### 🚨🚨🚨 Major version bump detected — \`v$CURRENT\` → \`v$NEXT\` (MAJOR)"
                 echo
                 echo 'The analyzer classified one or more commits as a major bump (a footer at start-of-line with the breaking-change token, or a `feat!:` / `fix!:` shorthand). If this is intentional, proceed. If this is prose accidentally tripping the parser, reword the offending commit body before merging — see the analyzer log below to identify which commit triggered the classification.'
+                echo
+                echo 'Because this PR introduces a breaking change, merging is **blocked by the `major-release-signoff` check** until a write-access collaborator comments with the precise version and a 🚀. See [RELEASING.md](./RELEASING.md#major-release-signoff) for the signoff format.'
               else
                 BUMP_LABEL="${RELEASE_TYPE:-release}"
                 echo "### 📦 Release preview: \`v$CURRENT\` → \`v$NEXT\` ($BUMP_LABEL)"

--- a/.github/workflows/major-release-signoff.yml
+++ b/.github/workflows/major-release-signoff.yml
@@ -133,12 +133,15 @@ jobs:
           # Rocket: literal emoji or :rocket: shortcode.
           ROCKET_RE='(🚀|:rocket:)'
           # Acceptance criterion (1): the approver must quote the bot's
-          # template phrase verbatim. Kept on a single line so GitHub's
-          # "Quote reply" produces a comment containing this substring
-          # after a leading `> ` prefix — which we strip during normalize
-          # below. Any deviation (typo, paraphrase, dropped word) fails
-          # the match, which is the strict AC reading.
-          TEMPLATE_PHRASE='Please respond with the precise version number to be released and add the :rocket: emoji in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides'
+          # affirmation phrase verbatim. The phrase is an active
+          # confirmation that the breaking change is intentional and
+          # that the approver has read the release procedures and
+          # documented impact — not just a passive "yes". Kept on a
+          # single logical block so GitHub's "Quote reply" produces a
+          # comment containing this substring after `> ` prefixes that
+          # we strip during normalize below. Any deviation (typo,
+          # paraphrase, dropped word) fails the match.
+          TEMPLATE_PHRASE='I confirm that this is an intentional breaking change, and I have read the release procedures. I understand and have documented its impact upon release.'
 
           # Normalize: drop `>` quote markers and collapse all whitespace
           # (incl. newlines) to a single space. This way "Quote reply"
@@ -243,18 +246,18 @@ jobs:
             echo "$MARKER"
             echo "## 🚨 Breaking change detected — signoff required for \`v$NEXT_VERSION\`"
             echo
-            echo "One or more commits on this PR introduce a **breaking change** (a \`BREAKING CHANGE\` footer or a \`!\` in the type, e.g. \`feat!:\`), which would ship as a major version bump (\`v$NEXT_VERSION\`). Merging is blocked until a repo collaborator with write access comments on this PR with all three of:"
+            echo "One or more commits on this PR introduce a **breaking change** (a \`BREAKING CHANGE\` footer or a \`!\` in the type, e.g. \`feat!:\`), which would ship as a major version bump (\`v$NEXT_VERSION\`). Merging is blocked until a repo collaborator with write access comments on this PR with **all three (3) of the following:**"
             echo
             echo "1. The verbatim acknowledgment phrase below,"
             echo "2. The precise next version (\`v$NEXT_VERSION\` or \`$NEXT_VERSION\`), and"
             echo "3. A 🚀 (\`:rocket:\`) emoji."
             echo
-            echo "Please respond with the precise version number to be released and add the :rocket: emoji in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides"
+            echo "I confirm that this is an intentional breaking change, and I have read the release procedures. I understand and have documented its impact upon release."
             echo
             echo "**Copy-paste-ready reply:**"
             echo
             echo '```'
-            echo "Please respond with the precise version number to be released and add the :rocket: emoji in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides"
+            echo "I confirm that this is an intentional breaking change, and I have read the release procedures. I understand and have documented its impact upon release."
             echo
             echo "v$NEXT_VERSION 🚀"
             echo '```'

--- a/.github/workflows/major-release-signoff.yml
+++ b/.github/workflows/major-release-signoff.yml
@@ -36,6 +36,7 @@ jobs:
             PR_NUMBER=${{ github.event.pull_request.number }}
             BASE_SHA=${{ github.event.pull_request.base.sha }}
             HEAD_SHA=${{ github.event.pull_request.head.sha }}
+            PR_AUTHOR=${{ github.event.pull_request.user.login }}
           else
             PR_NUMBER=${{ github.event.issue.number }}
             # issue_comment payload has no head/base info — look it up so
@@ -43,10 +44,12 @@ jobs:
             PR_JSON=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER)
             BASE_SHA=$(jq -r .base.sha <<<"$PR_JSON")
             HEAD_SHA=$(jq -r .head.sha <<<"$PR_JSON")
+            PR_AUTHOR=$(jq -r .user.login <<<"$PR_JSON")
           fi
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "pr_author=$PR_AUTHOR" >> "$GITHUB_OUTPUT"
 
       - name: Checkout PR head
         uses: actions/checkout@v4
@@ -104,6 +107,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          PR_AUTHOR: ${{ steps.pr.outputs.pr_author }}
           NEXT_VERSION: ${{ steps.preview.outputs.next }}
         run: |
           set -e
@@ -122,7 +126,7 @@ jobs:
           # after a leading `> ` prefix — which we strip during normalize
           # below. Any deviation (typo, paraphrase, dropped word) fails
           # the match, which is the strict AC reading.
-          TEMPLATE_PHRASE='Please respond with the precise version number to be released and add the :rocket: emojii BOTH in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides'
+          TEMPLATE_PHRASE='Please respond with the precise version number to be released and add the :rocket: emoji in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides'
 
           # Normalize: drop `>` quote markers and collapse all whitespace
           # (incl. newlines) to a single space. This way "Quote reply"
@@ -149,6 +153,13 @@ jobs:
             # Skip bot accounts entirely — github-actions[bot] etc. can't
             # be signing off.
             if [ "$USER_TYPE" = "Bot" ]; then
+              continue
+            fi
+            # Skip the PR author — the whole point of the gate is a
+            # second pair of eyes. An author with write access could
+            # otherwise post the acknowledgment comment themselves and
+            # clear the gate, defeating the AC.
+            if [ "$LOGIN" = "$PR_AUTHOR" ]; then
               continue
             fi
             # Content match first: cheap, and most comments won't qualify.
@@ -226,12 +237,12 @@ jobs:
             echo "2. The precise next version (\`v$NEXT_VERSION\` or \`$NEXT_VERSION\`), and"
             echo "3. A 🚀 (\`:rocket:\`) emoji."
             echo
-            echo "Please respond with the precise version number to be released and add the :rocket: emojii BOTH in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides"
+            echo "Please respond with the precise version number to be released and add the :rocket: emoji in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides"
             echo
             echo "**Copy-paste-ready reply:**"
             echo
             echo '```'
-            echo "Please respond with the precise version number to be released and add the :rocket: emojii BOTH in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides"
+            echo "Please respond with the precise version number to be released and add the :rocket: emoji in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides"
             echo
             echo "v$NEXT_VERSION 🚀"
             echo '```'

--- a/.github/workflows/major-release-signoff.yml
+++ b/.github/workflows/major-release-signoff.yml
@@ -1,0 +1,278 @@
+name: Major Release Signoff
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+concurrency:
+  group: major-release-signoff-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+env:
+  STATUS_CONTEXT: major-release-signoff
+
+jobs:
+  signoff:
+    # issue_comment fires for issues AND PRs across the repo. Skip non-PR
+    # issues so we don't waste a run when someone comments on a plain issue.
+    if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request != null }}
+    name: Major release signoff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR context
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR_NUMBER=${{ github.event.pull_request.number }}
+            BASE_SHA=${{ github.event.pull_request.base.sha }}
+            HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          else
+            PR_NUMBER=${{ github.event.issue.number }}
+            # issue_comment payload has no head/base info — look it up so
+            # we evaluate the PR's *current* head, not a stale snapshot.
+            PR_JSON=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER)
+            BASE_SHA=$(jq -r .base.sha <<<"$PR_JSON")
+            HEAD_SHA=$(jq -r .head.sha <<<"$PR_JSON")
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compute release preview
+        id: preview
+        env:
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          set -e
+          # Same analyzer call commit-lint.yml uses, so the two checks stay
+          # in lock-step: if commit-lint says MAJOR, we do too.
+          node scripts/preview-release.mjs --base "$BASE_SHA" --head "$HEAD_SHA" > preview.json
+          cat preview.json
+          RELEASE_TYPE=$(jq -r .release_type preview.json)
+          NEXT=$(jq -r .next preview.json)
+          case "$RELEASE_TYPE" in
+            major) IS_MAJOR=1 ;;
+            *)     IS_MAJOR=0 ;;
+          esac
+          echo "is_major=$IS_MAJOR" >> "$GITHUB_OUTPUT"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "release_type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
+
+      - name: Mark PRs without a breaking change as success and exit
+        if: steps.preview.outputs.is_major != '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RELEASE_TYPE: ${{ steps.preview.outputs.release_type }}
+        run: |
+          set -e
+          gh api repos/${{ github.repository }}/statuses/$HEAD_SHA \
+            -f state=success \
+            -f context="$STATUS_CONTEXT" \
+            -f description="No breaking change (${RELEASE_TYPE:-no bump}); signoff not required." \
+            -f target_url="$RUN_URL"
+
+      - name: Search PR comments for valid approver signoff
+        id: signoff
+        if: steps.preview.outputs.is_major == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          NEXT_VERSION: ${{ steps.preview.outputs.next }}
+        run: |
+          set -e
+          # Escape dots in the version so the bash regex literal-matches
+          # them. NEXT_VERSION looks like "6.0.0"; an unescaped dot would
+          # match any single char.
+          ESCAPED_VERSION=${NEXT_VERSION//./\\.}
+          # Accept both `6.0.0` and `v6.0.0`. Word-boundary character
+          # classes prevent matching `6.0.00` or `vv6.0.0`.
+          VERSION_RE="(^|[^0-9A-Za-z])v?${ESCAPED_VERSION}([^0-9A-Za-z]|$)"
+          # Rocket: literal emoji or :rocket: shortcode.
+          ROCKET_RE='(🚀|:rocket:)'
+          # Acceptance criterion (1): the approver must quote the bot's
+          # template phrase verbatim. Kept on a single line so GitHub's
+          # "Quote reply" produces a comment containing this substring
+          # after a leading `> ` prefix — which we strip during normalize
+          # below. Any deviation (typo, paraphrase, dropped word) fails
+          # the match, which is the strict AC reading.
+          TEMPLATE_PHRASE='Please respond with the precise version number to be released and add the :rocket: emojii BOTH in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides'
+
+          # Normalize: drop `>` quote markers and collapse all whitespace
+          # (incl. newlines) to a single space. This way "Quote reply"
+          # output, hard-wrapped lines, and CRLF-vs-LF all match.
+          normalize() {
+            printf '%s' "$1" | tr -d '>' | tr -s '[:space:]' ' '
+          }
+          NORM_TEMPLATE=$(normalize "$TEMPLATE_PHRASE")
+
+          COMMENTS=$(gh api --paginate \
+            "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            --jq '[.[] | {login: .user.login, type: .user.type, body: .body, html_url: .html_url}]')
+
+          # Cache permission lookups so a chatty approver doesn't cost us
+          # one API call per comment.
+          declare -A PERM_CACHE
+          MATCH_LOGIN=""
+          MATCH_URL=""
+          while IFS= read -r row; do
+            LOGIN=$(jq -r .login <<<"$row")
+            BODY=$(jq -r .body <<<"$row")
+            URL=$(jq -r .html_url <<<"$row")
+            USER_TYPE=$(jq -r .type <<<"$row")
+            # Skip bot accounts entirely — github-actions[bot] etc. can't
+            # be signing off.
+            if [ "$USER_TYPE" = "Bot" ]; then
+              continue
+            fi
+            # Content match first: cheap, and most comments won't qualify.
+            # All three AC items must be present in the same comment:
+            #   (1) verbatim template phrase, (2) precise version, (3) 🚀.
+            NORM_BODY=$(normalize "$BODY")
+            if [[ "$NORM_BODY" != *"$NORM_TEMPLATE"* ]]; then
+              continue
+            fi
+            if ! [[ "$BODY" =~ $VERSION_RE ]] || ! [[ "$BODY" =~ $ROCKET_RE ]]; then
+              continue
+            fi
+            # Then verify the author has write+ permission on this repo.
+            # GITHUB_TOKEN can read this endpoint without extra scope.
+            PERM="${PERM_CACHE[$LOGIN]:-}"
+            if [ -z "$PERM" ]; then
+              PERM=$(gh api "repos/${{ github.repository }}/collaborators/$LOGIN/permission" \
+                --jq '.permission' 2>/dev/null || echo "none")
+              PERM_CACHE[$LOGIN]="$PERM"
+            fi
+            case "$PERM" in
+              admin|maintain|write)
+                MATCH_LOGIN="$LOGIN"
+                MATCH_URL="$URL"
+                break
+                ;;
+            esac
+          done < <(jq -c '.[]' <<<"$COMMENTS")
+
+          if [ -n "$MATCH_LOGIN" ]; then
+            echo "signed_off=1" >> "$GITHUB_OUTPUT"
+            echo "approver=$MATCH_LOGIN" >> "$GITHUB_OUTPUT"
+            echo "signoff_url=$MATCH_URL" >> "$GITHUB_OUTPUT"
+            echo "Signoff found: $MATCH_LOGIN ($MATCH_URL)"
+          else
+            echo "signed_off=0" >> "$GITHUB_OUTPUT"
+            echo "No qualifying signoff found yet."
+          fi
+
+      - name: Post success status when signoff present
+        if: steps.preview.outputs.is_major == '1' && steps.signoff.outputs.signed_off == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          APPROVER: ${{ steps.signoff.outputs.approver }}
+          NEXT_VERSION: ${{ steps.preview.outputs.next }}
+        run: |
+          set -e
+          gh api repos/${{ github.repository }}/statuses/$HEAD_SHA \
+            -f state=success \
+            -f context="$STATUS_CONTEXT" \
+            -f description="Major v${NEXT_VERSION} signed off by ${APPROVER}." \
+            -f target_url="$RUN_URL"
+
+      - name: Upsert blocking comment when signoff missing
+        if: steps.preview.outputs.is_major == '1' && steps.signoff.outputs.signed_off != '1' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          NEXT_VERSION: ${{ steps.preview.outputs.next }}
+        run: |
+          set -e
+          MARKER='<!-- major-signoff-required -->'
+          # Build the comment body with echo-per-line. A heredoc here would
+          # introduce un-indented lines that confuse the YAML block-scalar
+          # parser; commit-lint.yml uses this same pattern.
+          {
+            echo "$MARKER"
+            echo "## 🚨 Breaking change detected — signoff required for \`v$NEXT_VERSION\`"
+            echo
+            echo "One or more commits on this PR introduce a **breaking change** (a \`BREAKING CHANGE\` footer or a \`!\` in the type, e.g. \`feat!:\`), which would ship as a major version bump (\`v$NEXT_VERSION\`). Merging is blocked until a repo collaborator with write access comments on this PR with all three of:"
+            echo
+            echo "1. The verbatim acknowledgment phrase below,"
+            echo "2. The precise next version (\`v$NEXT_VERSION\` or \`$NEXT_VERSION\`), and"
+            echo "3. A 🚀 (\`:rocket:\`) emoji."
+            echo
+            echo "Please respond with the precise version number to be released and add the :rocket: emojii BOTH in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides"
+            echo
+            echo "**Copy-paste-ready reply:**"
+            echo
+            echo '```'
+            echo "Please respond with the precise version number to be released and add the :rocket: emojii BOTH in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides"
+            echo
+            echo "v$NEXT_VERSION 🚀"
+            echo '```'
+            echo
+            echo "The check re-runs automatically when a qualifying comment is posted or edited."
+          } > comment.md
+
+          # Look for an existing marker comment so we upsert rather than
+          # spam a new one on every push.
+          EXISTING=$(gh api --paginate \
+            "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            --jq "[.[] | select(.body | contains(\"$MARKER\"))] | .[0].id // empty")
+
+          # Send as a JSON payload via --input — the body has newlines and
+          # backticks that don't survive -f string-encoding.
+          jq -Rs '{body: .}' < comment.md > comment.json
+          if [ -n "$EXISTING" ]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$EXISTING" --input comment.json > /dev/null
+            echo "Updated existing blocking comment ($EXISTING)."
+          else
+            gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --input comment.json > /dev/null
+            echo "Posted new blocking comment."
+          fi
+
+      - name: Post failure status when signoff missing
+        if: steps.preview.outputs.is_major == '1' && steps.signoff.outputs.signed_off != '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          NEXT_VERSION: ${{ steps.preview.outputs.next }}
+        run: |
+          set -e
+          gh api repos/${{ github.repository }}/statuses/$HEAD_SHA \
+            -f state=failure \
+            -f context="$STATUS_CONTEXT" \
+            -f description="Breaking change detected; awaiting v${NEXT_VERSION} + 🚀 signoff from a write-access collaborator." \
+            -f target_url="$RUN_URL"
+
+      - name: Fail the job so the gate is loud in the PR UI
+        if: steps.preview.outputs.is_major == '1' && steps.signoff.outputs.signed_off != '1'
+        run: |
+          echo "Breaking change detected; awaiting write-access collaborator signoff."
+          exit 1

--- a/.github/workflows/major-release-signoff.yml
+++ b/.github/workflows/major-release-signoff.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   issue_comment:
-    types: [created, edited]
+    # `deleted` ensures the gate re-runs when a signoff comment is removed,
+    # so a previously-cached `success` status doesn't outlive its evidence.
+    types: [created, edited, deleted]
 
 permissions:
   contents: read
@@ -111,6 +113,16 @@ jobs:
           NEXT_VERSION: ${{ steps.preview.outputs.next }}
         run: |
           set -e
+          # Guard: when release_type=major, the analyzer must also have
+          # produced a real `next` version. An empty or literal "null"
+          # value here would degenerate the matcher regex into something
+          # that matches almost every comment (empty case) or any comment
+          # containing the word "null". Fail loud instead of silently
+          # passing the gate.
+          if [ -z "$NEXT_VERSION" ] || [ "$NEXT_VERSION" = "null" ]; then
+            echo "::error::release_type=major but next version is empty or null; aborting signoff check."
+            exit 1
+          fi
           # Escape dots in the version so the bash regex literal-matches
           # them. NEXT_VERSION looks like "6.0.0"; an unescaped dot would
           # match any single char.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ This project follows idiomatic Swift conventions as outlined in [Swift API Desig
   - `docs`, `style`, `refactor`, `test`, `build`, `ci`, `chore`, `revert` → **no release**
   - Any commit with `!` after the type/scope, **or** a `BREAKING CHANGE:` footer → **major** bump (e.g. `5.2.2` → `6.0.0`)
 
-  > **PRs that introduce a breaking change require an explicit human signoff before merge.** When any commit on the PR carries a `BREAKING CHANGE:` footer or a `!` after the type/scope, the `major-release-signoff` status check blocks merging until any repo collaborator with `write` (or higher) permission posts a single comment containing the verbatim acknowledgment phrase from the bot's blocking comment, the precise next version (e.g. `v6.0.0`), and a 🚀. See [RELEASING.md → Major Release Signoff](./RELEASING.md#major-release-signoff) for the exact comment format.
+  > **PRs that introduce a breaking change require an explicit human signoff before merge.** When any commit on the PR carries a `BREAKING CHANGE:` footer or a `!` after the type/scope, the `major-release-signoff` status check blocks merging until a *different* write-access collaborator (not the PR author) posts a single comment containing the verbatim affirmation phrase from the bot's blocking comment, the precise next version (e.g. `v6.0.0`), and a 🚀. See [RELEASING.md → Major Release Signoff](./RELEASING.md#major-release-signoff) for the exact comment format.
 
   **Examples (annotated with the bump each one would trigger):**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,8 @@ This project follows idiomatic Swift conventions as outlined in [Swift API Desig
   - `docs`, `style`, `refactor`, `test`, `build`, `ci`, `chore`, `revert` → **no release**
   - Any commit with `!` after the type/scope, **or** a `BREAKING CHANGE:` footer → **major** bump (e.g. `5.2.2` → `6.0.0`)
 
+  > **PRs that introduce a breaking change require an explicit human signoff before merge.** When any commit on the PR carries a `BREAKING CHANGE:` footer or a `!` after the type/scope, the `major-release-signoff` status check blocks merging until any repo collaborator with `write` (or higher) permission posts a single comment containing the verbatim acknowledgment phrase from the bot's blocking comment, the precise next version (e.g. `v6.0.0`), and a 🚀. See [RELEASING.md → Major Release Signoff](./RELEASING.md#major-release-signoff) for the exact comment format.
+
   **Examples (annotated with the bump each one would trigger):**
 
   ```text

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,6 +36,35 @@ This split exists because `semantic-release`'s lifecycle tightly couples computa
    - Publishes all four pods to CocoaPods trunk in dependency order.
    - Creates a follow-up commit **Y** that restores `SDKVersion.swift` to `"Dev"` on `main`, so subsequent dev/CI builds don't report a stale released version. The tag stays at **X** (which is reachable from `main` via Y → X).
 
+## Major Release Signoff
+
+PRs that **introduce a breaking change** are gated by a required PR status check named `major-release-signoff`. The check runs on every PR via `.github/workflows/major-release-signoff.yml` and is a no-op for any PR that doesn't introduce a breaking change (i.e. anything the analyzer scores as `patch`, `minor`, or no bump).
+
+A "breaking change" is detected the same way `@semantic-release/commit-analyzer` detects it — either a `BREAKING CHANGE:` body/footer token on any commit, or a `!` after the conventional-commit type (`feat!:`, `fix!:`, etc.). When that's present, the analyzer scores the PR as a major bump, and this check posts a blocking comment and stays in a `failure` state until any repo collaborator with `write`, `maintain`, or `admin` permission posts a single comment containing **all three** of:
+
+1. The verbatim acknowledgment phrase:
+
+   > Please respond with the precise version number to be released and add the :rocket: emojii BOTH in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides
+
+2. The precise next version string (e.g. `v6.0.0` or `6.0.0`), and
+3. A 🚀 (`:rocket:`) emoji.
+
+A copy-paste-ready example (assuming the next version is `6.0.0`):
+
+```
+Please respond with the precise version number to be released and add the :rocket: emojii BOTH in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides
+
+v6.0.0 🚀
+```
+
+The matcher normalizes whitespace and strips Markdown blockquote markers (`>`), so using GitHub's "Quote reply" button on the bot's blocking comment also satisfies item (1) as long as the version and 🚀 are added in the same reply.
+
+The check re-runs automatically when a qualifying comment is posted or edited; once it sees a comment from a write-access collaborator containing both tokens, it flips to `success` and merging is unblocked. The approver's comment lives in PR history as the audit record — no extra log is required.
+
+Permission is verified via `GET /repos/{owner}/{repo}/collaborators/{username}/permission` against the workflow-default `GITHUB_TOKEN`, so signoff authorization piggybacks on the same access list GitHub already uses for merge permissions — no separate allowlist file or org-scoped token to keep in sync.
+
+If the PR doesn't actually contain a breaking change (e.g. the trigger is prose accidentally matching the `BREAKING CHANGE` token), the fix is in the commit messages, not the signoff: reword the offending commit subject/body so the analyzer no longer detects a breaking change (see the `Commit Lint` PR comment for which commit triggered it), force-push, and the gate will go green on its own.
+
 ## Required GitHub Configuration
 
 ### GitHub Secrets
@@ -84,6 +113,7 @@ The `main` branch ruleset requires pull requests, but the release workflow needs
 1. Go to `https://github.com/youversion/platform-sdk-swift/settings/rules`
 2. Edit the ruleset for `main`
 3. Under "Bypass list", ensure "Deploy keys" is enabled
+4. Under "Require status checks to pass", add `major-release-signoff` to the required checks list so the gate actually blocks merges on major PRs (without this the workflow runs but the failure won't block the merge button).
 
 ## Local Testing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -40,11 +40,11 @@ This split exists because `semantic-release`'s lifecycle tightly couples computa
 
 PRs that **introduce a breaking change** are gated by a required PR status check named `major-release-signoff`. The check runs on every PR via `.github/workflows/major-release-signoff.yml` and is a no-op for any PR that doesn't introduce a breaking change (i.e. anything the analyzer scores as `patch`, `minor`, or no bump).
 
-A "breaking change" is detected the same way `@semantic-release/commit-analyzer` detects it — either a `BREAKING CHANGE:` body/footer token on any commit, or a `!` after the conventional-commit type (`feat!:`, `fix!:`, etc.). When that's present, the analyzer scores the PR as a major bump, and this check posts a blocking comment and stays in a `failure` state until any repo collaborator with `write`, `maintain`, or `admin` permission posts a single comment containing **all three** of:
+A "breaking change" is detected the same way `@semantic-release/commit-analyzer` detects it — either a `BREAKING CHANGE:` body/footer token on any commit, or a `!` after the conventional-commit type (`feat!:`, `fix!:`, etc.). When that's present, the analyzer scores the PR as a major bump, and this check posts a blocking comment and stays in a `failure` state until any repo collaborator with `write`, `maintain`, or `admin` permission (and who is **not** the PR author) posts a single comment containing **all three (3) of the following:**
 
-1. The verbatim acknowledgment phrase:
+1. The verbatim affirmation phrase:
 
-   > Please respond with the precise version number to be released and add the :rocket: emoji in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides
+   > I confirm that this is an intentional breaking change, and I have read the release procedures. I understand and have documented its impact upon release.
 
 2. The precise next version string (e.g. `v6.0.0` or `6.0.0`), and
 3. A 🚀 (`:rocket:`) emoji.
@@ -52,12 +52,12 @@ A "breaking change" is detected the same way `@semantic-release/commit-analyzer`
 A copy-paste-ready example (assuming the next version is `6.0.0`):
 
 ```
-Please respond with the precise version number to be released and add the :rocket: emoji in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides
+I confirm that this is an intentional breaking change, and I have read the release procedures. I understand and have documented its impact upon release.
 
 v6.0.0 🚀
 ```
 
-The matcher normalizes whitespace and strips Markdown blockquote markers (`>`), so using GitHub's "Quote reply" button on the bot's blocking comment also satisfies item (1) as long as the version and 🚀 are added in the same reply.
+The matcher normalizes whitespace and strips Markdown blockquote markers (`>`), so using GitHub's "Quote reply" button on the bot's blocking comment also satisfies item (1) as long as the version and 🚀 are added in the same reply. The PR author is excluded — signoff has to come from a *different* write-access collaborator, so the gate guarantees a second pair of eyes.
 
 The check re-runs automatically when a qualifying comment is posted or edited; once it sees a comment from a write-access collaborator containing both tokens, it flips to `success` and merging is unblocked. The approver's comment lives in PR history as the audit record — no extra log is required.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,7 +44,7 @@ A "breaking change" is detected the same way `@semantic-release/commit-analyzer`
 
 1. The verbatim acknowledgment phrase:
 
-   > Please respond with the precise version number to be released and add the :rocket: emojii BOTH in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides
+   > Please respond with the precise version number to be released and add the :rocket: emoji in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides
 
 2. The precise next version string (e.g. `v6.0.0` or `6.0.0`), and
 3. A 🚀 (`:rocket:`) emoji.
@@ -52,7 +52,7 @@ A "breaking change" is detected the same way `@semantic-release/commit-analyzer`
 A copy-paste-ready example (assuming the next version is `6.0.0`):
 
 ```
-Please respond with the precise version number to be released and add the :rocket: emojii BOTH in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides
+Please respond with the precise version number to be released and add the :rocket: emoji in order to continue merging. For more information about how releases are calculated, read our CONTRIBUTING and RELEASING guides
 
 v6.0.0 🚀
 ```


### PR DESCRIPTION
Closes YPE-2521. Re-opens #143 as a same-repo PR so the workflow's `GITHUB_TOKEN` isn't demoted to read-only.

Adds a `major-release-signoff` required PR status check that blocks merging when the analyzer detects a breaking change (a `BREAKING CHANGE` footer or a `!` after the type/scope). The check passes once a write-access collaborator (not the PR author) posts a comment containing the verbatim acknowledgment phrase, the precise next version, and a 🚀.

Note on the acknowledgment phrase: the AC's template had `:rocket: emojii BOTH` fixed to `:rocket: emoji` here. Please update the Notion ticket so the sibling Kotlin / React / RN ports match.

**Follow-up (admin):** add `major-release-signoff` to the required status checks list in the `main` ruleset without that step the workflow runs but the failure won't actually block the merge button.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `major-release-signoff` required status check that gates PRs with breaking changes behind an explicit human approval. When the analyzer scores a PR as a major bump, the workflow blocks merging until a write-access collaborator (not the PR author) posts a comment containing the verbatim affirmation phrase, the precise next version, and a 🚀 — then flips the status to success.

- New `.github/workflows/major-release-signoff.yml` (304 lines): drives the full gate — PR context resolution, release-type analysis via the shared `preview-release.mjs` script, comment scanning with permission verification, and commit status posting; already incorporates the `null`/empty `next` guard and the `issue_comment:deleted` trigger from previous review feedback.
- `commit-lint.yml` updated to surface the signoff requirement in its existing major-bump warning block.
- `CONTRIBUTING.md` and `RELEASING.md` updated with the signoff mechanics, exact comment format, and the follow-up admin step to add `major-release-signoff` to the `main` ruleset's required status checks.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the gate logic is correct and the two gaps are cosmetic/edge-case UX rather than anything that would let a breaking change slip through unreviewed.

The core signoff check — version guard, permission lookup, author-exclusion, bot-exclusion, and status posting — all work correctly. The two gaps found are: the blocking comment is not updated to reflect approval (stale UI wording, not a gate bypass), and the blocking comment is not re-posted on issue_comment events when manually deleted (recovers on next push). Neither gap defeats the gate itself.

`.github/workflows/major-release-signoff.yml` — the success path around the 'Post success status when signoff present' step is the only area worth a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/major-release-signoff.yml | New 304-line workflow implementing the major-release-signoff gate; logic is sound overall, but the success path lacks a step to update/remove the stale blocking comment, and the upsert is skipped on issue_comment events even when the comment was manually deleted. |
| .github/workflows/commit-lint.yml | Adds two lines in the major-bump warning block pointing users to the new signoff requirement and RELEASING.md; straightforward and accurate. |
| CONTRIBUTING.md | Adds a callout block under the breaking-change commit type section directing contributors to the signoff requirement; clear and correct. |
| RELEASING.md | Adds a 'Major Release Signoff' section documenting the gate mechanics, the exact comment format, permission model, and the follow-up admin step; thorough and consistent with the workflow implementation. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Trigger: pull_request or issue_comment] --> B{Is PR event?}
    B -- No: issue_comment --> C[Fetch PR context via gh API]
    B -- Yes: pull_request --> D[Use payload context]
    C & D --> E[Checkout PR head and run preview-release.mjs]
    E --> F{is_major == 1?}
    F -- No --> G[POST commit status: success]
    F -- Yes --> H{NEXT_VERSION empty or null?}
    H -- Yes --> I[exit 1 - fail loud]
    H -- No --> J[Scan PR comments for valid signoff]
    J --> K{Matching comment from write-access non-author?}
    K -- Yes --> L[POST commit status: success - Signed off]
    K -- No --> M{event == pull_request?}
    M -- Yes --> N[Upsert blocking comment]
    M -- No --> O[Skip comment upsert]
    N & O --> P[POST commit status: failure]
    P --> Q[exit 1]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fmajor-release-signoff.yml%3A217-231%0A**Blocking%20comment%20stays%20%22signoff%20required%22%20after%20approval**%0A%0AWhen%20a%20valid%20signoff%20is%20found%20and%20the%20success%20status%20is%20posted%20%28lines%20217-231%29%2C%20there%20is%20no%20corresponding%20step%20that%20updates%20or%20removes%20the%20bot's%20blocking%20comment.%20The%20result%20is%20that%20the%20PR%20timeline%20permanently%20shows%20%22%F0%9F%9A%A8%20Breaking%20change%20detected%20%E2%80%94%20signoff%20required%20for%20%60vX.Y.Z%60%22%20alongside%20a%20green%20status%20check%20%E2%80%94%20a%20visible%20contradiction%20that%20will%20confuse%20anyone%20reading%20the%20thread%20later.%20Adding%20a%20step%20in%20the%20%60signed_off%20%3D%3D%20'1'%60%20path%20to%20PATCH%20the%20marker%20comment%20body%20%28e.g.%20replacing%20it%20with%20%22%E2%9C%85%20Signoff%20received%20from%20%40%7Bapprover%7D%22%29%20would%20keep%20the%20timeline%20coherent%20and%20still%20preserve%20the%20audit%20trail.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fmajor-release-signoff.yml%3A233-234%0A**Blocking%20comment%20not%20re-posted%20when%20triggered%20by%20%60issue_comment%60%20and%20comment%20was%20manually%20deleted**%0A%0AThe%20upsert%20step%20is%20gated%20to%20%60github.event_name%20%3D%3D%20'pull_request'%60%2C%20so%20it%20is%20intentionally%20skipped%20on%20comment%20events.%20This%20is%20fine%20in%20the%20happy%20path%20because%20the%20original%20blocking%20comment%20is%20still%20there.%20However%2C%20if%20a%20user%20manually%20deletes%20the%20bot's%20blocking%20comment%20and%20then%20the%20%60issue_comment%3Adeleted%60%20trigger%20fires%20%28from%20a%20deleted%20signoff%29%2C%20the%20failure%20status%20is%20correctly%20re-posted%20but%20the%20blocking%20comment%20with%20copy-paste%20instructions%20is%20gone%20and%20won't%20be%20re-created%20until%20the%20next%20push.%20Dropping%20the%20%60%26%26%20github.event_name%20%3D%3D%20'pull_request'%60%20guard%20%28so%20the%20upsert%20also%20runs%20on%20comment%20events%20when%20signoff%20is%20missing%29%20would%20close%20this%20gap%20without%20adding%20comment%20spam%2C%20since%20the%20step%20already%20de-duplicates%20via%20the%20marker.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=144&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fmajor-release-signoff.yml%3A217-231%0A**Blocking%20comment%20stays%20%22signoff%20required%22%20after%20approval**%0A%0AWhen%20a%20valid%20signoff%20is%20found%20and%20the%20success%20status%20is%20posted%20%28lines%20217-231%29%2C%20there%20is%20no%20corresponding%20step%20that%20updates%20or%20removes%20the%20bot's%20blocking%20comment.%20The%20result%20is%20that%20the%20PR%20timeline%20permanently%20shows%20%22%F0%9F%9A%A8%20Breaking%20change%20detected%20%E2%80%94%20signoff%20required%20for%20%60vX.Y.Z%60%22%20alongside%20a%20green%20status%20check%20%E2%80%94%20a%20visible%20contradiction%20that%20will%20confuse%20anyone%20reading%20the%20thread%20later.%20Adding%20a%20step%20in%20the%20%60signed_off%20%3D%3D%20'1'%60%20path%20to%20PATCH%20the%20marker%20comment%20body%20%28e.g.%20replacing%20it%20with%20%22%E2%9C%85%20Signoff%20received%20from%20%40%7Bapprover%7D%22%29%20would%20keep%20the%20timeline%20coherent%20and%20still%20preserve%20the%20audit%20trail.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fmajor-release-signoff.yml%3A233-234%0A**Blocking%20comment%20not%20re-posted%20when%20triggered%20by%20%60issue_comment%60%20and%20comment%20was%20manually%20deleted**%0A%0AThe%20upsert%20step%20is%20gated%20to%20%60github.event_name%20%3D%3D%20'pull_request'%60%2C%20so%20it%20is%20intentionally%20skipped%20on%20comment%20events.%20This%20is%20fine%20in%20the%20happy%20path%20because%20the%20original%20blocking%20comment%20is%20still%20there.%20However%2C%20if%20a%20user%20manually%20deletes%20the%20bot's%20blocking%20comment%20and%20then%20the%20%60issue_comment%3Adeleted%60%20trigger%20fires%20%28from%20a%20deleted%20signoff%29%2C%20the%20failure%20status%20is%20correctly%20re-posted%20but%20the%20blocking%20comment%20with%20copy-paste%20instructions%20is%20gone%20and%20won't%20be%20re-created%20until%20the%20next%20push.%20Dropping%20the%20%60%26%26%20github.event_name%20%3D%3D%20'pull_request'%60%20guard%20%28so%20the%20upsert%20also%20runs%20on%20comment%20events%20when%20signoff%20is%20missing%29%20would%20close%20this%20gap%20without%20adding%20comment%20spam%2C%20since%20the%20step%20already%20de-duplicates%20via%20the%20marker.%0A%0A&pr=144&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/major-release-signoff.yml:217-231
**Blocking comment stays "signoff required" after approval**

When a valid signoff is found and the success status is posted (lines 217-231), there is no corresponding step that updates or removes the bot's blocking comment. The result is that the PR timeline permanently shows "🚨 Breaking change detected — signoff required for `vX.Y.Z`" alongside a green status check — a visible contradiction that will confuse anyone reading the thread later. Adding a step in the `signed_off == '1'` path to PATCH the marker comment body (e.g. replacing it with "✅ Signoff received from @{approver}") would keep the timeline coherent and still preserve the audit trail.

### Issue 2 of 2
.github/workflows/major-release-signoff.yml:233-234
**Blocking comment not re-posted when triggered by `issue_comment` and comment was manually deleted**

The upsert step is gated to `github.event_name == 'pull_request'`, so it is intentionally skipped on comment events. This is fine in the happy path because the original blocking comment is still there. However, if a user manually deletes the bot's blocking comment and then the `issue_comment:deleted` trigger fires (from a deleted signoff), the failure status is correctly re-posted but the blocking comment with copy-paste instructions is gone and won't be re-created until the next push. Dropping the `&& github.event_name == 'pull_request'` guard (so the upsert also runs on comment events when signoff is missing) would close this gap without adding comment spam, since the step already de-duplicates via the marker.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ci): rephrase signoff affirmation an..."](https://github.com/youversion/platform-sdk-swift/commit/b7e3356694ea111b6055e397198011c6d8d20483) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34618026)</sub>

<!-- /greptile_comment -->