### PR TITLE
fix(reader): honor collectible term textColor over link tint

### DIFF
--- a/Sources/YouVersionPlatformCore/Bible/BibleTermHighlight.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleTermHighlight.swift
@@ -10,18 +10,24 @@ public struct BibleTermHighlight: CustomDebugStringConvertible, Sendable, Equata
     public let term: String
     /// A hex background color value for the highlight, e.g. "#E7F2FD".
     public let color: String
-    /// An optional hex color for the term text itself, e.g. "#2A85F4". When `nil` the
-    /// term keeps its surrounding scripture color.
+    /// An optional hex color for the term text itself, e.g. "#2A85F4". Used in light
+    /// reader themes and as the fallback. When `nil` the term keeps its surrounding
+    /// scripture color.
     public let textColor: String?
+    /// An optional hex color for the term text in dark reader themes, e.g. "#8FD7FF".
+    /// When `nil`, `textColor` is used in both themes. Resolved at render time so the
+    /// term recolors live when the reader theme changes.
+    public let textColorDark: String?
     /// An opaque identifier the host can map back to its own model (e.g. a collectible id).
     /// Delivered verbatim to `onCollectibleTap` when the term is tapped.
     public let id: String
 
-    public init(_ reference: BibleReference, term: String, color: String, textColor: String? = nil, id: String) {
+    public init(_ reference: BibleReference, term: String, color: String, textColor: String? = nil, textColorDark: String? = nil, id: String) {
         self.reference = reference
         self.term = term
         self.color = color
         self.textColor = textColor
+        self.textColorDark = textColorDark
         self.id = id
     }
 

--- a/Sources/YouVersionPlatformCore/Bible/BibleTermHighlight.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleTermHighlight.swift
@@ -22,7 +22,14 @@ public struct BibleTermHighlight: CustomDebugStringConvertible, Sendable, Equata
     /// Delivered verbatim to `onCollectibleTap` when the term is tapped.
     public let id: String
 
-    public init(_ reference: BibleReference, term: String, color: String, textColor: String? = nil, textColorDark: String? = nil, id: String) {
+    /// Original initializer — preserved unchanged for API stability. The term keeps the
+    /// same text color in both reader themes.
+    public init(_ reference: BibleReference, term: String, color: String, textColor: String? = nil, id: String) {
+        self.init(reference, term: term, color: color, textColor: textColor, textColorDark: nil, id: id)
+    }
+
+    /// Initializer that also supplies a dark-theme text color, resolved at render time.
+    public init(_ reference: BibleReference, term: String, color: String, textColor: String?, textColorDark: String?, id: String) {
         self.reference = reference
         self.term = term
         self.color = color

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
@@ -429,8 +429,13 @@ extension BibleTextView {
                 continue
             }
             t[start..<end].backgroundColor = Color(hex: highlight.color)
-            if let textColor = highlight.textColor {
-                t[start..<end].foregroundColor = Color(hex: textColor)
+            // Resolve the term text color for the current reader theme so it recolors
+            // live when the theme changes (dark variant falls back to `textColor`).
+            let resolvedTextColor = readerColorScheme == .dark
+                ? (highlight.textColorDark ?? highlight.textColor)
+                : highlight.textColor
+            if let resolvedTextColor {
+                t[start..<end].foregroundColor = Color(hex: resolvedTextColor)
             }
             t[start..<end].link = BibleVersionRendering.collectibleLink(id: highlight.id)
         }

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
@@ -160,6 +160,15 @@ extension BibleTextView {
                             height: height
                         )
                         context.draw(footnoteImage, in: rect)
+                    } else if let termColor = attrs?.termTextColor {
+                        // The term carries a `.link` (for tap routing), so SwiftUI would
+                        // color it with the global `.tint`. Recolor its glyphs by masking a
+                        // fill to the drawn text (`.sourceAtop`).
+                        context.drawLayer { layer in
+                            layer.draw(run)
+                            layer.blendMode = .sourceAtop
+                            layer.fill(Path(run.typographicBounds.rect), with: .color(termColor))
+                        }
                     } else {
                         context.draw(run)
                     }
@@ -177,6 +186,9 @@ extension BibleTextView {
         var noteIndicatorImage = false
         var noteIndicatorBox = false
         var noteIndicatorBoxColor: Color?
+        /// Text color for a collectible term. Set on the term's run so the renderer can
+        /// paint its glyphs in this color, overriding the global `.tint` that links use.
+        var termTextColor: Color?
     }
 
     private func textView(for double: BibleAttributedString, firstLineHeadIndent: Int, blockId: UUID, textOptions: BibleTextOptions) -> some View {
@@ -257,6 +269,15 @@ extension BibleTextView {
                         RenderHowAttribute(underlined: true, underlineColor: fgColor, audioActive: isActive, verseNumber: verse)
                     )
                 }
+            } else if category == .scripture {
+                // Emit scripture run-by-run so a collectible term carries its own text
+                // color for the renderer to apply (its `.link` would otherwise force the
+                // global `.tint` color).
+                appendTermAwareRuns(
+                    t,
+                    base: RenderHowAttribute(audioActive: isActive, verseNumber: verse),
+                    to: &textCombo
+                )
             } else if isActive {
                 // swiftlint:disable:next shorthand_operator
                 textCombo = textCombo + Text(t).customAttribute(
@@ -367,6 +388,26 @@ extension BibleTextView {
     /// first case-insensitive occurrence of each matching term within this scripture run.
     /// The link overrides the verse-level tap link only on the term's character range, so
     /// footnote and cross-reference tap targets (separate runs) are unaffected.
+    /// Concatenates a scripture run's sub-runs onto `textCombo`, tagging any collectible
+    /// term run with its text color via ``RenderHowAttribute/termTextColor`` so the
+    /// renderer can paint it (a term's `.link` otherwise forces the global `.tint`).
+    private func appendTermAwareRuns(
+        _ t: AttributedString,
+        base: RenderHowAttribute,
+        to textCombo: inout Text
+    ) {
+        let collectibleScheme = BibleVersionRendering.LinkSchemes.collectible.rawValue
+        for (link, foregroundColor, range) in t.runs[\.link, \.foregroundColor] {
+            let subStr = AttributedString(t[range])
+            var attr = base
+            if link?.scheme == collectibleScheme {
+                attr.termTextColor = foregroundColor
+            }
+            // swiftlint:disable:next shorthand_operator
+            textCombo = textCombo + Text(subStr).customAttribute(attr)
+        }
+    }
+
     private func applyTermHighlights(to t: inout AttributedString, reference: BibleReference?) {
         guard let reference else {
             return

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
@@ -20,6 +20,7 @@ public struct BibleTextView: View {
     // swiftlint:disable:next private_swiftui_state
     @State var noteIndicatedUSFMs: Set<String> = []
     @Binding var selectedVerses: Set<BibleReference>
+    @Environment(\.colorScheme) var readerColorScheme
 
     var ourHighlights: [BibleHighlight] {
         BibleHighlightsCache.shared.highlights(overlapping: reference)


### PR DESCRIPTION
https://github.com/user-attachments/assets/2cbefb9d-df36-46c0-b366-bd8ddf8b2128

## Summary
Collectible terms are rendered with a tappable `.link`, so SwiftUI colored them with the reader's global `.tint` (the scripture text color), ignoring the per-term `textColor` set on `BibleTermHighlight`. As a result the host app could not control the term's text color (only its background/halo).

This makes the reader honor the per-term `textColor`:
- Scripture runs are emitted run-by-run; a collectible-term run carries its text color via `RenderHowAttribute.termTextColor`.
- `BibleRenderer` recolors those glyphs (draw + `.sourceAtop` mask-fill), overriding the link tint.

Non-term scripture (Words of Christ, audio-active, selected/underlined verses) renders exactly as before.

## Why
The host (Bible Loop) needs the collectible term in a brand color (e.g. `#2A85F4`) distinct from scripture text. Before this change the term always took the scripture/tint color.

## Testing
- `xcodebuild -scheme YouVersionPlatform -destination "platform=iOS Simulator,name=iPhone 17 Pro" build` → succeeds.
- Verified in the Bible Loop app (light reader theme): the collectible term renders in `#2A85F4` with its halo, distinct from surrounding scripture.

## Follow-up (incoming in this PR)
A second commit adds a `textColorDark` variant so the term color can resolve per reader theme at render time (so it updates live on theme switch rather than being baked by the host).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes collectible term text color rendering by threading a per-term `termTextColor` attribute through the SwiftUI `Text` pipeline and using a `drawLayer` + `sourceAtop` recolor in the Canvas renderer to override the link tint that SwiftUI was applying. A `textColorDark` variant is also introduced on `BibleTermHighlight` so the host can supply theme-aware colors that resolve live on theme switch.

- **`BibleTermHighlight`**: adds `textColorDark?: String` and a new designated initializer; the original initializer delegates to it with `nil`, keeping the existing API fully backward-compatible.
- **`BibleTextView+Rendering`**: introduces `appendTermAwareRuns` to iterate scripture sub-runs by `(link, foregroundColor)` key paths, tagging collectible-link runs with their resolved `termTextColor`; the Canvas draw loop recolors those glyphs via `sourceAtop` blend, leaving all other rendering paths (underlined, audio-active, footnote) unchanged.
- **`BibleTextView`**: pulls `@Environment(\\.colorScheme)` so theme-aware color resolution in `applyTermHighlights` triggers a live re-render on theme change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is well-scoped, additive, and the recoloring logic is sound.

All three files make narrow, well-reasoned changes: BibleTermHighlight gains a new property and a delegating initializer that leaves existing callers untouched; appendTermAwareRuns correctly threads the resolved color through the Text pipeline without altering any non-scripture rendering paths; and the drawLayer+sourceAtop recolor in the Canvas renderer is the standard technique for overriding link-tint text color and handles anti-aliasing correctly. Theme switching triggers a re-render via @Environment(\.colorScheme). No data loss, crash paths, or silent behavior regressions were found.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/Bible/BibleTermHighlight.swift | Adds `textColorDark` property and a new designated initializer; the original initializer now delegates with `textColorDark: nil`, keeping the public API additive and backward-compatible. |
| Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift | Adds `termTextColor` to `RenderHowAttribute`, introduces `appendTermAwareRuns` to split scripture runs by link/color sub-runs, and recolors collectible-term glyphs in the Canvas renderer using a `drawLayer`+`sourceAtop` mask fill to override the link tint. Misplaced doc comment (straddling `appendTermAwareRuns` and `applyTermHighlights`) was flagged in a prior review. |
| Sources/YouVersionPlatformUI/Views/BibleTextView.swift | Adds `@Environment(\.colorScheme) var readerColorScheme` at internal access so `BibleTextView+Rendering.swift` can resolve the dark-theme text color at render time. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift`, line 387-393 ([link](https://github.com/youversion/platform-sdk-swift/blob/ad3ee28adac92d45ebe0ed865cd027152247c725/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift#L387-L393)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Doc comment belongs to `applyTermHighlights`, not `appendTermAwareRuns`**

   The four `///` lines starting with "Applies a distinct background…" were originally the doc comment for `applyTermHighlights`. They ended up immediately before the new `private func appendTermAwareRuns`, so Swift will attach the entire merged block to `appendTermAwareRuns` — leaving `applyTermHighlights` without documentation. The fix is to move those four lines back above `applyTermHighlights` and keep only the "Concatenates a scripture run's sub-runs…" block here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
   Line: 387-393

   Comment:
   **Doc comment belongs to `applyTermHighlights`, not `appendTermAwareRuns`**

   The four `///` lines starting with "Applies a distinct background…" were originally the doc comment for `applyTermHighlights`. They ended up immediately before the new `private func appendTermAwareRuns`, so Swift will attach the entire merged block to `appendTermAwareRuns` — leaving `applyTermHighlights` without documentation. The fix is to move those four lines back above `applyTermHighlights` and keep only the "Concatenates a scripture run's sub-runs…" block here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformUI%2FViews%2FBibleTextView%2BRendering.swift%0ALine%3A%20387-393%0A%0AComment%3A%0A**Doc%20comment%20belongs%20to%20%60applyTermHighlights%60%2C%20not%20%60appendTermAwareRuns%60**%0A%0AThe%20four%20%60%2F%2F%2F%60%20lines%20starting%20with%20%22Applies%20a%20distinct%20background%E2%80%A6%22%20were%20originally%20the%20doc%20comment%20for%20%60applyTermHighlights%60.%20They%20ended%20up%20immediately%20before%20the%20new%20%60private%20func%20appendTermAwareRuns%60%2C%20so%20Swift%20will%20attach%20the%20entire%20merged%20block%20to%20%60appendTermAwareRuns%60%20%E2%80%94%20leaving%20%60applyTermHighlights%60%20without%20documentation.%20The%20fix%20is%20to%20move%20those%20four%20lines%20back%20above%20%60applyTermHighlights%60%20and%20keep%20only%20the%20%22Concatenates%20a%20scripture%20run's%20sub-runs%E2%80%A6%22%20block%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=156&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformUI%2FViews%2FBibleTextView%2BRendering.swift%0ALine%3A%20387-393%0A%0AComment%3A%0A**Doc%20comment%20belongs%20to%20%60applyTermHighlights%60%2C%20not%20%60appendTermAwareRuns%60**%0A%0AThe%20four%20%60%2F%2F%2F%60%20lines%20starting%20with%20%22Applies%20a%20distinct%20background%E2%80%A6%22%20were%20originally%20the%20doc%20comment%20for%20%60applyTermHighlights%60.%20They%20ended%20up%20immediately%20before%20the%20new%20%60private%20func%20appendTermAwareRuns%60%2C%20so%20Swift%20will%20attach%20the%20entire%20merged%20block%20to%20%60appendTermAwareRuns%60%20%E2%80%94%20leaving%20%60applyTermHighlights%60%20without%20documentation.%20The%20fix%20is%20to%20move%20those%20four%20lines%20back%20above%20%60applyTermHighlights%60%20and%20keep%20only%20the%20%22Concatenates%20a%20scripture%20run's%20sub-runs%E2%80%A6%22%20block%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=156&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22air%2Ffix-collectible-term-color%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22air%2Ffix-collectible-term-color%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformUI%2FViews%2FBibleTextView%2BRendering.swift%0ALine%3A%20387-393%0A%0AComment%3A%0A**Doc%20comment%20belongs%20to%20%60applyTermHighlights%60%2C%20not%20%60appendTermAwareRuns%60**%0A%0AThe%20four%20%60%2F%2F%2F%60%20lines%20starting%20with%20%22Applies%20a%20distinct%20background%E2%80%A6%22%20were%20originally%20the%20doc%20comment%20for%20%60applyTermHighlights%60.%20They%20ended%20up%20immediately%20before%20the%20new%20%60private%20func%20appendTermAwareRuns%60%2C%20so%20Swift%20will%20attach%20the%20entire%20merged%20block%20to%20%60appendTermAwareRuns%60%20%E2%80%94%20leaving%20%60applyTermHighlights%60%20without%20documentation.%20The%20fix%20is%20to%20move%20those%20four%20lines%20back%20above%20%60applyTermHighlights%60%20and%20keep%20only%20the%20%22Concatenates%20a%20scripture%20run's%20sub-runs%E2%80%A6%22%20block%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=156&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(reader): keep BibleTermHighlight ini..."](https://github.com/youversion/platform-sdk-swift/commit/7d3a112af9d11fdbbfa5684480d69efb9ec57ecf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36249377)</sub>

<!-- /greptile_comment -->