### PR TITLE
fix(reader): adjust reader copyright and footnotes spacing

### DIFF
--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -269,7 +269,6 @@ private struct ReaderContent: View {
                         }
                         VStack(alignment: .center) {
                             bibleCopyrightBlock
-                                .frame(maxWidth: viewModel.readerMaxWidth)
                         }
                     }
                     .frame(maxWidth: viewModel.readerMaxWidth)

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -267,7 +267,10 @@ private struct ReaderContent: View {
                                 }
                             )
                         }
-                        bibleCopyrightBlock
+                        VStack(alignment: .center) {
+                            bibleCopyrightBlock
+                                .frame(maxWidth: viewModel.readerMaxWidth)
+                        }
                     }
                     .frame(maxWidth: viewModel.readerMaxWidth)
                     .padding(.vertical)

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFootnotesView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFootnotesView.swift
@@ -30,6 +30,7 @@ struct BibleReaderFootnotesView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.bottom)
                     Divider()
+                        .padding(.bottom, 8)
                     VStack(alignment: .leading) {
                         ForEach(Array(viewModel.footnotesToDisplay.enumerated()), id: \.offset) { index, footnote in
                             let character = String(UnicodeScalar(97 + (index % 26))!)
@@ -41,6 +42,7 @@ struct BibleReaderFootnotesView: View {
                                     .multilineTextAlignment(.leading)
                             }
                             Divider()
+                                .padding(.vertical, 8)
                         }
                     }
                 }
@@ -48,7 +50,7 @@ struct BibleReaderFootnotesView: View {
             }
         }
         .padding(.horizontal, 24)
-        .padding(.top, 24)
+        .padding(.top, 36)
     }
     
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two focused visual polish improvements to the Bible reader: centering the copyright block and adding breathing room to the footnotes sheet dividers.

- **`BibleReaderView`**: Wraps `bibleCopyrightBlock` in a `VStack(alignment: .center)` so it is horizontally centered within the reader's leading-aligned content stack. Since `bibleCopyrightBlock` itself already contains a `VStack(alignment: .center)`, this outer wrapper is what causes it to occupy the full proposed width and be centered against the parent's `.leading` alignment — the fix is subtle but correct.
- **`BibleReaderFootnotesView`**: Adds 8 pt bottom padding to the divider between the passage text and the footnote list, 8 pt vertical padding to every divider between footnote entries, and increases the sheet's top padding from 24 → 36 pt for more visual breathing room.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to visual spacing and layout centering with no effect on data, state, or logic.

Both files touch only padding values and view hierarchy wrapping. The centering wrapper in BibleReaderView is correctly placed to counteract the parent's leading alignment, and the footnote padding additions are additive-only. No logic, networking, or state management is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Wraps `bibleCopyrightBlock` in an additional `VStack(alignment: .center)` to center the copyright within the leading-aligned parent; straightforward and correct. |
| Sources/YouVersionPlatformReader/Sheets/BibleReaderFootnotesView.swift | Adds 8 pt padding around footnote dividers and bumps the top padding from 24 → 36 pt; clean spacing-only changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["ReaderContent (BibleReaderView)"]
    A --> B["ScrollView"]
    B --> C["VStack(alignment: .leading)"]
    C --> D["BibleTextView / BibleReaderIntroView"]
    C --> E["VStack(alignment: .center) NEW"]
    E --> F["bibleCopyrightBlock\n(VStack centered internally)"]
    C --> G[".frame(maxWidth: readerMaxWidth)"]

    H["BibleReaderFootnotesView"]
    H --> I["VStack(leading)"]
    I --> J["Title + ScrollView"]
    J --> K["BibleTextView .padding(.bottom)"]
    K --> L["Divider + .padding(.bottom, 8) NEW"]
    L --> M["ForEach footnotes"]
    M --> N["HStack (letter + text)"]
    N --> O["Divider + .padding(.vertical, 8) NEW"]

    style E fill:#d4edda,stroke:#28a745
    style L fill:#d4edda,stroke:#28a745
    style O fill:#d4edda,stroke:#28a745
```

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into YPE-1313-fix-bi..."](https://github.com/youversion/platform-sdk-swift/commit/393a199fb1ef34ca3266c7bd0dd36038f04d907a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34743562)</sub>

<!-- /greptile_comment -->