### PR TITLE
chore(ci): complete and document manual release procedure (YPE-2684)

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -43,8 +43,18 @@ jobs:
         id: commitlint
         run: |
           set +e
+          # Use `origin/<base ref>` as the lint range's lower bound, not
+          # `pull_request.base.sha`. `base.sha` is a snapshot of the base
+          # ref at PR-event time and goes stale: if commits land on the
+          # base branch after the PR's last sync (e.g. a release), they
+          # appear inside `base.sha..head.sha` when the PR pulls them in
+          # via merge, and the lint then flags commits that already
+          # passed on the base. `origin/<base ref>` is always current
+          # main on the runner (`fetch-depth: 0` above), so the range
+          # `origin/main..head.sha` is exactly "commits in this PR that
+          # are not yet on main" — what we actually want to lint.
           npx commitlint \
-            --from "${{ github.event.pull_request.base.sha }}" \
+            --from "origin/${{ github.event.pull_request.base.ref }}" \
             --to "${{ github.event.pull_request.head.sha }}" \
             --verbose > commitlint.log 2>&1
           STATUS=$?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,13 +117,15 @@ When writing or reviewing code in this repo, load the relevant skill:
 
 Releases are **manually triggered with an explicit version input** via `workflow_dispatch`. There is no auto-release on merges to `main`. Merging to `main` only lands code; a human decides when to cut a release and which version to ship.
 
-The release pipeline does not invoke `semantic-release` as an orchestrator. We use `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` as ESM libraries (via `scripts/preview-release.mjs` and `scripts/generate-release-notes.mjs`), and `scripts/release.sh` orchestrates the rest. See [RELEASING.md](./RELEASING.md) for the full operator guide.
+The release pipeline does not invoke `semantic-release` as an orchestrator. We use `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` as ESM libraries (via `scripts/preview-release.mjs` and `scripts/generate-release-notes.mjs`), and `scripts/release.sh` orchestrates the rest. See [RELEASING.md](./RELEASING.md) for the full operator guide and [RELEASE-RUNBOOK.md](./RELEASE-RUNBOOK.md) for failure recovery.
 
 To dispatch a release:
 ```bash
 gh workflow run release.yml -f version=5.3.0
 # add -f dry-run=true to validate the workflow without shipping
 ```
+
+If a dispatched release fails partway, **re-dispatch with the same version**. `release.sh` detects the existing tag on origin and resumes — push, GitHub release create, pod publish, and Dev-restore each skip already-completed work. Per-pod `pod trunk push` also retries once on transient trunk failures (e.g. trunk's "Calling the GitHub commit API timed out") before giving up. See [RELEASE-RUNBOOK.md](./RELEASE-RUNBOOK.md) for the symptom catalogue.
 
 Two pieces of state get version-bumped: the four `.podspec` files, and the `SDKVersion` constant used by the `x-yvp-sdk` HTTP header. They live in the same commit X but the SDKVersion handling has a twist.
 

--- a/RELEASE-RUNBOOK.md
+++ b/RELEASE-RUNBOOK.md
@@ -1,0 +1,200 @@
+# Release Runbook
+
+When a dispatched release fails partway, this runbook is the single place to look up the symptom, confirm the actual state, and run the right recovery. It assumes you've read [RELEASING.md](./RELEASING.md) for the normal happy-path flow.
+
+## Recovery cheat sheet
+
+For most partial failures, the answer is **re-dispatch `release.yml` with the same version**. `scripts/release.sh` detects when tag `$VERSION` already exists on origin and enters resume mode: it checks out the tag, regenerates the release notes, and runs the remaining steps idempotently. Each step (`git push`, `gh release create`, `pod trunk push`, Dev-restore) detects already-completed work and skips it.
+
+```bash
+gh workflow run release.yml -f version=<the same version that just failed>
+```
+
+The exceptions — where you should _not_ just re-dispatch — are listed under "When re-dispatch is unsafe" at the bottom.
+
+## State to check before recovering
+
+Run these commands on a fresh clone (or `cd` into the repo and `git fetch --tags origin`):
+
+```bash
+VERSION=<the version>
+
+# Tag on origin?
+git ls-remote origin "refs/tags/$VERSION"
+
+# Local main HEAD: X (release commit) or Y (Dev-restore)?
+git log origin/main -2 --format='%h %s'
+
+# Pods on trunk?
+for p in YouVersionPlatformCore YouVersionPlatformUI YouVersionPlatformReader YouVersionPlatform; do
+  echo "== $p =="
+  pod trunk info "$p" 2>/dev/null | grep -E "^[[:space:]]+- $VERSION " || echo "  NOT on trunk"
+done
+
+# GitHub release exists?
+gh release view "$VERSION" --json name,tagName,createdAt 2>/dev/null || echo "  NO release"
+```
+
+The four signals — `tag on origin?`, `main HEAD = X or Y?`, `pods on trunk?`, `release exists?` — uniquely identify which phase the original run reached.
+
+---
+
+## Failure modes
+
+### 1. `pod trunk push` fails with "Calling the GitHub commit API timed out"
+
+**Symptom.** During `publish-pods.sh`, one of the four `pod trunk push` calls exits non-zero after several minutes with `[!] Calling the GitHub commit API timed out`. Trunk's xcodebuild validation succeeded; trunk's internal call to GitHub's commit API timed out.
+
+**Example.** [Workflow run 26537791362](https://github.com/youversion/platform-sdk-swift/actions/runs/26537791362) for 5.2.3 (2026-05-27). Got to step 1/4 (Core), trunk validated, then GitHub API timeout.
+
+**State check.** `pod trunk info <Pod>` will either show the version (trunk accepted before the timeout — partial success) or not show it (trunk never recorded the publish). Both are possible from the same error.
+
+**Recovery.** Re-dispatch `release.yml -f version=$VERSION`. Resume mode engages, the per-pod `pod_already_published` check skips anything trunk did record, and `publish-pods.sh` retries the failed pod once with a 30s backoff before continuing. If both attempts on the same pod fail, the script exits — re-dispatch again (the second dispatch's already-published check will recognise anything that did land in the meantime).
+
+**Expected end state.** All four pods at `$VERSION` on trunk; main HEAD = Y (Dev-restore).
+
+---
+
+### 2. Partial pod publish (some pods on trunk, others not)
+
+**Symptom.** `pod trunk info` shows `$VERSION` for some pods but not others. Can result from #1, from CDN-propagation lag between dependent pushes, or from any other mid-publish failure.
+
+**State check.** `pod trunk info` for each of Core, UI, Reader, Platform.
+
+**Recovery.** Re-dispatch `release.yml -f version=$VERSION`. Published pods are skipped via `pod trunk info`; missing pods are pushed in dependency order.
+
+Alternative if you don't want the rest of the release pipeline to re-run (e.g. you want to skip Dev-restore): dispatch `manual-pod-publish.yml -f version=$VERSION -f restore_dev=false`. That workflow only runs `publish-pods.sh`.
+
+**Expected end state.** All four pods at `$VERSION` on trunk.
+
+---
+
+### 3. `release.sh` aborted after `git push` but before pod publish
+
+**Symptom.** Tag and main are pushed (commit X is on origin/main, tag `$VERSION` is on origin), GitHub release may or may not exist, but no pods are on trunk. The original workflow failed in `gh release create` or before `publish-pods.sh`.
+
+**State check.** `git ls-remote origin refs/tags/$VERSION` non-empty; `gh release view $VERSION`; `pod trunk info`.
+
+**Recovery.** Re-dispatch `release.yml -f version=$VERSION`. Tag push skipped (already on origin), GH release created or skipped (idempotent), pods published, Dev-restore runs.
+
+**Expected end state.** All four pods at `$VERSION` on trunk; main HEAD = Y.
+
+---
+
+### 4. `release.sh` aborted after pod publish but before Y commit
+
+**Symptom.** All four pods at `$VERSION` on trunk, but main HEAD is still X (SDKVersion reads `$VERSION`, not `"Dev"`). Original failure was inside `restore-dev-sdk-on-main.sh` — most likely the `git push origin HEAD:main` for Y was rejected (race with an unrelated commit), or the stamping logic hit a file-system error.
+
+**State check.** `git log origin/main -1 --format='%s'` reads `chore(release): $VERSION [skip ci]` (X), not `chore(release): restore SDKVersion to Dev after $VERSION [skip ci]` (Y). `pod trunk info` shows all four pods at `$VERSION`.
+
+**Recovery.** Re-dispatch `release.yml -f version=$VERSION`. All earlier steps are no-ops; `restore-dev-sdk-on-main.sh` runs and creates Y.
+
+**Expected end state.** main HEAD = Y with SDKVersion reading `"Dev"`.
+
+---
+
+### 5. Y push fails because main diverged
+
+**Symptom.** Same as #4, but the Dev-restore script aborts with a non-fast-forward push error because someone landed an unrelated commit on `main` between the X push and the Y push.
+
+**State check.** `git log origin/main -5 --format='%h %s'` — you'll see X then an unrelated commit on top of it. No Y yet.
+
+**Recovery.** Re-dispatch `release.yml -f version=$VERSION`. Resume mode now finds origin/main has advanced past X, skips the main push, fetches the latest main, and lets `restore-dev-sdk-on-main.sh` create Y on top of the new main HEAD. If that push also fails (yet another commit landed), repeat.
+
+If repeated divergence is making this loop, drain the inbox or pause merges to main for a few minutes, then re-dispatch.
+
+**Expected end state.** main HEAD = Y on top of the latest main (which now includes the unrelated commit and X is reachable via the new Y → previous main HEAD → X path).
+
+---
+
+### 6. `gh release create` fails after tag is pushed
+
+**Symptom.** Tag is on origin, main is on origin, no GitHub release on the Releases page, the workflow log shows `gh release create` failed (rate limit, transient API error, token scope).
+
+**State check.** `gh release view $VERSION` returns non-zero. `git ls-remote origin refs/tags/$VERSION` non-empty.
+
+**Recovery.** Re-dispatch `release.yml -f version=$VERSION`. The idempotent `if gh release view ... else create` block creates the release using regenerated notes. The rest of the pipeline continues.
+
+**Expected end state.** GitHub release `$VERSION` visible on the Releases page; pods on trunk; main HEAD = Y.
+
+---
+
+### 7. Tag exists on origin but the tree doesn't match `$VERSION` (rogue tag)
+
+**Symptom.** Re-dispatched `release.yml` exits with:
+
+```
+❌ Tag $VERSION exists but its tree's SDKVersion.swift does not read "$VERSION".
+```
+
+Or the equivalent for a podspec. This means someone created or moved the tag manually, or the tag is a leftover from a different process.
+
+**State check.** `git show refs/tags/$VERSION:Sources/YouVersionPlatformCore/SDKVersion.swift | grep current` and the four podspecs. The values won't match `$VERSION`.
+
+**Recovery.** **Do not auto-heal.** Decide deliberately:
+
+- If the rogue tag is a true mistake (e.g. test tag named after a real version), delete it: `git push origin --delete $VERSION`, also delete any GitHub release attached to it, then dispatch `release.yml -f version=$VERSION` fresh.
+- If the rogue tag points at a legitimate release commit that just isn't in the expected format (e.g. an older release scheme), don't reuse this VERSION at all — bump to the next semver and dispatch that.
+
+**Expected end state.** Either fresh-shipped at `$VERSION` (if you deleted the rogue tag) or shipped at a new version.
+
+---
+
+### 8. Wrong VERSION input (less than current, invalid semver)
+
+**Symptom.** `release.sh` exits during validation with `'X' is not valid semver` or `'X' is not strictly greater than current tag 'Y'`. This is _not_ a recovery scenario — it's a pre-flight catch.
+
+**State check.** None needed. Workflow log shows the exit reason.
+
+**Recovery.** Dispatch with a valid, strictly-greater semver.
+
+(Note: if the version you typed _equals_ the current tag, the script enters resume mode rather than failing. The "not strictly greater" check is suppressed in resume mode because re-dispatching with the same version is the resume gesture.)
+
+---
+
+### 9. Trunk session expired (`COCOAPODS_TRUNK_TOKEN` invalid)
+
+**Symptom.** `publish-pods.sh` fails on the first attempt with `Authentication token` or `not authorized`. The retry policy classifies these as hard-fail and does not retry.
+
+**State check.** Run `pod trunk me` with the token to confirm: `COCOAPODS_TRUNK_TOKEN=<token> pod trunk me`. If it says the token is invalid or expired, that's the cause.
+
+**Recovery.**
+
+1. Regenerate a trunk session token (locally, with a privileged trunk account): `pod trunk register support@youversion.com 'CI' --description='CI release token'`. Confirm the email, then `pod trunk me --verbose` shows the token in `~/.netrc`.
+2. Update the repo's `COCOAPODS_TRUNK_TOKEN` secret with the new value.
+3. Re-dispatch `release.yml -f version=$VERSION`. Resume mode picks up where it left off.
+
+**Expected end state.** Pods publish; release completes.
+
+---
+
+### 10. SSH push key rejected
+
+**Symptom.** Workflow fails on `git push origin HEAD:main` or `git push origin $VERSION` with permission denied. Usually means the deploy key was rotated, removed, or had write access disabled.
+
+**State check.** `https://github.com/youversion/platform-sdk-swift/settings/keys` — the deploy key matching the `RELEASE_SSH_KEY` secret should be listed with write access.
+
+**Recovery.**
+
+1. Generate a new SSH key pair (see [RELEASING.md → RELEASE_SSH_KEY](./RELEASING.md#1-release_ssh_key)).
+2. Add the public key as a Deploy Key with write access.
+3. Update the `RELEASE_SSH_KEY` secret with the new private key.
+4. Re-dispatch `release.yml -f version=$VERSION`. If the tag was already pushed before the failure, resume mode picks up; otherwise this runs as fresh.
+
+**Expected end state.** Pushes succeed; release completes.
+
+---
+
+## When re-dispatch is unsafe
+
+Re-dispatching `release.yml -f version=$VERSION` is the standard recovery for almost everything. Don't re-dispatch when:
+
+- The original failure was a **rogue tag** (#7): re-dispatch will exit immediately with a tag-content-mismatch error. Resolve the tag first.
+- The original failure was **wrong input** (#8): dispatch with a corrected version, not the wrong one.
+- You need to **change what's being released** (different commits, different notes): the tag is immutable from the release's perspective. Cut a new version.
+
+For everything else, re-dispatching is the right answer. The script's idempotency checks will skip whatever already succeeded.
+
+## Emergency: release by hand without the workflow
+
+If the workflow itself is broken (e.g. GitHub Actions outage, runner pool exhausted), `scripts/release.sh` can be invoked locally with the same environment variables. See [RELEASING.md → Need an emergency release without the workflow](./RELEASING.md#need-an-emergency-release-without-the-workflow).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -163,6 +163,8 @@ Pods are published in dependency order by `scripts/publish-pods.sh`:
 
 ## Troubleshooting
 
+For failure-by-failure recovery (trunk-API timeout, partial pod publish, post-push abort, diverged Dev-restore, rogue tag, expired trunk session, rejected SSH key) see [RELEASE-RUNBOOK.md](./RELEASE-RUNBOOK.md). The short version: **for almost every partial failure, re-dispatch `release.yml` with the same version**. `release.sh` detects when the tag already exists on origin and enters resume mode, replaying only the steps that didn't complete.
+
 ### The Commit Lint preview shows a major bump on a "patch" PR
 
 `conventional-commits-parser` treats `BREAKING CHANGE` at the start of any commit body line as a breaking-change footer, regardless of surrounding markdown or quotes. The most common cause: a long commit body wraps and a paragraph happens to start with that token. Reword the offending line on your branch.
@@ -171,32 +173,7 @@ The analyzer log in the PR comment's `<details>` block shows which commit trigge
 
 ### The release dispatch is rejected with "is not strictly greater than current tag"
 
-`release.sh` refuses to ship a version less than or equal to the latest tag. If you genuinely need to re-tag (e.g., recovering from a partial release), delete the old tag from origin first, then dispatch again.
-
-### CocoaPods publish failed midway
-
-The script is idempotent via `pod trunk info`. Re-dispatch with the same version; the already-published pods will be skipped and the missing ones retried. If `pod trunk info` itself is unreliable, check `pod trunk me` to confirm authentication.
-
-### The release script aborted after pushing the tag — main is stamped with the released version
-
-If `release.sh` dies in any of the post-push steps (`gh release create`, `publish-pods.sh`, `restore-dev-sdk-on-main.sh`), `main` HEAD is commit **X** with `SDKVersion.swift` reading the released version, and commit **Y** was never created. Re-running `release.sh` won't recover — its pre-flight requires `SDKVersion.swift` to read `"Dev"` and will refuse to proceed.
-
-Finish the release by running the remaining steps manually:
-
-```bash
-VERSION=<the version that was being released>
-
-# If the GitHub release wasn't created (check the Releases page):
-gh release create "$VERSION" --notes-file notes.md --title "$VERSION"
-
-# Idempotent via `pod trunk info` — safe regardless of how far the script got:
-bash scripts/publish-pods.sh "$VERSION"
-
-# Creates commit Y and restores SDKVersion to "Dev":
-bash scripts/restore-dev-sdk-on-main.sh "$VERSION"
-```
-
-`notes.md` is left in place when the script aborts (the success-path `rm` doesn't fire), so it's available for the `gh release create` call. Verify with `git log -2 --oneline` (Y on top of X) and `pod trunk info YouVersionPlatformCore` (latest matches `$VERSION`).
+`release.sh` refuses to ship a version less than or equal to the latest tag — except when you're dispatching the **same** version that's already tagged on origin, which is the resume gesture and is allowed. If you typed the wrong version, dispatch with a corrected one.
 
 ### Need an emergency release without the workflow
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,13 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
+  // Release commits (`chore(release): X.Y.Z [skip ci]`) carry the generated
+  // release-notes body, which routinely contains lines > 100 chars (URLs,
+  // embedded prior-commit bodies) and `* ` bullet lines the parser treats
+  // as footer entries. They're already on `main` by the time any PR sees
+  // them, so they don't need re-validation. Skip them outright as a
+  // belt-and-suspenders alongside the workflow's `origin/<base>..head`
+  // range, which already excludes them in the normal case.
+  ignores: [(message) => /^chore\(release\): \d+\.\d+\.\d+/.test(message)],
   rules: {
     "body-max-line-length": [2, "always", 300],
     "type-enum": [

--- a/scripts/publish-pods.sh
+++ b/scripts/publish-pods.sh
@@ -23,14 +23,79 @@ pod_already_published() {
     | grep -Eq "^[[:space:]]+- ${escaped} \("
 }
 
-publish_pod() {
+# Wraps `pod trunk push` in a bounded retry loop.
+#
+# Why retry at all: trunk's "Calling the GitHub commit API timed out" failure
+# (workflow run 26537791362, 2026-05-27) is upstream weather. The trunk service
+# accepts the spec, then calls GitHub to commit the change to the Specs repo;
+# if that call times out, the whole `pod trunk push` exits non-zero — sometimes
+# after trunk has actually accepted, sometimes before.
+#
+# Why only 2 attempts: each `pod trunk push` runs trunk-side xcodebuild (~9–18
+# min). Three attempts can blow past the 6h job ceiling once all four pods are
+# stacked. Two attempts plus safe-re-dispatch (release.sh resume mode) is the
+# correct division — the workflow is the outer retry loop.
+#
+# Why pre-check `pod_already_published` on every iteration: partial-success.
+# Trunk may have accepted before the GH-API call failed, so the second attempt
+# could otherwise re-upload (and trunk would reject as duplicate, masking the
+# real success).
+publish_pod_with_retry() {
   local pod_name="$1"
   local podspec="$2"
-  if pod_already_published "$pod_name" "$VERSION"; then
-    echo "  ✓ $pod_name $VERSION already on trunk — skipping"
-    return 0
-  fi
-  pod trunk push "$podspec" --allow-warnings --synchronous
+  local max_attempts=2
+  local attempt=1
+  local out
+  while [ "$attempt" -le "$max_attempts" ]; do
+    if pod_already_published "$pod_name" "$VERSION"; then
+      echo "  ✓ $pod_name $VERSION on trunk (attempt $attempt) — skipping"
+      return 0
+    fi
+
+    out=$(mktemp)
+    # Don't let pipefail kill us before we read $out — we want to inspect the
+    # exit code ourselves so we can classify transient vs hard failure.
+    set +e
+    pod trunk push "$podspec" --allow-warnings --synchronous 2>&1 | tee "$out"
+    local push_status=${PIPESTATUS[0]}
+    set -e
+
+    if [ "$push_status" -eq 0 ]; then
+      rm -f "$out"
+      return 0
+    fi
+
+    # Trunk may have accepted the spec before the GH-API call timed out.
+    # Re-check before classifying as failure.
+    if pod_already_published "$pod_name" "$VERSION"; then
+      echo "  ✓ $pod_name $VERSION on trunk despite non-zero exit (attempt $attempt)"
+      rm -f "$out"
+      return 0
+    fi
+
+    # Hard-fail signatures — auth, validation, bad spec. No point retrying.
+    if grep -qE "Authentication token|not authorized|invalid podspec|^\[!\] The .* validator|ERROR \|" "$out"; then
+      echo "  ✗ $pod_name: non-retryable failure on attempt $attempt"
+      rm -f "$out"
+      return 1
+    fi
+
+    # Transient signatures — upstream timeout, network blip, 5xx.
+    if [ "$attempt" -lt "$max_attempts" ] && \
+       grep -qE "timed out|timeout|50[234]|temporarily unavailable|Could not resolve host|Connection reset|RPC failed" "$out"; then
+      echo "  ⚠ $pod_name: transient trunk failure on attempt $attempt — sleeping 30s and retrying"
+      sleep 30
+      rm -f "$out"
+      attempt=$((attempt + 1))
+      continue
+    fi
+
+    # Unclassified failure — don't retry blind. Surface the output to the log.
+    echo "  ✗ $pod_name: unclassified failure on attempt $attempt"
+    rm -f "$out"
+    return 1
+  done
+  return 1
 }
 
 echo "Publishing version $VERSION to CocoaPods trunk..."
@@ -38,19 +103,19 @@ echo "IMPORTANT: Pods will be published in dependency order; already-published v
 
 echo ""
 echo "Step 1/4: YouVersionPlatformCore"
-publish_pod YouVersionPlatformCore YouVersionPlatformCore.podspec
+publish_pod_with_retry YouVersionPlatformCore YouVersionPlatformCore.podspec
 
 echo ""
 echo "Step 2/4: YouVersionPlatformUI"
-publish_pod YouVersionPlatformUI YouVersionPlatformUI.podspec
+publish_pod_with_retry YouVersionPlatformUI YouVersionPlatformUI.podspec
 
 echo ""
 echo "Step 3/4: YouVersionPlatformReader"
-publish_pod YouVersionPlatformReader YouVersionPlatformReader.podspec
+publish_pod_with_retry YouVersionPlatformReader YouVersionPlatformReader.podspec
 
 echo ""
 echo "Step 4/4: YouVersionPlatform"
-publish_pod YouVersionPlatform YouVersionPlatform.podspec
+publish_pod_with_retry YouVersionPlatform YouVersionPlatform.podspec
 
 echo ""
 echo "✅ Pod version $VERSION is on trunk."

--- a/scripts/publish-pods.sh
+++ b/scripts/publish-pods.sh
@@ -81,13 +81,18 @@ publish_pod_with_retry() {
     fi
 
     # Transient signatures — upstream timeout, network blip, 5xx.
-    if [ "$attempt" -lt "$max_attempts" ] && \
-       grep -qE "timed out|timeout|50[234]|temporarily unavailable|Could not resolve host|Connection reset|RPC failed" "$out"; then
-      echo "  ⚠ $pod_name: transient trunk failure on attempt $attempt — sleeping 30s and retrying"
-      sleep 30
-      rm -f "$out"
-      attempt=$((attempt + 1))
-      continue
+    if grep -qE "timed out|timeout|50[234]|temporarily unavailable|Could not resolve host|Connection reset|RPC failed" "$out"; then
+      if [ "$attempt" -lt "$max_attempts" ]; then
+        echo "  ⚠ $pod_name: transient trunk failure on attempt $attempt — sleeping 30s and retrying"
+        sleep 30
+        rm -f "$out"
+        attempt=$((attempt + 1))
+        continue
+      else
+        echo "  ✗ $pod_name: transient trunk failure on attempt $attempt — max attempts reached"
+        rm -f "$out"
+        return 1
+      fi
     fi
 
     # Unclassified failure — don't retry blind. Surface the output to the log.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,7 +15,7 @@
 #   analyzer's value is logged side-by-side for audit, but the human's
 #   input wins.
 #
-# Pre-conditions when this runs (most enforced by the workflow):
+# Fresh-run pre-conditions (enforced below):
 # - VERSION env var: the chosen target version.
 # - HEAD = origin/main HEAD.
 # - SDKVersion.swift reads "Dev".
@@ -24,6 +24,14 @@
 # - SSH remote configured for push.
 # - GH_TOKEN (or GITHUB_TOKEN) exported for `gh release create`.
 # - COCOAPODS_TRUNK_TOKEN exported for pod publish.
+#
+# Resume mode (auto-detected): if tag $VERSION already exists on origin
+# with a tree that has SDKVersion + all four podspecs stamped to $VERSION,
+# the script treats this as a re-dispatch after a prior partial run. It
+# checks out the tag, regenerates the release notes, and proceeds to the
+# idempotent post-tag steps (push, GitHub release, pod publish, Dev-restore),
+# each of which detects and skips already-completed work. See
+# RELEASE-RUNBOOK.md for failure-mode-by-failure-mode recovery details.
 #
 # Post-conditions on success:
 # - Tag $VERSION points at commit X (chore(release) commit stamping
@@ -59,13 +67,23 @@ echo "Chosen version: $VERSION"
 VALIDATION_CODE=0
 node scripts/release-validate.mjs "$VERSION" "$CURRENT_TAG" || VALIDATION_CODE=$?
 
+# In resume mode, $VERSION will equal $CURRENT_TAG (the tag already exists),
+# which release-validate.mjs rejects with code 12 ("not strictly greater").
+# Detect resume *before* failing on that, so re-dispatch with the same
+# version recovers a partial run instead of exiting.
+REMOTE_TAG_SHA=$(git ls-remote origin "refs/tags/$VERSION" 2>/dev/null | awk '{print $1}')
+RESUME=0
+if [ -n "$REMOTE_TAG_SHA" ]; then
+  RESUME=1
+fi
+
 if [ "$VALIDATION_CODE" -eq 11 ]; then
   echo "❌ '$VERSION' is not valid semver" >&2
   exit 1
-elif [ "$VALIDATION_CODE" -eq 12 ]; then
+elif [ "$VALIDATION_CODE" -eq 12 ] && [ "$RESUME" = "0" ]; then
   echo "❌ '$VERSION' is not strictly greater than current tag '$CURRENT_TAG'" >&2
   exit 1
-elif [ "$VALIDATION_CODE" -ne 0 ]; then
+elif [ "$VALIDATION_CODE" -ne 0 ] && [ "$VALIDATION_CODE" -ne 12 ]; then
   echo "❌ Version validation failed (exit $VALIDATION_CODE)" >&2
   exit 1
 fi
@@ -89,73 +107,152 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo "| Current tag       | \`$CURRENT_TAG\`   |"
     echo "| Analyzer-computed | \`$CALCULATED\` ($CALC_TYPE) |"
     echo "| Chosen (input)    | **\`$VERSION\`**   |"
+    if [ "$RESUME" = "1" ]; then
+      echo
+      echo "> 🔁 **Resume mode** — tag \`$VERSION\` already exists on origin. Will skip already-completed phases."
+    fi
     if [ "$DRY_RUN" = "1" ]; then
       echo
-      echo "> 🧪 **DRY_RUN=1** — workflow will build commit X + tag locally, then stop. No push, no GitHub release, no pod publish."
+      echo "> 🧪 **DRY_RUN=1** — workflow will stop before push/publish/restore."
     fi
   } >> "$GITHUB_STEP_SUMMARY"
 fi
 
 # Warn (don't block) if chosen version is more than one major above calculated.
-node scripts/release-warn-version-jump.mjs "$VERSION" "$CALCULATED" >&2 || true
-
-# --- Pre-flight -------------------------------------------------------------
-
-if ! grep -q 'static let current = "Dev"' Sources/YouVersionPlatformCore/SDKVersion.swift; then
-  echo "❌ SDKVersion.swift does not currently read \"Dev\" — main is in an unexpected state" >&2
-  echo "   Current: $(grep 'static let current' Sources/YouVersionPlatformCore/SDKVersion.swift | head -1)" >&2
-  exit 1
+# Skip the warning in resume mode — the decision was made on the original run.
+if [ "$RESUME" = "0" ]; then
+  node scripts/release-warn-version-jump.mjs "$VERSION" "$CALCULATED" >&2 || true
 fi
 
-if ! git diff --quiet || ! git diff --cached --quiet; then
-  echo "❌ Working tree is dirty — aborting" >&2
-  git status --short >&2
-  exit 1
-fi
+# --- Resume-mode setup ------------------------------------------------------
+#
+# When tag $VERSION already exists on origin, verify the tag's tree matches
+# what a normal release would have produced, then check the tag out so HEAD
+# is the X commit regardless of where origin/main currently points.
+#
+# Why content-verify the tag: a rogue or mismatched tag (different content,
+# moved by hand, leftover from a different process) must abort, not silently
+# heal. Healing the wrong tag would push unrelated work to consumers.
+#
+# Why also overlay scripts/ from origin/main: the tag predates this resume
+# logic. If we ran publish-pods.sh from the tagged tree, we'd lose the
+# retry-with-backoff and partial-success handling that's only present in the
+# current scripts. The same trick that manual-pod-publish.yml uses.
 
-# Guard against a non-main dispatch landing feature-branch commits on
-# main. `gh workflow run release.yml --ref feature-branch` would pass
-# every other pre-flight, and `git push origin HEAD:main` would then
-# bypass branch protection via the deploy key. Dry-runs are explicitly
-# supported on any branch (no push fires), so we skip this guard for them.
-if [ "$DRY_RUN" != "1" ]; then
-  HEAD_SHA=$(git rev-parse HEAD)
-  MAIN_SHA=$(git rev-parse origin/main 2>/dev/null || echo "")
-  if [ -z "$MAIN_SHA" ]; then
-    echo "❌ origin/main ref not found locally — workflow checkout must use fetch-depth: 0" >&2
+if [ "$RESUME" = "1" ]; then
+  echo
+  echo "🔁 Resume mode: tag $VERSION already exists on origin at $REMOTE_TAG_SHA."
+
+  # Make sure the tag is in the local refs (workflow checkout fetches tags,
+  # but local dev runs may not).
+  if ! git rev-parse "refs/tags/$VERSION^{}" >/dev/null 2>&1; then
+    git fetch origin "refs/tags/$VERSION:refs/tags/$VERSION"
+  fi
+
+  TAG_SDK_LINE=$(git show "refs/tags/$VERSION:Sources/YouVersionPlatformCore/SDKVersion.swift" 2>/dev/null \
+    | grep 'static let current' | head -1 || echo "")
+  if ! echo "$TAG_SDK_LINE" | grep -qF "static let current = \"$VERSION\""; then
+    echo "❌ Tag $VERSION exists but its tree's SDKVersion.swift does not read \"$VERSION\"." >&2
+    echo "   Found: $TAG_SDK_LINE" >&2
+    echo "   Refusing to resume against a tag whose content does not match. See RELEASE-RUNBOOK.md." >&2
     exit 1
   fi
-  if [ "$HEAD_SHA" != "$MAIN_SHA" ]; then
-    echo "❌ HEAD ($HEAD_SHA) is not at origin/main ($MAIN_SHA)" >&2
-    echo "   Live releases must be dispatched on the main branch. Re-run with --ref main." >&2
+  for PODSPEC in YouVersionPlatform YouVersionPlatformCore YouVersionPlatformReader YouVersionPlatformUI; do
+    if ! git show "refs/tags/$VERSION:${PODSPEC}.podspec" 2>/dev/null \
+      | grep -qF "s.version      = '$VERSION'"; then
+      echo "❌ Tag $VERSION exists but ${PODSPEC}.podspec does not read $VERSION." >&2
+      echo "   Refusing to resume against a tag whose content does not match. See RELEASE-RUNBOOK.md." >&2
+      exit 1
+    fi
+  done
+  echo "  ✓ Tag $VERSION content matches (SDKVersion + 4 podspecs all stamped to $VERSION)."
+
+  # Detach onto the tag so all post-tag steps operate from X.
+  git checkout --detach "refs/tags/$VERSION"
+
+  # Replace scripts/ with origin/main's copy so we pick up post-tag fixes
+  # (retry-with-backoff, idempotency checks, etc.) when re-running.
+  git fetch origin main 2>/dev/null || true
+  if git rev-parse --verify origin/main >/dev/null 2>&1; then
+    git checkout origin/main -- scripts/
+    echo "  ✓ Overlaid scripts/ from origin/main so resume uses the latest publish logic."
+  fi
+
+  # Regenerate notes using the same commit range the original run used.
+  # Using --head $VERSION (the tag) is intentional: commits that landed on
+  # main after X must not leak into this release's body.
+  PREV_TAG=$(git describe --tags --abbrev=0 "refs/tags/$VERSION^" 2>/dev/null || echo "")
+  if [ -z "$PREV_TAG" ]; then
+    echo "❌ Could not derive previous tag (parent of $VERSION)." >&2
     exit 1
   fi
+  echo "  Regenerating release notes for $VERSION (from $PREV_TAG)..."
+  node scripts/generate-release-notes.mjs \
+    --base "$PREV_TAG" \
+    --head "$VERSION" \
+    --version "$VERSION" \
+    > notes.md
+  echo "  Notes: $(wc -l < notes.md | tr -d ' ') lines."
 fi
 
-if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
-  # Workflow checks out with fetch-depth: 0, so this also catches tags
-  # already on origin — the local clone has every remote tag.
-  echo "❌ Tag $VERSION already exists (in local refs, which include everything fetched from origin)" >&2
-  exit 1
-fi
+# --- Fresh-run pre-flight + commit-X build ---------------------------------
 
-# --- Generate release notes -------------------------------------------------
+if [ "$RESUME" = "0" ]; then
+  if ! grep -q 'static let current = "Dev"' Sources/YouVersionPlatformCore/SDKVersion.swift; then
+    echo "❌ SDKVersion.swift does not currently read \"Dev\" — main is in an unexpected state" >&2
+    echo "   Current: $(grep 'static let current' Sources/YouVersionPlatformCore/SDKVersion.swift | head -1)" >&2
+    exit 1
+  fi
 
-echo
-echo "Generating release notes..."
-node scripts/generate-release-notes.mjs \
-  --base "$CURRENT_TAG" \
-  --head HEAD \
-  --version "$VERSION" \
-  > notes.md
-echo "Notes: $(wc -l < notes.md | tr -d ' ') lines."
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "❌ Working tree is dirty — aborting" >&2
+    git status --short >&2
+    exit 1
+  fi
 
-# --- Update CHANGELOG.md ----------------------------------------------------
+  # Guard against a non-main dispatch landing feature-branch commits on
+  # main. `gh workflow run release.yml --ref feature-branch` would pass
+  # every other pre-flight, and `git push origin HEAD:main` would then
+  # bypass branch protection via the deploy key. Dry-runs are explicitly
+  # supported on any branch (no push fires), so we skip this guard for them.
+  if [ "$DRY_RUN" != "1" ]; then
+    HEAD_SHA_CHECK=$(git rev-parse HEAD)
+    MAIN_SHA_CHECK=$(git rev-parse origin/main 2>/dev/null || echo "")
+    if [ -z "$MAIN_SHA_CHECK" ]; then
+      echo "❌ origin/main ref not found locally — workflow checkout must use fetch-depth: 0" >&2
+      exit 1
+    fi
+    if [ "$HEAD_SHA_CHECK" != "$MAIN_SHA_CHECK" ]; then
+      echo "❌ HEAD ($HEAD_SHA_CHECK) is not at origin/main ($MAIN_SHA_CHECK)" >&2
+      echo "   Live releases must be dispatched on the main branch. Re-run with --ref main." >&2
+      exit 1
+    fi
+  fi
 
-if [ -f CHANGELOG.md ]; then
-  # Preserve title + intro; prepend the new entry above the first existing
-  # version heading. If no existing version heading, append.
-  node - <<'NODE'
+  # Tag-already-exists is only a fresh-run failure. Resume mode requires it.
+  if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
+    echo "❌ Tag $VERSION already exists locally but not on origin — refusing to fresh-run." >&2
+    echo "   If you intended to resume, push the tag first or delete it locally." >&2
+    exit 1
+  fi
+
+  # --- Generate release notes -----------------------------------------------
+
+  echo
+  echo "Generating release notes..."
+  node scripts/generate-release-notes.mjs \
+    --base "$CURRENT_TAG" \
+    --head HEAD \
+    --version "$VERSION" \
+    > notes.md
+  echo "Notes: $(wc -l < notes.md | tr -d ' ') lines."
+
+  # --- Update CHANGELOG.md --------------------------------------------------
+
+  if [ -f CHANGELOG.md ]; then
+    # Preserve title + intro; prepend the new entry above the first existing
+    # version heading. If no existing version heading, append.
+    node - <<'NODE'
 const fs = require('fs');
 const notes = fs.readFileSync('notes.md', 'utf8').trimEnd() + '\n\n';
 const existing = fs.readFileSync('CHANGELOG.md', 'utf8');
@@ -168,73 +265,132 @@ if (m) {
 }
 fs.writeFileSync('CHANGELOG.md', out);
 NODE
+  else
+    printf '# Changelog\n\nAll notable changes to this project will be documented in this file.\n\n' > CHANGELOG.md
+    cat notes.md >> CHANGELOG.md
+  fi
+  echo "CHANGELOG.md updated."
+
+  # --- Stamp version into source files --------------------------------------
+
+  bash scripts/update-pod-versions.sh "$VERSION"
+  bash scripts/stamp-sdk-version.sh "$VERSION"
+
+  # --- Build X commit -------------------------------------------------------
+
+  git add \
+    CHANGELOG.md \
+    Sources/YouVersionPlatformCore/SDKVersion.swift \
+    YouVersionPlatform.podspec \
+    YouVersionPlatformCore.podspec \
+    YouVersionPlatformReader.podspec \
+    YouVersionPlatformUI.podspec
+
+  # Subject + blank + notes body. [skip ci] prevents push-triggered workflows
+  # from re-running on the release commit.
+  {
+    printf 'chore(release): %s [skip ci]\n\n' "$VERSION"
+    cat notes.md
+  } > .git/COMMIT_EDITMSG
+  git commit -F .git/COMMIT_EDITMSG
+
+  X_SHA=$(git rev-parse HEAD)
+  echo "Commit X created at $X_SHA."
+
+  # --- Tag X --------------------------------------------------------------
+
+  git tag "$VERSION"
+  echo "Tag $VERSION created at $X_SHA."
 else
-  printf '# Changelog\n\nAll notable changes to this project will be documented in this file.\n\n' > CHANGELOG.md
-  cat notes.md >> CHANGELOG.md
+  X_SHA=$(git rev-parse HEAD)
+  echo "  ✓ Using existing tag $VERSION at $X_SHA as commit X."
 fi
-echo "CHANGELOG.md updated."
 
-# --- Stamp version into source files ----------------------------------------
-
-bash scripts/update-pod-versions.sh "$VERSION"
-bash scripts/stamp-sdk-version.sh "$VERSION"
-
-# --- Build X commit ---------------------------------------------------------
-
-git add \
-  CHANGELOG.md \
-  Sources/YouVersionPlatformCore/SDKVersion.swift \
-  YouVersionPlatform.podspec \
-  YouVersionPlatformCore.podspec \
-  YouVersionPlatformReader.podspec \
-  YouVersionPlatformUI.podspec
-
-# Subject + blank + notes body. [skip ci] prevents push-triggered workflows
-# from re-running on the release commit.
-{
-  printf 'chore(release): %s [skip ci]\n\n' "$VERSION"
-  cat notes.md
-} > .git/COMMIT_EDITMSG
-git commit -F .git/COMMIT_EDITMSG
-
-X_SHA=$(git rev-parse HEAD)
-echo "Commit X created at $X_SHA."
-
-# --- Tag X ------------------------------------------------------------------
-
-git tag "$VERSION"
-echo "Tag $VERSION created at $X_SHA."
+# --- Dry-run exit (both modes) ---------------------------------------------
 
 if [ "$DRY_RUN" = "1" ]; then
   echo
-  echo "DRY_RUN=1 — stopping before push, GitHub release, pod publish, and Dev restore."
-  echo "Inspect locally:"
-  echo "  git log -1"
-  echo "  git tag -l '$VERSION'"
-  echo "  cat notes.md"
+  if [ "$RESUME" = "1" ]; then
+    echo "DRY_RUN=1 (resume mode) — stopping before push, GitHub release, pod publish, and Dev restore."
+    echo "Inspect locally:"
+    echo "  cat notes.md"
+    echo "  git log -1 $VERSION"
+  else
+    echo "DRY_RUN=1 — stopping before push, GitHub release, pod publish, and Dev restore."
+    echo "Inspect locally:"
+    echo "  git log -1"
+    echo "  git tag -l '$VERSION'"
+    echo "  cat notes.md"
+  fi
   exit 0
 fi
 
-# --- Push main + tag --------------------------------------------------------
+# --- Push main + tag (idempotent) ------------------------------------------
 
 echo
 echo "Pushing main and tag $VERSION..."
-git push origin HEAD:main
-git push origin "$VERSION"
 
-# --- Create GitHub release --------------------------------------------------
+# Refresh remote-tracking refs so the comparison below is accurate.
+git fetch origin main 2>/dev/null || true
+ORIGIN_MAIN_SHA=$(git rev-parse origin/main 2>/dev/null || echo "")
+
+if [ "$RESUME" = "0" ]; then
+  # Fresh run: X is local, push it.
+  git push origin HEAD:main
+elif [ "$ORIGIN_MAIN_SHA" = "$X_SHA" ]; then
+  echo "  ✓ origin/main already at $X_SHA — skipping main push."
+elif [ -n "$ORIGIN_MAIN_SHA" ] && git merge-base --is-ancestor "$X_SHA" "$ORIGIN_MAIN_SHA" 2>/dev/null; then
+  # Resume after a successful X-push where Y or unrelated commits subsequently
+  # landed on main. Don't try to re-push HEAD:main from a detached tag head;
+  # the Dev-restore step handles the main-branch case.
+  echo "  ✓ origin/main has advanced past X (likely Y already created) — skipping main push."
+else
+  echo "❌ Resume mode: tag $VERSION at $X_SHA is not reachable from origin/main ($ORIGIN_MAIN_SHA)." >&2
+  echo "   Refusing to push from a detached state that doesn't descend from main. See RELEASE-RUNBOOK.md." >&2
+  exit 1
+fi
+
+REMOTE_TAG_NOW=$(git ls-remote origin "refs/tags/$VERSION" 2>/dev/null | awk '{print $1}')
+if [ -z "$REMOTE_TAG_NOW" ]; then
+  git push origin "$VERSION"
+elif [ "$REMOTE_TAG_NOW" = "$X_SHA" ]; then
+  echo "  ✓ Tag $VERSION already at $X_SHA on origin — skipping tag push."
+else
+  echo "❌ Tag $VERSION on origin points at $REMOTE_TAG_NOW, but local X is $X_SHA." >&2
+  echo "   Refusing to force-update tags. See RELEASE-RUNBOOK.md." >&2
+  exit 1
+fi
+
+# --- Create GitHub release (idempotent) ------------------------------------
 
 echo
-echo "Creating GitHub release..."
-gh release create "$VERSION" --notes-file notes.md --title "$VERSION"
+if gh release view "$VERSION" >/dev/null 2>&1; then
+  echo "GitHub release $VERSION already exists — leaving as-is."
+else
+  echo "Creating GitHub release..."
+  gh release create "$VERSION" --notes-file notes.md --title "$VERSION"
+fi
 
-# --- Publish pods -----------------------------------------------------------
+# --- Publish pods (idempotent per-pod + retry on transient failures) -------
 
 echo
 echo "Publishing pods..."
 bash scripts/publish-pods.sh "$VERSION"
 
-# --- Restore Dev on main (Y commit) -----------------------------------------
+# --- Restore Dev on main (Y commit) ----------------------------------------
+#
+# In resume mode HEAD is detached at the tag, but Dev-restore must commit
+# on top of origin/main. Switch to main first.
+
+if [ "$RESUME" = "1" ]; then
+  echo
+  echo "Resume: checking out main before Dev-restore..."
+  git fetch origin main
+  # -B re-creates main from origin/main (in CI this is a fresh branch; in
+  # local re-runs it resets any local main to origin/main, which is what
+  # we want — no stale local diverge).
+  git checkout -B main origin/main
+fi
 
 echo
 echo "Restoring SDKVersion to Dev on main..."

--- a/scripts/restore-dev-sdk-on-main.sh
+++ b/scripts/restore-dev-sdk-on-main.sh
@@ -46,6 +46,35 @@ fi
 
 cd "$(dirname "$0")/.."
 
+# --- Already-restored fast path ---------------------------------------------
+#
+# When release.sh re-runs against an in-flight $VERSION (resume mode), this
+# script may be called after a previous run already created the Y commit and
+# pushed it. Detect that exact state and exit 0 — otherwise the strict
+# pre-flights below (which expect HEAD=X with SDKVersion=$VERSION) would
+# refuse to proceed and block recovery.
+#
+# Required state to recognize "Y already present":
+#   - HEAD's SDKVersion.swift reads "Dev"
+#   - HEAD~1 is the tag $VERSION's commit (i.e. X)
+#   - HEAD~1's SDKVersion.swift reads "$VERSION"
+#
+# All three together rule out look-alike states (a Dev commit that isn't our
+# Y; an HEAD~1 that happens to match the tag by coincidence in a non-release
+# context).
+if grep -qF 'static let current = "Dev"' Sources/YouVersionPlatformCore/SDKVersion.swift; then
+  TAG_SHA_FOR_IDEMP=$(git rev-parse "refs/tags/$VERSION^{}" 2>/dev/null || echo "")
+  HEAD_PARENT_SHA=$(git rev-parse HEAD~1 2>/dev/null || echo "")
+  if [ -n "$TAG_SHA_FOR_IDEMP" ] && [ "$TAG_SHA_FOR_IDEMP" = "$HEAD_PARENT_SHA" ]; then
+    PARENT_SDK_LINE=$(git show "HEAD~1:Sources/YouVersionPlatformCore/SDKVersion.swift" 2>/dev/null \
+      | grep 'static let current' | head -1 || echo "")
+    if echo "$PARENT_SDK_LINE" | grep -qF "static let current = \"$VERSION\""; then
+      echo "✓ Dev-restore commit Y for $VERSION already present at HEAD — nothing to do."
+      exit 0
+    fi
+  fi
+fi
+
 # --- Pre-flight assertions ---------------------------------------------------
 
 # 1. SDKVersion at HEAD must read $VERSION. If not, prepareCmd is

--- a/scripts/restore-dev-sdk-on-main.sh
+++ b/scripts/restore-dev-sdk-on-main.sh
@@ -58,19 +58,21 @@ cd "$(dirname "$0")/.."
 #
 # Required state to recognize "Y already present":
 #   - HEAD's SDKVersion.swift reads "Dev"
-#   - HEAD~1 is the tag $VERSION's commit (i.e. X)
-#   - HEAD~1's SDKVersion.swift reads "$VERSION"
+#   - Tag $VERSION is reachable from HEAD (ancestor-or-equal)
+#   - Tag $VERSION's own tree has SDKVersion reading "$VERSION"
 #
-# All three together rule out look-alike states (a Dev commit that isn't our
-# Y; an HEAD~1 that happens to match the tag by coincidence in a non-release
-# context).
+# Using an ancestor check (not strict HEAD~1 equality) covers both the normal
+# topology (Y directly on X) and the diverged-main topology (Y on C on X,
+# Failure Mode #5), where HEAD~1 is C — not X — and the strict parent check
+# would incorrectly miss the already-restored state.
 if grep -qF 'static let current = "Dev"' Sources/YouVersionPlatformCore/SDKVersion.swift; then
   TAG_SHA_FOR_IDEMP=$(git rev-parse "refs/tags/$VERSION^{}" 2>/dev/null || echo "")
-  HEAD_PARENT_SHA=$(git rev-parse HEAD~1 2>/dev/null || echo "")
-  if [ -n "$TAG_SHA_FOR_IDEMP" ] && [ "$TAG_SHA_FOR_IDEMP" = "$HEAD_PARENT_SHA" ]; then
-    PARENT_SDK_LINE=$(git show "HEAD~1:Sources/YouVersionPlatformCore/SDKVersion.swift" 2>/dev/null \
+  HEAD_SHA_FOR_IDEMP=$(git rev-parse HEAD 2>/dev/null || echo "")
+  if [ -n "$TAG_SHA_FOR_IDEMP" ] && [ -n "$HEAD_SHA_FOR_IDEMP" ] && \
+     git merge-base --is-ancestor "$TAG_SHA_FOR_IDEMP" "$HEAD_SHA_FOR_IDEMP" 2>/dev/null; then
+    TAG_SDK_LINE_IDEMP=$(git show "refs/tags/$VERSION:Sources/YouVersionPlatformCore/SDKVersion.swift" 2>/dev/null \
       | grep 'static let current' | head -1 || echo "")
-    if echo "$PARENT_SDK_LINE" | grep -qF "static let current = \"$VERSION\""; then
+    if echo "$TAG_SDK_LINE_IDEMP" | grep -qF "static let current = \"$VERSION\""; then
       echo "✓ Dev-restore commit Y for $VERSION already present at HEAD — nothing to do."
       exit 0
     fi

--- a/scripts/restore-dev-sdk-on-main.sh
+++ b/scripts/restore-dev-sdk-on-main.sh
@@ -26,10 +26,12 @@
 # Y on top of X here.
 #
 # Pre-conditions when this script runs:
-# - HEAD is X (semantic-release's release commit, just pushed to main).
+# - HEAD is X, or (in release.sh resume mode where main diverged after X was
+#   pushed) a descendant of X — i.e. tag $VERSION must be reachable from HEAD.
 # - SDKVersion.swift at HEAD reads "$VERSION" (set by prepareCmd's
-#   stamp-sdk-version.sh invocation).
-# - Tag $VERSION exists locally and on origin, pointing at HEAD.
+#   stamp-sdk-version.sh invocation; descendant commits should not be touching
+#   SDKVersion.swift, so it still reads the version stamped at X).
+# - Tag $VERSION exists locally and on origin, reachable from HEAD.
 #
 # Post-conditions on success:
 # - main HEAD = Y, with SDKVersion.swift = "Dev".
@@ -88,15 +90,22 @@ if ! grep -qF "$EXPECTED_LINE" Sources/YouVersionPlatformCore/SDKVersion.swift; 
   exit 1
 fi
 
-# 2. Tag $VERSION must exist and point at HEAD. semantic-release creates and
-#    pushes the tag between prepare and publish; if it didn't (or pointed
-#    elsewhere), our topology assumption is broken.
+# 2. Tag $VERSION must exist and be reachable from HEAD. The release script
+#    creates and pushes the tag at X between prepare and publish; if it
+#    didn't (or pointed somewhere disjoint), our topology assumption is
+#    broken.
 #
 #    Use refs/tags/$VERSION^{} to dereference to the target commit. This is
-#    a no-op for lightweight tags (which is what semantic-release creates
-#    today) but correctly resolves annotated tags to their commit SHA, so
-#    the comparison stays valid if any plugin or upstream change starts
+#    a no-op for lightweight tags (which is what we create today) but
+#    correctly resolves annotated tags to their commit SHA, so the
+#    reachability check stays valid if any plugin or upstream change starts
 #    producing annotated tags.
+#
+#    Reachability (ancestor-or-equal), not strict equality: in release.sh
+#    resume mode after a diverged-main failure (RELEASE-RUNBOOK.md Failure
+#    Mode #5), HEAD is origin/main = C — an unrelated commit on top of X,
+#    not X itself. The resulting topology X → C → Y is still valid (tag
+#    stays at X; X is reachable from main via Y → C → X).
 TAG_SHA=$(git rev-parse "refs/tags/$VERSION^{}" 2>/dev/null || echo "")
 HEAD_SHA=$(git rev-parse HEAD)
 if [ -z "$TAG_SHA" ]; then
@@ -104,9 +113,9 @@ if [ -z "$TAG_SHA" ]; then
   echo "   semantic-release should have created it before invoking this script." >&2
   exit 1
 fi
-if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
-  echo "❌ Tag $VERSION points at $TAG_SHA but HEAD is $HEAD_SHA." >&2
-  echo "   Aborting before pushing Dev-restore — this would leave the tag and main out of sync." >&2
+if ! git merge-base --is-ancestor "$TAG_SHA" "$HEAD_SHA"; then
+  echo "❌ Tag $VERSION at $TAG_SHA is not reachable from HEAD ($HEAD_SHA)." >&2
+  echo "   Aborting before pushing Dev-restore — the tag and main would end up disjoint." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Hardens the manual release pipeline against the failure mode that left 5.2.3 stuck mid-flight ([run 26537791362](https://github.com/youversion/platform-sdk-swift/actions/runs/26537791362)), and lands the new failure-mode runbook + commit-lint hygiene fixes.

Two commits:

1. **`chore(ci): resume-on-re-dispatch + retry, failure-mode runbook`** — resumable `scripts/release.sh` (detects existing tag on origin, regenerates notes, runs only the unfinished phases), 2-attempt retry-with-backoff in `scripts/publish-pods.sh` around the trunk → GitHub-API timeout, idempotent `scripts/restore-dev-sdk-on-main.sh`, new top-level `RELEASE-RUNBOOK.md`, and corresponding trims to `RELEASING.md` + a note in `AGENTS.md`.
2. **`chore(ci): exclude already-on-main commits from PR lint range, ignore release commits`** — `commit-lint.yml` now uses `origin/<base ref>..head.sha` instead of the stale `pull_request.base.sha`, and `commitlint.config.js` adds an `ignores` predicate so any `chore(release): X.Y.Z` subject is skipped even if it slips into a PR's range via off-main merge paths.

After merge, recovery of the in-flight 5.2.3 release is one command: `gh workflow run release.yml -f version=5.2.3 --ref main`. The script's resume mode picks up where 5.2.3 stopped — pushes already done, GitHub release already exists, publish-pods.sh fills the four-pod gap on trunk, restore-dev-sdk-on-main.sh creates Y.

## Test plan

- [x] CI green on this PR (commit-lint now using the corrected range; if you re-trigger PR #142's lint after this lands and that branch is rebased, the 5.2.3 release commit no longer appears in the lint range)
- [ ] After merge: `gh workflow run release.yml -f version=5.2.3 --ref main`
- [ ] Confirm `pod trunk info` shows 5.2.3 for all four pods (Core, UI, Reader, Platform)
- [ ] Confirm `git log origin/main -2 --pretty='%h %s'` shows the new Y commit on top of X (`0521554`)
- [ ] Confirm SDKVersion on origin/main reads "Dev"
- [ ] Spot-check `RELEASE-RUNBOOK.md` rendering on the merged commit's GitHub page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the manual release pipeline against the partial-run failure that stranded the 5.2.3 release mid-flight. It adds a resumable `release.sh` (auto-detects an existing origin tag and replays only the unfinished phases), a per-pod 2-attempt retry with backoff in `publish-pods.sh`, an idempotent `restore-dev-sdk-on-main.sh` with a topology-aware fast path, a new `RELEASE-RUNBOOK.md` covering 10 distinct failure modes, and a commit-lint range/ignore fix.

- **`scripts/release.sh`**: Resume mode is auto-detected when `$VERSION` already exists on origin; after content-verifying the tag, it checks out the tagged commit, overlays `scripts/` from `origin/main` so the latest retry logic is always used, and runs all post-tag steps idempotently.
- **`scripts/restore-dev-sdk-on-main.sh`**: Both the already-restored fast path and pre-flight #2 now use `git merge-base --is-ancestor` instead of strict SHA equality, correctly handling the diverged-main topology (Failure Mode #5) where `HEAD` is an unrelated commit C sitting on top of X.
- **`scripts/publish-pods.sh` / `.github/workflows/commit-lint.yml` / `commitlint.config.js`**: Per-pod retry with transient/hard-fail classification; commitlint range fixed to `origin/<base ref>` with a belt-and-suspenders `ignores` predicate for release commits.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed code paths are well-guarded and the two issues flagged in the previous review round are correctly resolved.

The resume mode in release.sh is carefully defensive: it content-verifies the tag before proceeding, detaches to the tagged commit, overlays the latest scripts from origin/main, and handles every documented mid-flight topology. restore-dev-sdk-on-main.sh now uses ancestor-reachability checks in both the idempotency fast path and pre-flight #2, covering the diverged-main case that was previously a blocker. publish-pods.sh's retry loop correctly captures PIPESTATUS[0] under set +e, re-checks pod_already_published after each non-zero exit, and separates hard-fail from transient signatures before deciding whether to retry.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/release.sh | Large refactor adding resume mode: tag detection, content verification, scripts overlay, notes regeneration, and idempotent push/release/pod/restore steps. Logic is thorough and handles all documented failure topologies. |
| scripts/restore-dev-sdk-on-main.sh | Adds an idempotency fast path and relaxes pre-flight #2 from strict SHA equality to git merge-base --is-ancestor, correctly covering both normal (Y→X) and diverged-main (Y→C→X) topologies. Both previously flagged P1s are resolved here. |
| scripts/publish-pods.sh | publish_pod replaced with publish_pod_with_retry: 2-attempt loop with pre-check, set+e PIPESTATUS capture, post-exit pod_already_published re-check, and hard/transient/unclassified failure classification. Correct use of PIPESTATUS[0] after set +e guards. |
| .github/workflows/commit-lint.yml | Switches commitlint --from from the stale pull_request.base.sha snapshot to origin/<base ref>, ensuring the lint range reflects the live state of main on the runner rather than a potentially outdated SHA. |
| commitlint.config.js | Adds an ignores predicate matching chore(release): X.Y.Z subjects so release commits that slip into a PR's lint range via off-main merge paths are skipped outright. |
| RELEASE-RUNBOOK.md | New 200-line runbook covering 10 failure modes with state-check commands, recovery steps, and expected end states. Comprehensive and well-structured. |
| RELEASING.md | Removes now-superseded manual recovery instructions (pointing readers to RELEASE-RUNBOOK.md) and updates the 'is not strictly greater' note to reflect new resume-mode semantics. |
| AGENTS.md | Minor update adding a link to RELEASE-RUNBOOK.md and a one-sentence description of the re-dispatch recovery gesture. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[release.yml dispatched\nwith VERSION=X.Y.Z] --> B{Tag X.Y.Z\non origin?}
    B -- No --> C[Fresh-run pre-flights\nDev check · dirty-tree check\nbranch-on-main check]
    C --> D[Generate notes\nStamp version\nBuild commit X\nCreate local tag]
    B -- Yes --> E[Resume mode\nContent-verify tag\nSDKVersion + 4 podspecs\nall stamped to X.Y.Z]
    E -->|Mismatch| FAIL1[❌ Rogue tag\nsee Runbook §7]
    E -->|Match| F[git checkout --detach tag\ngit checkout origin/main -- scripts/\nRegenerate notes from PREV_TAG..X.Y.Z]
    D --> G[Push main + tag\nidempotent checks]
    F --> G
    G --> H{GitHub release\nexists?}
    H -- No --> I[gh release create]
    H -- Yes --> J[Skip]
    I --> K[publish-pods.sh\nper-pod retry loop]
    J --> K
    K --> L{pod_already_published?}
    L -- Yes --> M[Skip pod]
    L -- No --> N[pod trunk push\nwith retry on transient errors]
    N -->|Hard fail auth/validation| FAIL2[❌ Exit — fix secret\nthen re-dispatch]
    N -->|Transient fail attempt 1| O[Sleep 30s then retry]
    O --> L
    N -->|Transient fail attempt 2| FAIL3[❌ Exit — re-dispatch\nwill resume here]
    N -->|Success| P[Next pod]
    M --> P
    P --> Q{All 4 pods done?}
    Q -- No --> L
    Q -- Yes --> R[restore-dev-sdk-on-main.sh]
    R --> S{SDKVersion=Dev AND\ntag reachable from HEAD?}
    S -- Yes --> T[✅ Already restored — exit 0]
    S -- No --> U[git checkout -B main origin/main\nStamp Dev · Commit Y · Push Y]
    U --> V[✅ Release complete\nTag→X · main HEAD→Y]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/restore-dev-sdk-on-main.sh`, line 107-111 ([link](https://github.com/youversion/platform-sdk-swift/blob/edaba643449bb9563ff55f7db44216427446abec/scripts/restore-dev-sdk-on-main.sh#L107-L111)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Pre-flight #2 rejects the Failure Mode #5 re-dispatch**

   In the diverged-main scenario (Failure Mode #5), `release.sh` ends its resume path with `git checkout -B main origin/main`, so `HEAD` is the unrelated commit C — not X. The strict `TAG_SHA != HEAD_SHA` check then exits with "Tag $VERSION points at $TAG_SHA but HEAD is $HEAD_SHA", blocking recovery even though the runbook documents re-dispatch as the fix.

   The check should allow HEAD to be a _descendant_ of X, not just equal to it. Replacing the strict equality with an ancestor check makes this work for both the normal case (HEAD == X) and the diverged case (HEAD == C, where X is ancestor of C). The resulting Y topology (X → C → Y) is valid: the tag still points at X, and X is reachable from main through Y.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/restore-dev-sdk-on-main.sh
   Line: 107-111

   Comment:
   **Pre-flight #2 rejects the Failure Mode #5 re-dispatch**

   In the diverged-main scenario (Failure Mode #5), `release.sh` ends its resume path with `git checkout -B main origin/main`, so `HEAD` is the unrelated commit C — not X. The strict `TAG_SHA != HEAD_SHA` check then exits with "Tag $VERSION points at $TAG_SHA but HEAD is $HEAD_SHA", blocking recovery even though the runbook documents re-dispatch as the fix.

   The check should allow HEAD to be a _descendant_ of X, not just equal to it. Replacing the strict equality with an ancestor check makes this work for both the normal case (HEAD == X) and the diverged case (HEAD == C, where X is ancestor of C). The resulting Y topology (X → C → Y) is valid: the tag still points at X, and X is reachable from main through Y.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Frestore-dev-sdk-on-main.sh%0ALine%3A%20107-111%0A%0AComment%3A%0A**Pre-flight%20%232%20rejects%20the%20Failure%20Mode%20%235%20re-dispatch**%0A%0AIn%20the%20diverged-main%20scenario%20%28Failure%20Mode%20%235%29%2C%20%60release.sh%60%20ends%20its%20resume%20path%20with%20%60git%20checkout%20-B%20main%20origin%2Fmain%60%2C%20so%20%60HEAD%60%20is%20the%20unrelated%20commit%20C%20%E2%80%94%20not%20X.%20The%20strict%20%60TAG_SHA%20!%3D%20HEAD_SHA%60%20check%20then%20exits%20with%20%22Tag%20%24VERSION%20points%20at%20%24TAG_SHA%20but%20HEAD%20is%20%24HEAD_SHA%22%2C%20blocking%20recovery%20even%20though%20the%20runbook%20documents%20re-dispatch%20as%20the%20fix.%0A%0AThe%20check%20should%20allow%20HEAD%20to%20be%20a%20_descendant_%20of%20X%2C%20not%20just%20equal%20to%20it.%20Replacing%20the%20strict%20equality%20with%20an%20ancestor%20check%20makes%20this%20work%20for%20both%20the%20normal%20case%20%28HEAD%20%3D%3D%20X%29%20and%20the%20diverged%20case%20%28HEAD%20%3D%3D%20C%2C%20where%20X%20is%20ancestor%20of%20C%29.%20The%20resulting%20Y%20topology%20%28X%20%E2%86%92%20C%20%E2%86%92%20Y%29%20is%20valid%3A%20the%20tag%20still%20points%20at%20X%2C%20and%20X%20is%20reachable%20from%20main%20through%20Y.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=145&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Frestore-dev-sdk-on-main.sh%0ALine%3A%20107-111%0A%0AComment%3A%0A**Pre-flight%20%232%20rejects%20the%20Failure%20Mode%20%235%20re-dispatch**%0A%0AIn%20the%20diverged-main%20scenario%20%28Failure%20Mode%20%235%29%2C%20%60release.sh%60%20ends%20its%20resume%20path%20with%20%60git%20checkout%20-B%20main%20origin%2Fmain%60%2C%20so%20%60HEAD%60%20is%20the%20unrelated%20commit%20C%20%E2%80%94%20not%20X.%20The%20strict%20%60TAG_SHA%20!%3D%20HEAD_SHA%60%20check%20then%20exits%20with%20%22Tag%20%24VERSION%20points%20at%20%24TAG_SHA%20but%20HEAD%20is%20%24HEAD_SHA%22%2C%20blocking%20recovery%20even%20though%20the%20runbook%20documents%20re-dispatch%20as%20the%20fix.%0A%0AThe%20check%20should%20allow%20HEAD%20to%20be%20a%20_descendant_%20of%20X%2C%20not%20just%20equal%20to%20it.%20Replacing%20the%20strict%20equality%20with%20an%20ancestor%20check%20makes%20this%20work%20for%20both%20the%20normal%20case%20%28HEAD%20%3D%3D%20X%29%20and%20the%20diverged%20case%20%28HEAD%20%3D%3D%20C%2C%20where%20X%20is%20ancestor%20of%20C%29.%20The%20resulting%20Y%20topology%20%28X%20%E2%86%92%20C%20%E2%86%92%20Y%29%20is%20valid%3A%20the%20tag%20still%20points%20at%20X%2C%20and%20X%20is%20reachable%20from%20main%20through%20Y.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=145&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["chore(ci): use ancestor check in Dev-res..."](https://github.com/youversion/platform-sdk-swift/commit/9f5778e2dea749981600e8f6b518698c17ac6bf4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34675285)</sub>

<!-- /greptile_comment -->