### PR TITLE
fix: render small caps using the current font

### DIFF
--- a/Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift
+++ b/Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift
@@ -7,7 +7,6 @@ public enum BibleTextFontOption {
     case font076emItalic
     case font100em
     case font100emItalic
-    case font100emSmallCaps
     case font100em500
     case font100em500Italic
     case font117em500
@@ -37,6 +36,8 @@ public enum BibleTextFontOption {
     case header3
     @available(*, deprecated, renamed: "font100em500")
     case header4
+    @available(*, deprecated, message: "set inSmallcaps instead")
+    case font100emSmallCaps
 }
 
 public struct BibleTextFonts {
@@ -71,7 +72,6 @@ public struct BibleTextFonts {
             .font076emItalic: Self.font(familyName: italicFamilyName, size: baseSize * 0.76).italic(),
             .font100em: Self.font(familyName: familyName, size: baseSize),
             .font100emItalic: Self.font(familyName: italicFamilyName, size: baseSize).italic(),
-            .font100emSmallCaps: Self.font(familyName: familyName, size: baseSize).lowercaseSmallCaps(),
             .font100em500: Self.font(familyName: familyName, size: baseSize).weight(.medium),
             .font100em500Italic: Self.font(familyName: italicFamilyName, size: baseSize).weight(.medium).italic(),
             .font117em500: Self.font(familyName: familyName, size: baseSize * 1.17).weight(.medium),
@@ -90,7 +90,8 @@ public struct BibleTextFonts {
             .header4: Self.font(familyName: familyName, size: baseSize * 1.1),
             .header: Self.font(familyName: familyName, size: baseSize).bold(),
             .headerSmallerItalic: Self.font(familyName: italicFamilyName, size: baseSize * 0.76).italic(),
-            .textFont: Self.font(familyName: familyName, size: baseSize)
+            .textFont: Self.font(familyName: familyName, size: baseSize),
+            .font100emSmallCaps: Self.font(familyName: familyName, size: baseSize).lowercaseSmallCaps()
         ]
     }
 

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleAttributedString.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleAttributedString.swift
@@ -43,8 +43,9 @@ public final class BibleAttributedString: Equatable, Hashable {
     }
 
     @discardableResult
-    public func setFont(_ option: BibleTextFontOption, from fonts: BibleTextFonts) -> BibleAttributedString {
-        two.font = fonts.font(for: option)
+    public func setFont(_ option: BibleTextFontOption, inSmallcaps: Bool = false, from fonts: BibleTextFonts) -> BibleAttributedString {
+        let font = fonts.font(for: option)
+        two.font = inSmallcaps ? font.lowercaseSmallCaps() : font
         return self
     }
 

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleAttributedString.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleAttributedString.swift
@@ -43,7 +43,7 @@ public final class BibleAttributedString: Equatable, Hashable {
     }
 
     @discardableResult
-    public func setFont(_ option: BibleTextFontOption, inSmallcaps: Bool = false, from fonts: BibleTextFonts) -> BibleAttributedString {
+    public func setFont(_ option: BibleTextFontOption, from fonts: BibleTextFonts, inSmallcaps: Bool = false) -> BibleAttributedString {
         let font = fonts.font(for: option)
         two.font = inSmallcaps ? font.lowercaseSmallCaps() : font
         return self

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift
@@ -191,7 +191,7 @@ public enum BibleVersionRendering {
                 // The concept is/was HTML, which does this collapsing internally.
                 txt = BibleAttributedString(" ")
             }
-            txt.setFont(stateDown.currentFont, inSmallcaps: stateDown.smallcaps, from: stateIn.fonts)
+            txt.setFont(stateDown.currentFont, from: stateIn.fonts, inSmallcaps: stateDown.smallcaps)
             if stateDown.woc {
                 txt.setColor(stateIn.wocColor)
             }

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift
@@ -191,7 +191,7 @@ public enum BibleVersionRendering {
                 // The concept is/was HTML, which does this collapsing internally.
                 txt = BibleAttributedString(" ")
             }
-            txt.setFont(stateDown.currentFont, from: stateIn.fonts)
+            txt.setFont(stateDown.currentFont, inSmallcaps: stateDown.smallcaps, from: stateIn.fonts)
             if stateDown.woc {
                 txt.setColor(stateIn.wocColor)
             }

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRenderingStyles.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRenderingStyles.swift
@@ -305,11 +305,6 @@ final class BibleVersionRenderingStyles {
         stateDown: inout BibleVersionRendering.StateDown,
         stateUp: inout BibleVersionRendering.StateUp
     ) {
-        // this is a weird place to do this, but the tag is on a block, and block classes don't usually change fonts, so...
-        if stateDown.smallcaps {
-            stateDown.currentFont = .font100emSmallCaps
-        }
-
         for c in node.classes {
             if c == "wj" {
                 stateDown.woc = true
@@ -321,7 +316,6 @@ final class BibleVersionRenderingStyles {
                     }
                 }
             } else if node.classes.contains("nd") || node.classes.contains("sc") {
-                stateDown.currentFont = .font100emSmallCaps
                 stateDown.smallcaps = true
             } else if node.classes.contains("tl") || node.classes.contains("it") || node.classes.contains("add") {
                 stateDown.currentFont = .font100emItalic


### PR DESCRIPTION
## Description

fix: render small caps using the current font, instead of the current behavior which is to use the base text font for scripture. That gave the wrong results when small caps were used in e.g. headlines. See PSA.3 BSB for an example of both usages.

## Type of Change

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [x] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a rendering bug where small caps text always applied `lowercaseSmallCaps()` against the base scripture font, ignoring whatever font was active at the render site (e.g. a headline font). The fix threads a `smallcaps` boolean flag from the style interpreter down to `setFont`, where it applies `.lowercaseSmallCaps()` on the already-resolved font instead of redirecting to the hard-coded `font100emSmallCaps` option.

- `BibleVersionRenderingStyles` now only sets `stateDown.smallcaps = true` for `nd`/`sc` nodes and `pc` blocks — it no longer overrides `currentFont` to `font100emSmallCaps`, so the active font (header, italic, etc.) is preserved.
- `BibleAttributedString.setFont(_:from:inSmallcaps:)` gains an `inSmallcaps` parameter that applies `.lowercaseSmallCaps()` on the resolved font when true, and `font100emSmallCaps` is deprecated with a migration message to steer callers toward the new API.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is well-scoped, the default `inSmallcaps: false` keeps all other call sites unchanged, and the logic correctly applies small caps to the active font rather than the base font.

The change is a straightforward rerouting of where `.lowercaseSmallCaps()` is applied. The `inSmallcaps` default of `false` means every other `setFont` call is unaffected, and both paths in `interpretTextAttr` and `interpretBlockClasses` now consistently use the flag rather than overriding the font option directly.

No files require special attention. The only open items are minor: the capitalisation of the `inSmallcaps` parameter label and the two-hop deprecation chain in `BibleTextFonts`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift | Deprecates `font100emSmallCaps` with a migration message; moves its dictionary entry to the deprecated block. The old `smallCaps → font100emSmallCaps` renamed chain now leads to a second dead-end deprecation, which may confuse consumers following Xcode's auto-fix. |
| Sources/YouVersionPlatformUI/Views/Rendering/BibleAttributedString.swift | Adds `inSmallcaps: Bool = false` parameter to `setFont`; applies `.lowercaseSmallCaps()` on the resolved font when true. Logic is correct; minor capitalisation nit on the parameter name. |
| Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift | Passes `inSmallcaps: stateDown.smallcaps` to the updated `setFont` call; all other `setFont` calls correctly omit the parameter and use the default `false`. |
| Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRenderingStyles.swift | Removes the block-level `currentFont = .font100emSmallCaps` overrides from both `interpretBlockClasses` and `interpretTextAttr`, now relying solely on the `smallcaps` flag; fix is correct and consistent across both code paths. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Styles as BibleVersionRenderingStyles
    participant Rendering as BibleVersionRendering
    participant AttrStr as BibleAttributedString
    participant Fonts as BibleTextFonts

    Styles->>Styles: interpretTextAttr(node with "nd"/"sc")
    note over Styles: sets stateDown.smallcaps = true
    note over Styles: (no longer overrides currentFont)

    Rendering->>AttrStr: setFont(stateDown.currentFont, from: fonts, inSmallcaps: stateDown.smallcaps)
    AttrStr->>Fonts: font(for: currentFont)
    Fonts-->>AttrStr: resolvedFont (e.g. header font)
    note over AttrStr: if inSmallcaps → resolvedFont.lowercaseSmallCaps()
    AttrStr-->>Rendering: BibleAttributedString with correct small-caps font
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformUI%2FViews%2FRendering%2FBibleAttributedString.swift%3A46-48%0AThe%20parameter%20label%20%60inSmallcaps%60%20has%20an%20inconsistent%20capitalization%3A%20the%20second%20word%20%60Smallcaps%60%20should%20be%20%60SmallCaps%60%20to%20follow%20Swift's%20camelCase%20naming%20convention%20where%20each%20word%20begins%20with%20a%20capital%20letter.%20It's%20also%20worth%20ensuring%20the%20call%20site%20%28%60inSmallcaps%3A%20stateDown.smallcaps%60%29%20is%20updated%20to%20match.%0A%0A%60%60%60suggestion%0A%20%20%20%20public%20func%20setFont%28_%20option%3A%20BibleTextFontOption%2C%20from%20fonts%3A%20BibleTextFonts%2C%20inSmallCaps%3A%20Bool%20%3D%20false%29%20-%3E%20BibleAttributedString%20%7B%0A%20%20%20%20%20%20%20%20let%20font%20%3D%20fonts.font%28for%3A%20option%29%0A%20%20%20%20%20%20%20%20two.font%20%3D%20inSmallCaps%20%3F%20font.lowercaseSmallCaps%28%29%20%3A%20font%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformUI%2FObjects%2FBibleTextFonts.swift%3A23-24%0A**Broken%20two-hop%20deprecation%20chain**%0A%0AThe%20%60smallCaps%60%20case%20carries%20%60renamed%3A%20%22font100emSmallCaps%22%60%2C%20which%20causes%20Xcode%20to%20offer%20an%20auto-fix%20that%20migrates%20code%20to%20%60font100emSmallCaps%60.%20But%20%60font100emSmallCaps%60%20is%20now%20itself%20deprecated%20with%20the%20opaque%20message%20%22set%20inSmallcaps%20instead%22%20and%20no%20%60renamed%3A%60%20to%20guide%20the%20next%20migration%20step.%20Anyone%20following%20Xcode's%20auto-fix%20will%20land%20on%20a%20second%20deprecation%20with%20no%20automated%20path%20forward.%20Consider%20updating%20the%20%60smallCaps%60%20deprecation%20message%20to%20reflect%20the%20full%20correct%20migration%2C%20e.g.%20%60deprecated%2C%20message%3A%20%22use%20setFont%28_%3Afrom%3AinSmallCaps%3A%29%20with%20inSmallCaps%3A%20true%22%60%2C%20so%20callers%20get%20the%20full%20picture%20in%20one%20step.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformUI%2FViews%2FRendering%2FBibleAttributedString.swift%3A46-48%0AThe%20parameter%20label%20%60inSmallcaps%60%20has%20an%20inconsistent%20capitalization%3A%20the%20second%20word%20%60Smallcaps%60%20should%20be%20%60SmallCaps%60%20to%20follow%20Swift's%20camelCase%20naming%20convention%20where%20each%20word%20begins%20with%20a%20capital%20letter.%20It's%20also%20worth%20ensuring%20the%20call%20site%20%28%60inSmallcaps%3A%20stateDown.smallcaps%60%29%20is%20updated%20to%20match.%0A%0A%60%60%60suggestion%0A%20%20%20%20public%20func%20setFont%28_%20option%3A%20BibleTextFontOption%2C%20from%20fonts%3A%20BibleTextFonts%2C%20inSmallCaps%3A%20Bool%20%3D%20false%29%20-%3E%20BibleAttributedString%20%7B%0A%20%20%20%20%20%20%20%20let%20font%20%3D%20fonts.font%28for%3A%20option%29%0A%20%20%20%20%20%20%20%20two.font%20%3D%20inSmallCaps%20%3F%20font.lowercaseSmallCaps%28%29%20%3A%20font%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformUI%2FObjects%2FBibleTextFonts.swift%3A23-24%0A**Broken%20two-hop%20deprecation%20chain**%0A%0AThe%20%60smallCaps%60%20case%20carries%20%60renamed%3A%20%22font100emSmallCaps%22%60%2C%20which%20causes%20Xcode%20to%20offer%20an%20auto-fix%20that%20migrates%20code%20to%20%60font100emSmallCaps%60.%20But%20%60font100emSmallCaps%60%20is%20now%20itself%20deprecated%20with%20the%20opaque%20message%20%22set%20inSmallcaps%20instead%22%20and%20no%20%60renamed%3A%60%20to%20guide%20the%20next%20migration%20step.%20Anyone%20following%20Xcode's%20auto-fix%20will%20land%20on%20a%20second%20deprecation%20with%20no%20automated%20path%20forward.%20Consider%20updating%20the%20%60smallCaps%60%20deprecation%20message%20to%20reflect%20the%20full%20correct%20migration%2C%20e.g.%20%60deprecated%2C%20message%3A%20%22use%20setFont%28_%3Afrom%3AinSmallCaps%3A%29%20with%20inSmallCaps%3A%20true%22%60%2C%20so%20callers%20get%20the%20full%20picture%20in%20one%20step.%0A%0A&pr=149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22YPE-1948-fix_smallcaps%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22YPE-1948-fix_smallcaps%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformUI%2FViews%2FRendering%2FBibleAttributedString.swift%3A46-48%0AThe%20parameter%20label%20%60inSmallcaps%60%20has%20an%20inconsistent%20capitalization%3A%20the%20second%20word%20%60Smallcaps%60%20should%20be%20%60SmallCaps%60%20to%20follow%20Swift's%20camelCase%20naming%20convention%20where%20each%20word%20begins%20with%20a%20capital%20letter.%20It's%20also%20worth%20ensuring%20the%20call%20site%20%28%60inSmallcaps%3A%20stateDown.smallcaps%60%29%20is%20updated%20to%20match.%0A%0A%60%60%60suggestion%0A%20%20%20%20public%20func%20setFont%28_%20option%3A%20BibleTextFontOption%2C%20from%20fonts%3A%20BibleTextFonts%2C%20inSmallCaps%3A%20Bool%20%3D%20false%29%20-%3E%20BibleAttributedString%20%7B%0A%20%20%20%20%20%20%20%20let%20font%20%3D%20fonts.font%28for%3A%20option%29%0A%20%20%20%20%20%20%20%20two.font%20%3D%20inSmallCaps%20%3F%20font.lowercaseSmallCaps%28%29%20%3A%20font%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformUI%2FObjects%2FBibleTextFonts.swift%3A23-24%0A**Broken%20two-hop%20deprecation%20chain**%0A%0AThe%20%60smallCaps%60%20case%20carries%20%60renamed%3A%20%22font100emSmallCaps%22%60%2C%20which%20causes%20Xcode%20to%20offer%20an%20auto-fix%20that%20migrates%20code%20to%20%60font100emSmallCaps%60.%20But%20%60font100emSmallCaps%60%20is%20now%20itself%20deprecated%20with%20the%20opaque%20message%20%22set%20inSmallcaps%20instead%22%20and%20no%20%60renamed%3A%60%20to%20guide%20the%20next%20migration%20step.%20Anyone%20following%20Xcode's%20auto-fix%20will%20land%20on%20a%20second%20deprecation%20with%20no%20automated%20path%20forward.%20Consider%20updating%20the%20%60smallCaps%60%20deprecation%20message%20to%20reflect%20the%20full%20correct%20migration%2C%20e.g.%20%60deprecated%2C%20message%3A%20%22use%20setFont%28_%3Afrom%3AinSmallCaps%3A%29%20with%20inSmallCaps%3A%20true%22%60%2C%20so%20callers%20get%20the%20full%20picture%20in%20one%20step.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
Sources/YouVersionPlatformUI/Views/Rendering/BibleAttributedString.swift:46-48
The parameter label `inSmallcaps` has an inconsistent capitalization: the second word `Smallcaps` should be `SmallCaps` to follow Swift's camelCase naming convention where each word begins with a capital letter. It's also worth ensuring the call site (`inSmallcaps: stateDown.smallcaps`) is updated to match.

```suggestion
    public func setFont(_ option: BibleTextFontOption, from fonts: BibleTextFonts, inSmallCaps: Bool = false) -> BibleAttributedString {
        let font = fonts.font(for: option)
        two.font = inSmallCaps ? font.lowercaseSmallCaps() : font
```

### Issue 2 of 2
Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift:23-24
**Broken two-hop deprecation chain**

The `smallCaps` case carries `renamed: "font100emSmallCaps"`, which causes Xcode to offer an auto-fix that migrates code to `font100emSmallCaps`. But `font100emSmallCaps` is now itself deprecated with the opaque message "set inSmallcaps instead" and no `renamed:` to guide the next migration step. Anyone following Xcode's auto-fix will land on a second deprecation with no automated path forward. Consider updating the `smallCaps` deprecation message to reflect the full correct migration, e.g. `deprecated, message: "use setFont(_:from:inSmallCaps:) with inSmallCaps: true"`, so callers get the full picture in one step.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: move inSmallCaps to the end for com..."](https://github.com/youversion/platform-sdk-swift/commit/aeec85b2d90f2792f8216891195cf95310a40977) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35231261)</sub>

<!-- /greptile_comment -->