### PR TITLE
fix: add .serialized to child suites that mutate YouVersionPlatformConfiguration

### DIFF
--- a/Tests/YouVersionPlatformCoreTests/ConfigurationStateTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/ConfigurationStateTests.swift
@@ -1,8 +1,8 @@
 import Testing
 
-/// Parent suite that serializes all tests touching `YouVersionPlatformConfiguration`'s
-/// global state. `.serialized` only prevents parallelism *within* a suite, so suites
-/// that share mutable static state must be nested under a common serialized parent to
-/// prevent cross-suite races.
+/// Parent suite for all tests that mutate `YouVersionPlatformConfiguration` global state.
+/// Each nested suite must also carry `.serialized` — the parent trait does not propagate
+/// through nested `@Suite` declarations, so without it the child suite's own tests can
+/// still interleave with each other and with sibling suites.
 @Suite(.serialized)
 struct ConfigurationStateTests {}

--- a/Tests/YouVersionPlatformCoreTests/URLRequestYouVersionTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/URLRequestYouVersionTests.swift
@@ -6,7 +6,7 @@ import Testing
 @testable import YouVersionPlatformCore
 
 extension ConfigurationStateTests {
-    @Suite struct URLRequestYouVersionTests {
+    @Suite(.serialized) struct URLRequestYouVersionTests {
         
         @Test func sdkVersionHeaderIsSetWhenAppKeyConfigured() async throws {
             let originalAppKey = YouVersionPlatformConfiguration.appKey

--- a/Tests/YouVersionPlatformCoreTests/UsersAuthHelpersTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/UsersAuthHelpersTests.swift
@@ -7,23 +7,23 @@ import Testing
 
 extension ConfigurationStateTests {
     @Suite struct UsersAuthHelpersTests {
-        
+
         @Test func obtainCodeReturnsAuthorizationCode() throws {
             let location = "youversionauth://callback?state=xyz&code=abc123&scope=bibles"
-            
+
             let code = try YouVersionAPI.Users.obtainCode(from: location)
-            
+
             #expect(code == "abc123")
         }
-        
+
         @Test func obtainCodeMissingAuthorizationCodeThrows() {
             let location = "youversionauth://callback?state=xyz"
-            
+
             #expect(throws: URLError.self) {
                 _ = try YouVersionAPI.Users.obtainCode(from: location)
             }
         }
-        
+
         @Test func extractResultParsesClaimsAndPermissions() throws {
             let payload: [String: Any] = [
                 "sub": "user-123",
@@ -33,7 +33,7 @@ extension ConfigurationStateTests {
                 "nonce": "xyz"
             ]
             let token = try makeTestJWT(claims: payload)
-            
+
             let tokens = YouVersionAPI.Users.TokenResponse(
                 accessToken: "access-token",
                 expiresIn: "3600",
@@ -42,9 +42,9 @@ extension ConfigurationStateTests {
                 scope: "openid,email,profile",
                 tokenType: "Bearer"
             )
-            
+
             let result = try YouVersionAPI.Users.extractSignInWithYouVersionResult(from: tokens, nonce: "xyz")
-            
+
             #expect(result.accessToken == "access-token")
             #expect(result.refreshToken == "refresh-token")
             #expect(result.idToken == token)
@@ -54,7 +54,7 @@ extension ConfigurationStateTests {
             #expect(result.profilePicture == "https://example.com/avatar.png")
             #expect(result.email == "user@example.com")
         }
-        
+
         @Test func extractResultFailsBadNonce() throws {
             let payload: [String: Any] = [
                 "sub": "user-123",
@@ -64,7 +64,7 @@ extension ConfigurationStateTests {
                 "nonce": "BADVALUE"
             ]
             let token = try makeTestJWT(claims: payload)
-            
+
             let tokens = YouVersionAPI.Users.TokenResponse(
                 accessToken: "access-token",
                 expiresIn: "3600",
@@ -73,19 +73,22 @@ extension ConfigurationStateTests {
                 scope: "openid,email,profile",
                 tokenType: "Bearer"
             )
-            
+
             #expect(throws: URLError.self) {
                 _ = try YouVersionAPI.Users.extractSignInWithYouVersionResult(from: tokens, nonce: "xyz")
             }
         }
-        
+    }
+
+    @Suite(.serialized) struct RefreshSignInTests {
+
         @Test func refreshSignInSuccessReturnsNewTokens() async throws {
             let originalAppKey = YouVersionPlatformConfiguration.appKey
             await YouVersionPlatformConfiguration.configure(appKey: "test-app")
-            
+
             let (session, token) = HTTPMocking.makeSession()
             defer { HTTPMocking.clear(token: token) }
-            
+
             let responsePayload: [String: String] = [
                 "access_token": "new-access",
                 "expires_in": "7200",
@@ -93,7 +96,7 @@ extension ConfigurationStateTests {
                 "scope": "ignored"
             ]
             let responseData = try JSONEncoder().encode(responsePayload)
-            
+
             HTTPMocking.setHandler(token: token) { request in
                 #expect(request.url?.path == "/auth/token")
                 #expect(request.httpMethod == "POST")
@@ -102,38 +105,38 @@ extension ConfigurationStateTests {
                 #expect(body.contains("grant_type=refresh_token"))
                 #expect(body.contains("client_id=test-app"))
                 #expect(body.contains("refresh_token=refresh-token-value"))
-                
+
                 let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
                 return (responseData, response)
             }
-            
+
             let result = try await YouVersionAPI.Users.refreshSignIn(
                 withToken: "refresh-token-value",
                 idToken: "id-token",
                 session: session
             )
-            
+
             #expect(result.accessToken == "new-access")
             #expect(result.refreshToken == "new-refresh")
             #expect(result.idToken == "id-token")
             #expect(result.permissions.isEmpty)
             #expect(result.yvpUserId == nil)
-            
+
             await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
         }
-        
+
         @Test func refreshSignInNon200Throws() async {
             let originalAppKey = YouVersionPlatformConfiguration.appKey
             await YouVersionPlatformConfiguration.configure(appKey: "test-app")
-            
+
             let (session, token) = HTTPMocking.makeSession()
             defer { HTTPMocking.clear(token: token) }
-            
+
             HTTPMocking.setHandler(token: token) { request in
                 let response = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
                 return (Data(), response)
             }
-            
+
             await #expect(throws: URLError.self) {
                 _ = try await YouVersionAPI.Users.refreshSignIn(
                     withToken: "refresh-token-value",
@@ -141,7 +144,7 @@ extension ConfigurationStateTests {
                     session: session
                 )
             }
-            
+
             await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
         }
     }

--- a/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
@@ -6,7 +6,7 @@ import Testing
 @testable import YouVersionPlatformCore
 
 extension ConfigurationStateTests {
-    @Suite struct YouVersionPlatformConfigurationTests {
+    @Suite(.serialized) struct YouVersionPlatformConfigurationTests {
         
         // MARK: - configure
         


### PR DESCRIPTION
## Summary

- Fixes a flaky race in `URLRequestYouVersionTests` where `appKey` set by one test was visible to a concurrent sibling test.
- Root cause: Swift Testing's `.serialized` trait does not propagate through nested `@Suite` declarations. `ConfigurationStateTests` had no direct `@Test` members, so its `.serialized` had no practical effect on the three child suites that were missing the trait.
- Adds `.serialized` to `URLRequestYouVersionTests`, `YouVersionPlatformConfigurationTests`, and the new `RefreshSignInTests`.
- Splits the two `refreshSignIn` tests out of `UsersAuthHelpersTests` into a new `RefreshSignInTests` suite, so the four pure parsing tests in `UsersAuthHelpersTests` (which touch no global state) continue running in parallel.
- Updates the comment in `ConfigurationStateTests` to accurately describe that each nested suite needs its own `.serialized`.

## Test plan

- [ ] Run the full `YouVersionPlatformCoreTests` target repeatedly (e.g. with `--parallel` and a repeat count) and confirm `URLRequestYouVersionTests` no longer flakes.
- [ ] Confirm `UsersAuthHelpersTests` (`obtainCode*`, `extractResult*`) still run in parallel (not serialized).
- [ ] Confirm `RefreshSignInTests` runs serially and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a real concurrency bug where Swift Testing's `.serialized` trait was applied only to the parent `ConfigurationStateTests` suite but not to its child suites — meaning child tests could still race each other despite the parent's trait. The fix adds `.serialized` directly to each child suite that writes to `YouVersionPlatformConfiguration` global state, and correctly splits the two stateful `refreshSignIn` tests into their own `RefreshSignInTests` suite so the four pure-parsing tests in `UsersAuthHelpersTests` remain parallel.

- **`URLRequestYouVersionTests` and `YouVersionPlatformConfigurationTests`**: receive `.serialized` since both suites mutate `appKey` and other global configuration properties.
- **`RefreshSignInTests`** (new): extracts the two `refreshSignIn` tests that call `configure(appKey:)` into a dedicated `.serialized` suite, cleanly separating stateful from stateless tests.
- **`UsersAuthHelpersTests`**: intentionally left without `.serialized`; its four `obtainCode` / `extractResult` tests are pure URL and JWT parsing with no global-state reads or writes, so they can safely continue running in parallel.

<h3>Confidence Score: 5/5</h3>

Test-only change that correctly places .serialized on each suite that mutates shared global state; no production code is touched.

All four changed files are test files. The fix is surgically targeted: .serialized is added only where global state is written, and the pure-parsing tests in UsersAuthHelpersTests are correctly left without serialization. The new RefreshSignInTests suite properly captures and restores originalAppKey in both tests, and the updated ConfigurationStateTests comment accurately describes the non-propagation behavior. No production logic is altered.

No files require special attention — all changes are confined to test files and follow the established save/restore pattern used throughout the suite.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Tests/YouVersionPlatformCoreTests/ConfigurationStateTests.swift | Comment updated to accurately explain that .serialized does not propagate through nested @Suite declarations — each child suite that touches global state must carry the trait itself. |
| Tests/YouVersionPlatformCoreTests/URLRequestYouVersionTests.swift | Added .serialized to URLRequestYouVersionTests; all tests in this suite read and write YouVersionPlatformConfiguration.appKey, so serialization is required and correctly applied. |
| Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift | Added .serialized to YouVersionPlatformConfigurationTests; every test in this suite writes to YouVersionPlatformConfiguration properties, making serialization necessary. No logic changes. |
| Tests/YouVersionPlatformCoreTests/UsersAuthHelpersTests.swift | Split the two stateful refreshSignIn tests into a new .serialized RefreshSignInTests suite nested under ConfigurationStateTests; the remaining four pure-parsing tests in UsersAuthHelpersTests keep running in parallel as intended. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@Suite(.serialized)\nConfigurationStateTests"]

    A --> B["@Suite(.serialized)\nURLRequestYouVersionTests\n✅ serialized — writes appKey"]
    A --> C["@Suite(.serialized)\nYouVersionPlatformConfigurationTests\n✅ serialized — writes global config"]
    A --> D["@Suite\nUsersAuthHelpersTests\n✅ no serialization needed\n(pure URL/JWT parsing)"]
    A --> E["@Suite(.serialized)\nRefreshSignInTests ← NEW\n✅ serialized — writes appKey"]

    B --> B1["sdkVersionHeaderIsSetWhenAppKeyConfigured"]
    B --> B2["sdkVersionHeaderIsAbsentWhenAppKeyNotConfigured"]

    D --> D1["obtainCodeReturnsAuthorizationCode"]
    D --> D2["obtainCodeMissingAuthorizationCodeThrows"]
    D --> D3["extractResultParsesClaimsAndPermissions"]
    D --> D4["extractResultFailsBadNonce"]

    E --> E1["refreshSignInSuccessReturnsNewTokens"]
    E --> E2["refreshSignInNon200Throws"]

    style B fill:#d4edda
    style C fill:#d4edda
    style E fill:#d4edda
    style D fill:#fff3cd
```

<sub>Reviews (1): Last reviewed commit: ["fix: add .serialized to child suites tha..."](https://github.com/youversion/platform-sdk-swift/commit/7cc4f68e3c5a96e526cfb9eabbc5b0cdb165ca84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35904175)</sub>

<!-- /greptile_comment -->