### PR TITLE
fix: display footnotes with correct internal formatting as well as size

### DIFF
--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFootnotesView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFootnotesView.swift
@@ -3,23 +3,10 @@ import YouVersionPlatformUI
 
 struct BibleReaderFootnotesView: View {
     @Environment(BibleReaderViewModel.self) private var viewModel
+    @State private var footnotes: [BibleFootnote] = []
 
     var body: some View {
-        let textOptions = BibleTextOptions(
-            fontFamily: viewModel.textOptions.fontFamily,
-            fontSize: 16,
-            lineSpacing: viewModel.textOptions.lineSpacing,
-            paragraphSpacing: viewModel.textOptions.paragraphSpacing,
-            textColor: viewModel.textOptions.textColor,
-            verseNumberColor: viewModel.textOptions.verseNumberColor,
-            wordsOfChristColor: viewModel.textOptions.wordsOfChristColor,
-            renderHeadlines: false,
-            renderVerseNumbers: false,
-            footnoteMode: .letters,
-            footnoteMarker: nil,
-        )
-
-        return VStack(alignment: .leading) {
+        VStack(alignment: .leading) {
             if let version = viewModel.version,
                 let reference = viewModel.footnotesToDisplay.first?.reference {
                 Text(version.displayTitle(for: reference))
@@ -32,13 +19,12 @@ struct BibleReaderFootnotesView: View {
                     Divider()
                         .padding(.bottom, 8)
                     VStack(alignment: .leading) {
-                        ForEach(Array(viewModel.footnotesToDisplay.enumerated()), id: \.offset) { index, footnote in
+                        ForEach(Array(footnotes.enumerated()), id: \.offset) { index, footnote in
                             let character = String(UnicodeScalar(97 + (index % 26))!)
-                            let txt = footnote.text.setFont(.footnote, from: BibleTextFonts(familyName: "San Francisco", baseSize: 15))
                             HStack(alignment: .firstTextBaseline) {
                                 Text(character + ".")
                                     .font(YouVersionFonts.labelSmall)
-                                Text(txt.asAttributedString)
+                                Text(footnote.text.asAttributedString)
                                     .multilineTextAlignment(.leading)
                             }
                             Divider()
@@ -51,6 +37,40 @@ struct BibleReaderFootnotesView: View {
         }
         .padding(.horizontal, 24)
         .padding(.top, 36)
+        .task {
+            // We prefer not to display viewModel.footnotes[] since it is in the user's
+            // Bible font family and size, which might look odd in the context of this view.
+            let textOptions = self.textOptions
+            if let reference = viewModel.footnotesToDisplay.first?.reference,
+               let blocks = try? await BibleVersionRendering.textBlocks(
+                reference: reference,
+                renderHeadlines: textOptions.renderHeadlines,
+                renderVerseNumbers: textOptions.renderVerseNumbers,
+                footnotesMode: textOptions.footnoteMode,
+                footnoteMarker: textOptions.footnoteMarker,
+                textColor: textOptions.textColor ?? Color.primary,
+                verseNumColor: textOptions.verseNumberColor ?? Color.secondary,
+                wocColor: textOptions.textColor ?? Color.primary,
+                fonts: BibleTextFonts(familyName: textOptions.fontFamily, baseSize: textOptions.fontSize)
+               ) {
+                self.footnotes = blocks.flatMap(\.footnotes).filter { $0.reference == reference }
+            } else {
+                self.footnotes = viewModel.footnotesToDisplay
+            }
+        }
+    }
+    
+    var textOptions: BibleTextOptions {
+        BibleTextOptions(
+            fontFamily: "Untitled Serif",
+            fontSize: 16,
+            lineSpacing: 0.4,
+            paragraphSpacing: 0,
+            renderHeadlines: false,
+            renderVerseNumbers: false,
+            footnoteMode: .letters,
+            footnoteMarker: nil,
+        )
     }
     
 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFootnotesView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFootnotesView.swift
@@ -37,7 +37,7 @@ struct BibleReaderFootnotesView: View {
         }
         .padding(.horizontal, 24)
         .padding(.top, 36)
-        .task {
+        .task(id: viewModel.footnotesToDisplay.first?.reference) {
             // We prefer not to display viewModel.footnotes[] since it is in the user's
             // Bible font family and size, which might look odd in the context of this view.
             let textOptions = self.textOptions

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFootnotesView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFootnotesView.swift
@@ -60,7 +60,7 @@ struct BibleReaderFootnotesView: View {
         }
     }
     
-    var textOptions: BibleTextOptions {
+    private var textOptions: BibleTextOptions {
         BibleTextOptions(
             fontFamily: "Untitled Serif",
             fontSize: 16,

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderIntroFootnoteView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderIntroFootnoteView.swift
@@ -11,8 +11,7 @@ struct BibleReaderIntroFootnoteView: View {
                     .font(YouVersionFonts.headerSmall)
                     .padding(.bottom)
                 ForEach(Array(viewModel.footnotesToDisplay.enumerated()), id: \.offset) { index, footnote in
-                    let txt = footnote.text.setFont(.footnote, from: BibleTextFonts(familyName: "San Francisco", baseSize: 15))
-                    Text(txt.asAttributedString)
+                    Text(footnote.text.asAttributedString)
                         .multilineTextAlignment(.leading)
                         .lineSpacing(8)
                         .padding(.bottom)

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderIntroFootnoteView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderIntroFootnoteView.swift
@@ -3,7 +3,7 @@ import YouVersionPlatformUI
 
 struct BibleReaderIntroFootnoteView: View {
     @Environment(BibleReaderViewModel.self) private var viewModel
-
+    
     var body: some View {
         ScrollView {
             VStack(alignment: .leading) {
@@ -11,7 +11,8 @@ struct BibleReaderIntroFootnoteView: View {
                     .font(YouVersionFonts.headerSmall)
                     .padding(.bottom)
                 ForEach(Array(viewModel.footnotesToDisplay.enumerated()), id: \.offset) { index, footnote in
-                    Text(footnote.text.asAttributedString)
+                    let txt = footnote.text.setFont(.footnote, from: BibleTextFonts(familyName: "San Francisco", baseSize: 15))
+                    Text(txt.asAttributedString)
                         .multilineTextAlignment(.leading)
                         .lineSpacing(8)
                         .padding(.bottom)

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift
@@ -262,7 +262,6 @@ public enum BibleVersionRendering {
                 chapter: stateUp.chapter,
                 verse: stateUp.verse
             )
-            stateDown.currentFont = .footnote
             for child in node.children {
                 handleBlockChild(child, stateIn: stateIn, stateDown: stateDown, stateUp: &footState)
             }

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRenderingStyles.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRenderingStyles.swift
@@ -325,6 +325,9 @@ final class BibleVersionRenderingStyles {
             case "tl", "it", "add", "fq", "fqa", "qs", "qt", "bk":
                 stateDown.currentFont = .font100emItalic
 
+            case "bdit":
+                stateDown.currentFont = .font100em500Italic
+            
             case "ord", "fv", "sup":
                 stateDown.currentFont = .verseNumFont  // superscript, really; same thing in practice.
                 stateDown.baselineOffset = stateIn.fonts.verseNumBaselineOffset

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRenderingStyles.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRenderingStyles.swift
@@ -38,6 +38,13 @@ final class BibleVersionRenderingStyles {
                 stateDown.currentFont = .font117em500
                 stateDown.textCategory = .header
 
+            case "is":
+                stateDown.currentFont = .font100em500
+                stateDown.alignment = .center
+                stateDown.marginTop = fontSize / 2
+                stateUp.firstLineHeadIndent = 0
+                stateUp.headIndent = 0
+
             case "li1", "ili", "ili1":
                 stateUp.firstLineHeadIndent = 0
                 stateUp.headIndent = 2
@@ -241,15 +248,19 @@ final class BibleVersionRenderingStyles {
                 stateDown.alignment = .center
                 stateDown.marginTop = fontSize / 3
 
-            case "is", "is1":
+            case "is1":
                 stateDown.currentFont = .font100em500
                 stateDown.alignment = .center
                 stateDown.marginTop = fontSize / 2
+                stateUp.firstLineHeadIndent = 0
+                stateUp.headIndent = 0
 
             case "is2":
                 stateDown.currentFont = .font100em500
                 stateDown.alignment = .center
                 stateDown.marginTop = fontSize / 3
+                stateUp.firstLineHeadIndent = 0
+                stateUp.headIndent = 0
 
             case "io", "io1":
                 stateUp.headIndent = 2


### PR DESCRIPTION
## Description

fix: display footnotes with correct internal formatting as well as size

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [x] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes footnote rendering in the Bible reader sheet by re-fetching footnote content with a consistent fixed typography (Untitled Serif 16 pt) rather than relying on the user's per-Bible font settings, and removes a blanket `.footnote` font override in the rendering pipeline so that internal inline styles (italic, bold-italic, etc.) are applied correctly.

- **`BibleReaderFootnotesView`**: Adds a `@State var footnotes` array populated by a `.task(id:)`-driven call to `BibleVersionRendering.textBlocks(...)`, with a fallback to `viewModel.footnotesToDisplay`. The `textOptions` computed property is now `private` and drives both the verse `BibleTextView` and the re-fetch.
- **`BibleVersionRendering`**: Drops `stateDown.currentFont = .footnote` from the marker branch so child nodes in a footnote inherit and respect their own inline style declarations instead of being forced to a smaller size.
- **`BibleVersionRenderingStyles`**: Splits `"is"`/`"is1"` into separate cases with proper indent resets, mirrors the same fix to `"is2"`, and adds a new `"bdit"` bold-italic span handler.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changes are scoped to the footnote sheet display and internal typography style tables with no data-persistence side effects.

The re-fetch approach is sound: using .task(id:) correctly cancels and restarts on reference change, the rendering pipeline fix is a one-line removal with a narrow scope, and the style table changes are additive. The two style nits (wrong wocColor argument and no pre-fetch clear) are edge-case-only and don't affect the core fix.

Sources/YouVersionPlatformReader/Sheets/BibleReaderFootnotesView.swift — the task closure has a minor wocColor mismatch and doesn't clear stale footnotes before re-fetching.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/Sheets/BibleReaderFootnotesView.swift | Refactored footnotes display to re-fetch content with fixed Untitled Serif / 16 pt typography via a .task(id:), with a minor wocColor mismatch and no pre-fetch stale-clear. |
| Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRendering.swift | Removes the forced .footnote font override on footnote child nodes when a marker is present, allowing internal inline styles (italic, bold-italic, etc.) to inherit the rendering context correctly. |
| Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRenderingStyles.swift | Splits the combined "is"/"is1" case, adds firstLineHeadIndent/headIndent resets to is1 and is2, and adds a new "bdit" (bold-italic) span handler. |
| Sources/YouVersionPlatformReader/Sheets/BibleReaderIntroFootnoteView.swift | Trivial whitespace-only change (trailing space on blank line). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant V as BibleReaderFootnotesView
    participant VM as BibleReaderViewModel
    participant R as BibleVersionRendering

    V->>VM: observe footnotesToDisplay.first?.reference
    note over V: .task(id: reference) fires
    V->>V: "self.footnotes = [] (suggested)"
    V->>R: textBlocks(reference, textOptions: Untitled Serif 16pt)
    R-->>V: [BibleBlock] with .footnotes
    V->>V: filter blocks.flatMap(\.footnotes) where ref matches
    V->>V: "self.footnotes = filtered results"
    note over V: fallback if fetch fails
    V->>VM: "self.footnotes = viewModel.footnotesToDisplay"
    V->>V: render footnotes via Text(footnote.text.asAttributedString)
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformReader%2FSheets%2FBibleReaderFootnotesView.swift%3A53%0A%60wocColor%60%20receives%20%60textOptions.textColor%20%3F%3F%20Color.primary%60%20%28which%20is%20always%20%60Color.primary%60%20since%20%60textOptions.textColor%60%20is%20nil%29%2C%20instead%20of%20%60textOptions.wordsOfChristColor%60.%20The%20%60wordsOfChristColor%60%20property%20defaults%20to%20YouVersion%20red%2C%20so%20any%20footnote%20content%20that%20carries%20Words%20of%20Christ%20markup%20would%20silently%20render%20in%20the%20body%20text%20colour%20rather%20than%20the%20expected%20red.%20%60BibleTextView%60%20in%20the%20same%20view%20passes%20%60textOptions.wordsOfChristColor%60%20correctly%20on%20line%2016%2C%20so%20this%20is%20an%20inconsistency.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20wocColor%3A%20textOptions.wordsOfChristColor%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformReader%2FSheets%2FBibleReaderFootnotesView.swift%3A40-43%0AWhen%20%60.task%28id%3A%29%60%20fires%20because%20the%20reference%20changes%2C%20the%20%60footnotes%60%20array%20still%20holds%20the%20previous%20footnotes%20until%20the%20async%20fetch%20completes.%20The%20user%20momentarily%20sees%20content%20from%20the%20wrong%20reference.%20Clearing%20the%20array%20at%20the%20top%20of%20the%20task%20prevents%20stale%20data%20from%20being%20visible%20during%20the%20reload.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.task%28id%3A%20viewModel.footnotesToDisplay.first%3F.reference%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20self.footnotes%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20We%20prefer%20not%20to%20display%20viewModel.footnotes%5B%5D%20since%20it%20is%20in%20the%20user's%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Bible%20font%20family%20and%20size%2C%20which%20might%20look%20odd%20in%20the%20context%20of%20this%20view.%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20textOptions%20%3D%20self.textOptions%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=158&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformReader%2FSheets%2FBibleReaderFootnotesView.swift%3A53%0A%60wocColor%60%20receives%20%60textOptions.textColor%20%3F%3F%20Color.primary%60%20%28which%20is%20always%20%60Color.primary%60%20since%20%60textOptions.textColor%60%20is%20nil%29%2C%20instead%20of%20%60textOptions.wordsOfChristColor%60.%20The%20%60wordsOfChristColor%60%20property%20defaults%20to%20YouVersion%20red%2C%20so%20any%20footnote%20content%20that%20carries%20Words%20of%20Christ%20markup%20would%20silently%20render%20in%20the%20body%20text%20colour%20rather%20than%20the%20expected%20red.%20%60BibleTextView%60%20in%20the%20same%20view%20passes%20%60textOptions.wordsOfChristColor%60%20correctly%20on%20line%2016%2C%20so%20this%20is%20an%20inconsistency.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20wocColor%3A%20textOptions.wordsOfChristColor%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformReader%2FSheets%2FBibleReaderFootnotesView.swift%3A40-43%0AWhen%20%60.task%28id%3A%29%60%20fires%20because%20the%20reference%20changes%2C%20the%20%60footnotes%60%20array%20still%20holds%20the%20previous%20footnotes%20until%20the%20async%20fetch%20completes.%20The%20user%20momentarily%20sees%20content%20from%20the%20wrong%20reference.%20Clearing%20the%20array%20at%20the%20top%20of%20the%20task%20prevents%20stale%20data%20from%20being%20visible%20during%20the%20reload.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.task%28id%3A%20viewModel.footnotesToDisplay.first%3F.reference%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20self.footnotes%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20We%20prefer%20not%20to%20display%20viewModel.footnotes%5B%5D%20since%20it%20is%20in%20the%20user's%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Bible%20font%20family%20and%20size%2C%20which%20might%20look%20odd%20in%20the%20context%20of%20this%20view.%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20textOptions%20%3D%20self.textOptions%0A%60%60%60%0A%0A&pr=158&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22YPE-1946-footnote-rich-rendering%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22YPE-1946-footnote-rich-rendering%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformReader%2FSheets%2FBibleReaderFootnotesView.swift%3A53%0A%60wocColor%60%20receives%20%60textOptions.textColor%20%3F%3F%20Color.primary%60%20%28which%20is%20always%20%60Color.primary%60%20since%20%60textOptions.textColor%60%20is%20nil%29%2C%20instead%20of%20%60textOptions.wordsOfChristColor%60.%20The%20%60wordsOfChristColor%60%20property%20defaults%20to%20YouVersion%20red%2C%20so%20any%20footnote%20content%20that%20carries%20Words%20of%20Christ%20markup%20would%20silently%20render%20in%20the%20body%20text%20colour%20rather%20than%20the%20expected%20red.%20%60BibleTextView%60%20in%20the%20same%20view%20passes%20%60textOptions.wordsOfChristColor%60%20correctly%20on%20line%2016%2C%20so%20this%20is%20an%20inconsistency.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20wocColor%3A%20textOptions.wordsOfChristColor%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformReader%2FSheets%2FBibleReaderFootnotesView.swift%3A40-43%0AWhen%20%60.task%28id%3A%29%60%20fires%20because%20the%20reference%20changes%2C%20the%20%60footnotes%60%20array%20still%20holds%20the%20previous%20footnotes%20until%20the%20async%20fetch%20completes.%20The%20user%20momentarily%20sees%20content%20from%20the%20wrong%20reference.%20Clearing%20the%20array%20at%20the%20top%20of%20the%20task%20prevents%20stale%20data%20from%20being%20visible%20during%20the%20reload.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.task%28id%3A%20viewModel.footnotesToDisplay.first%3F.reference%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20self.footnotes%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20We%20prefer%20not%20to%20display%20viewModel.footnotes%5B%5D%20since%20it%20is%20in%20the%20user's%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Bible%20font%20family%20and%20size%2C%20which%20might%20look%20odd%20in%20the%20context%20of%20this%20view.%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20textOptions%20%3D%20self.textOptions%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=158&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
Sources/YouVersionPlatformReader/Sheets/BibleReaderFootnotesView.swift:53
`wocColor` receives `textOptions.textColor ?? Color.primary` (which is always `Color.primary` since `textOptions.textColor` is nil), instead of `textOptions.wordsOfChristColor`. The `wordsOfChristColor` property defaults to YouVersion red, so any footnote content that carries Words of Christ markup would silently render in the body text colour rather than the expected red. `BibleTextView` in the same view passes `textOptions.wordsOfChristColor` correctly on line 16, so this is an inconsistency.

```suggestion
                wocColor: textOptions.wordsOfChristColor,
```

### Issue 2 of 2
Sources/YouVersionPlatformReader/Sheets/BibleReaderFootnotesView.swift:40-43
When `.task(id:)` fires because the reference changes, the `footnotes` array still holds the previous footnotes until the async fetch completes. The user momentarily sees content from the wrong reference. Clearing the array at the top of the task prevents stale data from being visible during the reload.

```suggestion
        .task(id: viewModel.footnotesToDisplay.first?.reference) {
            self.footnotes = []
            // We prefer not to display viewModel.footnotes[] since it is in the user's
            // Bible font family and size, which might look odd in the context of this view.
            let textOptions = self.textOptions
```

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix: remove rich formatting on intro mat..."](https://github.com/youversion/platform-sdk-swift/commit/340fa0d6d5ad438ec7a12fe50fd6afe754a4aa3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36262256)</sub>

<!-- /greptile_comment -->