### PR TITLE
perf(reader): improve long chapter scroll performance

### DIFF
--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -31,6 +31,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
 
     // MARK: - UI state of the Reader itself
     var showChrome = true
+    @ObservationIgnored
     var lastScrollOffset: CGFloat = 0
     var scrollToTop = false
     var isChangingChapter = false

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
@@ -106,7 +106,7 @@ public struct BibleTextView: View {
     }
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        LazyVStack(alignment: .leading, spacing: 0) {
             if let phase = loadingPhase {
                 if let placeholder {
                     placeholder(phase)

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderScrollObservationTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderScrollObservationTests.swift
@@ -1,0 +1,52 @@
+import Observation
+import SwiftUI
+import Testing
+@testable import YouVersionPlatformReader
+
+@MainActor
+@Suite(.serialized) struct BibleReaderScrollObservationTests {
+    private typealias Support = BibleReaderViewModelTestSupport
+    private final class InvalidationFlag: @unchecked Sendable {
+        var didInvalidate = false
+    }
+
+    @Test
+    func lastScrollOffsetDoesNotInvalidateObservationTracking() {
+        let scrollDownOffsets = stride(from: CGFloat(0), through: CGFloat(-1_000), by: CGFloat(-20)).map(\.self)
+        let scrollUpOffsets = stride(from: CGFloat(-1_000), through: CGFloat(0), by: CGFloat(20)).map(\.self)
+        let offsets = scrollDownOffsets + scrollUpOffsets
+
+        let invalidations = countInvalidations(read: { viewModel in
+            _ = viewModel.lastScrollOffset
+        }, mutate: { viewModel, offset in
+            viewModel.handleScroll(offset: offset)
+        }, offsets: offsets)
+
+        #expect(invalidations == 0)
+    }
+
+    private func countInvalidations(
+        read: (BibleReaderViewModel) -> Void,
+        mutate: (BibleReaderViewModel, CGFloat) -> Void,
+        offsets: [CGFloat]
+    ) -> Int {
+        let viewModel = Support.makeViewModel()
+        viewModel.showChrome = true
+        viewModel.lastScrollOffset = 0
+
+        return offsets.reduce(into: 0) { invalidations, offset in
+            let invalidationFlag = InvalidationFlag()
+            withObservationTracking {
+                read(viewModel)
+            } onChange: {
+                invalidationFlag.didInvalidate = true
+            }
+
+            mutate(viewModel, offset)
+
+            if invalidationFlag.didInvalidate {
+                invalidations += 1
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Render Bible text blocks with `LazyVStack` so long chapters do not eagerly materialize every block.
- Mark scroll offset bookkeeping as `@ObservationIgnored` so offset updates do not invalidate observation-dependent UI.
- Add a focused regression test for the ignored scroll-offset observation behavior.

## Validation
- `swift test`
- `LINUX_SOURCEKIT_LIB_PATH=/root/.local/share/swiftly/toolchains/6.1.3/usr/lib swiftlint --strict`

## Measurement Context
- Psalm 119 runtime snapshot measurement from the optimization pass: eager `VStack` rendered about 801 UI elements at top; `LazyVStack` rendered about 140 at top, about 82.5% fewer visible runtime nodes.
- Scroll-offset observation regression: synthetic scroll-offset mutations produce 0 observation invalidations for `lastScrollOffset`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies two focused performance optimizations to the Bible reader: replacing `VStack` with `LazyVStack` in `BibleTextView` to defer off-screen block creation (measured at ~82.5% node reduction for Psalm 119), and marking `lastScrollOffset` with `@ObservationIgnored` so high-frequency scroll events no longer invalidate observation-tracked SwiftUI views. A dedicated regression test verifies the observation behavior.

- **`BibleTextView.swift`**: `VStack` → `LazyVStack` in `body`; the blocks rendered by `view(for:)` are stateless computed views so lazy destruction and recreation is safe.
- **`BibleReaderViewModel.swift`**: `@ObservationIgnored` added to `lastScrollOffset`; the `handleScroll` hot path now updates the offset without triggering observation invalidations anywhere in the UI.
- **`BibleReaderScrollObservationTests.swift`**: New `@Suite(.serialized)` test that reads `lastScrollOffset` under `withObservationTracking` and confirms zero `onChange` fires across 100 synthetic scroll events.

<h3>Confidence Score: 4/5</h3>

The changes are targeted and well-reasoned; the LazyVStack swap is safe because the block views are stateless, and the @ObservationIgnored annotation is correctly scoped to a write-only bookkeeping property.

Both changes are validated by measurements and a new regression test. The only flag is the @unchecked Sendable pattern in the test helper, which is safe in practice but adds a silent concurrency contract for future maintainers.

BibleReaderScrollObservationTests.swift — the @unchecked Sendable InvalidationFlag class is worth revisiting if the test is ever extended or refactored.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformUI/Views/BibleTextView.swift | VStack replaced with LazyVStack in body; stateless block views and stable UUID-based ForEach IDs make this a safe drop-in swap. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | @ObservationIgnored added to lastScrollOffset; property remains fully mutable/readable, only removed from the observation tracking graph. |
| Tests/YouVersionPlatformReaderTests/BibleReaderScrollObservationTests.swift | New regression test verifying @ObservationIgnored behavior; uses @unchecked Sendable for a mutable flag in a context where it is safe but is worth a second look. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant ScrollView
    participant BibleReaderView
    participant BibleReaderViewModel
    participant BibleTextView

    ScrollView->>BibleReaderView: onGeometryChange(offset)
    BibleReaderView->>BibleReaderViewModel: handleScroll(offset:)
    BibleReaderViewModel->>BibleReaderViewModel: update showChrome (observed)
    BibleReaderViewModel->>BibleReaderViewModel: "lastScrollOffset = offset (@ObservationIgnored)"
    Note over BibleReaderViewModel: No observation invalidation fired

    ScrollView->>BibleTextView: viewport geometry update
    BibleTextView->>BibleTextView: LazyVStack renders only visible blocks
    Note over BibleTextView: Off-screen blocks not materialized
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ATests%2FYouVersionPlatformReaderTests%2FBibleReaderScrollObservationTests.swift%3A9-11%0A**%60%40unchecked%20Sendable%60%20flag%20on%20mutable%20class**%0A%0A%60InvalidationFlag%60%20has%20an%20unsynchronized%20mutable%20%60Bool%60%20and%20satisfies%20%60Sendable%60%20only%20via%20%60%40unchecked%60.%20This%20is%20safe%20today%20because%20the%20test%20suite%2C%20%60handleScroll%60%2C%20and%20the%20%60withObservationTracking%60%20%60onChange%60%20closure%20all%20run%20on%20%60%40MainActor%60%2C%20but%20the%20%60%40unchecked%60%20marker%20is%20a%20silent%20contract%20that%20future%20readers%20might%20not%20notice.%20Consider%20a%20%60nonisolated%28unsafe%29%20var%60%20in%20the%20%60%40MainActor%60-scoped%20test%2C%20or%20simply%20a%20plain%20%60Bool%60%20local%20variable%20captured%20by%20the%20closure%20%28a%20%60var%60%20in%20the%20%60reduce%60%20body%20works%20fine%20here%20since%20the%20%60onChange%60%20closure%20fires%20synchronously%20on%20the%20same%20actor%20before%20the%20next%20iteration%29.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=155&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ATests%2FYouVersionPlatformReaderTests%2FBibleReaderScrollObservationTests.swift%3A9-11%0A**%60%40unchecked%20Sendable%60%20flag%20on%20mutable%20class**%0A%0A%60InvalidationFlag%60%20has%20an%20unsynchronized%20mutable%20%60Bool%60%20and%20satisfies%20%60Sendable%60%20only%20via%20%60%40unchecked%60.%20This%20is%20safe%20today%20because%20the%20test%20suite%2C%20%60handleScroll%60%2C%20and%20the%20%60withObservationTracking%60%20%60onChange%60%20closure%20all%20run%20on%20%60%40MainActor%60%2C%20but%20the%20%60%40unchecked%60%20marker%20is%20a%20silent%20contract%20that%20future%20readers%20might%20not%20notice.%20Consider%20a%20%60nonisolated%28unsafe%29%20var%60%20in%20the%20%60%40MainActor%60-scoped%20test%2C%20or%20simply%20a%20plain%20%60Bool%60%20local%20variable%20captured%20by%20the%20closure%20%28a%20%60var%60%20in%20the%20%60reduce%60%20body%20works%20fine%20here%20since%20the%20%60onChange%60%20closure%20fires%20synchronously%20on%20the%20same%20actor%20before%20the%20next%20iteration%29.%0A%0A&pr=155&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22YPE-9999-reader-lazy-scroll-observation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22YPE-9999-reader-lazy-scroll-observation%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ATests%2FYouVersionPlatformReaderTests%2FBibleReaderScrollObservationTests.swift%3A9-11%0A**%60%40unchecked%20Sendable%60%20flag%20on%20mutable%20class**%0A%0A%60InvalidationFlag%60%20has%20an%20unsynchronized%20mutable%20%60Bool%60%20and%20satisfies%20%60Sendable%60%20only%20via%20%60%40unchecked%60.%20This%20is%20safe%20today%20because%20the%20test%20suite%2C%20%60handleScroll%60%2C%20and%20the%20%60withObservationTracking%60%20%60onChange%60%20closure%20all%20run%20on%20%60%40MainActor%60%2C%20but%20the%20%60%40unchecked%60%20marker%20is%20a%20silent%20contract%20that%20future%20readers%20might%20not%20notice.%20Consider%20a%20%60nonisolated%28unsafe%29%20var%60%20in%20the%20%60%40MainActor%60-scoped%20test%2C%20or%20simply%20a%20plain%20%60Bool%60%20local%20variable%20captured%20by%20the%20closure%20%28a%20%60var%60%20in%20the%20%60reduce%60%20body%20works%20fine%20here%20since%20the%20%60onChange%60%20closure%20fires%20synchronously%20on%20the%20same%20actor%20before%20the%20next%20iteration%29.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=155&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Tests/YouVersionPlatformReaderTests/BibleReaderScrollObservationTests.swift:9-11
**`@unchecked Sendable` flag on mutable class**

`InvalidationFlag` has an unsynchronized mutable `Bool` and satisfies `Sendable` only via `@unchecked`. This is safe today because the test suite, `handleScroll`, and the `withObservationTracking` `onChange` closure all run on `@MainActor`, but the `@unchecked` marker is a silent contract that future readers might not notice. Consider a `nonisolated(unsafe) var` in the `@MainActor`-scoped test, or simply a plain `Bool` local variable captured by the closure (a `var` in the `reduce` body works fine here since the `onChange` closure fires synchronously on the same actor before the next iteration).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(reader): improve long chapter scrol..."](https://github.com/youversion/platform-sdk-swift/commit/b1f7fa40f8d2199db97262a44c89eab7abc41a25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35938645)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->