### PR TITLE
chore: update localizable strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ fastlane/test_output
 coverage/
 
 .claude/settings.local.json
+.omc
 
 # Node.js (semantic-release)
 node_modules/

--- a/Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings
+++ b/Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings
@@ -1,2095 +1,2096 @@
 {
-  "localizations" : {
-    "de" : {
-      "name" : "German"
+  "version": "1.0",
+  "sourceLanguage": "en",
+  "localizations": {
+    "de": {
+      "name": "German"
     },
-    "es-MX" : {
-      "name" : "Spanish (Latin America)"
+    "es-MX": {
+      "name": "Spanish (Latin America)"
     },
-    "fr" : {
-      "name" : "French"
+    "fr": {
+      "name": "French"
     }
   },
-  "sourceLanguage" : "en",
-  "strings" : {
-    "bookChapterPicker.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bücher"
+  "strings": {
+    "bibleCard.unavailableReference": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This passage is unavailable in the selected Bible version."
           }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Books"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Libros"
+        }
+      }
+    },
+    "bibleText.connectionIssue": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We’re having difficulties with your connection. Please download a Bible version when you’re online."
           }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Livres"
+        }
+      }
+    },
+    "bibleText.unavailableVersion": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your previously selected Bible version is unavailable. Please switch to another one."
           }
         }
       }
     },
-    "button.moreVersions" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weitere Versionen"
+    "bookChapterPicker.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bücher"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "More Versions"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Books"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Más versiones"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Libros"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plus de versions"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Livres"
           }
         }
       }
     },
-    "button.signOut" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abmelden"
+    "button.moreVersions": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weitere Versionen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign Out"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More Versions"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerrar sesión"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más versiones"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se déconnecter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plus de versions"
           }
         }
       }
     },
-    "bibleText.connectionIssue" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We’re having difficulties with your connection. Please download a Bible version when you’re online."
+    "button.signOut": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abmelden"
           }
-        }
-      }
-    },
-    "bibleText.unavailableVersion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your previously selected Bible version is unavailable. Please switch to another one."
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign Out"
           }
-        }
-      }
-    },
-    "bibleCard.unavailableReference" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This passage is unavailable in the selected Bible version."
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerrar sesión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se déconnecter"
           }
         }
       }
     },
-    "download.agreeButton" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Akzeptieren und herunterladen"
+    "download.agreeButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Akzeptieren und herunterladen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agree and Download"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agree and Download"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aceptar y descargar"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aceptar y descargar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accepter et télécharger"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accepter et télécharger"
           }
         }
       }
     },
-    "download.agreementParagraph" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unsere Vereinbarung mit dem Herausgeber dieser Bibelversion erfordert, dass wir bestimmte Informationen mit ihnen teilen, um diese Version offline anzubieten. Mit dem Fortfahren stimmst du zu, deine Informationen zu teilen und zu erlauben, dass der Herausgeber dir E-Mails sendet."
+    "download.agreementParagraph": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unsere Vereinbarung mit dem Herausgeber dieser Bibelversion erfordert, dass wir bestimmte Informationen mit ihnen teilen, um diese Version offline anzubieten. Mit dem Fortfahren stimmst du zu, deine Informationen zu teilen und zu erlauben, dass der Herausgeber dir E-Mails sendet."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Our agreement with the publisher of this Bible version requires us to share certain information with them in order to offer this version for offline use. By proceeding you agree to share your information and to allow the publisher to email you."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Our agreement with the publisher of this Bible version requires us to share certain information with them in order to offer this version for offline use. By proceeding you agree to share your information and to allow the publisher to email you."
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nuestro acuerdo con el editor de esta versión de la Biblia requiere que compartamos cierta información con ellos para ofrecer esta versión sin conexión. Al continuar, aceptas compartir tu información y permitir que el editor te envíe correos electrónicos."
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuestro acuerdo con el editor de esta versión de la Biblia requiere que compartamos cierta información con ellos para ofrecer esta versión sin conexión. Al continuar, aceptas compartir tu información y permitir que el editor te envíe correos electrónicos."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notre accord avec l'éditeur de cette version de la Bible nous oblige à partager certaines informations avec lui afin de proposer cette version hors ligne. En continuant, tu acceptes de partager tes informations et de permettre à l'éditeur de t'envoyer des e-mails."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notre accord avec l'éditeur de cette version de la Bible nous oblige à partager certaines informations avec lui afin de proposer cette version hors ligne. En continuant, tu acceptes de partager tes informations et de permettre à l'éditeur de t'envoyer des e-mails."
           }
         }
       }
     },
-    "download.callToAction" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lies sie jederzeit, überall – sogar offline"
+    "download.callToAction": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lies sie jederzeit, überall – sogar offline"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Read it anytime, anywhere—even offline"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Read it anytime, anywhere—even offline"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Léela cuando quieras, donde quieras, incluso sin conexión"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Léela cuando quieras, donde quieras, incluso sin conexión"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lis-la à tout moment, n'importe où, même hors ligne"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lis-la à tout moment, n'importe où, même hors ligne"
           }
         }
       }
     },
-    "download.disagreeButton" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nur online lesen"
+    "download.disagreeButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur online lesen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Read Online Only"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Read Online Only"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leer solo en línea"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leer solo en línea"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lire en ligne uniquement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lire en ligne uniquement"
           }
         }
       }
     },
-    "fontList.others" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Andere"
+    "fontList.others": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Andere"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Others"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Others"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otras"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otras"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autres"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autres"
           }
         }
       }
     },
-    "fontList.suggested" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empfohlen"
+    "fontList.suggested": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empfohlen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suggested"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suggested"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sugeridas"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sugeridas"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suggérées"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suggérées"
           }
         }
       }
     },
-    "fontList.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schriftarten für die Bibellektüre"
+    "fontList.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schriftarten für die Bibellektüre"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bible Reading Fonts"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bible Reading Fonts"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fuentes de lectura bíblica"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuentes de lectura bíblica"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Polices de lecture biblique"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polices de lecture biblique"
           }
         }
       }
     },
-    "fontSettings.label" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schriftart"
+    "fontSettings.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schriftart"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Font"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fuente"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Police"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Police"
           }
         }
       }
     },
-    "generic.back" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zurück"
+    "generic.back": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurück"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Back"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atrás"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atrás"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour"
           }
         }
       }
     },
-    "generic.cancel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+    "generic.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         }
       }
     },
-    "generic.done" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fertig"
+    "generic.done": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fertig"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Done"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Listo"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminé"
           }
         }
       }
     },
-    "generic.error" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler"
+    "generic.error": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur"
           }
         }
       }
     },
-    "generic.ok" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+    "generic.ok": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         }
       }
     },
-    "generic.search" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suchen"
+    "generic.search": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suchen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher"
           }
         }
       }
     },
-    "languageList.all" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle"
+    "languageList.all": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todos"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toutes"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toutes"
           }
         }
       }
     },
-    "languageList.allWithCount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$@ (%1$d)"
+    "languageList.allWithCount": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ (%1$d)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$@ (%1$d)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ (%1$d)"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$@ (%1$d)"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ (%1$d)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$@ (%1$d)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ (%1$d)"
           }
         }
       }
     },
-    "languageList.regional" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regional"
+    "languageList.regional": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regional"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regional"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regional"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regional"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regional"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Régionales"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Régionales"
           }
         }
       }
     },
-    "languageList.suggested" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empfohlen"
+    "languageList.suggested": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empfohlen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suggested"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suggested"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sugeridos"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sugeridos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suggérées"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suggérées"
           }
         }
       }
     },
-    "languageList.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bibelsprachen"
+    "languageList.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bibelsprachen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bible Languages"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bible Languages"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Idiomas de la Biblia"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idiomas de la Biblia"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Langues bibliques"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langues bibliques"
           }
         }
       }
     },
-    "menu.download" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Herunterladen"
+    "menu.download": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herunterladen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descargar"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Télécharger"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger"
           }
         }
       }
     },
-    "menu.fontSettings" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schriftarteinstellungen"
+    "menu.fontSettings": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schriftarteinstellungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Font Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font Settings"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes de fuente"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de fuente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réglages de police"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglages de police"
           }
         }
       }
     },
-    "menu.moreInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mehr Infos"
+    "menu.moreInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehr Infos"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "More info"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More info"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Más información"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más información"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plus d'infos"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plus d'infos"
           }
         }
       }
     },
-    "menu.removeDownload" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download entfernen"
+    "menu.removeDownload": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download entfernen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove Download"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Download"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminar descarga"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar descarga"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer le téléchargement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer le téléchargement"
           }
         }
       }
     },
-    "menu.removeFromList" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Von der Liste entfernen"
+    "menu.removeFromList": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Von der Liste entfernen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove from list"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove from list"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminar de la lista"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar de la lista"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retirer de la liste"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retirer de la liste"
           }
         }
       }
     },
-    "menu.signIn" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anmelden"
+    "menu.signIn": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anmelden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign In"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign In"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciar sesión"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar sesión"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se connecter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se connecter"
           }
         }
       }
     },
-    "menu.signOut" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abmelden"
+    "menu.signOut": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abmelden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign Out"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign Out"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerrar sesión"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerrar sesión"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se déconnecter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se déconnecter"
           }
         }
       }
     },
-    "myVersions.defaultVersionName" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "diese Version"
+    "myVersions.defaultVersionName": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "diese Version"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "this version"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "this version"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "esta versión"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "esta versión"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "cette version"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cette version"
           }
         }
       }
     },
-    "myVersions.downloadCompleteBodyFormat" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erfolgreicher Download von %@."
+    "myVersions.downloadCompleteBodyFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erfolgreicher Download von %@."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Successful download of %@."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Successful download of %@."
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descarga exitosa de %@."
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descarga exitosa de %@."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Téléchargement réussi de %@."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Téléchargement réussi de %@."
           }
         }
       }
     },
-    "myVersions.downloadCompleteTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download abgeschlossen"
+    "myVersions.downloadCompleteTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download abgeschlossen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download Complete"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download Complete"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descarga completa"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descarga completa"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Téléchargement terminé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Téléchargement terminé"
           }
         }
       }
     },
-    "myVersions.downloadErrorBody" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diese Version konnte zu diesem Zeitpunkt nicht heruntergeladen werden."
+    "myVersions.downloadErrorBody": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Version konnte zu diesem Zeitpunkt nicht heruntergeladen werden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "It was not possible to download this version at this time."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "It was not possible to download this version at this time."
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No fue posible descargar esta versión en este momento."
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No fue posible descargar esta versión en este momento."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Il n'a pas été possible de télécharger cette version pour le moment."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il n'a pas été possible de télécharger cette version pour le moment."
           }
         }
       }
     },
-    "myVersions.downloadFailedBodyFormat" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ konnte nicht heruntergeladen werden.\n\n%@"
+    "myVersions.downloadFailedBodyFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ konnte nicht heruntergeladen werden.\n\n%@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "It was not possible to download %@.\n\n%@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "It was not possible to download %@.\n\n%@"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No fue posible descargar %@.\n\n%@"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No fue posible descargar %@.\n\n%@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de télécharger %@.\n\n%@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de télécharger %@.\n\n%@"
           }
         }
       }
     },
-    "myVersions.downloadFailedTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download fehlgeschlagen"
+    "myVersions.downloadFailedTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download fehlgeschlagen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download Failed"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download Failed"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descarga fallida"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descarga fallida"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec du téléchargement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec du téléchargement"
           }
         }
       }
     },
-    "myVersions.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Meine Versionen"
+    "myVersions.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meine Versionen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "My Versions"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "My Versions"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mis versiones"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mis versiones"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mes versions"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mes versions"
           }
         }
       }
     },
-    "myVersions.versionInfoComingSoon" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "INFOS FOLGEN"
+    "myVersions.versionInfoComingSoon": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "INFOS FOLGEN"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "INFO TO COME"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "INFO TO COME"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "INFORMACIÓN POR VENIR"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "INFORMACIÓN POR VENIR"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "INFOS À VENIR"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "INFOS À VENIR"
           }
         }
       }
     },
-    "reader.learnMore" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mehr erfahren"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Learn more"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saber más"
+    "reader.availableLanguagesErrorBody": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "It was not possible to get the list of available languages. Please try again later."
           }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En savoir plus"
-          }
         }
       }
     },
-    "reader.footnoteTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Footnote"
+    "reader.footnoteTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Footnote"
           }
         }
       }
     },
-    "reader.introLoadError" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The Introductory material could not be loaded."
+    "reader.introLoadError": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Introductory material could not be loaded."
           }
         }
       }
     },
-    "reader.availableLanguagesErrorBody" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "It was not possible to get the list of available languages. Please try again later."
+    "reader.learnMore": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehr erfahren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Learn more"
+          }
+        },
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saber más"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En savoir plus"
           }
         }
       }
     },
-    "reader.noVersionsAvailable" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es sind keine Bibelversionen verfügbar. Verbinde dich erneut und lade eine Bibelversion herunter, um offline weiterzumachen."
+    "reader.noVersionsAvailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es sind keine Bibelversionen verfügbar. Verbinde dich erneut und lade eine Bibelversion herunter, um offline weiterzumachen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Bible versions are available. Re-connect and download a Bible version to proceed offline."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Bible versions are available. Re-connect and download a Bible version to proceed offline."
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay versiones de la Biblia disponibles. Vuelve a conectarte y descarga una versión de la Biblia para continuar sin conexión."
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay versiones de la Biblia disponibles. Vuelve a conectarte y descarga una versión de la Biblia para continuar sin conexión."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune version de la Bible n'est disponible. Reconnecte-toi et télécharge une version de la Bible pour continuer hors ligne."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune version de la Bible n'est disponible. Reconnecte-toi et télécharge une version de la Bible pour continuer hors ligne."
           }
         }
       }
     },
-    "reader.versionAccessErrorBody" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "It was not possible to access this Bible version. Please try again later."
+    "reader.versionAccessErrorBody": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "It was not possible to access this Bible version. Please try again later."
           }
         }
       }
     },
-    "shareableVerse.referencesSeparator" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ", "
+    "shareableVerse.referencesSeparator": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ", "
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ", "
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ","
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ", "
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ", "
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ", "
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ", "
           }
         }
       }
     },
-    "shareableVerse.unavailable" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(Bibeltext nicht verfügbar)"
+    "shareableVerse.unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(Bibeltext nicht verfügbar)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(Bible text is unavailable))"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(Bible text is unavailable)"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(Texto bíblico no disponible)"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(Texto bíblico no disponible)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(Texte biblique indisponible)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(Texte biblique indisponible)"
           }
         }
       }
     },
-    "signIn.appMessage" : {
-      "extractionState" : "manual"
+    "signIn.appMessage": {
+      "extractionState": "manual"
     },
-    "signIn.button.accessibility" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mit YouVersion anmelden"
+    "signIn.button.accessibility": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit YouVersion anmelden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign in with YouVersion"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign in with YouVersion"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inicia sesión con YouVersion"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicia sesión con YouVersion"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se connecter avec YouVersion"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se connecter avec YouVersion"
           }
         }
       }
     },
-    "signIn.button.compact" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anmelden"
+    "signIn.button.compact": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anmelden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign in"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign in"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciar sesión"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar sesión"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se connecter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se connecter"
           }
         }
       }
     },
-    "signIn.button.full" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mit %@ anmelden"
+    "signIn.button.full": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit %@ anmelden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign in with %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign in with %@"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inicia sesión con %@"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicia sesión con %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se connecter avec %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se connecter avec %@"
           }
         }
       }
     },
-    "signIn.introducing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WIR STELLEN VOR"
+    "signIn.introducing": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WIR STELLEN VOR"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "INTRODUCING"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "INTRODUCING"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PRESENTAMOS"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRESENTAMOS"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NOUS PRÉSENTONS"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOUS PRÉSENTONS"
           }
         }
       }
     },
-    "signIn.noButton" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nein danke"
+    "signIn.noButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nein danke"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Thanks"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Thanks"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No, gracias"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No, gracias"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non merci"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non merci"
           }
         }
       }
     },
-    "signIn.paragraph" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ möchte sich mit deinem YouVersion Bible App-Konto verbinden. Dies ermöglicht ihnen, deine Bibel-App-Aktivitäten zu sehen und damit zu interagieren. Möchtest du fortfahren?"
+    "signIn.paragraph": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ möchte sich mit deinem YouVersion Bible App-Konto verbinden. Dies ermöglicht ihnen, deine Bibel-App-Aktivitäten zu sehen und damit zu interagieren. Möchtest du fortfahren?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ wants to connect to your YouVersion Bible App account. This will allow them to see and interact with your Bible App activity. Would you like to proceed?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ wants to connect to your YouVersion Bible App account. This will allow them to see and interact with your Bible App activity. Would you like to proceed?"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ quiere conectarse a tu cuenta de YouVersion Bible App. Esto les permitirá ver e interactuar con tu actividad en la aplicación. ¿Te gustaría continuar?"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ quiere conectarse a tu cuenta de YouVersion Bible App. Esto les permitirá ver e interactuar con tu actividad en la aplicación. ¿Te gustaría continuar?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ souhaite se connecter à ton compte YouVersion Bible App. Cela lui permettra de voir et d'interagir avec ton activité dans l'application. Souhaites-tu continuer ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ souhaite se connecter à ton compte YouVersion Bible App. Cela lui permettra de voir et d'interagir avec ton activité dans l'application. Souhaites-tu continuer ?"
           }
         }
       }
     },
-    "signIn.yesButton" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ja"
+    "signIn.yesButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ja"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yes Please"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yes Please"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sí"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sí"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oui"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oui"
           }
         }
       }
     },
-    "signOut.explanation" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Du musst dich erneut anmelden, um auf deine Markierungen zuzugreifen."
+    "signOut.explanation": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du musst dich erneut anmelden, um auf deine Markierungen zuzugreifen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You'll need to sign in again to access your highlights."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You'll need to sign in again to access your highlights."
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tendrás que iniciar sesión nuevamente para acceder a tus destacados."
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tendrás que iniciar sesión nuevamente para acceder a tus destacados."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu devras te reconnecter pour accéder à tes surlignages."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu devras te reconnecter pour accéder à tes surlignages."
           }
         }
       }
     },
-    "signOut.question" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bist du sicher, dass du dich von YouVersion abmelden möchtest?"
+    "signOut.question": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bist du sicher, dass du dich von YouVersion abmelden möchtest?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Are you sure you want to sign out from YouVersion?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Are you sure you want to sign out from YouVersion?"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Estás seguro de que quieres cerrar sesión en YouVersion?"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Estás seguro de que quieres cerrar sesión en YouVersion?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es-tu sûr de vouloir te déconnecter de YouVersion ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es-tu sûr de vouloir te déconnecter de YouVersion ?"
           }
         }
       }
     },
-    "tab.bible" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bibel"
+    "tab.bible": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bibel"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bible"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bible"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Biblia"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biblia"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bible"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bible"
           }
         }
       }
     },
-    "tab.profile" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Profil"
+    "tab.profile": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profil"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Profile"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profile"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Perfil"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Perfil"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Profil"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profil"
           }
         }
       }
     },
-    "tab.votd" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vers des Tages"
+    "tab.votd": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vers des Tages"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verse of the Day"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verse of the Day"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versículo del día"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versículo del día"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verset du jour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verset du jour"
           }
         }
       }
     },
-    "tab.widget" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widget"
+    "tab.widget": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Widget"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widget"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Widget"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widget"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Widget"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widget"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Widget"
           }
         }
       }
     },
-    "verseActions.copy" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopieren"
+    "verseActions.copy": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiar"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copier"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier"
           }
         }
       }
     },
-    "verseActions.share" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Teilen"
+    "verseActions.share": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teilen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Share"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compartir"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compartir"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Partager"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partager"
           }
         }
       }
     },
-    "verseActions.swipeUpLabel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wische nach oben für mehr"
+    "verseActions.swipeUpLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wische nach oben für mehr"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swipe up for more"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swipe up for more"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desliza hacia arriba para más"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desliza hacia arriba para más"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Balaye vers le haut pour plus"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Balaye vers le haut pour plus"
           }
         }
       }
     },
-    "versionInfo.addButton" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hinzufügen"
+    "versionInfo.addButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinzufügen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregar"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter"
           }
         }
       }
     },
-    "versionInfo.addedButton" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hinzugefügt"
+    "versionInfo.addedButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinzugefügt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Added"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Added"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregada"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregada"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajoutée"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajoutée"
           }
         }
       }
     },
-    "versionInfo.detailsLabel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Details"
+    "versionInfo.detailsLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Details"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Details"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Details"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detalles"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalles"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Détails"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Détails"
           }
         }
       }
     },
-    "versionInfo.downloadButton" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Herunterladen"
+    "versionInfo.downloadButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herunterladen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descargar"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Télécharger"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger"
           }
         }
       }
     },
-    "versionInfo.publisherWithSizeFormat" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@  •  %2$@"
+    "versionInfo.publisherWithSizeFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@  •  %2$@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@  •  %2$@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@  •  %2$@"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@  •  %2$@"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@  •  %2$@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@  •  %2$@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@  •  %2$@"
           }
         }
       }
     },
-    "versionInfo.readButton" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lesen"
+    "versionInfo.readButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lesen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Read"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Read"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leer"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leer"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lire"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lire"
           }
         }
       }
     },
-    "versionInfo.sampleButton" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Probe"
+    "versionInfo.sampleButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Probe"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sample"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sample"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Muestra"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muestra"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échantillon"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échantillon"
           }
         }
       }
     },
-    "versionInfo.sharingOKButton" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+    "versionInfo.sharingOKButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         }
       }
     },
-    "versionInfo.sharingPrivacyButton" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datenschutzrichtlinie"
+    "versionInfo.sharingPrivacyButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenschutzrichtlinie"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacy Policy"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy Policy"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Política de privacidad"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Política de privacidad"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Politique de confidentialité"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Politique de confidentialité"
           }
         }
       }
     },
-    "versionInfo.sharingTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Du wirst teilen"
+    "versionInfo.sharingTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du wirst teilen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You will share"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You will share"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compartirás"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compartirás"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu vas partager"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu vas partager"
           }
         }
       }
     },
-    "versionList.searchPlaceholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versionen suchen"
+    "versionList.searchPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versionen suchen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search versions"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search versions"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar versiones"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar versiones"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher des versions"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des versions"
           }
         }
       }
     },
-    "versionList.statisticsFormat" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$#@versions_string@ in %2$#@languages_string@"
+    "versionList.statisticsFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$#@versions_string@ in %2$#@languages_string@"
           },
-          "substitutions" : {
-            "languages_string" : {
-              "argNum" : 2,
-              "formatSpecifier" : "lu",
-              "variations" : {
-                "plural" : {
-                  "one" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu Sprache"
+          "substitutions": {
+            "languages_string": {
+              "argNum": 2,
+              "formatSpecifier": "lu",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu Sprache"
                     }
                   },
-                  "other" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu Sprachen"
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu Sprachen"
                     }
                   }
                 }
               }
             },
-            "versions_string" : {
-              "argNum" : 1,
-              "formatSpecifier" : "lu",
-              "variations" : {
-                "plural" : {
-                  "one" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu Übersetzung"
+            "versions_string": {
+              "argNum": 1,
+              "formatSpecifier": "lu",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu Übersetzung"
                     }
                   },
-                  "other" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu Übersetzungen"
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu Übersetzungen"
                     }
                   }
                 }
@@ -2097,47 +2098,47 @@
             }
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%#@versions_string@ in %#@languages_string@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@versions_string@ in %#@languages_string@"
           },
-          "substitutions" : {
-            "languages_string" : {
-              "argNum" : 2,
-              "formatSpecifier" : "lu",
-              "variations" : {
-                "plural" : {
-                  "one" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu Language"
+          "substitutions": {
+            "languages_string": {
+              "argNum": 2,
+              "formatSpecifier": "lu",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu Language"
                     }
                   },
-                  "other" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu Languages"
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu Languages"
                     }
                   }
                 }
               }
             },
-            "versions_string" : {
-              "argNum" : 1,
-              "formatSpecifier" : "lu",
-              "variations" : {
-                "plural" : {
-                  "one" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu Version"
+            "versions_string": {
+              "argNum": 1,
+              "formatSpecifier": "lu",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu Version"
                     }
                   },
-                  "other" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu Versions"
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu Versions"
                     }
                   }
                 }
@@ -2145,47 +2146,47 @@
             }
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%#@versions_string@ en %#@languages_string@"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@versions_string@ en %#@languages_string@"
           },
-          "substitutions" : {
-            "languages_string" : {
-              "argNum" : 2,
-              "formatSpecifier" : "lu",
-              "variations" : {
-                "plural" : {
-                  "one" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu idioma"
+          "substitutions": {
+            "languages_string": {
+              "argNum": 2,
+              "formatSpecifier": "lu",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu idioma"
                     }
                   },
-                  "other" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu idiomas"
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu idiomas"
                     }
                   }
                 }
               }
             },
-            "versions_string" : {
-              "argNum" : 1,
-              "formatSpecifier" : "lu",
-              "variations" : {
-                "plural" : {
-                  "one" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu Versión"
+            "versions_string": {
+              "argNum": 1,
+              "formatSpecifier": "lu",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu Versión"
                     }
                   },
-                  "other" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu Versiones"
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu Versiones"
                     }
                   }
                 }
@@ -2193,47 +2194,47 @@
             }
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$#@versions_string@ dans %2$#@languages_string@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$#@versions_string@ dans %2$#@languages_string@"
           },
-          "substitutions" : {
-            "languages_string" : {
-              "argNum" : 2,
-              "formatSpecifier" : "lu",
-              "variations" : {
-                "plural" : {
-                  "one" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu langue"
+          "substitutions": {
+            "languages_string": {
+              "argNum": 2,
+              "formatSpecifier": "lu",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu langue"
                     }
                   },
-                  "other" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu langues"
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu langues"
                     }
                   }
                 }
               }
             },
-            "versions_string" : {
-              "argNum" : 1,
-              "formatSpecifier" : "lu",
-              "variations" : {
-                "plural" : {
-                  "one" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu version"
+            "versions_string": {
+              "argNum": 1,
+              "formatSpecifier": "lu",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu version"
                     }
                   },
-                  "other" : {
-                    "stringUnit" : {
-                      "state" : "translated",
-                      "value" : "%lu versions"
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lu versions"
                     }
                   }
                 }
@@ -2243,35 +2244,34 @@
         }
       }
     },
-    "widget.poweredBy" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unterstützt von"
+    "widget.poweredBy": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unterstützt von"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Powered by"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Powered by"
           }
         },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desarrollado por"
+        "es-MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desarrollado por"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Propulsé par"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Propulsé par"
           }
         }
       }
     }
-  },
-  "version" : "1.1"
+  }
 }

--- a/Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings
+++ b/Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "1.1",
   "sourceLanguage": "en",
   "localizations": {
     "de": {

--- a/Tests/YouVersionPlatformUITests/LocalizationTests.swift
+++ b/Tests/YouVersionPlatformUITests/LocalizationTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+import YouVersionPlatformUI
+
+@Suite struct LocalizationTests {
+    @Test
+    func englishDefaultCancelIsTranslated() {
+        let value = String.localized("generic.cancel")
+
+        #expect(value == "Cancel")
+        #expect(value != "generic.cancel")
+    }
+
+    @Test
+    func germanStringsAreTranslated() {
+        #expect(
+            localizedString(forKey: "generic.cancel", languageCode: "de") == "Abbrechen"
+        )
+        #expect(
+            localizedString(forKey: "bookChapterPicker.title", languageCode: "de") == "Bücher"
+        )
+    }
+
+    @Test
+    func frenchAndSpanishMexicoCancelAreTranslated() {
+        #expect(
+            localizedString(forKey: "generic.cancel", languageCode: "fr") == "Annuler"
+        )
+        #expect(
+            localizedString(forKey: "generic.cancel", languageCode: "es-MX") == "Cancelar"
+        )
+    }
+
+    @Test
+    func germanSignInButtonFormatStringInsertsAppName() {
+        let format = localizedString(forKey: "signIn.button.full", languageCode: "de")
+        let value = String(format: format, "YouVersion")
+
+        #expect(value == "Mit YouVersion anmelden")
+    }
+
+    @Test
+    func youVersionUIBundleContainsExpectedLanguageBundles() {
+        let bundle = Bundle.YouVersionUIBundle
+
+        for languageCode in ["de", "fr", "es-MX"] {
+            #expect(bundle.path(forResource: languageCode, ofType: "lproj") != nil)
+        }
+    }
+
+    @Test
+    func genericOkIsTranslatedInEnglish() {
+        #expect(
+            localizedString(forKey: "generic.ok", languageCode: "en") == "OK"
+        )
+    }
+}
+
+private func localizedString(
+    forKey key: String,
+    languageCode: String,
+    bundle: Bundle = .YouVersionUIBundle
+) -> String {
+    guard let lprojPath = bundle.path(forResource: languageCode, ofType: "lproj"),
+          let localizedBundle = Bundle(path: lprojPath) else {
+        Issue.record("Missing \(languageCode).lproj in \(bundle.bundlePath)")
+        return key
+    }
+    return localizedBundle.localizedString(forKey: key, value: nil, table: "Localizable")
+}


### PR DESCRIPTION
## Description

This PR puts in place the localizable strings downloaded from Crowdin. These strings are a first pass set of strings and can be expected to change and be updated as we refine the strings. 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [ ] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [x] `chore:` Other changes (maintenance, etc.)

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] All commit messages follow [conventional commits](https://www.conventionalcommits.org/) format

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers the first-pass Crowdin-generated localizable strings for the YouVersion Platform SDK. The xcstrings file is reformatted (compact JSON, alphabetical key order, version bumped to 1.1) and three new English-only strings are added (`bibleCard.unavailableReference`, `bibleText.connectionIssue`, `bibleText.unavailableVersion`). A brand-new `LocalizationTests.swift` suite validates bundle presence, per-language string resolution, and format-string interpolation.

- **Localizable.xcstrings**: Reformatted by Crowdin; existing translation values are identical, three new EN-only strings added (expected first-pass behaviour).
- **LocalizationTests.swift**: New test file using Swift Testing that covers English default lookup, German/French/Spanish-MX bundle resolution, and format-string insertion — good foundational coverage for the localization layer.
- **.gitignore**: `.omc` (Xcode-generated) added to avoid accidental tracking.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a formatting and content update to localizable strings with no logic changes, and the new test suite validates the core localization plumbing correctly.

The change is a Crowdin export refresh: all existing translation values are byte-for-byte identical, the three newly added strings are English-only by design (first-pass, as noted in the PR description), and the new test file correctly exercises bundle resolution and format-string interpolation for all supported locales.

No files require special attention. The English-only entries for `generic.ok`, `bibleCard.unavailableReference`, `bibleText.connectionIssue`, and `bibleText.unavailableVersion` are expected gaps to be filled in a future Crowdin pass.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .gitignore | Adds `.omc` to gitignore — an Xcode-generated directory that should not be tracked. |
| Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings | Reformats JSON (removes spaced colons), reorders keys alphabetically, bumps format version to 1.1, and adds 3 new English-only strings; existing translation values are unchanged. |
| Tests/YouVersionPlatformUITests/LocalizationTests.swift | New test suite covering default-language lookup, per-language bundle resolution for de/fr/es-MX, format-string interpolation, and bundle presence; uses Swift Testing's `@Suite` and `#expect`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Crowdin Export] -->|Reformatted xcstrings v1.1| B[Localizable.xcstrings]
    B --> C[Xcode / SPM Compilation]
    C --> D[en.lproj/Localizable.strings]
    C --> E[de.lproj/Localizable.strings]
    C --> F[fr.lproj/Localizable.strings]
    C --> G[es-MX.lproj/Localizable.strings]
    D & E & F & G --> H[Bundle.YouVersionUIBundle]
    H --> I[String.localized - default en]
    H --> J[localizedString forKey languageCode]
    I --> K[LocalizationTests]
    J --> K
    B -.->|EN only - no de/fr/es-MX| L["bibleCard.unavailableReference\nbibleText.connectionIssue\nbibleText.unavailableVersion"]
    L -.->|Fallback to EN| E & F & G
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ATests%2FYouVersionPlatformUITests%2FLocalizationTests.swift%3A51-56%0A**%60generic.ok%60%20missing%20non-English%20translations**%0A%0AThe%20test%20verifies%20that%20%60generic.ok%60%20resolves%20to%20%60%22OK%22%60%20for%20English%2C%20which%20works%20because%20the%20xcstrings%20file%20has%20an%20explicit%20%60en%60%20entry%20for%20it.%20However%2C%20%60generic.ok%60%20has%20no%20%60de%60%2C%20%60fr%60%2C%20or%20%60es-MX%60%20entries%2C%20so%20users%20on%20those%20locales%20will%20silently%20receive%20the%20English%20%22OK%22%20as%20a%20fallback.%20%22OK%22%20is%20likely%20universally%20understood%2C%20but%20if%20completeness%20is%20desired%20you%20may%20want%20to%20add%20it%20to%20the%20next%20Crowdin%20translation%20pass.%20No%20action%20needed%20right%20now%20if%20this%20is%20intentional%20for%20the%20first-pass%20strings.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=153&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ATests%2FYouVersionPlatformUITests%2FLocalizationTests.swift%3A51-56%0A**%60generic.ok%60%20missing%20non-English%20translations**%0A%0AThe%20test%20verifies%20that%20%60generic.ok%60%20resolves%20to%20%60%22OK%22%60%20for%20English%2C%20which%20works%20because%20the%20xcstrings%20file%20has%20an%20explicit%20%60en%60%20entry%20for%20it.%20However%2C%20%60generic.ok%60%20has%20no%20%60de%60%2C%20%60fr%60%2C%20or%20%60es-MX%60%20entries%2C%20so%20users%20on%20those%20locales%20will%20silently%20receive%20the%20English%20%22OK%22%20as%20a%20fallback.%20%22OK%22%20is%20likely%20universally%20understood%2C%20but%20if%20completeness%20is%20desired%20you%20may%20want%20to%20add%20it%20to%20the%20next%20Crowdin%20translation%20pass.%20No%20action%20needed%20right%20now%20if%20this%20is%20intentional%20for%20the%20first-pass%20strings.%0A%0A&pr=153&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22update_localizable_strings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22update_localizable_strings%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ATests%2FYouVersionPlatformUITests%2FLocalizationTests.swift%3A51-56%0A**%60generic.ok%60%20missing%20non-English%20translations**%0A%0AThe%20test%20verifies%20that%20%60generic.ok%60%20resolves%20to%20%60%22OK%22%60%20for%20English%2C%20which%20works%20because%20the%20xcstrings%20file%20has%20an%20explicit%20%60en%60%20entry%20for%20it.%20However%2C%20%60generic.ok%60%20has%20no%20%60de%60%2C%20%60fr%60%2C%20or%20%60es-MX%60%20entries%2C%20so%20users%20on%20those%20locales%20will%20silently%20receive%20the%20English%20%22OK%22%20as%20a%20fallback.%20%22OK%22%20is%20likely%20universally%20understood%2C%20but%20if%20completeness%20is%20desired%20you%20may%20want%20to%20add%20it%20to%20the%20next%20Crowdin%20translation%20pass.%20No%20action%20needed%20right%20now%20if%20this%20is%20intentional%20for%20the%20first-pass%20strings.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=153&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Tests/YouVersionPlatformUITests/LocalizationTests.swift:51-56
**`generic.ok` missing non-English translations**

The test verifies that `generic.ok` resolves to `"OK"` for English, which works because the xcstrings file has an explicit `en` entry for it. However, `generic.ok` has no `de`, `fr`, or `es-MX` entries, so users on those locales will silently receive the English "OK" as a fallback. "OK" is likely universally understood, but if completeness is desired you may want to add it to the next Crowdin translation pass. No action needed right now if this is intentional for the first-pass strings.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: add test"](https://github.com/youversion/platform-sdk-swift/commit/2274f110ccc25bd20e309326a144b4f4075e1593) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35694149)</sub>

<!-- /greptile_comment -->