### PR TITLE
fix: swap values for the muted text color between dark and light

### DIFF
--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/ReaderThemes.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/ReaderThemes.swift
@@ -50,7 +50,7 @@ extension ReaderThemeProviding {
     }
 
     public var readerTextMutedColor: Color {
-        readerTextPrimaryColor == readerWhiteColor ? Color(hex: "#636161") : Color(hex: "#bfbdbd")
+        readerTextPrimaryColor == readerWhiteColor ? Color(hex: "#bfbdbd") : Color(hex: "#636161")
     }
 
     public var readerSurfacePrimaryColor: Color {


### PR DESCRIPTION
fix: swap values for the muted text color between dark and light

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects a color swap bug in `readerTextMutedColor` where the lighter gray (`#bfbdbd`) was incorrectly assigned to light themes and the darker gray (`#636161`) to dark themes, making muted text hard to see in both modes. The fix aligns the property with every other color in the file that follows the same light/dark split.

- **`readerTextMutedColor` (line 52–54):** Swaps the two hex values so dark themes get `#bfbdbd` (lighter, legible on a dark canvas) and light themes get `#636161` (darker, legible on a white canvas) — now consistent with `readerBorderSecondaryColor` and the rest of the theme system.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single-line color swap with no logic changes, no API surface impact, and no risk of regression beyond the visual fix it delivers.

The change touches exactly one computed property and swaps two hardcoded hex strings that were demonstrably in the wrong positions. The corrected values match the pattern used by every parallel color property in the same file, and the condition being branched on is unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformUI/Views/VersionPicking/ReaderThemes.swift | One-line fix swapping muted text colors so dark themes receive the lighter gray (#bfbdbd) and light themes receive the darker gray (#636161), correcting a visual regression. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[readerTextMutedColor] --> B{readerTextPrimaryColor == readerWhiteColor?}
    B -- "Yes → dark theme" --> C["#bfbdbd (lighter gray) visible on dark background ✓"]
    B -- "No → light theme" --> D["#636161 (darker gray) visible on light background ✓"]
```

<sub>Reviews (1): Last reviewed commit: ["fix: swap values for the muted text colo..."](https://github.com/youversion/platform-sdk-swift/commit/cf85e0450989c29ba5440a83b97d0d967fc4e216) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34980537)</sub>

<!-- /greptile_comment -->