### PR TITLE
fix: ignore unsupported HTML nodes in BibleTextNodeParser

### DIFF
--- a/Sources/YouVersionPlatformCore/Bible/BibleTextNodeParser.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleTextNodeParser.swift
@@ -100,8 +100,7 @@ struct BibleTextNodeParser {
             }
 
             let tag = source.substring(with: match.range)
-            let trimmedTag = tag.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmedTag.hasSuffix("/>") else {
+            guard !tag.hasSuffix("/>") else {
                 continue
             }
 

--- a/Sources/YouVersionPlatformCore/Bible/BibleTextNodeParser.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleTextNodeParser.swift
@@ -33,6 +33,11 @@ struct BibleTextNodeParser {
         "wbr"
     ])
 
+    private static let voidElementExpression: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: #"<([A-Za-z][A-Za-z0-9:-]*)([^<>]*)>"#)
+    }()
+
     static func parse(_ html: String) throws -> BibleTextNode {
         let sanitized = sanitizeForXML(html: html)
         guard let data = sanitized.data(using: .utf8) else {
@@ -83,15 +88,10 @@ struct BibleTextNodeParser {
     }
 
     private static func selfClosedHTMLVoidElements(in html: String) -> String {
-        let pattern = #"<([A-Za-z][A-Za-z0-9:-]*)([^<>]*)>"#
-        guard let expression = try? NSRegularExpression(pattern: pattern) else {
-            return html
-        }
-
         let source = html as NSString
         let mutableHTML = NSMutableString(string: html)
         let fullRange = NSRange(location: 0, length: source.length)
-        let matches = expression.matches(in: html, range: fullRange)
+        let matches = voidElementExpression.matches(in: html, range: fullRange)
 
         for match in matches.reversed() {
             let elementName = source.substring(with: match.range(at: 1)).lowercased()

--- a/Sources/YouVersionPlatformCore/Bible/BibleTextNodeParser.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleTextNodeParser.swift
@@ -5,6 +5,33 @@ import FoundationXML
 
 /// Parses YouVersion Bible chapter HTML into an immutable `BibleTextNode` tree.
 struct BibleTextNodeParser {
+    private static let supportedElementNames = Set([
+        "block",
+        "div",
+        "root",
+        "span",
+        "table",
+        "td",
+        "text",
+        "tr"
+    ])
+
+    private static let htmlVoidElementNames = Set([
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr"
+    ])
 
     static func parse(_ html: String) throws -> BibleTextNode {
         let sanitized = sanitizeForXML(html: html)
@@ -32,9 +59,7 @@ struct BibleTextNodeParser {
         var s = html
 
         // Self-close common void elements if they appear unclosed
-        s = s.replacingOccurrences(of: "<br>", with: "<br/>")
-            .replacingOccurrences(of: "<br >", with: "<br/>")
-            .replacingOccurrences(of: "<br />", with: "<br/>")
+        s = selfClosedHTMLVoidElements(in: s)
 
         // Decode common HTML named entities to Unicode characters XML can handle
         let replacements: [String: String] = [
@@ -55,6 +80,36 @@ struct BibleTextNodeParser {
 
         // Wrap with a root element to guarantee a single top-level node
         return "<root>\n" + s + "\n</root>"
+    }
+
+    private static func selfClosedHTMLVoidElements(in html: String) -> String {
+        let pattern = #"<([A-Za-z][A-Za-z0-9:-]*)([^<>]*)>"#
+        guard let expression = try? NSRegularExpression(pattern: pattern) else {
+            return html
+        }
+
+        let source = html as NSString
+        let mutableHTML = NSMutableString(string: html)
+        let fullRange = NSRange(location: 0, length: source.length)
+        let matches = expression.matches(in: html, range: fullRange)
+
+        for match in matches.reversed() {
+            let elementName = source.substring(with: match.range(at: 1)).lowercased()
+            guard htmlVoidElementNames.contains(elementName) else {
+                continue
+            }
+
+            let tag = source.substring(with: match.range)
+            let trimmedTag = tag.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedTag.hasSuffix("/>") else {
+                continue
+            }
+
+            let replacement = String(tag.dropLast()) + "/>"
+            mutableHTML.replaceCharacters(in: match.range, with: replacement)
+        }
+
+        return mutableHTML as String
     }
 
     /// Builds the BibleTextNode tree bottom-up so all nodes are immutable once created.
@@ -88,7 +143,7 @@ struct BibleTextNodeParser {
                     partialResult[entry.key] = entry.value
                 }
             }
-            stack.append(Frame(name: elementName, classes: classes, attributes: filteredAttributes, children: []))
+            stack.append(Frame(name: elementName.lowercased(), classes: classes, attributes: filteredAttributes, children: []))
         }
 
         func parser(_ parser: XMLParser, foundCharacters string: String) {
@@ -135,6 +190,14 @@ struct BibleTextNodeParser {
             guard let frame = stack.popLast() else {
                 return
             }
+
+            guard BibleTextNodeParser.supportedElementNames.contains(frame.name) else {
+                if !stack.isEmpty {
+                    stack[stack.count - 1].children.append(contentsOf: frame.children)
+                }
+                return
+            }
+
             let node = BibleTextNode(
                 name: frame.name,
                 children: frame.children,

--- a/Tests/YouVersionPlatformCoreTests/BibleTextNodeTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleTextNodeTests.swift
@@ -115,6 +115,50 @@ func testParse_LeadingWhitespaceBeforeFirstChildIsIgnored() throws {
     #expect(renderedText == "One Two")
 }
 
+@Test
+func testParse_UnsupportedElementsAreIgnoredAndChildrenArePreserved() throws {
+    let html = "<div>Before <p>inside <em>emphasis</em></p> after <custom><span class=\"nd\">Lord</span></custom>.</div>"
+
+    let root = try BibleTextNode(html: html)
+    expectSupportedNodeTypes(in: root)
+
+    let block = try #require(root.children.first)
+    let renderedText = collectRenderedText(from: block)
+
+    #expect(renderedText == "Before inside emphasis after Lord.")
+}
+
+@Test
+func testParse_UnsupportedVoidElementsAreIgnored() throws {
+    let html = "<div>Before <br> after <br class=\"poetry\"> done <img alt=\"ignored\"> end</div>"
+
+    let root = try BibleTextNode(html: html)
+    expectSupportedNodeTypes(in: root)
+
+    let block = try #require(root.children.first)
+    let renderedText = collectRenderedText(from: block)
+
+    #expect(renderedText == "Before after done end")
+}
+
+@Test
+func testParse_UnclosedHTMLVoidElementsParseSuccessfully() throws {
+    let html = """
+    <div>Before
+    <area><base><BR><col><embed><hr><img alt="ignored"><input value="ignored">
+    <link><meta name="ignored" content="ignored"><param><source><track><wbr>
+    after</div>
+    """
+
+    let root = try BibleTextNode(html: html)
+    expectSupportedNodeTypes(in: root)
+
+    let block = try #require(root.children.first)
+    let renderedText = collectRenderedText(from: block)
+
+    #expect(renderedText == "Before after")
+}
+
 private func collectRenderedText(from node: BibleTextNode) -> String {
     var text = ""
     appendRenderedText(from: node, into: &text)
@@ -128,5 +172,13 @@ private func appendRenderedText(from node: BibleTextNode, into text: inout Strin
 
     for child in node.children {
         appendRenderedText(from: child, into: &text)
+    }
+}
+
+private func expectSupportedNodeTypes(in node: BibleTextNode) {
+    _ = node.type
+
+    for child in node.children {
+        expectSupportedNodeTypes(in: child)
     }
 }


### PR DESCRIPTION
## Description

fix: ignore unsupported HTML nodes in BibleTextNodeParser

Our parsing engine was built for a specific set of HTML tag names, and called fatalError for anything unexpected. Improve that so future-delivered HTML with other tags and/or with other self-closing tags won't cause crashes.

## Type of Change

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [x] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens `BibleTextNodeParser` against unexpected HTML by replacing the three hardcoded `<br>` sanitisation calls with a regex-driven self-closer that handles all 14 HTML void elements, and by adding a `supportedElementNames` guard in `didEndElement` that silently promotes an unsupported element's children into its parent rather than crashing.

- **`selfClosedHTMLVoidElements`**: A lazily-initialised `NSRegularExpression` scans the raw HTML for any void-element tag, self-closes it in-place (iterating in reverse to preserve `NSRange` correctness), and skips tags that are already self-closed — covering `<br>`, `<img>`, `<hr>`, etc. uniformly.
- **Unsupported container elements**: `didEndElement` now checks `supportedElementNames` and, if the element is unknown, discards the frame but grafts its children onto the parent, preserving text content without crashing.
- **Tests**: Three new test cases verify child-promotion semantics, void-element filtering, and successful parsing of all 14 HTML void elements.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix correctly prevents crashes from unsupported HTML tags and is covered by three new tests.

The parser-level filtering and regex-based void-element sanitisation are logically sound, reverse-iteration preserves NSRange correctness, and all three new test cases exercise the changed paths. No incorrect behaviour was found on the changed paths.

No files require special attention, though the coupling between `supportedElementNames` in the parser and the `switch` in `BibleTextNode.type` is worth keeping an eye on as new element types are introduced.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/Bible/BibleTextNodeParser.swift | Replaces hardcoded `<br>` sanitisation with a regex-based void-element self-closer covering all 14 HTML void elements, and adds a `supportedElementNames` guard in `didEndElement` that silently promotes unsupported elements' children up the tree instead of crashing. |
| Tests/YouVersionPlatformCoreTests/BibleTextNodeTests.swift | Adds three focused tests covering: unsupported container elements with child promotion, unsupported void elements being ignored, and all 14 HTML void elements parsing without crash. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BibleTextNodeParser.parse] --> B[sanitizeForXML]
    B --> C[selfClosedHTMLVoidElements\nregex over all void elements]
    C --> D[Entity replacements]
    D --> E[Wrap in root element]
    E --> F[XMLParser.parse]
    F --> G{didStartElement}
    G --> H[Push Frame onto stack]
    F --> I{didEndElement}
    I --> J[Pop Frame from stack]
    J --> K{name in\nsupportedElementNames?}
    K -- Yes --> L[Create BibleTextNode\nAppend to parent]
    K -- No --> M[Promote children\nto parent frame\nno crash]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformCore%2FBible%2FBibleTextNodeParser.swift%3A8-17%0A**Two%20sources%20of%20truth%20for%20supported%20element%20names**%0A%0A%60supportedElementNames%60%20here%20and%20the%20%60switch%60%20cases%20in%20%60BibleTextNode.type%60%20%28%60BibleTextNode.swift%60%20line%2023%E2%80%9333%29%20must%20always%20define%20the%20same%20set.%20Right%20now%20they%20match%2C%20but%20if%20a%20future%20contributor%20adds%20%28say%29%20%60%22figure%22%60%20to%20%60supportedElementNames%60%20without%20adding%20a%20corresponding%20%60case%20%22figure%22%3A%60%20in%20%60BibleTextNode.type%60%2C%20the%20app%20will%20hit%20%60fatalError%28%22Unknown%20node%20type%3A%20%E2%80%A6%22%29%60%20at%20runtime%20whenever%20that%20element%20appears%20in%20parsed%20HTML%20%E2%80%94%20exactly%20the%20class%20of%20crash%20this%20PR%20is%20trying%20to%20eliminate.%20Centralising%20the%20definition%20%28e.g.%20deriving%20%60supportedElementNames%60%20from%20%60BibleTextNodeType%60%2C%20or%20guarding%20the%20%60type%60%20switch%20with%20a%20graceful%20fallback%29%20would%20remove%20the%20coupling.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=152&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformCore%2FBible%2FBibleTextNodeParser.swift%3A8-17%0A**Two%20sources%20of%20truth%20for%20supported%20element%20names**%0A%0A%60supportedElementNames%60%20here%20and%20the%20%60switch%60%20cases%20in%20%60BibleTextNode.type%60%20%28%60BibleTextNode.swift%60%20line%2023%E2%80%9333%29%20must%20always%20define%20the%20same%20set.%20Right%20now%20they%20match%2C%20but%20if%20a%20future%20contributor%20adds%20%28say%29%20%60%22figure%22%60%20to%20%60supportedElementNames%60%20without%20adding%20a%20corresponding%20%60case%20%22figure%22%3A%60%20in%20%60BibleTextNode.type%60%2C%20the%20app%20will%20hit%20%60fatalError%28%22Unknown%20node%20type%3A%20%E2%80%A6%22%29%60%20at%20runtime%20whenever%20that%20element%20appears%20in%20parsed%20HTML%20%E2%80%94%20exactly%20the%20class%20of%20crash%20this%20PR%20is%20trying%20to%20eliminate.%20Centralising%20the%20definition%20%28e.g.%20deriving%20%60supportedElementNames%60%20from%20%60BibleTextNodeType%60%2C%20or%20guarding%20the%20%60type%60%20switch%20with%20a%20graceful%20fallback%29%20would%20remove%20the%20coupling.%0A%0A&pr=152&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22YPE-1625-harden-parser%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22YPE-1625-harden-parser%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformCore%2FBible%2FBibleTextNodeParser.swift%3A8-17%0A**Two%20sources%20of%20truth%20for%20supported%20element%20names**%0A%0A%60supportedElementNames%60%20here%20and%20the%20%60switch%60%20cases%20in%20%60BibleTextNode.type%60%20%28%60BibleTextNode.swift%60%20line%2023%E2%80%9333%29%20must%20always%20define%20the%20same%20set.%20Right%20now%20they%20match%2C%20but%20if%20a%20future%20contributor%20adds%20%28say%29%20%60%22figure%22%60%20to%20%60supportedElementNames%60%20without%20adding%20a%20corresponding%20%60case%20%22figure%22%3A%60%20in%20%60BibleTextNode.type%60%2C%20the%20app%20will%20hit%20%60fatalError%28%22Unknown%20node%20type%3A%20%E2%80%A6%22%29%60%20at%20runtime%20whenever%20that%20element%20appears%20in%20parsed%20HTML%20%E2%80%94%20exactly%20the%20class%20of%20crash%20this%20PR%20is%20trying%20to%20eliminate.%20Centralising%20the%20definition%20%28e.g.%20deriving%20%60supportedElementNames%60%20from%20%60BibleTextNodeType%60%2C%20or%20guarding%20the%20%60type%60%20switch%20with%20a%20graceful%20fallback%29%20would%20remove%20the%20coupling.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/YouVersionPlatformCore/Bible/BibleTextNodeParser.swift:8-17
**Two sources of truth for supported element names**

`supportedElementNames` here and the `switch` cases in `BibleTextNode.type` (`BibleTextNode.swift` line 23–33) must always define the same set. Right now they match, but if a future contributor adds (say) `"figure"` to `supportedElementNames` without adding a corresponding `case "figure":` in `BibleTextNode.type`, the app will hit `fatalError("Unknown node type: …")` at runtime whenever that element appears in parsed HTML — exactly the class of crash this PR is trying to eliminate. Centralising the definition (e.g. deriving `supportedElementNames` from `BibleTextNodeType`, or guarding the `type` switch with a graceful fallback) would remove the coupling.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["chore: merge main"](https://github.com/youversion/platform-sdk-swift/commit/c1f4557d3a58ad5a69ff1d404c90dc1eedc31adb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35454403)</sub>

<!-- /greptile_comment -->