### PR TITLE
feat: align to the new highlights and data exchange APIs

### DIFF
--- a/.api-baseline/YouVersionPlatformCore.json
+++ b/.api-baseline/YouVersionPlatformCore.json
@@ -784,6 +784,551 @@
       },
       {
         "kind": "TypeDecl",
+        "name": "DataExchangeToken",
+        "printedName": "DataExchangeToken",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "token",
+            "printedName": "token",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore17DataExchangeTokenV5tokenSSvp",
+            "mangledName": "$s22YouVersionPlatformCore17DataExchangeTokenV5tokenSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore17DataExchangeTokenV5tokenSSvg",
+                "mangledName": "$s22YouVersionPlatformCore17DataExchangeTokenV5tokenSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "__derived_struct_equals",
+            "printedName": "__derived_struct_equals(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "DataExchangeToken",
+                "printedName": "YouVersionPlatformCore.DataExchangeToken",
+                "usr": "s:22YouVersionPlatformCore17DataExchangeTokenV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "DataExchangeToken",
+                "printedName": "YouVersionPlatformCore.DataExchangeToken",
+                "usr": "s:22YouVersionPlatformCore17DataExchangeTokenV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore17DataExchangeTokenV23__derived_struct_equalsySbAC_ACtFZ",
+            "mangledName": "$s22YouVersionPlatformCore17DataExchangeTokenV23__derived_struct_equalsySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Implements"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "encode",
+            "printedName": "encode(to:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Encoder",
+                "printedName": "any Swift.Encoder",
+                "usr": "s:s7EncoderP"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore17DataExchangeTokenV6encode2toys7Encoder_p_tKF",
+            "mangledName": "$s22YouVersionPlatformCore17DataExchangeTokenV6encode2toys7Encoder_p_tKF",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "DataExchangeToken",
+                "printedName": "YouVersionPlatformCore.DataExchangeToken",
+                "usr": "s:22YouVersionPlatformCore17DataExchangeTokenV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore17DataExchangeTokenV4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore17DataExchangeTokenV4fromACs7Decoder_p_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true,
+            "throwing": true,
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:22YouVersionPlatformCore17DataExchangeTokenV",
+        "mangledName": "$s22YouVersionPlatformCore17DataExchangeTokenV",
+        "moduleName": "YouVersionPlatformCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "DataExchangePermission",
+        "printedName": "DataExchangePermission",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "highlights",
+            "printedName": "highlights",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.DataExchangePermission.Type) -> YouVersionPlatformCore.DataExchangePermission",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "DataExchangePermission",
+                    "printedName": "YouVersionPlatformCore.DataExchangePermission",
+                    "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.DataExchangePermission.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "DataExchangePermission",
+                        "printedName": "YouVersionPlatformCore.DataExchangePermission",
+                        "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO10highlightsyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore22DataExchangePermissionO10highlightsyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "unknown",
+            "printedName": "unknown",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.DataExchangePermission.Type) -> (Swift.String) -> YouVersionPlatformCore.DataExchangePermission",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(Swift.String) -> YouVersionPlatformCore.DataExchangePermission",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "DataExchangePermission",
+                        "printedName": "YouVersionPlatformCore.DataExchangePermission",
+                        "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.DataExchangePermission.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "DataExchangePermission",
+                        "printedName": "YouVersionPlatformCore.DataExchangePermission",
+                        "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO7unknownyACSScACmF",
+            "mangledName": "$s22YouVersionPlatformCore22DataExchangePermissionO7unknownyACSScACmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(rawValue:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "DataExchangePermission",
+                "printedName": "YouVersionPlatformCore.DataExchangePermission",
+                "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO8rawValueACSS_tcfc",
+            "mangledName": "$s22YouVersionPlatformCore22DataExchangePermissionO8rawValueACSS_tcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "rawValue",
+            "printedName": "rawValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO8rawValueSSvp",
+            "mangledName": "$s22YouVersionPlatformCore22DataExchangePermissionO8rawValueSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO8rawValueSSvg",
+                "mangledName": "$s22YouVersionPlatformCore22DataExchangePermissionO8rawValueSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "description",
+            "printedName": "description",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO11descriptionSSvp",
+            "mangledName": "$s22YouVersionPlatformCore22DataExchangePermissionO11descriptionSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO11descriptionSSvg",
+                "mangledName": "$s22YouVersionPlatformCore22DataExchangePermissionO11descriptionSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "DataExchangePermission",
+                "printedName": "YouVersionPlatformCore.DataExchangePermission",
+                "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore22DataExchangePermissionO4fromACs7Decoder_p_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "throwing": true,
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "encode",
+            "printedName": "encode(to:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Encoder",
+                "printedName": "any Swift.Encoder",
+                "usr": "s:s7EncoderP"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO6encode2toys7Encoder_p_tKF",
+            "mangledName": "$s22YouVersionPlatformCore22DataExchangePermissionO6encode2toys7Encoder_p_tKF",
+            "moduleName": "YouVersionPlatformCore",
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "RawValue",
+            "printedName": "RawValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO8RawValuea",
+            "mangledName": "$s22YouVersionPlatformCore22DataExchangePermissionO8RawValuea",
+            "moduleName": "YouVersionPlatformCore",
+            "implicit": true
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO",
+        "mangledName": "$s22YouVersionPlatformCore22DataExchangePermissionO",
+        "moduleName": "YouVersionPlatformCore",
+        "isEnumExhaustive": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomStringConvertible",
+            "printedName": "CustomStringConvertible",
+            "usr": "s:s23CustomStringConvertibleP",
+            "mangledName": "$ss23CustomStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE",
+            "mangledName": "$sSE"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "RawRepresentable",
+            "printedName": "RawRepresentable",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "RawValue",
+                "printedName": "RawValue",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:SY",
+            "mangledName": "$sSY"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
         "name": "LanguageOverview",
         "printedName": "LanguageOverview",
         "children": [
@@ -2766,6 +3311,78 @@
         "children": [
           {
             "kind": "Function",
+            "name": "dataExchangeTokenURL",
+            "printedName": "dataExchangeTokenURL(appKey:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO20dataExchangeTokenURL6appKey10Foundation0I0VSgSS_tFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO20dataExchangeTokenURL6appKey10Foundation0I0VSgSS_tFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "dataExchangeURL",
+            "printedName": "dataExchangeURL(token:appKey:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO15dataExchangeURL5token6appKey10Foundation0H0VSgSS_SStFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO15dataExchangeURL5token6appKey10Foundation0H0VSgSS_SStFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
             "name": "organizationsURL",
             "printedName": "organizationsURL(id:)",
             "children": [
@@ -4209,6 +4826,43 @@
             "declKind": "EnumElement",
             "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO5emailyA2CmF",
             "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO5emailyA2CmF",
+            "moduleName": "YouVersionPlatformCore"
+          },
+          {
+            "kind": "Var",
+            "name": "highlights",
+            "printedName": "highlights",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformCore.SignInWithYouVersionPermission.Type) -> YouVersionPlatformCore.SignInWithYouVersionPermission",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPermission",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SignInWithYouVersionPermission",
+                        "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                        "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO10highlightsyA2CmF",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO10highlightsyA2CmF",
             "moduleName": "YouVersionPlatformCore"
           },
           {
@@ -6127,6 +6781,55 @@
               {
                 "kind": "Function",
                 "name": "version",
+                "printedName": "version(withId:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO7version6withId11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO7version6withId11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "isFromExtension": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "version",
                 "printedName": "version(versionId:accessToken:session:)",
                 "children": [
                   {
@@ -6167,6 +6870,58 @@
                 "declKind": "Func",
                 "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO7version0G2Id11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
                 "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO7version0G2Id11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "deprecated": true,
+                "declAttributes": [
+                  "Available"
+                ],
+                "isFromExtension": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "metadataForVersion",
+                "printedName": "metadataForVersion(withId:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5BibleO011metadataForB06withId11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO011metadataForB06withId11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
                 "moduleName": "YouVersionPlatformCore",
                 "static": true,
                 "isFromExtension": true,
@@ -6217,6 +6972,10 @@
                 "mangledName": "$s22YouVersionPlatformCore0aB3APIO5BibleO05basicB09versionId11accessToken7sessionAA0fB0VSi_SSSgSo12NSURLSessionCtYaKFZ",
                 "moduleName": "YouVersionPlatformCore",
                 "static": true,
+                "deprecated": true,
+                "declAttributes": [
+                  "Available"
+                ],
                 "isFromExtension": true,
                 "throwing": true,
                 "funcSelfKind": "NonMutating"
@@ -6740,6 +7499,68 @@
               },
               {
                 "kind": "Function",
+                "name": "highlights",
+                "printedName": "highlights(bibleId:passageId:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.HighlightResponse]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "HighlightResponse",
+                        "printedName": "YouVersionPlatformCore.HighlightResponse",
+                        "usr": "s:22YouVersionPlatformCore17HighlightResponseV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO10HighlightsO10highlights7bibleId07passageI011accessToken7sessionSayAA17HighlightResponseVGSi_S2SSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO10HighlightsO10highlights7bibleId07passageI011accessToken7sessionSayAA17HighlightResponseVGSi_S2SSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
                 "name": "getHighlights",
                 "printedName": "getHighlights(bibleId:passageId:accessToken:session:)",
                 "children": [
@@ -6797,6 +7618,10 @@
                 "mangledName": "$s22YouVersionPlatformCore0aB3APIO10HighlightsO03getF07bibleId07passageI011accessToken7sessionSayAA17HighlightResponseVGSi_S2SSgSo12NSURLSessionCtYaKFZ",
                 "moduleName": "YouVersionPlatformCore",
                 "static": true,
+                "deprecated": true,
+                "declAttributes": [
+                  "Available"
+                ],
                 "throwing": true,
                 "funcSelfKind": "NonMutating"
               },
@@ -6918,6 +7743,117 @@
             "declKind": "Enum",
             "usr": "s:22YouVersionPlatformCore0aB3APIO10HighlightsO",
             "mangledName": "$s22YouVersionPlatformCore0aB3APIO10HighlightsO",
+            "moduleName": "YouVersionPlatformCore",
+            "isFromExtension": true,
+            "isEnumExhaustive": true,
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "hasPermission",
+            "printedName": "hasPermission(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "DataExchangePermission",
+                "printedName": "YouVersionPlatformCore.DataExchangePermission",
+                "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0aB3APIO13hasPermissionySbAA012DataExchangeG0OFZ",
+            "mangledName": "$s22YouVersionPlatformCore0aB3APIO13hasPermissionySbAA012DataExchangeG0OFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "TypeDecl",
+            "name": "DataExchange",
+            "printedName": "DataExchange",
+            "children": [
+              {
+                "kind": "Function",
+                "name": "updateToken",
+                "printedName": "updateToken(withPermissions:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "DataExchangeToken",
+                    "printedName": "YouVersionPlatformCore.DataExchangeToken",
+                    "usr": "s:22YouVersionPlatformCore17DataExchangeTokenV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Set",
+                    "printedName": "Swift.Set<YouVersionPlatformCore.DataExchangePermission>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "DataExchangePermission",
+                        "printedName": "YouVersionPlatformCore.DataExchangePermission",
+                        "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO"
+                      }
+                    ],
+                    "usr": "s:Sh"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO12DataExchangeO11updateToken15withPermissions06accessI07sessionAA0fgI0VShyAA0fG10PermissionOG_SSSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO12DataExchangeO11updateToken15withPermissions06accessI07sessionAA0fgI0VShyAA0fG10PermissionOG_SSSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              }
+            ],
+            "declKind": "Enum",
+            "usr": "s:22YouVersionPlatformCore0aB3APIO12DataExchangeO",
+            "mangledName": "$s22YouVersionPlatformCore0aB3APIO12DataExchangeO",
             "moduleName": "YouVersionPlatformCore",
             "isFromExtension": true,
             "isEnumExhaustive": true,
@@ -7116,6 +8052,63 @@
             "children": [
               {
                 "kind": "Function",
+                "name": "signInResult",
+                "printedName": "signInResult(from:state:codeVerifier:redirectUri:nonce:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionResult",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO12signInResult4from5state12codeVerifier11redirectUri5nonce7sessionAA04Signh4WithabI0V10Foundation3URLV_S4SSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO12signInResult4from5state12codeVerifier11redirectUri5nonce7sessionAA04Signh4WithabI0V10Foundation3URLV_S4SSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
                 "name": "getSignInResult",
                 "printedName": "getSignInResult(from:state:codeVerifier:redirectUri:nonce:session:)",
                 "children": [
@@ -7168,6 +8161,57 @@
                 "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO15getSignInResult4from5state12codeVerifier11redirectUri5nonce7sessionAA0hi4WithabJ0V10Foundation3URLV_S4SSo12NSURLSessionCtYaKFZ",
                 "moduleName": "YouVersionPlatformCore",
                 "static": true,
+                "deprecated": true,
+                "declAttributes": [
+                  "Available"
+                ],
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "refreshSignIn",
+                "printedName": "refreshSignIn(withToken:idToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionResult",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO13refreshSignIn9withToken02idK07sessionAA0hi4WithaB6ResultVSS_SSSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO13refreshSignIn9withToken02idK07sessionAA0hi4WithaB6ResultVSS_SSSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
                 "throwing": true,
                 "funcSelfKind": "NonMutating"
               },
@@ -7215,6 +8259,10 @@
                 "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO14performRefresh4with7idToken7sessionAA010SignInWithaB6ResultVSS_SSSgSo12NSURLSessionCtYaKFZ",
                 "moduleName": "YouVersionPlatformCore",
                 "static": true,
+                "deprecated": true,
+                "declAttributes": [
+                  "Available"
+                ],
                 "throwing": true,
                 "funcSelfKind": "NonMutating"
               },
@@ -9188,287 +10236,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "ChapterDiskCache",
-        "printedName": "ChapterDiskCache",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(versionId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC06removeB09versionIdySi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC06removeB09versionIdySi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Var",
-            "name": "unownedExecutor",
-            "printedName": "unownedExecutor",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UnownedSerialExecutor",
-                "printedName": "_Concurrency.UnownedSerialExecutor",
-                "usr": "s:Sce"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevp",
-            "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
-            "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
-              "Available",
-              "Final",
-              "Nonisolated",
-              "Semantics"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UnownedSerialExecutor",
-                    "printedName": "_Concurrency.UnownedSerialExecutor",
-                    "usr": "s:Sce"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevg",
-                "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC",
-        "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC",
-        "moduleName": "YouVersionPlatformCore",
-        "hasMissingDesignatedInitializers": true,
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Actor",
-            "printedName": "Actor",
-            "usr": "s:ScA",
-            "mangledName": "$sScA"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "ChapterDownloadCache",
-        "printedName": "ChapterDownloadCache",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "chaptersArePresent",
-            "printedName": "chaptersArePresent(versionId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC18chaptersArePresent9versionIdSbSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC18chaptersArePresent9versionIdSbSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Nonisolated"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(versionId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC06removeB09versionIdySi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC06removeB09versionIdySi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Var",
-            "name": "unownedExecutor",
-            "printedName": "unownedExecutor",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UnownedSerialExecutor",
-                "printedName": "_Concurrency.UnownedSerialExecutor",
-                "usr": "s:Sce"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevp",
-            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
-            "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
-              "Available",
-              "Final",
-              "Nonisolated",
-              "Semantics"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UnownedSerialExecutor",
-                    "printedName": "_Concurrency.UnownedSerialExecutor",
-                    "usr": "s:Sce"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevg",
-                "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC",
-        "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC",
-        "moduleName": "YouVersionPlatformCore",
-        "hasMissingDesignatedInitializers": true,
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Actor",
-            "printedName": "Actor",
-            "usr": "s:ScA",
-            "mangledName": "$sScA"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "BibleChapterRepository",
         "printedName": "BibleChapterRepository",
         "children": [
@@ -9524,6 +10291,24 @@
             ]
           },
           {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleChapterRepository",
+                "printedName": "YouVersionPlatformCore.BibleChapterRepository",
+                "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Convenience"
+          },
+          {
             "kind": "Function",
             "name": "chapter",
             "printedName": "chapter(withReference:)",
@@ -9569,9 +10354,6 @@
             "usr": "s:22YouVersionPlatformCore22BibleChapterRepositoryC06removeB06withIdySi_tYaF",
             "mangledName": "$s22YouVersionPlatformCore22BibleChapterRepositoryC06removeB06withIdySi_tYaF",
             "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Custom"
-            ],
             "funcSelfKind": "NonMutating"
           },
           {
@@ -13825,6 +14607,31 @@
             "init_kind": "Designated"
           },
           {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV4fromACs7Decoder_p_tKcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "throwing": true,
+            "init_kind": "Designated"
+          },
+          {
             "kind": "Var",
             "name": "debugDescription",
             "printedName": "debugDescription",
@@ -14380,32 +15187,6 @@
                 "accessorKind": "get"
               }
             ]
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(from:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "BibleReference",
-                "printedName": "YouVersionPlatformCore.BibleReference",
-                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Decoder",
-                "printedName": "any Swift.Decoder",
-                "usr": "s:s7DecoderP"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore14BibleReferenceV4fromACs7Decoder_p_tKcfc",
-            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV4fromACs7Decoder_p_tKcfc",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "throwing": true,
-            "init_kind": "Designated"
           }
         ],
         "declKind": "Struct",
@@ -16945,76 +17726,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "BibleVersionAPIClient",
-        "printedName": "BibleVersionAPIClient",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP7version6withIdAA0eB0VSi_tYaKF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP7version6withIdAA0eB0VSi_tYaKF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionAPIClient>",
-            "protocolReq": true,
-            "throwing": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          }
-        ],
-        "declKind": "Protocol",
-        "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP",
-        "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP",
-        "moduleName": "YouVersionPlatformCore",
-        "genericSig": "<Self : Swift.Sendable>",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "BibleVersionRepositoryProtocol",
         "printedName": "BibleVersionRepositoryProtocol",
         "children": [
@@ -17235,1146 +17946,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "BibleVersionCaching",
-        "printedName": "BibleVersionCaching",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "YouVersionPlatformCore.BibleVersion?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "BibleVersion",
-                    "printedName": "YouVersionPlatformCore.BibleVersion",
-                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP7version6withIdAA0eB0VSgSi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP7version6withIdAA0eB0VSgSi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
-            "protocolReq": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "addVersion",
-            "printedName": "addVersion(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP03addB0yyAA0eB0VYaF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP03addB0yyAA0eB0VYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
-            "protocolReq": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP06removeB06withIdySi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP06removeB06withIdySi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
-            "protocolReq": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "versionIsPresent",
-            "printedName": "versionIsPresent(for:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP16versionIsPresent3forSbSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP16versionIsPresent3forSbSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
-            "protocolReq": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeUnpermittedVersions",
-            "printedName": "removeUnpermittedVersions(permittedIds:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Set",
-                "printedName": "Swift.Set<Swift.Int>",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sh"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
-            "protocolReq": true,
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          }
-        ],
-        "declKind": "Protocol",
-        "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
-        "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP",
-        "moduleName": "YouVersionPlatformCore",
-        "genericSig": "<Self : Swift.Sendable>",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "VersionClient",
-        "printedName": "VersionClient",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "VersionClient",
-                "printedName": "YouVersionPlatformCore.VersionClient",
-                "usr": "s:22YouVersionPlatformCore0B6ClientC"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore0B6ClientCACycfc",
-            "mangledName": "$s22YouVersionPlatformCore0B6ClientCACycfc",
-            "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B6ClientC7version6withIdAA05BibleB0VSi_tYaKF",
-            "mangledName": "$s22YouVersionPlatformCore0B6ClientC7version6withIdAA05BibleB0VSi_tYaKF",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Final"
-            ],
-            "throwing": true,
-            "funcSelfKind": "NonMutating"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore0B6ClientC",
-        "mangledName": "$s22YouVersionPlatformCore0B6ClientC",
-        "moduleName": "YouVersionPlatformCore",
-        "declAttributes": [
-          "Final"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "BibleVersionAPIClient",
-            "printedName": "BibleVersionAPIClient",
-            "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "VersionMemoryCache",
-        "printedName": "VersionMemoryCache",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "VersionMemoryCache",
-                "printedName": "YouVersionPlatformCore.VersionMemoryCache",
-                "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheCACycfc",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheCACycfc",
-            "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "YouVersionPlatformCore.BibleVersion?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "BibleVersion",
-                    "printedName": "YouVersionPlatformCore.BibleVersion",
-                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "versionIsPresent",
-            "printedName": "versionIsPresent(for:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC16versionIsPresent3forSbSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC16versionIsPresent3forSbSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Nonisolated"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "addVersion",
-            "printedName": "addVersion(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC03addB0yyAA05BibleB0VYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC03addB0yyAA05BibleB0VYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC06removeB06withIdySi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC06removeB06withIdySi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeUnpermittedVersions",
-            "printedName": "removeUnpermittedVersions(permittedIds:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Set",
-                "printedName": "Swift.Set<Swift.Int>",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sh"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Var",
-            "name": "unownedExecutor",
-            "printedName": "unownedExecutor",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UnownedSerialExecutor",
-                "printedName": "_Concurrency.UnownedSerialExecutor",
-                "usr": "s:Sce"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevp",
-            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
-            "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
-              "Available",
-              "Final",
-              "Nonisolated",
-              "Semantics"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UnownedSerialExecutor",
-                    "printedName": "_Concurrency.UnownedSerialExecutor",
-                    "usr": "s:Sce"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevg",
-                "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC",
-        "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC",
-        "moduleName": "YouVersionPlatformCore",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "BibleVersionCaching",
-            "printedName": "BibleVersionCaching",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Actor",
-            "printedName": "Actor",
-            "usr": "s:ScA",
-            "mangledName": "$sScA"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "VersionDiskCache",
-        "printedName": "VersionDiskCache",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "VersionDiskCache",
-                "printedName": "YouVersionPlatformCore.VersionDiskCache",
-                "usr": "s:22YouVersionPlatformCore0B9DiskCacheC"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheCACycfc",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheCACycfc",
-            "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "YouVersionPlatformCore.BibleVersion?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "BibleVersion",
-                    "printedName": "YouVersionPlatformCore.BibleVersion",
-                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC7version6withIdAA05BibleB0VSgSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC7version6withIdAA05BibleB0VSgSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "versionIsPresent",
-            "printedName": "versionIsPresent(for:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC16versionIsPresent3forSbSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC16versionIsPresent3forSbSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Nonisolated"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "addVersion",
-            "printedName": "addVersion(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC03addB0yyAA05BibleB0VYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC03addB0yyAA05BibleB0VYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC06removeB06withIdySi_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC06removeB06withIdySi_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeUnpermittedVersions",
-            "printedName": "removeUnpermittedVersions(permittedIds:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Set",
-                "printedName": "Swift.Set<Swift.Int>",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sh"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Var",
-            "name": "unownedExecutor",
-            "printedName": "unownedExecutor",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UnownedSerialExecutor",
-                "printedName": "_Concurrency.UnownedSerialExecutor",
-                "usr": "s:Sce"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevp",
-            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
-            "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
-              "Available",
-              "Final",
-              "Nonisolated",
-              "Semantics"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UnownedSerialExecutor",
-                    "printedName": "_Concurrency.UnownedSerialExecutor",
-                    "usr": "s:Sce"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevg",
-                "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore0B9DiskCacheC",
-        "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC",
-        "moduleName": "YouVersionPlatformCore",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "BibleVersionCaching",
-            "printedName": "BibleVersionCaching",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Actor",
-            "printedName": "Actor",
-            "usr": "s:ScA",
-            "mangledName": "$sScA"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "VersionDownloadCache",
-        "printedName": "VersionDownloadCache",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "VersionDownloadCache",
-                "printedName": "YouVersionPlatformCore.VersionDownloadCache",
-                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheCACycfc",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheCACycfc",
-            "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Function",
-            "name": "versionIsPresent",
-            "printedName": "versionIsPresent(for:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC16versionIsPresent3forSbSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC16versionIsPresent3forSbSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "declAttributes": [
-              "Nonisolated"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "version",
-            "printedName": "version(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "YouVersionPlatformCore.BibleVersion?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "BibleVersion",
-                    "printedName": "YouVersionPlatformCore.BibleVersion",
-                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC7version6withIdAA05BibleB0VSgSi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC7version6withIdAA05BibleB0VSgSi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "addVersion",
-            "printedName": "addVersion(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleVersion",
-                "printedName": "YouVersionPlatformCore.BibleVersion",
-                "usr": "s:22YouVersionPlatformCore05BibleB0V"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC03addB0yyAA05BibleB0VYaF",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC03addB0yyAA05BibleB0VYaF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeVersion",
-            "printedName": "removeVersion(withId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC06removeB06withIdySi_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC06removeB06withIdySi_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "removeUnpermittedVersions",
-            "printedName": "removeUnpermittedVersions(permittedIds:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Set",
-                "printedName": "Swift.Set<Swift.Int>",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sh"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tF",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tF",
-            "moduleName": "YouVersionPlatformCore",
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Var",
-            "name": "downloadedVersions",
-            "printedName": "downloadedVersions",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Array",
-                "printedName": "[Swift.Int]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sa"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvpZ",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvpZ",
-            "moduleName": "YouVersionPlatformCore",
-            "static": true,
-            "declAttributes": [
-              "Final"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Array",
-                    "printedName": "[Swift.Int]",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Int",
-                        "printedName": "Swift.Int",
-                        "usr": "s:Si"
-                      }
-                    ],
-                    "usr": "s:Sa"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvgZ",
-                "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvgZ",
-                "moduleName": "YouVersionPlatformCore",
-                "static": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "unownedExecutor",
-            "printedName": "unownedExecutor",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UnownedSerialExecutor",
-                "printedName": "_Concurrency.UnownedSerialExecutor",
-                "usr": "s:Sce"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevp",
-            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
-            "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
-              "Available",
-              "Final",
-              "Nonisolated",
-              "Semantics"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UnownedSerialExecutor",
-                    "printedName": "_Concurrency.UnownedSerialExecutor",
-                    "usr": "s:Sce"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevg",
-                "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Final"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC",
-        "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC",
-        "moduleName": "YouVersionPlatformCore",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Sendable",
-            "printedName": "Sendable",
-            "usr": "s:s8SendableP",
-            "mangledName": "$ss8SendableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SendableMetatype",
-            "printedName": "SendableMetatype",
-            "usr": "s:s16SendableMetatypeP",
-            "mangledName": "$ss16SendableMetatypeP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "BibleVersionCaching",
-            "printedName": "BibleVersionCaching",
-            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
-            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Actor",
-            "printedName": "Actor",
-            "usr": "s:ScA",
-            "mangledName": "$sScA"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "BibleVersionRepository",
         "printedName": "BibleVersionRepository",
         "children": [
@@ -18432,6 +18003,24 @@
           {
             "kind": "Constructor",
             "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionRepository",
+                "printedName": "YouVersionPlatformCore.BibleVersionRepository",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Convenience"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
             "printedName": "init(apiClient:memoryCache:diskCache:downloadCache:)",
             "children": [
               {
@@ -18473,7 +18062,11 @@
             "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC9apiClient11memoryCache04diskJ008downloadJ0AcA0eB9APIClient_p_AA0eB7Caching_pAaI_pAaI_ptcfc",
             "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC9apiClient11memoryCache04diskJ008downloadJ0AcA0eB9APIClient_p_AA0eB7Caching_pAaI_pAaI_ptcfc",
             "moduleName": "YouVersionPlatformCore",
-            "init_kind": "Designated"
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
+            "init_kind": "Convenience"
           },
           {
             "kind": "Function",
@@ -18535,6 +18128,30 @@
           },
           {
             "kind": "Function",
+            "name": "containsVersion",
+            "printedName": "containsVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC08containsB06withIdSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC08containsB06withIdSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
             "name": "versionIsPresent",
             "printedName": "versionIsPresent(for:)",
             "children": [
@@ -18555,6 +18172,10 @@
             "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC16versionIsPresent3forSbSi_tF",
             "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC16versionIsPresent3forSbSi_tF",
             "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
             "funcSelfKind": "NonMutating"
           },
           {
@@ -18876,6 +18497,125 @@
             "funcSelfKind": "NonMutating"
           },
           {
+            "kind": "Var",
+            "name": "downloadedVersionIds",
+            "printedName": "downloadedVersionIds",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvp",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.Int]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvg",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC010downloadedB3IdsSaySiGvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "defaultDownloadedVersionIds",
+            "printedName": "defaultDownloadedVersionIds",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC017defaultDownloadedB3IdsSaySiGvpZ",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC017defaultDownloadedB3IdsSaySiGvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "isInternal": true,
+            "declAttributes": [
+              "Final"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.Int]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC017defaultDownloadedB3IdsSaySiGvgZ",
+                "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC017defaultDownloadedB3IdsSaySiGvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "isInternal": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
             "kind": "Function",
             "name": "removeVersion",
             "printedName": "removeVersion(withId:)",
@@ -18989,6 +18729,7 @@
         "usr": "s:22YouVersionPlatformCore05BibleB10RepositoryC",
         "mangledName": "$s22YouVersionPlatformCore05BibleB10RepositoryC",
         "moduleName": "YouVersionPlatformCore",
+        "hasMissingDesignatedInitializers": true,
         "conformances": [
           {
             "kind": "Conformance",
@@ -19031,6 +18772,1545 @@
             "printedName": "BibleVersionRepositoryProtocol",
             "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP",
             "mangledName": "$s22YouVersionPlatformCore05BibleB18RepositoryProtocolP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersionAPIClient",
+        "printedName": "BibleVersionAPIClient",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP7version6withIdAA0eB0VSi_tYaKF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP7version6withIdAA0eB0VSi_tYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionAPIClient>",
+            "protocolReq": true,
+            "throwing": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP",
+        "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP",
+        "moduleName": "YouVersionPlatformCore",
+        "genericSig": "<Self : Swift.Sendable>",
+        "deprecated": true,
+        "declAttributes": [
+          "Available"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleVersionCaching",
+        "printedName": "BibleVersionCaching",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP7version6withIdAA0eB0VSgSi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP7version6withIdAA0eB0VSgSi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP03addB0yyAA0eB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP03addB0yyAA0eB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleVersionCaching>",
+            "protocolReq": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+        "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP",
+        "moduleName": "YouVersionPlatformCore",
+        "genericSig": "<Self : Swift.Sendable>",
+        "deprecated": true,
+        "declAttributes": [
+          "Available"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionClient",
+        "printedName": "VersionClient",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionClient",
+                "printedName": "YouVersionPlatformCore.VersionClient",
+                "usr": "s:22YouVersionPlatformCore0B6ClientC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B6ClientCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B6ClientCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B6ClientC7version6withIdAA05BibleB0VSi_tYaKF",
+            "mangledName": "$s22YouVersionPlatformCore0B6ClientC7version6withIdAA05BibleB0VSi_tYaKF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Final"
+            ],
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B6ClientC",
+        "mangledName": "$s22YouVersionPlatformCore0B6ClientC",
+        "moduleName": "YouVersionPlatformCore",
+        "deprecated": true,
+        "declAttributes": [
+          "Final",
+          "Available"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionAPIClient",
+            "printedName": "BibleVersionAPIClient",
+            "usr": "s:22YouVersionPlatformCore05BibleB9APIClientP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB9APIClientP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionMemoryCache",
+        "printedName": "VersionMemoryCache",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionMemoryCache",
+                "printedName": "YouVersionPlatformCore.VersionMemoryCache",
+                "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC03addB0yyAA05BibleB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC03addB0yyAA05BibleB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B11MemoryCacheC",
+        "mangledName": "$s22YouVersionPlatformCore0B11MemoryCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "deprecated": true,
+        "declAttributes": [
+          "Available"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionCaching",
+            "printedName": "BibleVersionCaching",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionDiskCache",
+        "printedName": "VersionDiskCache",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionDiskCache",
+                "printedName": "YouVersionPlatformCore.VersionDiskCache",
+                "usr": "s:22YouVersionPlatformCore0B9DiskCacheC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC03addB0yyAA05BibleB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC03addB0yyAA05BibleB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B9DiskCacheC",
+        "mangledName": "$s22YouVersionPlatformCore0B9DiskCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "deprecated": true,
+        "declAttributes": [
+          "Available"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionCaching",
+            "printedName": "BibleVersionCaching",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "VersionDownloadCache",
+        "printedName": "VersionDownloadCache",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "VersionDownloadCache",
+                "printedName": "YouVersionPlatformCore.VersionDownloadCache",
+                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheCACycfc",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheCACycfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "versionIsPresent",
+            "printedName": "versionIsPresent(for:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC16versionIsPresent3forSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC16versionIsPresent3forSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "version",
+            "printedName": "version(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC7version6withIdAA05BibleB0VSgSi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "addVersion",
+            "printedName": "addVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC03addB0yyAA05BibleB0VYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC03addB0yyAA05BibleB0VYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(withId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC06removeB06withIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC06removeB06withIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeUnpermittedVersions",
+            "printedName": "removeUnpermittedVersions(permittedIds:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC25removeUnpermittedVersions12permittedIdsyShySiG_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "downloadedVersions",
+            "printedName": "downloadedVersions",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "Final"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.Int]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC18downloadedVersionsSaySiGvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore0B13DownloadCacheC",
+        "mangledName": "$s22YouVersionPlatformCore0B13DownloadCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "deprecated": true,
+        "declAttributes": [
+          "Available"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleVersionCaching",
+            "printedName": "BibleVersionCaching",
+            "usr": "s:22YouVersionPlatformCore05BibleB7CachingP",
+            "mangledName": "$s22YouVersionPlatformCore05BibleB7CachingP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "ChapterDiskCache",
+        "printedName": "ChapterDiskCache",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC06removeB09versionIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC06removeB09versionIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore16ChapterDiskCacheC",
+        "mangledName": "$s22YouVersionPlatformCore16ChapterDiskCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "deprecated": true,
+        "declAttributes": [
+          "Available"
+        ],
+        "hasMissingDesignatedInitializers": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Actor",
+            "printedName": "Actor",
+            "usr": "s:ScA",
+            "mangledName": "$sScA"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "ChapterDownloadCache",
+        "printedName": "ChapterDownloadCache",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "chaptersArePresent",
+            "printedName": "chaptersArePresent(versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC18chaptersArePresent9versionIdSbSi_tF",
+            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC18chaptersArePresent9versionIdSbSi_tF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "removeVersion",
+            "printedName": "removeVersion(versionId:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC06removeB09versionIdySi_tYaF",
+            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC06removeB09versionIdySi_tYaF",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "unownedExecutor",
+            "printedName": "unownedExecutor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "UnownedSerialExecutor",
+                "printedName": "_Concurrency.UnownedSerialExecutor",
+                "usr": "s:Sce"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevp",
+            "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevp",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "implicit": true,
+            "intro_Macosx": "10.15",
+            "intro_iOS": "13.0",
+            "intro_tvOS": "13.0",
+            "intro_watchOS": "6.0",
+            "declAttributes": [
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Available",
+              "Final",
+              "Nonisolated",
+              "Semantics"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UnownedSerialExecutor",
+                    "printedName": "_Concurrency.UnownedSerialExecutor",
+                    "usr": "s:Sce"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevg",
+                "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC15unownedExecutorScevg",
+                "moduleName": "YouVersionPlatformCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:22YouVersionPlatformCore20ChapterDownloadCacheC",
+        "mangledName": "$s22YouVersionPlatformCore20ChapterDownloadCacheC",
+        "moduleName": "YouVersionPlatformCore",
+        "deprecated": true,
+        "declAttributes": [
+          "Available"
+        ],
+        "hasMissingDesignatedInitializers": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
           },
           {
             "kind": "Conformance",
@@ -20182,6 +21462,170 @@
           },
           {
             "kind": "Var",
+            "name": "permittedLanguageTags",
+            "printedName": "permittedLanguageTags",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Set<Swift.String>?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Set",
+                    "printedName": "Swift.Set<Swift.String>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sh"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV21permittedLanguageTagsShySSGSgvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV21permittedLanguageTagsShySSGSgvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "Nonisolated",
+              "SetterAccess",
+              "HasStorage"
+            ],
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.Set<Swift.String>?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Set",
+                        "printedName": "Swift.Set<Swift.String>",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "usr": "s:Sh"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV21permittedLanguageTagsShySSGSgvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV21permittedLanguageTagsShySSGSgvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "permittedVersionIds",
+            "printedName": "permittedVersionIds",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Set<Swift.Int>?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Set",
+                    "printedName": "Swift.Set<Swift.Int>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sh"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV09permittedB3IdsShySiGSgvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV09permittedB3IdsShySiGSgvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "Nonisolated",
+              "SetterAccess",
+              "HasStorage"
+            ],
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.Set<Swift.Int>?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Set",
+                        "printedName": "Swift.Set<Swift.Int>",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Int",
+                            "printedName": "Swift.Int",
+                            "usr": "s:Si"
+                          }
+                        ],
+                        "usr": "s:Sh"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV09permittedB3IdsShySiGSgvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV09permittedB3IdsShySiGSgvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
             "name": "installId",
             "printedName": "installId",
             "children": [
@@ -20249,7 +21693,7 @@
           {
             "kind": "Function",
             "name": "configure",
-            "printedName": "configure(appKey:apiHost:appName:isSignInEnabled:signInPromptMessage:)",
+            "printedName": "configure(appKey:apiHost:appName:isSignInEnabled:signInPromptMessage:permittedLanguageTags:permittedVersionIds:)",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -20321,11 +21765,57 @@
                 ],
                 "hasDefaultArg": true,
                 "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Set<Swift.String>?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Set",
+                    "printedName": "Swift.Set<Swift.String>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sh"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Set<Swift.Int>?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Set",
+                    "printedName": "Swift.Set<Swift.Int>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sh"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
               }
             ],
             "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV9configure6appKey7apiHost0G4Name15isSignInEnabled04signN13PromptMessageySSSg_A2JSbAJtFZ",
-            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV9configure6appKey7apiHost0G4Name15isSignInEnabled04signN13PromptMessageySSSg_A2JSbAJtFZ",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV9configure6appKey7apiHost0G4Name15isSignInEnabled04signN13PromptMessage21permittedLanguageTags0sB3IdsySSSg_A2LSbALShySSGSgShySiGSgtFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV9configure6appKey7apiHost0G4Name15isSignInEnabled04signN13PromptMessage21permittedLanguageTags0sB3IdsySSSg_A2LSbALShySSGSgShySiGSgtFZ",
             "moduleName": "YouVersionPlatformCore",
             "static": true,
             "declAttributes": [
@@ -20582,6 +22072,38 @@
                 "accessorKind": "get"
               }
             ]
+          },
+          {
+            "kind": "Function",
+            "name": "saveDataExchangePermissions",
+            "printedName": "saveDataExchangePermissions(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.DataExchangePermission]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "DataExchangePermission",
+                    "printedName": "YouVersionPlatformCore.DataExchangePermission",
+                    "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV27saveDataExchangePermissionsyySayAA0gH10PermissionOGFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV27saveDataExchangePermissionsyySayAA0gH10PermissionOGFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
           }
         ],
         "declKind": "Struct",

--- a/.api-baseline/YouVersionPlatformUI.json
+++ b/.api-baseline/YouVersionPlatformUI.json
@@ -62,6 +62,721 @@
       },
       {
         "kind": "TypeDecl",
+        "name": "DataExchangeRequestResult",
+        "printedName": "DataExchangeRequestResult",
+        "children": [
+          {
+            "kind": "TypeDecl",
+            "name": "Status",
+            "printedName": "Status",
+            "children": [
+              {
+                "kind": "Var",
+                "name": "granted",
+                "printedName": "granted",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformUI.DataExchangeRequestResult.Status.Type) -> YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Status",
+                        "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                        "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Status",
+                            "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                            "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO7grantedyA2EmF",
+                "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO7grantedyA2EmF",
+                "moduleName": "YouVersionPlatformUI"
+              },
+              {
+                "kind": "Var",
+                "name": "cancel",
+                "printedName": "cancel",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformUI.DataExchangeRequestResult.Status.Type) -> YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Status",
+                        "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                        "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Status",
+                            "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                            "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO6cancelyA2EmF",
+                "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO6cancelyA2EmF",
+                "moduleName": "YouVersionPlatformUI"
+              },
+              {
+                "kind": "Var",
+                "name": "missing",
+                "printedName": "missing",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformUI.DataExchangeRequestResult.Status.Type) -> YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Status",
+                        "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                        "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Status",
+                            "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                            "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO7missingyA2EmF",
+                "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO7missingyA2EmF",
+                "moduleName": "YouVersionPlatformUI"
+              },
+              {
+                "kind": "Var",
+                "name": "unknown",
+                "printedName": "unknown",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformUI.DataExchangeRequestResult.Status.Type) -> (Swift.String) -> YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                    "children": [
+                      {
+                        "kind": "TypeFunc",
+                        "name": "Function",
+                        "printedName": "(Swift.String) -> YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Status",
+                            "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                            "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO"
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status.Type",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Status",
+                            "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                            "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "EnumElement",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO7unknownyAESScAEmF",
+                "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO7unknownyAESScAEmF",
+                "moduleName": "YouVersionPlatformUI"
+              },
+              {
+                "kind": "Constructor",
+                "name": "init",
+                "printedName": "init(rawValue:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Status",
+                    "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                    "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Constructor",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO8rawValueAESS_tcfc",
+                "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO8rawValueAESS_tcfc",
+                "moduleName": "YouVersionPlatformUI",
+                "init_kind": "Designated"
+              },
+              {
+                "kind": "Var",
+                "name": "rawValue",
+                "printedName": "rawValue",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO8rawValueSSvp",
+                "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO8rawValueSSvp",
+                "moduleName": "YouVersionPlatformUI",
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO8rawValueSSvg",
+                    "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO8rawValueSSvg",
+                    "moduleName": "YouVersionPlatformUI",
+                    "accessorKind": "get"
+                  }
+                ]
+              },
+              {
+                "kind": "Var",
+                "name": "description",
+                "printedName": "description",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO11descriptionSSvp",
+                "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO11descriptionSSvp",
+                "moduleName": "YouVersionPlatformUI",
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO11descriptionSSvg",
+                    "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO11descriptionSSvg",
+                    "moduleName": "YouVersionPlatformUI",
+                    "accessorKind": "get"
+                  }
+                ]
+              },
+              {
+                "kind": "TypeAlias",
+                "name": "RawValue",
+                "printedName": "RawValue",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "TypeAlias",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO8RawValuea",
+                "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO8RawValuea",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true
+              }
+            ],
+            "declKind": "Enum",
+            "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO",
+            "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO",
+            "moduleName": "YouVersionPlatformUI",
+            "isEnumExhaustive": true,
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "CustomStringConvertible",
+                "printedName": "CustomStringConvertible",
+                "usr": "s:s23CustomStringConvertibleP",
+                "mangledName": "$ss23CustomStringConvertibleP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Equatable",
+                "printedName": "Equatable",
+                "usr": "s:SQ",
+                "mangledName": "$sSQ"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Hashable",
+                "printedName": "Hashable",
+                "usr": "s:SH",
+                "mangledName": "$sSH"
+              },
+              {
+                "kind": "Conformance",
+                "name": "RawRepresentable",
+                "printedName": "RawRepresentable",
+                "children": [
+                  {
+                    "kind": "TypeWitness",
+                    "name": "RawValue",
+                    "printedName": "RawValue",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ]
+                  }
+                ],
+                "usr": "s:SY",
+                "mangledName": "$sSY"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Sendable",
+                "printedName": "Sendable",
+                "usr": "s:s8SendableP",
+                "mangledName": "$ss8SendableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "SendableMetatype",
+                "printedName": "SendableMetatype",
+                "usr": "s:s16SendableMetatypeP",
+                "mangledName": "$ss16SendableMetatypeP"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "status",
+            "printedName": "status",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Status",
+                "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6statusAC6StatusOvp",
+            "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV6statusAC6StatusOvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Status",
+                    "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                    "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6statusAC6StatusOvg",
+                "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV6statusAC6StatusOvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "grantedPermissions",
+            "printedName": "grantedPermissions",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.DataExchangePermission]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "DataExchangePermission",
+                    "printedName": "YouVersionPlatformCore.DataExchangePermission",
+                    "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV18grantedPermissionsSay0abC4Core0eF10PermissionOGvp",
+            "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV18grantedPermissionsSay0abC4Core0eF10PermissionOGvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.DataExchangePermission]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "DataExchangePermission",
+                        "printedName": "YouVersionPlatformCore.DataExchangePermission",
+                        "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV18grantedPermissionsSay0abC4Core0eF10PermissionOGvg",
+                "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV18grantedPermissionsSay0abC4Core0eF10PermissionOGvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(status:grantedPermissions:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "DataExchangeRequestResult",
+                "printedName": "YouVersionPlatformUI.DataExchangeRequestResult",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Status",
+                "printedName": "YouVersionPlatformUI.DataExchangeRequestResult.Status",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6StatusO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.DataExchangePermission]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "DataExchangePermission",
+                    "printedName": "YouVersionPlatformCore.DataExchangePermission",
+                    "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV6status18grantedPermissionsA2C6StatusO_Say0abC4Core0eF10PermissionOGtcfc",
+            "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV6status18grantedPermissionsA2C6StatusO_Say0abC4Core0eF10PermissionOGtcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "isGranted",
+            "printedName": "isGranted",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV9isGrantedSbvp",
+            "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV9isGrantedSbvp",
+            "moduleName": "YouVersionPlatformUI",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV9isGrantedSbvg",
+                "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV9isGrantedSbvg",
+                "moduleName": "YouVersionPlatformUI",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "__derived_struct_equals",
+            "printedName": "__derived_struct_equals(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "DataExchangeRequestResult",
+                "printedName": "YouVersionPlatformUI.DataExchangeRequestResult",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "DataExchangeRequestResult",
+                "printedName": "YouVersionPlatformUI.DataExchangeRequestResult",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV23__derived_struct_equalsySbAC_ACtFZ",
+            "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV23__derived_struct_equalsySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Implements"
+            ],
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV",
+        "mangledName": "$s20YouVersionPlatformUI25DataExchangeRequestResultV",
+        "moduleName": "YouVersionPlatformUI",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "DataExchangeSession",
+        "printedName": "DataExchangeSession",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(contextProvider:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "DataExchangeSession",
+                "printedName": "YouVersionPlatformUI.DataExchangeSession",
+                "usr": "s:20YouVersionPlatformUI19DataExchangeSessionV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "ASWebAuthenticationPresentationContextProviding",
+                "printedName": "any AuthenticationServices.ASWebAuthenticationPresentationContextProviding",
+                "usr": "c:objc(pl)ASWebAuthenticationPresentationContextProviding"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI19DataExchangeSessionV15contextProviderACSo47ASWebAuthenticationPresentationContextProviding_p_tcfc",
+            "mangledName": "$s20YouVersionPlatformUI19DataExchangeSessionV15contextProviderACSo47ASWebAuthenticationPresentationContextProviding_p_tcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "requestDataExchange",
+            "printedName": "requestDataExchange(permissions:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "DataExchangeRequestResult",
+                "printedName": "YouVersionPlatformUI.DataExchangeRequestResult",
+                "usr": "s:20YouVersionPlatformUI25DataExchangeRequestResultV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<YouVersionPlatformCore.DataExchangePermission>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "DataExchangePermission",
+                    "printedName": "YouVersionPlatformCore.DataExchangePermission",
+                    "usr": "s:22YouVersionPlatformCore22DataExchangePermissionO"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI19DataExchangeSessionV07requesteF011permissionsAA0eF13RequestResultVShy0abC4Core0eF10PermissionOG_tYaKF",
+            "mangledName": "$s20YouVersionPlatformUI19DataExchangeSessionV07requesteF011permissionsAA0eF13RequestResultVShy0abC4Core0eF10PermissionOG_tYaKF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI19DataExchangeSessionV",
+        "mangledName": "$s20YouVersionPlatformUI19DataExchangeSessionV",
+        "moduleName": "YouVersionPlatformUI",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
         "name": "BibleTextFontOption",
         "printedName": "BibleTextFontOption",
         "children": [
@@ -872,8 +1587,8 @@
         "children": [
           {
             "kind": "Var",
-            "name": "fontSystemM",
-            "printedName": "fontSystemM",
+            "name": "systemMedium",
+            "printedName": "systemMedium",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -883,8 +1598,8 @@
               }
             ],
             "declKind": "Var",
-            "usr": "s:20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvpZ",
-            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvpZ",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO12systemMedium05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12systemMedium05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
             "declAttributes": [
@@ -907,14 +1622,400 @@
                   }
                 ],
                 "declKind": "Accessor",
-                "usr": "s:20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvgZ",
-                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvgZ",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO12systemMedium05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12systemMedium05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
                 "implicit": true,
                 "declAttributes": [
                   "Transparent"
                 ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "headerMedium",
+            "printedName": "headerMedium",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO12headerMedium05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12headerMedium05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO12headerMedium05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12headerMedium05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "headerSmall",
+            "printedName": "headerSmall",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO11headerSmall05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11headerSmall05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO11headerSmall05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11headerSmall05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "eyebrowSmall",
+            "printedName": "eyebrowSmall",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO12eyebrowSmall05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12eyebrowSmall05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO12eyebrowSmall05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12eyebrowSmall05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "labelMedium",
+            "printedName": "labelMedium",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO11labelMedium05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11labelMedium05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO11labelMedium05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11labelMedium05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "labelSmall",
+            "printedName": "labelSmall",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO10labelSmall05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10labelSmall05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO10labelSmall05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10labelSmall05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "captionsLarge",
+            "printedName": "captionsLarge",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO13captionsLarge05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13captionsLarge05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO13captionsLarge05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13captionsLarge05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "captionsSmall",
+            "printedName": "captionsSmall",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO13captionsSmall05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13captionsSmall05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO13captionsSmall05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13captionsSmall05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "fontSystemM",
+            "printedName": "fontSystemM",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Font",
+                "printedName": "SwiftUI.Font",
+                "usr": "s:7SwiftUI4FontV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvpZ",
+            "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Font",
+                    "printedName": "SwiftUI.Font",
+                    "usr": "s:7SwiftUI4FontV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvgZ",
+                "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontSystemM05SwiftD04FontVvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
                 "accessorKind": "get"
               }
             ]
@@ -936,12 +2037,10 @@
             "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontHeaderM05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
-              "HasInitialValue",
-              "HasStorage"
+              "Available"
             ],
-            "isLet": true,
-            "hasStorage": true,
             "accessors": [
               {
                 "kind": "Accessor",
@@ -960,10 +2059,6 @@
                 "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontHeaderM05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
                 "accessorKind": "get"
               }
             ]
@@ -985,12 +2080,10 @@
             "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontHeaderS05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
-              "HasInitialValue",
-              "HasStorage"
+              "Available"
             ],
-            "isLet": true,
-            "hasStorage": true,
             "accessors": [
               {
                 "kind": "Accessor",
@@ -1009,10 +2102,6 @@
                 "mangledName": "$s20YouVersionPlatformUI0aB5FontsO11fontHeaderS05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
                 "accessorKind": "get"
               }
             ]
@@ -1034,12 +2123,10 @@
             "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12fontEyebrowS05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
-              "HasInitialValue",
-              "HasStorage"
+              "Available"
             ],
-            "isLet": true,
-            "hasStorage": true,
             "accessors": [
               {
                 "kind": "Accessor",
@@ -1058,10 +2145,6 @@
                 "mangledName": "$s20YouVersionPlatformUI0aB5FontsO12fontEyebrowS05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
                 "accessorKind": "get"
               }
             ]
@@ -1083,12 +2166,10 @@
             "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10fontLabelM05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
-              "HasInitialValue",
-              "HasStorage"
+              "Available"
             ],
-            "isLet": true,
-            "hasStorage": true,
             "accessors": [
               {
                 "kind": "Accessor",
@@ -1107,10 +2188,6 @@
                 "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10fontLabelM05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
                 "accessorKind": "get"
               }
             ]
@@ -1132,12 +2209,10 @@
             "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10fontLabelS05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
-              "HasInitialValue",
-              "HasStorage"
+              "Available"
             ],
-            "isLet": true,
-            "hasStorage": true,
             "accessors": [
               {
                 "kind": "Accessor",
@@ -1156,10 +2231,6 @@
                 "mangledName": "$s20YouVersionPlatformUI0aB5FontsO10fontLabelS05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
                 "accessorKind": "get"
               }
             ]
@@ -1181,12 +2252,10 @@
             "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13fontCaptionsL05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
-              "HasInitialValue",
-              "HasStorage"
+              "Available"
             ],
-            "isLet": true,
-            "hasStorage": true,
             "accessors": [
               {
                 "kind": "Accessor",
@@ -1205,10 +2274,6 @@
                 "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13fontCaptionsL05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
                 "accessorKind": "get"
               }
             ]
@@ -1230,12 +2295,10 @@
             "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13fontCaptionsS05SwiftD04FontVvpZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
-              "HasInitialValue",
-              "HasStorage"
+              "Available"
             ],
-            "isLet": true,
-            "hasStorage": true,
             "accessors": [
               {
                 "kind": "Accessor",
@@ -1254,10 +2317,6 @@
                 "mangledName": "$s20YouVersionPlatformUI0aB5FontsO13fontCaptionsS05SwiftD04FontVvgZ",
                 "moduleName": "YouVersionPlatformUI",
                 "static": true,
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
                 "accessorKind": "get"
               }
             ]
@@ -1930,6 +2989,129 @@
             "init_kind": "Designated"
           },
           {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(html:reference:textOptions:onVerseTap:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextView",
+                "printedName": "YouVersionPlatformUI.BibleTextView",
+                "usr": "s:20YouVersionPlatformUI13BibleTextViewV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextOptions",
+                "printedName": "YouVersionPlatformUI.BibleTextOptions",
+                "hasDefaultArg": true,
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.BibleTextView.VerseTapAction?",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "VerseTapAction",
+                    "printedName": "YouVersionPlatformUI.BibleTextView.VerseTapAction",
+                    "children": [
+                      {
+                        "kind": "TypeFunc",
+                        "name": "Function",
+                        "printedName": "(YouVersionPlatformCore.BibleReference, Swift.String, [YouVersionPlatformUI.BibleFootnote], Swift.String?) -> Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNameAlias",
+                            "name": "Void",
+                            "printedName": "Swift.Void",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Void",
+                                "printedName": "()"
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Tuple",
+                            "printedName": "(YouVersionPlatformCore.BibleReference, Swift.String, [YouVersionPlatformUI.BibleFootnote], Swift.String?)",
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "BibleReference",
+                                "printedName": "YouVersionPlatformCore.BibleReference",
+                                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Array",
+                                "printedName": "[YouVersionPlatformUI.BibleFootnote]",
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "BibleFootnote",
+                                    "printedName": "YouVersionPlatformUI.BibleFootnote",
+                                    "usr": "s:20YouVersionPlatformUI13BibleFootnoteV"
+                                  }
+                                ],
+                                "usr": "s:Sa"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Optional",
+                                "printedName": "Swift.String?",
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "String",
+                                    "printedName": "Swift.String",
+                                    "usr": "s:SS"
+                                  }
+                                ],
+                                "usr": "s:Sq"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI13BibleTextViewV4html9reference11textOptions10onVerseTapACSS_0abC4Core0E9ReferenceVAA0efK0VyAJ_SSSayAA0E8FootnoteVGSSSgtcSgtcfc",
+            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV4html9reference11textOptions10onVerseTapACSS_0abC4Core0E9ReferenceVAA0efK0VyAJ_SSSayAA0E8FootnoteVGSSSgtcSgtcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
             "kind": "Var",
             "name": "body",
             "printedName": "body",
@@ -1983,64 +3165,6 @@
                 "accessorKind": "get"
               }
             ]
-          },
-          {
-            "kind": "Function",
-            "name": "viewWithPrefetchedData",
-            "printedName": "viewWithPrefetchedData(reference:fontFamily:fontSize:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "(some SwiftUI.View)?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "OpaqueTypeArchetype",
-                    "printedName": "some SwiftUI.View",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "View",
-                        "printedName": "SwiftUI.View",
-                        "usr": "s:7SwiftUI4ViewP"
-                      }
-                    ]
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "BibleReference",
-                "printedName": "YouVersionPlatformCore.BibleReference",
-                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "hasDefaultArg": true,
-                "usr": "s:SS"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "CGFloat",
-                "printedName": "CoreGraphics.CGFloat",
-                "hasDefaultArg": true,
-                "usr": "s:14CoreFoundation7CGFloatV"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:20YouVersionPlatformUI13BibleTextViewV22viewWithPrefetchedData9reference10fontFamily0M4SizeQrSg0abC4Core0E9ReferenceV_SS0P10Foundation7CGFloatVtYaFZ",
-            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV22viewWithPrefetchedData9reference10fontFamily0M4SizeQrSg0abC4Core0E9ReferenceV_SS0P8Graphics7CGFloatVtYaFZ",
-            "moduleName": "YouVersionPlatformUI",
-            "static": true,
-            "declAttributes": [
-              "Preconcurrency",
-              "Custom"
-            ],
-            "funcSelfKind": "NonMutating"
           },
           {
             "kind": "Function",
@@ -2174,8 +3298,70 @@
             "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV12viewFromHtml4html9reference11textOptions10onVerseTapQrSgSS_0abC4Core0E9ReferenceVAA0efN0VyAL_SSSayAA0E8FootnoteVGSSSgtcSgtFZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
               "Preconcurrency",
+              "Available",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "viewWithPrefetchedData",
+            "printedName": "viewWithPrefetchedData(reference:fontFamily:fontSize:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "(some SwiftUI.View)?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "OpaqueTypeArchetype",
+                    "printedName": "some SwiftUI.View",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "View",
+                        "printedName": "SwiftUI.View",
+                        "usr": "s:7SwiftUI4ViewP"
+                      }
+                    ]
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "hasDefaultArg": true,
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "hasDefaultArg": true,
+                "usr": "s:14CoreFoundation7CGFloatV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI13BibleTextViewV22viewWithPrefetchedData9reference10fontFamily0M4SizeQrSg0abC4Core0E9ReferenceV_SS0P10Foundation7CGFloatVtYaFZ",
+            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV22viewWithPrefetchedData9reference10fontFamily0M4SizeQrSg0abC4Core0E9ReferenceV_SS0P8Graphics7CGFloatVtYaFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "deprecated": true,
+            "declAttributes": [
+              "Preconcurrency",
+              "Available",
               "Custom"
             ],
             "funcSelfKind": "NonMutating"
@@ -2559,8 +3745,8 @@
           },
           {
             "kind": "Var",
-            "name": "verseNumColor",
-            "printedName": "verseNumColor",
+            "name": "verseNumberColor",
+            "printedName": "verseNumberColor",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -2578,8 +3764,8 @@
               }
             ],
             "declKind": "Var",
-            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvp",
-            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvp",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV16verseNumberColor05SwiftD00J0VSgvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV16verseNumberColor05SwiftD00J0VSgvp",
             "moduleName": "YouVersionPlatformUI",
             "declAttributes": [
               "HasStorage"
@@ -2608,8 +3794,8 @@
                   }
                 ],
                 "declKind": "Accessor",
-                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvg",
-                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvg",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV16verseNumberColor05SwiftD00J0VSgvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV16verseNumberColor05SwiftD00J0VSgvg",
                 "moduleName": "YouVersionPlatformUI",
                 "implicit": true,
                 "declAttributes": [
@@ -2621,8 +3807,8 @@
           },
           {
             "kind": "Var",
-            "name": "wocColor",
-            "printedName": "wocColor",
+            "name": "wordsOfChristColor",
+            "printedName": "wordsOfChristColor",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -2632,8 +3818,8 @@
               }
             ],
             "declKind": "Var",
-            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvp",
-            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvp",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV18wordsOfChristColor05SwiftD00K0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV18wordsOfChristColor05SwiftD00K0Vvp",
             "moduleName": "YouVersionPlatformUI",
             "declAttributes": [
               "HasStorage"
@@ -2654,8 +3840,8 @@
                   }
                 ],
                 "declKind": "Accessor",
-                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvg",
-                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvg",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV18wordsOfChristColor05SwiftD00K0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV18wordsOfChristColor05SwiftD00K0Vvg",
                 "moduleName": "YouVersionPlatformUI",
                 "implicit": true,
                 "declAttributes": [
@@ -2914,6 +4100,246 @@
           {
             "kind": "Constructor",
             "name": "init",
+            "printedName": "init(fontFamily:fontSize:lineSpacing:paragraphSpacing:textColor:verseNumberColor:wordsOfChristColor:renderHeadlines:renderVerseNumbers:footnoteMode:footnoteMarker:verseSelectionStyle:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextOptions",
+                "printedName": "YouVersionPlatformUI.BibleTextOptions",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "hasDefaultArg": true,
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "CGFloat",
+                "printedName": "CoreGraphics.CGFloat",
+                "hasDefaultArg": true,
+                "usr": "s:14CoreFoundation7CGFloatV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "CoreGraphics.CGFloat?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CGFloat",
+                    "printedName": "CoreGraphics.CGFloat",
+                    "usr": "s:14CoreFoundation7CGFloatV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "CoreGraphics.CGFloat?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "CGFloat",
+                    "printedName": "CoreGraphics.CGFloat",
+                    "usr": "s:14CoreFoundation7CGFloatV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "hasDefaultArg": true,
+                "usr": "s:7SwiftUI5ColorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleTextFootnoteMode",
+                "printedName": "YouVersionPlatformUI.BibleTextFootnoteMode",
+                "hasDefaultArg": true,
+                "usr": "s:20YouVersionPlatformUI21BibleTextFootnoteModeO"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.BibleAttributedString?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleAttributedString",
+                    "printedName": "YouVersionPlatformUI.BibleAttributedString",
+                    "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "VerseSelectionStyle",
+                "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                "hasDefaultArg": true,
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV10fontFamily0H4Size11lineSpacing09paragraphL09textColor011verseNumberO0013wordsOfChristO015renderHeadlines0U12VerseNumbers12footnoteMode0Y6Marker0P14SelectionStyleACSS_14CoreFoundation7CGFloatVARSgAS05SwiftD00O0VSgAwVS2bAA0ef8FootnoteZ0OAA0E16AttributedStringCSgAA0W14SelectionStyleVtcfc",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV10fontFamily0H4Size11lineSpacing09paragraphL09textColor011verseNumberO0013wordsOfChristO015renderHeadlines0U12VerseNumbers12footnoteMode0Y6Marker0P14SelectionStyleACSS_12CoreGraphics7CGFloatVARSgAS05SwiftD00O0VSgAwVS2bAA0ef8FootnoteZ0OAA0E16AttributedStringCSgAA0W14SelectionStyleVtcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "verseNumColor",
+            "printedName": "verseNumColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "SwiftUI.Color?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "SwiftUI.Color?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Color",
+                        "printedName": "SwiftUI.Color",
+                        "usr": "s:7SwiftUI5ColorV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV13verseNumColor05SwiftD00J0VSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "wocColor",
+            "printedName": "wocColor",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Color",
+                "printedName": "SwiftUI.Color",
+                "usr": "s:7SwiftUI5ColorV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvp",
+            "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Color",
+                    "printedName": "SwiftUI.Color",
+                    "usr": "s:7SwiftUI5ColorV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvg",
+                "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV8wocColor05SwiftD00I0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
             "printedName": "init(fontFamily:fontSize:lineSpacing:paragraphSpacing:textColor:verseNumColor:wocColor:renderHeadlines:renderVerseNumbers:footnoteMode:footnoteMarker:verseSelectionStyle:)",
             "children": [
               {
@@ -3051,6 +4477,11 @@
             "usr": "s:20YouVersionPlatformUI16BibleTextOptionsV10fontFamily0H4Size11lineSpacing09paragraphL09textColor08verseNumO003wocO015renderHeadlines0S12VerseNumbers12footnoteMode0W6Marker0P14SelectionStyleACSS_14CoreFoundation7CGFloatVARSgAS05SwiftD00O0VSgAwVS2bAA0ef8FootnoteX0OAA0E16AttributedStringCSgAA0uZ5StyleVtcfc",
             "mangledName": "$s20YouVersionPlatformUI16BibleTextOptionsV10fontFamily0H4Size11lineSpacing09paragraphL09textColor08verseNumO003wocO015renderHeadlines0S12VerseNumbers12footnoteMode0W6Marker0P14SelectionStyleACSS_12CoreGraphics7CGFloatVARSgAS05SwiftD00O0VSgAwVS2bAA0ef8FootnoteX0OAA0E16AttributedStringCSgAA0uZ5StyleVtcfc",
             "moduleName": "YouVersionPlatformUI",
+            "deprecated": true,
+            "declAttributes": [
+              "DisfavoredOverload",
+              "Available"
+            ],
             "init_kind": "Designated"
           }
         ],
@@ -8245,6 +9676,68 @@
         "children": [
           {
             "kind": "Var",
+            "name": "currentVersion",
+            "printedName": "currentVersion",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleVersion?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleVersion",
+                    "printedName": "YouVersionPlatformCore.BibleVersion",
+                    "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC07currentB00abC4Core0eB0VSgvp",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC07currentB00abC4Core0eB0VSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasInitialValue",
+              "Final",
+              "SetterAccess",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "YouVersionPlatformCore.BibleVersion?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleVersion",
+                        "printedName": "YouVersionPlatformCore.BibleVersion",
+                        "usr": "s:22YouVersionPlatformCore05BibleB0V"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC07currentB00abC4Core0eB0VSgvg",
+                "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC07currentB00abC4Core0eB0VSgvg",
+                "moduleName": "YouVersionPlatformUI",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
             "name": "onVersionChange",
             "printedName": "onVersionChange",
             "children": [
@@ -8278,8 +9771,10 @@
             "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Changeyy0abC4Core0eB0Vcvp",
             "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Changeyy0abC4Core0eB0Vcvp",
             "moduleName": "YouVersionPlatformUI",
+            "deprecated": true,
             "declAttributes": [
               "Final",
+              "Available",
               "Custom"
             ],
             "accessors": [
@@ -8666,6 +10161,34 @@
           {
             "kind": "Constructor",
             "name": "init",
+            "printedName": "init(versionRepository:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionsViewModel",
+                "printedName": "YouVersionPlatformUI.BibleVersionsViewModel",
+                "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersionRepositoryProtocol",
+                "printedName": "any YouVersionPlatformCore.BibleVersionRepositoryProtocol",
+                "hasDefaultArg": true,
+                "usr": "s:22YouVersionPlatformCore05BibleB18RepositoryProtocolP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC17versionRepositoryAC0abC4Core0ebJ8Protocol_p_tcfc",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC17versionRepositoryAC0abC4Core0ebJ8Protocol_p_tcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
             "printedName": "init(onVersionChange:versionRepository:)",
             "children": [
               {
@@ -8711,10 +10234,12 @@
             "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Change17versionRepositoryACy0abC4Core0eB0Vc_AF0ebL8Protocol_ptcfc",
             "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC02onB6Change17versionRepositoryACy0abC4Core0eB0Vc_AF0ebL8Protocol_ptcfc",
             "moduleName": "YouVersionPlatformUI",
+            "deprecated": true,
             "declAttributes": [
+              "Available",
               "Custom"
             ],
-            "init_kind": "Designated"
+            "init_kind": "Convenience"
           },
           {
             "kind": "Function",
@@ -9407,6 +10932,34 @@
             "declKind": "Func",
             "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC08switchToB0yySiF",
             "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC08switchToB0yySiF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "switchToVersion",
+            "printedName": "switchToVersion(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleVersion",
+                "printedName": "YouVersionPlatformCore.BibleVersion",
+                "usr": "s:22YouVersionPlatformCore05BibleB0V"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI22BibleVersionsViewModelC08switchToB0yy0abC4Core0eB0VF",
+            "mangledName": "$s20YouVersionPlatformUI22BibleVersionsViewModelC08switchToB0yy0abC4Core0eB0VF",
             "moduleName": "YouVersionPlatformUI",
             "declAttributes": [
               "Final",
@@ -12678,8 +14231,10 @@
             "mangledName": "$s7SwiftUI4ViewP018YouVersionPlatformB0E2if_9transformQrSb_qd__xXEtAaBRd__lF",
             "moduleName": "YouVersionPlatformUI",
             "genericSig": "<Self, Content where Self : SwiftUI.View, Content : SwiftUI.View>",
+            "deprecated": true,
             "declAttributes": [
               "Preconcurrency",
+              "Available",
               "Custom",
               "Custom"
             ],

--- a/Sources/YouVersionPlatformCore/APIs/Bible/Highlights.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/Highlights.swift
@@ -160,13 +160,16 @@ public extension YouVersionAPI {
             guard let url = URLBuilder.highlightsURL else {
                 throw URLError(.badURL)
             }
-
+            
             let highlightRequest = HighlightRequest(
-                bibleId: bibleId,
-                passageId: passageId,
-                color: color.lowercased()
+                requestId: UUID().uuidString,
+                highlight: HighlightRequestBody(
+                    bibleId: bibleId,
+                    passageId: passageId,
+                    color: color.lowercased()
+                )
             )
-
+            
             var request = YouVersionAPI.urlRequest(with: url, accessToken: accessToken, session: session)
             request.httpMethod = method
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -233,7 +236,17 @@ public extension YouVersionAPI {
 
 // MARK: - Request/Response Models
 
-private struct HighlightRequest: Codable, CustomDebugStringConvertible {
+private struct HighlightRequest: Codable {
+    let requestId: String
+    let highlight: HighlightRequestBody
+    
+    enum CodingKeys: String, CodingKey {
+        case requestId = "request_id"
+        case highlight
+    }
+}
+
+private struct HighlightRequestBody: Codable, CustomDebugStringConvertible {
     let bibleId: Int
     let passageId: String
     let color: String

--- a/Sources/YouVersionPlatformCore/APIs/DataExchange/DataExchange.swift
+++ b/Sources/YouVersionPlatformCore/APIs/DataExchange/DataExchange.swift
@@ -68,4 +68,8 @@ public struct DataExchangeToken: Codable, Sendable, Equatable {
 
 private struct DataExchangeTokenRequest: Codable {
     let permissions: [String]
+    
+    enum CodingKeys: String, CodingKey {
+        case permissions = "requested_permissions"
+    }
 }

--- a/Sources/YouVersionPlatformCore/APIs/Users/SignInWithYouVersionPKCEAuthorizationRequest.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Users/SignInWithYouVersionPKCEAuthorizationRequest.swift
@@ -82,6 +82,9 @@ public enum SignInWithYouVersionPKCEAuthorizationRequestBuilder {
         if let scopeValue = scopeValue(permissions: permissions) {
             queryItems.append(URLQueryItem(name: "scope", value: scopeValue))
         }
+        if let requestedPermissionsValue = requestedPermissionsValue(permissions: permissions), !requestedPermissionsValue.isEmpty {
+            queryItems.append(URLQueryItem(name: "requested_permissions", value: requestedPermissionsValue))
+        }
 
         guard let url = URLBuilder.authorizeURL(queryItems: queryItems) else {
             throw SignInWithYouVersionPKCEAuthorizationError.unableToConstructAuthorizeURL
@@ -131,11 +134,22 @@ public enum SignInWithYouVersionPKCEAuthorizationRequestBuilder {
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
     }
+    
+    private static var optionalPermissions: Set<SignInWithYouVersionPermission> {
+        [.highlights]
+    }
 
     private static func scopeValue(
         permissions: Set<SignInWithYouVersionPermission>
     ) -> String? {
-        let fullScopes = permissions.union(Set([SignInWithYouVersionPermission.openid]))
+        let fullScopes = permissions.union(Set([SignInWithYouVersionPermission.openid])).subtracting(optionalPermissions)
         return fullScopes.map(\.rawValue).sorted().joined(separator: " ")
+    }
+
+    private static func requestedPermissionsValue(
+        permissions: Set<SignInWithYouVersionPermission>
+    ) -> String? {
+        let requestedPermissions = permissions.intersection(optionalPermissions)
+        return requestedPermissions.map(\.rawValue).sorted().joined(separator: ",")
     }
 }

--- a/Sources/YouVersionPlatformCore/APIs/Users/SignInWithYouVersionPKCEAuthorizationRequest.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Users/SignInWithYouVersionPKCEAuthorizationRequest.swift
@@ -137,9 +137,7 @@ public enum SignInWithYouVersionPKCEAuthorizationRequestBuilder {
             .replacingOccurrences(of: "=", with: "")
     }
     
-    private static var optionalPermissions: Set<SignInWithYouVersionPermission> {
-        [.highlights]
-    }
+    private static let optionalPermissions: Set<SignInWithYouVersionPermission> = [.highlights]
 
     private static func scopeValue(
         permissions: Set<SignInWithYouVersionPermission>

--- a/Sources/YouVersionPlatformCore/APIs/Users/SignInWithYouVersionPKCEAuthorizationRequest.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Users/SignInWithYouVersionPKCEAuthorizationRequest.swift
@@ -79,11 +79,13 @@ public enum SignInWithYouVersionPKCEAuthorizationRequestBuilder {
         if let installId = YouVersionPlatformConfiguration.installId {
             queryItems.append(URLQueryItem(name: "x-yvp-installation-id", value: installId))
         }
-        if let scopeValue = scopeValue(permissions: permissions) {
+        let scopeValue = scopeValue(permissions: permissions)
+        if !scopeValue.isEmpty {
             queryItems.append(URLQueryItem(name: "scope", value: scopeValue))
         }
-        if let requestedPermissionsValue = requestedPermissionsValue(permissions: permissions), !requestedPermissionsValue.isEmpty {
-            queryItems.append(URLQueryItem(name: "requested_permissions", value: requestedPermissionsValue))
+        let permissionsValue = requestedPermissionsValue(permissions: permissions)
+        if !permissionsValue.isEmpty {
+            queryItems.append(URLQueryItem(name: "requested_permissions", value: permissionsValue))
         }
 
         guard let url = URLBuilder.authorizeURL(queryItems: queryItems) else {
@@ -141,14 +143,14 @@ public enum SignInWithYouVersionPKCEAuthorizationRequestBuilder {
 
     private static func scopeValue(
         permissions: Set<SignInWithYouVersionPermission>
-    ) -> String? {
+    ) -> String {
         let fullScopes = permissions.union(Set([SignInWithYouVersionPermission.openid])).subtracting(optionalPermissions)
         return fullScopes.map(\.rawValue).sorted().joined(separator: " ")
     }
 
     private static func requestedPermissionsValue(
         permissions: Set<SignInWithYouVersionPermission>
-    ) -> String? {
+    ) -> String {
         let requestedPermissions = permissions.intersection(optionalPermissions)
         return requestedPermissions.map(\.rawValue).sorted().joined(separator: ",")
     }

--- a/Sources/YouVersionPlatformCore/APIs/Users/SignInWithYouVersionPermission.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Users/SignInWithYouVersionPermission.swift
@@ -4,6 +4,7 @@ public enum SignInWithYouVersionPermission: String, CaseIterable, Hashable, Coda
     case openid
     case profile
     case email
+    case highlights
 
     public var description: String { rawValue }
 }

--- a/Sources/YouVersionPlatformCore/APIs/Users/Users.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Users/Users.swift
@@ -17,7 +17,7 @@ public extension YouVersionAPI {
             let location = try await obtainLocation(from: callbackURL, state: state, session: session)
             let code = try obtainCode(from: location)
             let tokens = try await obtainTokens(from: code, codeVerifier: codeVerifier, redirectUri: redirectUri, session: session)
-            return try extractSignInWithYouVersionResult(from: tokens, nonce: nonce)
+            return try extractSignInWithYouVersionResult(from: tokens, nonce: nonce, callbackURL: callbackURL)
         }
 
         @available(*, deprecated, renamed: "signInResult(from:state:codeVerifier:redirectUri:nonce:session:)")
@@ -119,15 +119,24 @@ public extension YouVersionAPI {
             return try JSONDecoder().decode(TokenResponse.self, from: data)
         }
 
-        static func extractSignInWithYouVersionResult(from tokens: TokenResponse, nonce: String) throws -> SignInWithYouVersionResult {
+        static func extractSignInWithYouVersionResult(from tokens: TokenResponse, nonce: String, callbackURL: URL) throws -> SignInWithYouVersionResult {
             let idClaims = try decodeJWT(tokens.idToken)
             guard idClaims["nonce"] as? String == nonce else {
                 YouVersionPlatformLogger.error("Nonce mismatch", category: "Auth")
                 throw URLError(.badServerResponse)
             }
-            let permissions = tokens.scope
+            var permissions = tokens.scope
                 .split(separator: ",")
                 .compactMap { SignInWithYouVersionPermission(rawValue: String($0)) }
+            let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)
+            if let grantedPermissions = components?.queryItems?.first(where: { $0.name == "granted_permissions" })?.value {
+                let granted = grantedPermissions
+                    .split(separator: ",")
+                    .compactMap { SignInWithYouVersionPermission(rawValue: String($0)) }
+                permissions = Array(Set(permissions).union(Set(granted))).sorted {
+                    $0.rawValue < $1.rawValue
+                }
+            }
             return SignInWithYouVersionResult(
                 accessToken: tokens.accessToken,
                 expiresIn: tokens.expiresIn,

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -276,7 +276,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
                 completeDataExchangeFlow(with: result)
             } catch {
                 completeDataExchangeFlow(with: DataExchangeRequestResult(status: .cancel, grantedPermissions: []))
-                YouVersionPlatformLogger.error("\(error)", category: "BibleReader")
+                YouVersionPlatformLogger.error("startDataExchange failed: \(error)", category: "BibleReader")
             }
         }
     }
@@ -311,13 +311,18 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         Task {
             do {
                 startSignInFlow = false
-                _ = try await YouVersionAPI.Users.signIn(
-                    permissions: [.profile, .email],
+                let result = try await YouVersionAPI.Users.signIn(
+                    permissions: [.profile, .highlights],
                     contextProvider: contextProvider
                 )
-                
                 await updateSignInState()
-                continuePendingHighlightAfterSignIn()
+                if result.permissions.contains(.highlights) {
+                    // TODO: fix that the .highlights permission exists in two enums.
+                    YouVersionPlatformConfiguration.saveDataExchangePermissions([.highlights])
+                    continuePendingHighlightAfterSignIn()
+                } else {
+                    print("no permissions; taking no action")
+                }
             } catch {
                 YouVersionPlatformLogger.error("\(error)", category: "Reader")
             }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -321,7 +321,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
                     YouVersionPlatformConfiguration.saveDataExchangePermissions([.highlights])
                     continuePendingHighlightAfterSignIn()
                 } else {
-                    print("no permissions; taking no action")
+                    clearPendingHighlight()
                 }
             } catch {
                 YouVersionPlatformLogger.error("\(error)", category: "Reader")

--- a/Sources/YouVersionPlatformUI/APIs/DataExchangeSession.swift
+++ b/Sources/YouVersionPlatformUI/APIs/DataExchangeSession.swift
@@ -76,8 +76,15 @@ public struct DataExchangeSession {
         guard let appKey = YouVersionPlatformConfiguration.appKey else {
             throw YouVersionAPIError.missingAuthentication
         }
+        
+        let token: DataExchangeToken
+        do {
+            token = try await YouVersionAPI.DataExchange.updateToken(withPermissions: permissions)
+        } catch {
+            YouVersionPlatformLogger.error("DataExchange.updateToken failed: \(error)", category: "DataExchange")
+            throw URLError(.badServerResponse)
+        }
 
-        let token = try await YouVersionAPI.DataExchange.updateToken(withPermissions: permissions)
         guard let url = URLBuilder.dataExchangeURL(token: token.token, appKey: appKey) else {
             throw URLError(.badURL)
         }

--- a/Tests/YouVersionPlatformCoreTests/DataExchangeAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/DataExchangeAPITests.swift
@@ -194,6 +194,10 @@ extension ConfigurationStateTests {
         
         private struct Body: Decodable {
             let permissions: [String]
+
+            enum CodingKeys: String, CodingKey {
+                case permissions = "requested_permissions"
+            }
         }
     }
 }

--- a/Tests/YouVersionPlatformCoreTests/HighlightsAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/HighlightsAPITests.swift
@@ -47,6 +47,16 @@ extension URLRequest {
         defer { HTTPMocking.clear(token: token) }
         
         struct Body: Decodable {
+            let requestId: String
+            let highlight: Highlight
+            
+            enum CodingKeys: String, CodingKey {
+                case requestId = "request_id"
+                case highlight
+            }
+        }
+        
+        struct Highlight: Decodable {
             let bibleId: Int
             let passageId: String
             let color: String
@@ -82,9 +92,10 @@ extension URLRequest {
         let jsonBody = try #require(capturedJSONBody)
         let jsonData = try JSONSerialization.data(withJSONObject: jsonBody)
         let decoded = try JSONDecoder().decode(Body.self, from: jsonData)
-        #expect(decoded.bibleId == 1)
-        #expect(decoded.passageId == "GEN.1.1")
-        #expect(decoded.color == "ff00ff")
+        #expect(UUID(uuidString: decoded.requestId) != nil)
+        #expect(decoded.highlight.bibleId == 1)
+        #expect(decoded.highlight.passageId == "GEN.1.1")
+        #expect(decoded.highlight.color == "ff00ff")
         #expect(result)
     }
     

--- a/Tests/YouVersionPlatformCoreTests/UsersAuthHelpersTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/UsersAuthHelpersTests.swift
@@ -25,6 +25,7 @@ extension ConfigurationStateTests {
         }
         
         @Test func extractResultParsesClaimsAndPermissions() throws {
+            let callbackURL = URL(string: "youversionauth://callback")!
             let payload: [String: Any] = [
                 "sub": "user-123",
                 "name": "Test User",
@@ -43,7 +44,11 @@ extension ConfigurationStateTests {
                 tokenType: "Bearer"
             )
             
-            let result = try YouVersionAPI.Users.extractSignInWithYouVersionResult(from: tokens, nonce: "xyz")
+            let result = try YouVersionAPI.Users.extractSignInWithYouVersionResult(
+                from: tokens,
+                nonce: "xyz",
+                callbackURL: callbackURL
+            )
             
             #expect(result.accessToken == "access-token")
             #expect(result.refreshToken == "refresh-token")
@@ -56,6 +61,7 @@ extension ConfigurationStateTests {
         }
         
         @Test func extractResultFailsBadNonce() throws {
+            let callbackURL = URL(string: "youversionauth://callback")!
             let payload: [String: Any] = [
                 "sub": "user-123",
                 "name": "Test User",
@@ -75,7 +81,11 @@ extension ConfigurationStateTests {
             )
             
             #expect(throws: URLError.self) {
-                _ = try YouVersionAPI.Users.extractSignInWithYouVersionResult(from: tokens, nonce: "xyz")
+                _ = try YouVersionAPI.Users.extractSignInWithYouVersionResult(
+                    from: tokens,
+                    nonce: "xyz",
+                    callbackURL: callbackURL
+                )
             }
         }
         

--- a/Tests/YouVersionPlatformCoreTests/UsersAuthHelpersTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/UsersAuthHelpersTests.swift
@@ -60,6 +60,48 @@ extension ConfigurationStateTests {
             #expect(result.email == "user@example.com")
         }
         
+        @Test func extractResultMergesGrantedPermissionsFromCallbackURL() throws {
+            let callbackURL = URL(string: "youversionauth://callback?granted_permissions=highlights")!
+            let token = try makeTestJWT(claims: ["nonce": "xyz"])
+            let tokens = makeTokenResponse(idToken: token, scope: "openid,email")
+            
+            let result = try YouVersionAPI.Users.extractSignInWithYouVersionResult(
+                from: tokens,
+                nonce: "xyz",
+                callbackURL: callbackURL
+            )
+            
+            #expect(Set(result.permissions) == Set([.openid, .email, .highlights]))
+        }
+        
+        @Test func extractResultUsesTokenScopePermissionsWhenCallbackDoesNotIncludeGrantedPermissions() throws {
+            let callbackURL = URL(string: "youversionauth://callback?code=abc123")!
+            let token = try makeTestJWT(claims: ["nonce": "xyz"])
+            let tokens = makeTokenResponse(idToken: token, scope: "openid,email")
+            
+            let result = try YouVersionAPI.Users.extractSignInWithYouVersionResult(
+                from: tokens,
+                nonce: "xyz",
+                callbackURL: callbackURL
+            )
+            
+            #expect(result.permissions == [.openid, .email])
+        }
+        
+        @Test func extractResultIgnoresUnknownGrantedPermissionsFromCallbackURL() throws {
+            let callbackURL = URL(string: "youversionauth://callback?granted_permissions=unknown,highlights")!
+            let token = try makeTestJWT(claims: ["nonce": "xyz"])
+            let tokens = makeTokenResponse(idToken: token, scope: "openid,email")
+            
+            let result = try YouVersionAPI.Users.extractSignInWithYouVersionResult(
+                from: tokens,
+                nonce: "xyz",
+                callbackURL: callbackURL
+            )
+            
+            #expect(Set(result.permissions) == Set([.openid, .email, .highlights]))
+        }
+        
         @Test func extractResultFailsBadNonce() throws {
             let callbackURL = URL(string: "youversionauth://callback")!
             let payload: [String: Any] = [
@@ -157,6 +199,17 @@ extension ConfigurationStateTests {
     }
 }
 
+private func makeTokenResponse(idToken: String, scope: String) -> YouVersionAPI.Users.TokenResponse {
+    YouVersionAPI.Users.TokenResponse(
+        accessToken: "access-token",
+        expiresIn: "3600",
+        idToken: idToken,
+        refreshToken: "refresh-token",
+        scope: scope,
+        tokenType: "Bearer"
+    )
+}
+
 private func makeTestJWT(claims: [String: Any]) throws -> String {
     let header = ["alg": "RS256", "typ": "JWT"]
     let headerData = try JSONSerialization.data(withJSONObject: header)
@@ -172,4 +225,3 @@ private func base64URLEncodedString(_ data: Data) -> String {
         .replacingOccurrences(of: "/", with: "_")
         .replacingOccurrences(of: "=", with: "")
 }
-

--- a/Tests/YouVersionPlatformUITests/ColorHexTests.swift
+++ b/Tests/YouVersionPlatformUITests/ColorHexTests.swift
@@ -12,10 +12,10 @@ import UIKit
             return
         }
 
-        #expect(components.red.isApproximatelyEqual(to: 1.0))
-        #expect(components.green.isApproximatelyEqual(to: 170.0 / 255.0))
-        #expect(components.blue.isApproximatelyEqual(to: 51.0 / 255.0))
-        #expect(components.alpha.isApproximatelyEqual(to: 1.0))
+        #expect(components.red.isApproximatelyEqual(to: 1.0) == true)
+        #expect(components.green.isApproximatelyEqual(to: 170.0 / 255.0) == true)
+        #expect(components.blue.isApproximatelyEqual(to: 51.0 / 255.0) == true)
+        #expect(components.alpha.isApproximatelyEqual(to: 1.0) == true)
     }
 
     @Test
@@ -24,10 +24,10 @@ import UIKit
             return
         }
 
-        #expect(components.red.isApproximatelyEqual(to: 221.0 / 255.0))
-        #expect(components.green.isApproximatelyEqual(to: 170.0 / 255.0))
-        #expect(components.blue.isApproximatelyEqual(to: 255.0 / 255.0))
-        #expect(components.alpha.isApproximatelyEqual(to: 128.0 / 255.0))
+        #expect(components.red.isApproximatelyEqual(to: 221.0 / 255.0) == true)
+        #expect(components.green.isApproximatelyEqual(to: 170.0 / 255.0) == true)
+        #expect(components.blue.isApproximatelyEqual(to: 255.0 / 255.0) == true)
+        #expect(components.alpha.isApproximatelyEqual(to: 128.0 / 255.0) == true)
     }
 
     private func colorComponents(for color: Color) throws -> ColorComponents? {


### PR DESCRIPTION
## Description

Make highlights work again, given the API changes.

The API changed, as did the data exchange flow (combining the two-step flow into a single-step, when on the happy path.)

## Type of Change

- [x] `feat:` New feature (non-breaking change which adds functionality)
- [ ] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the highlights and data exchange features to a revised API: the write/update highlight body now wraps fields in a `request_id` + `highlight` envelope, `DataExchangeToken` drops the optional `id` field in favour of a non-optional `token` string, and the two-step data exchange browser flow is collapsed into a single step (fetch token → open session → parse callback).

- **`DataExchange.swift` + `DataExchangeSession.swift`**: `updateToken` now POSTs `requested_permissions` and returns `DataExchangeToken.token`; `requestDataExchange` fetches the token first, then opens the `ASWebAuthenticationSession` in one pass, saving granted permissions on the way out.
- **`SignInWithYouVersionPKCEAuthorizationRequest.swift` + `Users.swift`**: PKCE authorize URL now separates required OIDC scopes from optional permissions (`requested_permissions`), and the sign-in result extraction merges any `granted_permissions` from the callback URL into the token-scope list via a union.
- **`Highlights.swift`**: POST/PUT now serialises a `HighlightRequest` wrapper with a UUID `request_id`; DELETE continues to pass `bible_id` and `passage_id` as URL query/path parameters.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core permission-grant and highlight-write paths work correctly for the single optional permission in use today.

The functional changes are well-tested: new token endpoint, request-body shape, and response parsing all have dedicated test cases. The two observations are forward-looking — one around how a future second permission would be parsed in the data exchange callback, and one around error-type fidelity surfaced to callers. Neither affects current behaviour.

DataExchangeSession.swift — the `requestResult` parsing strategy and the error re-throw shape are the two spots worth a second look before adding more optional permissions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformUI/APIs/DataExchangeSession.swift | Refactored to single-step flow: fetches token first, then opens the browser session in one go; `requestResult` parses the callback URL for `data_exchange_status` and `granted_permissions`. Minor concerns around error-type swallowing and a latent inconsistency in how `granted_permissions` is split versus the auth callback path. |
| Sources/YouVersionPlatformCore/APIs/DataExchange/DataExchange.swift | Aligned to new API: `updateToken` now POSTs a `requested_permissions` body and returns a `DataExchangeToken` with a non-optional `token` string. Clean, well-tested change. |
| Sources/YouVersionPlatformCore/APIs/Bible/Highlights.swift | POST/PUT body now wraps the highlight in a `HighlightRequest` envelope with a `request_id` UUID; DELETE continues to use URL path/query params. Models, coding keys, and test coverage all look correct. |
| Sources/YouVersionPlatformCore/APIs/Users/Users.swift | Merges optional `granted_permissions` from the PKCE callback URL into the token-scope permissions using a union, preserving existing behaviour while supporting the new highlights grant path. |
| Sources/YouVersionPlatformCore/APIs/Users/SignInWithYouVersionPKCEAuthorizationRequest.swift | Splits permissions into OIDC `scope` (required) and `requested_permissions` (optional, currently only `.highlights`). The `optionalPermissions` constant is now a `static let`, avoiding repeated allocation. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Sign-in now requests `.highlights` permission, and `completeDataExchangeFlow` gates highlight application on `grantedPermissions.contains(.highlights)`. The noted `.email` permission removal was already discussed in a previous review thread. |
| Tests/YouVersionPlatformCoreTests/DataExchangeAPITests.swift | Comprehensive tests for the new `updateToken` API covering success, missing auth, 401, non-201, non-HTTP response, and malformed JSON cases. |
| Tests/YouVersionPlatformCoreTests/HighlightsAPITests.swift | Tests cover create, read, update, delete, 204 empty, 401 empty, and unexpected status code paths; validates both request shape (HTTP method, URL params, JSON body structure) and response parsing. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant DataExchangeSession
    participant YouVersionAPI
    participant Browser as ASWebAuthenticationSession
    participant Server

    App->>DataExchangeSession: requestDataExchange(permissions)
    DataExchangeSession->>YouVersionAPI: DataExchange.updateToken(permissions)
    YouVersionAPI->>Server: "POST /data-exchange/token {requested_permissions}"
    Server-->>YouVersionAPI: "201 {token}"
    YouVersionAPI-->>DataExchangeSession: DataExchangeToken
    DataExchangeSession->>Browser: open dataExchangeURL(token, appKey)
    Browser->>Server: User grants/cancels permissions
    Server-->>Browser: "redirect youversionauth://callback?data_exchange_status=granted&granted_permissions=highlights"
    Browser-->>DataExchangeSession: callbackURL
    DataExchangeSession->>DataExchangeSession: requestResult(from: callbackURL)
    Note over DataExchangeSession: Parses status + grantedPermissions
    alt isGranted
        DataExchangeSession->>DataExchangeSession: saveDataExchangePermissions(grantedPermissions)
    end
    DataExchangeSession-->>App: DataExchangeRequestResult
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformUI%2FAPIs%2FDataExchangeSession.swift%3A113-117%0A**%60granted_permissions%60%20parsed%20differently%20than%20in%20the%20auth%20callback**%0A%0A%60requestResult%60%20collects%20each%20%60granted_permissions%60%20query%20item%20individually%2C%20treating%20each%20item's%20value%20as%20a%20single%20permission%20string.%20By%20contrast%2C%20%60Users.extractSignInWithYouVersionResult%60%20takes%20the%20*first*%20%60granted_permissions%60%20query%20item%20and%20splits%20its%20value%20on%20commas.%20Since%20%60requestedPermissionsValue%60%20serialises%20permissions%20as%20a%20comma-separated%20string%2C%20the%20server%20is%20likely%20to%20respond%20with%20the%20same%20format%20%28%60%3Fgranted_permissions%3Dhighlights%2Cnotes%60%29.%20If%20that%20ever%20happens%20here%2C%20the%20whole%20string%20%60%22highlights%2Cnotes%22%60%20would%20be%20mapped%20to%20one%20%60.unknown%28%22highlights%2Cnotes%22%29%60%20permission%20and%20%60.contains%28.highlights%29%60%20would%20return%20%60false%60%2C%20silently%20suppressing%20the%20highlight.%20Only%20one%20optional%20permission%20exists%20today%2C%20so%20this%20gap%20is%20latent%20rather%20than%20immediately%20breaking%2C%20but%20aligning%20both%20parsing%20paths%20now%20would%20avoid%20a%20subtle%20regression%20when%20a%20second%20permission%20is%20introduced.%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformUI%2FAPIs%2FDataExchangeSession.swift%3A81-86%0A**Specific%20error%20types%20from%20%60updateToken%60%20are%20swallowed**%0A%0A%60YouVersionAPI.DataExchange.updateToken%60%20can%20throw%20typed%20errors%20such%20as%20%60YouVersionAPIError.missingAuthentication%60%20%28no%20access%20token%29%20or%20%60YouVersionAPIError.notPermitted%60%20%28401%20from%20server%29%2C%20but%20they%20are%20all%20caught%20here%20and%20re-thrown%20as%20a%20generic%20%60URLError%28.badServerResponse%29%60.%20Callers%20that%20want%20to%20distinguish%20%22user%20is%20not%20signed%20in%22%20from%20%22server%20rejected%20the%20request%22%20%28e.g.%20to%20show%20different%20recovery%20UI%29%20can't%20do%20so%20after%20this%20transformation.%20Consider%20re-throwing%20the%20original%20error%2C%20or%20at%20least%20differentiating%20the%20auth-missing%20case.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformUI%2FAPIs%2FDataExchangeSession.swift%3A113-117%0A**%60granted_permissions%60%20parsed%20differently%20than%20in%20the%20auth%20callback**%0A%0A%60requestResult%60%20collects%20each%20%60granted_permissions%60%20query%20item%20individually%2C%20treating%20each%20item's%20value%20as%20a%20single%20permission%20string.%20By%20contrast%2C%20%60Users.extractSignInWithYouVersionResult%60%20takes%20the%20*first*%20%60granted_permissions%60%20query%20item%20and%20splits%20its%20value%20on%20commas.%20Since%20%60requestedPermissionsValue%60%20serialises%20permissions%20as%20a%20comma-separated%20string%2C%20the%20server%20is%20likely%20to%20respond%20with%20the%20same%20format%20%28%60%3Fgranted_permissions%3Dhighlights%2Cnotes%60%29.%20If%20that%20ever%20happens%20here%2C%20the%20whole%20string%20%60%22highlights%2Cnotes%22%60%20would%20be%20mapped%20to%20one%20%60.unknown%28%22highlights%2Cnotes%22%29%60%20permission%20and%20%60.contains%28.highlights%29%60%20would%20return%20%60false%60%2C%20silently%20suppressing%20the%20highlight.%20Only%20one%20optional%20permission%20exists%20today%2C%20so%20this%20gap%20is%20latent%20rather%20than%20immediately%20breaking%2C%20but%20aligning%20both%20parsing%20paths%20now%20would%20avoid%20a%20subtle%20regression%20when%20a%20second%20permission%20is%20introduced.%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformUI%2FAPIs%2FDataExchangeSession.swift%3A81-86%0A**Specific%20error%20types%20from%20%60updateToken%60%20are%20swallowed**%0A%0A%60YouVersionAPI.DataExchange.updateToken%60%20can%20throw%20typed%20errors%20such%20as%20%60YouVersionAPIError.missingAuthentication%60%20%28no%20access%20token%29%20or%20%60YouVersionAPIError.notPermitted%60%20%28401%20from%20server%29%2C%20but%20they%20are%20all%20caught%20here%20and%20re-thrown%20as%20a%20generic%20%60URLError%28.badServerResponse%29%60.%20Callers%20that%20want%20to%20distinguish%20%22user%20is%20not%20signed%20in%22%20from%20%22server%20rejected%20the%20request%22%20%28e.g.%20to%20show%20different%20recovery%20UI%29%20can't%20do%20so%20after%20this%20transformation.%20Consider%20re-throwing%20the%20original%20error%2C%20or%20at%20least%20differentiating%20the%20auth-missing%20case.%0A%0A&pr=159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22new-data-exchange-api%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22new-data-exchange-api%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ASources%2FYouVersionPlatformUI%2FAPIs%2FDataExchangeSession.swift%3A113-117%0A**%60granted_permissions%60%20parsed%20differently%20than%20in%20the%20auth%20callback**%0A%0A%60requestResult%60%20collects%20each%20%60granted_permissions%60%20query%20item%20individually%2C%20treating%20each%20item's%20value%20as%20a%20single%20permission%20string.%20By%20contrast%2C%20%60Users.extractSignInWithYouVersionResult%60%20takes%20the%20*first*%20%60granted_permissions%60%20query%20item%20and%20splits%20its%20value%20on%20commas.%20Since%20%60requestedPermissionsValue%60%20serialises%20permissions%20as%20a%20comma-separated%20string%2C%20the%20server%20is%20likely%20to%20respond%20with%20the%20same%20format%20%28%60%3Fgranted_permissions%3Dhighlights%2Cnotes%60%29.%20If%20that%20ever%20happens%20here%2C%20the%20whole%20string%20%60%22highlights%2Cnotes%22%60%20would%20be%20mapped%20to%20one%20%60.unknown%28%22highlights%2Cnotes%22%29%60%20permission%20and%20%60.contains%28.highlights%29%60%20would%20return%20%60false%60%2C%20silently%20suppressing%20the%20highlight.%20Only%20one%20optional%20permission%20exists%20today%2C%20so%20this%20gap%20is%20latent%20rather%20than%20immediately%20breaking%2C%20but%20aligning%20both%20parsing%20paths%20now%20would%20avoid%20a%20subtle%20regression%20when%20a%20second%20permission%20is%20introduced.%0A%0A%23%23%23%20Issue%202%20of%202%0ASources%2FYouVersionPlatformUI%2FAPIs%2FDataExchangeSession.swift%3A81-86%0A**Specific%20error%20types%20from%20%60updateToken%60%20are%20swallowed**%0A%0A%60YouVersionAPI.DataExchange.updateToken%60%20can%20throw%20typed%20errors%20such%20as%20%60YouVersionAPIError.missingAuthentication%60%20%28no%20access%20token%29%20or%20%60YouVersionAPIError.notPermitted%60%20%28401%20from%20server%29%2C%20but%20they%20are%20all%20caught%20here%20and%20re-thrown%20as%20a%20generic%20%60URLError%28.badServerResponse%29%60.%20Callers%20that%20want%20to%20distinguish%20%22user%20is%20not%20signed%20in%22%20from%20%22server%20rejected%20the%20request%22%20%28e.g.%20to%20show%20different%20recovery%20UI%29%20can't%20do%20so%20after%20this%20transformation.%20Consider%20re-throwing%20the%20original%20error%2C%20or%20at%20least%20differentiating%20the%20auth-missing%20case.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
Sources/YouVersionPlatformUI/APIs/DataExchangeSession.swift:113-117
**`granted_permissions` parsed differently than in the auth callback**

`requestResult` collects each `granted_permissions` query item individually, treating each item's value as a single permission string. By contrast, `Users.extractSignInWithYouVersionResult` takes the *first* `granted_permissions` query item and splits its value on commas. Since `requestedPermissionsValue` serialises permissions as a comma-separated string, the server is likely to respond with the same format (`?granted_permissions=highlights,notes`). If that ever happens here, the whole string `"highlights,notes"` would be mapped to one `.unknown("highlights,notes")` permission and `.contains(.highlights)` would return `false`, silently suppressing the highlight. Only one optional permission exists today, so this gap is latent rather than immediately breaking, but aligning both parsing paths now would avoid a subtle regression when a second permission is introduced.

### Issue 2 of 2
Sources/YouVersionPlatformUI/APIs/DataExchangeSession.swift:81-86
**Specific error types from `updateToken` are swallowed**

`YouVersionAPI.DataExchange.updateToken` can throw typed errors such as `YouVersionAPIError.missingAuthentication` (no access token) or `YouVersionAPIError.notPermitted` (401 from server), but they are all caught here and re-thrown as a generic `URLError(.badServerResponse)`. Callers that want to distinguish "user is not signed in" from "server rejected the request" (e.g. to show different recovery UI) can't do so after this transformation. Consider re-throwing the original error, or at least differentiating the auth-missing case.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["chore: update API stability check merely..."](https://github.com/youversion/platform-sdk-swift/commit/7cdc8eb133f2692b6ff683472d0a9a3044e9ed72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36789896)</sub>

<!-- /greptile_comment -->