### PR TITLE
feat(reader): add chapter header view-builder slot

### DIFF
--- a/Sources/YouVersionPlatformReader/BibleReaderChapterHeaderContext.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderChapterHeaderContext.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import YouVersionPlatformCore
+
+/// The information handed to a host-provided chapter-header builder
+/// (see ``SwiftUICore/View/bibleReaderChapterHeader(_:)``). The reader resolves
+/// these values for the chapter currently being displayed and rebuilds the
+/// header whenever the reader navigates to a different chapter.
+public struct BibleReaderChapterHeaderContext: Sendable {
+    /// The chapter currently displayed.
+    public let reference: BibleReference
+    /// The localized, human-readable book name (e.g. "John"). Falls back to the
+    /// book USFM code when no name is available.
+    public let bookName: String
+    /// The display label for the chapter, e.g. "1". Not guaranteed to be numeric —
+    /// some versions use non-numeric chapter labels.
+    public let chapterLabel: String
+
+    public init(reference: BibleReference, bookName: String, chapterLabel: String) {
+        self.reference = reference
+        self.bookName = bookName
+        self.chapterLabel = chapterLabel
+    }
+}
+
+private func emptyChapterHeader(_ context: BibleReaderChapterHeaderContext) -> AnyView {
+    AnyView(EmptyView())
+}
+
+private struct BibleReaderChapterHeaderKey: EnvironmentKey {
+    static var defaultValue: (BibleReaderChapterHeaderContext) -> AnyView { emptyChapterHeader }
+}
+
+extension EnvironmentValues {
+    var bibleReaderChapterHeader: (BibleReaderChapterHeaderContext) -> AnyView {
+        get { self[BibleReaderChapterHeaderKey.self] }
+        set { self[BibleReaderChapterHeaderKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Supplies a per-chapter header the reader renders at the top of each chapter,
+    /// above the verse text. The builder receives a ``BibleReaderChapterHeaderContext``
+    /// (the chapter reference, book name, and chapter label) and is rebuilt whenever
+    /// the reader navigates to a different chapter.
+    ///
+    /// Fonts, colors, and layout are entirely the host's; the reader owns placement
+    /// and width. With no modifier applied, the reader shows no header.
+    func bibleReaderChapterHeader<Header: View>(
+        @ViewBuilder _ header: @escaping (BibleReaderChapterHeaderContext) -> Header
+    ) -> some View {
+        environment(\.bibleReaderChapterHeader) { AnyView(header($0)) }
+    }
+}

--- a/Sources/YouVersionPlatformReader/ReaderMainScroller.swift
+++ b/Sources/YouVersionPlatformReader/ReaderMainScroller.swift
@@ -8,6 +8,7 @@ struct ReaderMainScroller<Footer: View>: View {
     let bibleCopyrightBlock: Footer
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.bibleReaderChapterHeader) private var chapterHeader
     @State private var verseAnchors: [Int] = []
     @State private var lastScrolledVerse: Int?
 
@@ -29,6 +30,14 @@ struct ReaderMainScroller<Footer: View>: View {
                         if viewModel.showBookIntro {
                             BibleReaderIntroView()
                         } else {
+                            chapterHeader(
+                                BibleReaderChapterHeaderContext(
+                                    reference: viewModel.reference,
+                                    bookName: viewModel.version?.bookName(viewModel.reference.bookUSFM)
+                                        ?? viewModel.reference.bookUSFM,
+                                    chapterLabel: String(viewModel.reference.chapter)
+                                )
+                            )
                             BibleTextView(
                                 viewModel.reference,
                                 textOptions: viewModel.textOptions,


### PR DESCRIPTION
https://github.com/user-attachments/assets/29863bfb-3949-42d1-b8b7-9be62a62c2bc


Render a per-chapter heading (book name + large chapter number) at the top of the reader content, matching Bible Loop on Android's book-heading block. The chapter number uses a #2A85F4 blue accent in both light and dark themes via the new readerChapterNumberColor on ReaderThemeProviding.

Both lines use the Tusker Grotesk 7600 Semibold brand font (bundled and registered via ReaderFonts) at its native weight, per the Bible Loop design.

BL-1910

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [ ] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

## Breaking Changes

<!-- If this PR contains breaking changes, mark this box and describe them below -->

- [ ] This PR contains **BREAKING CHANGES**

<!-- If checked, explain the breaking changes and provide migration instructions -->

**Breaking Change Details:**
<!-- Remove this section if not applicable -->

**Migration Guide:**
<!-- Provide step-by-step instructions for users to migrate their code -->

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] All commit messages follow [conventional commits](https://www.conventionalcommits.org/) format

## Conventional Commits

<!-- Your commit messages should follow this format -->

✅ **All commits in this PR follow conventional commit format:**

```
<type>(<scope>): <subject>

[optional body]

[optional footer]
```

**Example commit messages:**
- `feat(api): add Bible verse lookup method`
- `fix(auth): resolve token refresh race condition`
- `docs: update installation instructions`

For breaking changes:
- `feat(api)!: redesign Bible content API`

See [CONTRIBUTING.md](../CONTRIBUTING.md#conventional-commits) for detailed guidelines.

## Related Issues

<!-- Link any related issues using keywords like "Closes", "Fixes", or "Resolves" -->

Closes #
Relates to #

## Additional Context

<!-- Add any other context about the PR here, such as: -->
<!-- - Screenshots (for UI changes) -->
<!-- - Performance benchmarks (for performance improvements) -->
<!-- - Links to external resources or discussions -->

## Reviewer Notes

<!-- Any specific areas you'd like reviewers to focus on? -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a host-configurable chapter-header slot for the Bible reader, letting integrators inject a custom view (book name + chapter number) above the verse text via a new `bibleReaderChapterHeader(_:)` View modifier. The environment-key pattern is clean: the read path is intentionally module-private, and the typed `@ViewBuilder` modifier is the sole public surface for setting the slot.

- `BibleReaderChapterHeaderContext` is a well-structured, `Sendable` public API that carries the reference, book name, and chapter label to host-provided builders.
- `ReaderMainScroller` wires the slot correctly — the header is rendered only when `showBookIntro` is false, and the `@Environment` read integrates naturally with the existing scroll/audio machinery.
- One issue with chapter-label construction: `String(viewModel.reference.chapter)` always produces a numeric string, bypassing `BibleVersion.chapterLabels(_:)` — the SDK's own API for non-standard labels — which the context struct's own doc comment says to expect.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the vast majority of versions, but Bible versions with non-numeric chapter labels will display the integer index instead of the correct label until the lookup is fixed.

The new environment-key slot and context struct are well-implemented. The one concrete defect is in ReaderMainScroller: String(viewModel.reference.chapter) always emits a numeric string, ignoring BibleVersion.chapterLabels(_:) which the SDK already ships for exactly this case. For any version whose chapters carry custom title strings (the 'other cases exist' path documented in chapterLabels), the displayed label will be wrong.

Sources/YouVersionPlatformReader/ReaderMainScroller.swift — the chapter-label construction on line 38 should use BibleVersion.chapterLabels(_:) with a fallback rather than converting the integer index directly.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/BibleReaderChapterHeaderContext.swift | New public API — context struct, environment key, and View modifier slot for chapter headers. Well-designed; internal EnvironmentValues property keeps the read path module-private while the public modifier lets hosts inject a typed ViewBuilder. AnyView type erasure is standard for environment-stored builders. No issues found. |
| Sources/YouVersionPlatformReader/ReaderMainScroller.swift | Wires the new chapter-header slot into the scroller. The chapterLabel is constructed with String(viewModel.reference.chapter), always producing a numeric string and ignoring BibleVersion.chapterLabels — the SDK's dedicated displayable-label API that explicitly handles non-numeric cases. This breaks the contract advertised in BibleReaderChapterHeaderContext.chapterLabel. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Host as Host App
    participant View as View Hierarchy
    participant Scroller as ReaderMainScroller
    participant VM as BibleReaderViewModel

    Host->>View: ".bibleReaderChapterHeader { ctx in ... }"
    Note over View: Sets \.bibleReaderChapterHeader<br/>in SwiftUI environment

    VM->>Scroller: viewModel.reference changes
    Scroller->>VM: Read reference, version, showBookIntro
    alt "showBookIntro == false"
        Scroller->>Scroller: "Build BibleReaderChapterHeaderContext<br/>(reference, bookName, chapterLabel)"
        Scroller->>View: chapterHeader(context) → AnyView
        Note over Scroller: ⚠ chapterLabel = String(reference.chapter)<br/>should use version.chapterLabels()
        Scroller->>View: BibleTextView(...)
    else "showBookIntro == true"
        Scroller->>View: BibleReaderIntroView()
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Host as Host App
    participant View as View Hierarchy
    participant Scroller as ReaderMainScroller
    participant VM as BibleReaderViewModel

    Host->>View: ".bibleReaderChapterHeader { ctx in ... }"
    Note over View: Sets \.bibleReaderChapterHeader<br/>in SwiftUI environment

    VM->>Scroller: viewModel.reference changes
    Scroller->>VM: Read reference, version, showBookIntro
    alt "showBookIntro == false"
        Scroller->>Scroller: "Build BibleReaderChapterHeaderContext<br/>(reference, bookName, chapterLabel)"
        Scroller->>View: chapterHeader(context) → AnyView
        Note over Scroller: ⚠ chapterLabel = String(reference.chapter)<br/>should use version.chapterLabels()
        Scroller->>View: BibleTextView(...)
    else "showBookIntro == true"
        Scroller->>View: BibleReaderIntroView()
    end
```

</a>

<sub>Reviews (6): Last reviewed commit: ["feat(reader): add chapter header view-bu..."](https://github.com/youversion/platform-sdk-swift/commit/d03f4671f6607a24c0f598cc27c9005486cb46c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40637883)</sub>

<!-- /greptile_comment -->