### PR TITLE
fix(tests): support xcstrings fallback in localization tests

### DIFF
--- a/Tests/YouVersionPlatformUITests/LocalizationTests.swift
+++ b/Tests/YouVersionPlatformUITests/LocalizationTests.swift
@@ -5,7 +5,7 @@ import YouVersionPlatformUI
 @Suite struct LocalizationTests {
     @Test
     func englishDefaultCancelIsTranslated() {
-        let value = String.localized("generic.cancel")
+        let value = localizedString(forKey: "generic.cancel", languageCode: "en")
 
         #expect(value == "Cancel")
         #expect(value != "generic.cancel")
@@ -40,11 +40,11 @@ import YouVersionPlatformUI
     }
 
     @Test
-    func youVersionUIBundleContainsExpectedLanguageBundles() {
-        let bundle = Bundle.YouVersionUIBundle
-
+    func youVersionUIBundleContainsExpectedLocalizations() {
         for languageCode in ["de", "fr", "es-MX"] {
-            #expect(bundle.path(forResource: languageCode, ofType: "lproj") != nil)
+            #expect(
+                localizedString(forKey: "generic.cancel", languageCode: languageCode) != "generic.cancel"
+            )
         }
     }
 
@@ -61,10 +61,42 @@ private func localizedString(
     languageCode: String,
     bundle: Bundle = .YouVersionUIBundle
 ) -> String {
-    guard let lprojPath = bundle.path(forResource: languageCode, ofType: "lproj"),
-          let localizedBundle = Bundle(path: lprojPath) else {
-        Issue.record("Missing \(languageCode).lproj in \(bundle.bundlePath)")
-        return key
+    if let lprojPath = bundle.path(forResource: languageCode, ofType: "lproj"),
+       let localizedBundle = Bundle(path: lprojPath) {
+        return localizedBundle.localizedString(forKey: key, value: nil, table: "Localizable")
     }
-    return localizedBundle.localizedString(forKey: key, value: nil, table: "Localizable")
+
+    if let value = stringCatalogLocalizedString(forKey: key, languageCode: languageCode, bundle: bundle) {
+        return value
+    }
+
+    Issue.record("Missing \(languageCode) localization for \(key) in \(bundle.bundlePath)")
+    return key
+}
+
+private func stringCatalogLocalizedString(
+    forKey key: String,
+    languageCode: String,
+    bundle: Bundle
+) -> String? {
+    guard let url = bundle.url(forResource: "Localizable", withExtension: "xcstrings") else {
+        return nil
+    }
+
+    do {
+        let data = try Data(contentsOf: url)
+        guard let catalog = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let strings = catalog["strings"] as? [String: Any],
+              let entry = strings[key] as? [String: Any],
+              let localizations = entry["localizations"] as? [String: Any],
+              let localization = localizations[languageCode] as? [String: Any],
+              let stringUnit = localization["stringUnit"] as? [String: Any],
+              let value = stringUnit["value"] as? String else {
+            return nil
+        }
+        return value
+    } catch {
+        Issue.record("Unable to read Localizable.xcstrings in \(bundle.bundlePath): \(error)")
+        return nil
+    }
 }


### PR DESCRIPTION
## Summary
- Make `LocalizationTests` work with both compiled `.lproj` resources and SwiftPM’s raw `Localizable.xcstrings` bundle layout.
- Update the English and bundle-coverage checks to validate actual localized output instead of assuming physical `.lproj` directories exist.
- Keep the helper resilient across local `swift test` and CI/iOS simulator builds.

## Testing
- `swift test --filter LocalizationTests`
- `swift test`
- `swiftlint --strict`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `LocalizationTests` so the test helper resolves localized strings through a two-tier fallback: compiled `.lproj` bundles first (Xcode/CI builds), then raw `.xcstrings` JSON parsing (SwiftPM `swift test`). The bundle-coverage test is also migrated from checking for `.lproj` directory existence to validating actual translated output.

- `localizedString` now tries `stringCatalogLocalizedString` when no `.lproj` is found, reading and parsing `Localizable.xcstrings` as JSON to extract the translation for the requested language code.
- `youVersionUIBundleContainsExpectedLanguageBundles` is renamed to `youVersionUIBundleContainsExpectedLocalizations` and now asserts that the returned value differs from the key, making it environment-independent.

<h3>Confidence Score: 4/5</h3>

Safe to merge — changes are test-only and the two-tier fallback correctly handles both SwiftPM and Xcode build layouts.

The fallback logic works correctly for the tested keys (all use the `stringUnit` structure). The two issues flagged are about edge cases not exercised by the current test suite: plural/variant strings using `variations` would silently appear untranslated, and a stale `.lproj` artifact could shadow the xcstrings values without a clear error. Neither is a current defect given the existing catalog, but both could surprise future contributors.

Tests/YouVersionPlatformUITests/LocalizationTests.swift — specifically the xcstrings JSON parser in `stringCatalogLocalizedString`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Tests/YouVersionPlatformUITests/LocalizationTests.swift | Adds a two-tier localization lookup (compiled .lproj → raw .xcstrings JSON) so tests pass under both Xcode and SwiftPM builds; also migrates the bundle-coverage test to validate actual translated output rather than directory presence. Parser only covers stringUnit entries — variations/plural forms would silently fall through. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ATests%2FYouVersionPlatformUITests%2FLocalizationTests.swift%3A88-96%0A**xcstrings%20%60variations%60%20entries%20silently%20skipped**%0A%0AThe%20parser%20only%20handles%20the%20%60stringUnit%60%20path%20in%20the%20%60.xcstrings%60%20structure.%20Entries%20that%20use%20a%20%60variations%60%20key%20%28plural%20forms%2C%20device-variant%20strings%2C%20etc.%29%20will%20fail%20the%20entire%20%60guard%60%20chain%20and%20return%20%60nil%60%2C%20causing%20%60localizedString%60%20to%20call%20%60Issue.record%60%20and%20return%20the%20raw%20key%20%E2%80%94%20with%20no%20indication%20that%20the%20*structure*%20was%20unexpected%20rather%20than%20the%20localization%20being%20absent.%20Any%20plural%20or%20device-variant%20string%20added%20to%20the%20catalog%20in%20the%20future%20would%20silently%20appear%20untranslated%20in%20these%20tests.%0A%0A%23%23%23%20Issue%202%20of%202%0ATests%2FYouVersionPlatformUITests%2FLocalizationTests.swift%3A64-67%0A**lproj%20branch%20short-circuits%20without%20key-existence%20check**%0A%0AIf%20a%20%60.lproj%60%20bundle%20is%20present%20but%20is%20missing%20a%20given%20key%2C%20%60Bundle.localizedString%28forKey%3Avalue%3Atable%3A%29%60%20returns%20the%20key%20itself%20%28because%20%60value%60%20is%20%60nil%60%29.%20The%20function%20then%20returns%20that%20raw%20key%20immediately%20%E2%80%94%20the%20xcstrings%20fallback%20is%20never%20attempted%20and%20%60Issue.record%60%20is%20never%20called.%20In%20practice%2C%20compiled%20%60.lproj%60%20bundles%20should%20contain%20all%20keys%20from%20the%20catalog%2C%20but%20if%20they%20ever%20drift%20%28e.g.%20a%20stale%20build%20artifact%29%2C%20the%20failure%20will%20look%20identical%20to%20a%20missing%20translation%20with%20no%20hint%20that%20the%20fallback%20path%20was%20not%20consulted.%20A%20comment%20documenting%20this%20assumption%20would%20help%20future%20readers.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=157&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ATests%2FYouVersionPlatformUITests%2FLocalizationTests.swift%3A88-96%0A**xcstrings%20%60variations%60%20entries%20silently%20skipped**%0A%0AThe%20parser%20only%20handles%20the%20%60stringUnit%60%20path%20in%20the%20%60.xcstrings%60%20structure.%20Entries%20that%20use%20a%20%60variations%60%20key%20%28plural%20forms%2C%20device-variant%20strings%2C%20etc.%29%20will%20fail%20the%20entire%20%60guard%60%20chain%20and%20return%20%60nil%60%2C%20causing%20%60localizedString%60%20to%20call%20%60Issue.record%60%20and%20return%20the%20raw%20key%20%E2%80%94%20with%20no%20indication%20that%20the%20*structure*%20was%20unexpected%20rather%20than%20the%20localization%20being%20absent.%20Any%20plural%20or%20device-variant%20string%20added%20to%20the%20catalog%20in%20the%20future%20would%20silently%20appear%20untranslated%20in%20these%20tests.%0A%0A%23%23%23%20Issue%202%20of%202%0ATests%2FYouVersionPlatformUITests%2FLocalizationTests.swift%3A64-67%0A**lproj%20branch%20short-circuits%20without%20key-existence%20check**%0A%0AIf%20a%20%60.lproj%60%20bundle%20is%20present%20but%20is%20missing%20a%20given%20key%2C%20%60Bundle.localizedString%28forKey%3Avalue%3Atable%3A%29%60%20returns%20the%20key%20itself%20%28because%20%60value%60%20is%20%60nil%60%29.%20The%20function%20then%20returns%20that%20raw%20key%20immediately%20%E2%80%94%20the%20xcstrings%20fallback%20is%20never%20attempted%20and%20%60Issue.record%60%20is%20never%20called.%20In%20practice%2C%20compiled%20%60.lproj%60%20bundles%20should%20contain%20all%20keys%20from%20the%20catalog%2C%20but%20if%20they%20ever%20drift%20%28e.g.%20a%20stale%20build%20artifact%29%2C%20the%20failure%20will%20look%20identical%20to%20a%20missing%20translation%20with%20no%20hint%20that%20the%20fallback%20path%20was%20not%20consulted.%20A%20comment%20documenting%20this%20assumption%20would%20help%20future%20readers.%0A%0A&pr=157&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22fix-localization-test-setup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-localization-test-setup%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ATests%2FYouVersionPlatformUITests%2FLocalizationTests.swift%3A88-96%0A**xcstrings%20%60variations%60%20entries%20silently%20skipped**%0A%0AThe%20parser%20only%20handles%20the%20%60stringUnit%60%20path%20in%20the%20%60.xcstrings%60%20structure.%20Entries%20that%20use%20a%20%60variations%60%20key%20%28plural%20forms%2C%20device-variant%20strings%2C%20etc.%29%20will%20fail%20the%20entire%20%60guard%60%20chain%20and%20return%20%60nil%60%2C%20causing%20%60localizedString%60%20to%20call%20%60Issue.record%60%20and%20return%20the%20raw%20key%20%E2%80%94%20with%20no%20indication%20that%20the%20*structure*%20was%20unexpected%20rather%20than%20the%20localization%20being%20absent.%20Any%20plural%20or%20device-variant%20string%20added%20to%20the%20catalog%20in%20the%20future%20would%20silently%20appear%20untranslated%20in%20these%20tests.%0A%0A%23%23%23%20Issue%202%20of%202%0ATests%2FYouVersionPlatformUITests%2FLocalizationTests.swift%3A64-67%0A**lproj%20branch%20short-circuits%20without%20key-existence%20check**%0A%0AIf%20a%20%60.lproj%60%20bundle%20is%20present%20but%20is%20missing%20a%20given%20key%2C%20%60Bundle.localizedString%28forKey%3Avalue%3Atable%3A%29%60%20returns%20the%20key%20itself%20%28because%20%60value%60%20is%20%60nil%60%29.%20The%20function%20then%20returns%20that%20raw%20key%20immediately%20%E2%80%94%20the%20xcstrings%20fallback%20is%20never%20attempted%20and%20%60Issue.record%60%20is%20never%20called.%20In%20practice%2C%20compiled%20%60.lproj%60%20bundles%20should%20contain%20all%20keys%20from%20the%20catalog%2C%20but%20if%20they%20ever%20drift%20%28e.g.%20a%20stale%20build%20artifact%29%2C%20the%20failure%20will%20look%20identical%20to%20a%20missing%20translation%20with%20no%20hint%20that%20the%20fallback%20path%20was%20not%20consulted.%20A%20comment%20documenting%20this%20assumption%20would%20help%20future%20readers.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=157&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
Tests/YouVersionPlatformUITests/LocalizationTests.swift:88-96
**xcstrings `variations` entries silently skipped**

The parser only handles the `stringUnit` path in the `.xcstrings` structure. Entries that use a `variations` key (plural forms, device-variant strings, etc.) will fail the entire `guard` chain and return `nil`, causing `localizedString` to call `Issue.record` and return the raw key — with no indication that the *structure* was unexpected rather than the localization being absent. Any plural or device-variant string added to the catalog in the future would silently appear untranslated in these tests.

### Issue 2 of 2
Tests/YouVersionPlatformUITests/LocalizationTests.swift:64-67
**lproj branch short-circuits without key-existence check**

If a `.lproj` bundle is present but is missing a given key, `Bundle.localizedString(forKey:value:table:)` returns the key itself (because `value` is `nil`). The function then returns that raw key immediately — the xcstrings fallback is never attempted and `Issue.record` is never called. In practice, compiled `.lproj` bundles should contain all keys from the catalog, but if they ever drift (e.g. a stale build artifact), the failure will look identical to a missing translation with no hint that the fallback path was not consulted. A comment documenting this assumption would help future readers.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: localization tests when run locally"](https://github.com/youversion/platform-sdk-swift/commit/63ddcb365d5abdd20a7700de5ea2df707a6bef95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36252847)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->