### PR TITLE
fix(reader): reveal chapter selection when tapping a book in the reader

### DIFF
--- a/Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift
@@ -58,9 +58,7 @@ public struct BibleReaderBookAndChapterPickerView: View {
                             bookRow(bookCode)
                             if expandedBookCode == bookCode {
                                 chapterListView(bookCode)
-                                    .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
-                                    .listRowBackground(viewModel.readerCanvasPrimaryColor)
-                                    .listRowSeparator(.hidden)
+                                    .bookPickerRow(background: viewModel.readerCanvasPrimaryColor, verticalInset: 0)
                             }
                         }
                     }
@@ -96,9 +94,7 @@ public struct BibleReaderBookAndChapterPickerView: View {
         }
         .buttonStyle(.plain)
         .id(bookCode)
-        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
-        .listRowBackground(viewModel.readerCanvasPrimaryColor)
-        .listRowSeparator(.hidden)
+        .bookPickerRow(background: viewModel.readerCanvasPrimaryColor, verticalInset: 8)
     }
 
     private func chapterListView(_ bookCode: String) -> some View {
@@ -166,4 +162,15 @@ public struct BibleReaderBookAndChapterPickerView: View {
         }
     )
     .environment(BibleReaderViewModel.preview)
+}
+
+private extension View {
+    /// Shared row styling for the book/chapter picker list: a full-width canvas
+    /// background, hidden separators, and horizontal insets with a configurable
+    /// vertical inset.
+    func bookPickerRow(background: Color, verticalInset: CGFloat) -> some View {
+        listRowInsets(EdgeInsets(top: verticalInset, leading: 16, bottom: verticalInset, trailing: 16))
+            .listRowBackground(background)
+            .listRowSeparator(.hidden)
+    }
 }

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift
@@ -171,6 +171,8 @@ private extension View {
     func bookPickerRow(background: Color, verticalInset: CGFloat) -> some View {
         listRowInsets(EdgeInsets(top: verticalInset, leading: 16, bottom: verticalInset, trailing: 16))
             .listRowBackground(background)
+#if !os(tvOS)
             .listRowSeparator(.hidden)
+#endif
     }
 }

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift
@@ -52,36 +52,33 @@ public struct BibleReaderBookAndChapterPickerView: View {
                     }
                 }
                 .padding(.vertical, 16)
-                List {
-                    ForEach(bookCodes, id: \.self) { bookCode in
-                        Section {
+                ScrollViewReader { proxy in
+                    List {
+                        ForEach(bookCodes, id: \.self) { bookCode in
+                            bookRow(bookCode)
                             if expandedBookCode == bookCode {
                                 chapterListView(bookCode)
-#if !os(tvOS)
-                                    .listSectionSeparator(.hidden)
-#endif
+                                    .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                                    .listRowBackground(viewModel.readerCanvasPrimaryColor)
+                                    .listRowSeparator(.hidden)
                             }
-                        } header: {
-                            ZStack(alignment: .leading) {
-                                viewModel.readerCanvasPrimaryColor
-                                sectionHeaderView(bookCode)
-                                    .padding(.vertical, 4)
-                                    .padding(.horizontal, 16)
-                            }
-                            .listRowInsets(EdgeInsets())
                         }
-                        .listRowBackground(viewModel.readerCanvasPrimaryColor)
+                    }
+                    .background(viewModel.readerCanvasPrimaryColor)
+                    .listStyle(.plain)
+                    .onAppear {
+                        if let expandedBookCode {
+                            proxy.scrollTo(expandedBookCode, anchor: .top)
+                        }
                     }
                 }
-                .background(viewModel.readerCanvasPrimaryColor)
-                .listStyle(.plain)
             }
         }
         .foregroundStyle(viewModel.readerTextPrimaryColor)
         .background(viewModel.readerCanvasPrimaryColor)
     }
 
-    private func sectionHeaderView(_ bookCode: String) -> some View {
+    private func bookRow(_ bookCode: String) -> some View {
         Button {
             withAnimation(reduceMotion ? nil : .default) {
                 expandedBookCode = expandedBookCode == bookCode ? nil : bookCode
@@ -94,11 +91,14 @@ public struct BibleReaderBookAndChapterPickerView: View {
                 Image(systemName: expandedBookCode == bookCode ? "chevron.up" : "chevron.down")
                     .font(.system(size: 14))
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .listRowInsets(EdgeInsets(top: 2, leading: 16, bottom: 2, trailing: 16))
-        .textCase(nil)
+        .id(bookCode)
+        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+        .listRowBackground(viewModel.readerCanvasPrimaryColor)
+        .listRowSeparator(.hidden)
     }
 
     private func chapterListView(_ bookCode: String) -> some View {

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
@@ -91,7 +91,12 @@ public struct BibleReaderHeaderView: View {
             halfPillPickersView(
                 bookAndChapter: title,
                 versionAbbreviation: version.localizedAbbreviation ?? version.abbreviation ?? String(version.id),
-                handleChapterTap: { viewModel.showingBookPicker.toggle() },
+                handleChapterTap: {
+                    if !viewModel.showingBookPicker {
+                        viewModel.headerExpandedBookCode = viewModel.reference.bookUSFM
+                    }
+                    viewModel.showingBookPicker.toggle()
+                },
                 handleVersionTap: { viewModel.versionsViewModel.openVersionsStack(currentBibleLanguage: version.languageTag ?? "en") }
             )
         } else {


### PR DESCRIPTION
https://github.com/user-attachments/assets/a4643d88-a23b-4279-b78d-4a0afac6282d


## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [ ] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

## Breaking Changes

<!-- If this PR contains breaking changes, mark this box and describe them below -->

- [ ] This PR contains **BREAKING CHANGES**

<!-- If checked, explain the breaking changes and provide migration instructions -->

**Breaking Change Details:**
<!-- Remove this section if not applicable -->

**Migration Guide:**
<!-- Provide step-by-step instructions for users to migrate their code -->

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] All commit messages follow [conventional commits](https://www.conventionalcommits.org/) format

## Conventional Commits

<!-- Your commit messages should follow this format -->

✅ **All commits in this PR follow conventional commit format:**

```
<type>(<scope>): <subject>

[optional body]

[optional footer]
```

**Example commit messages:**
- `feat(api): add Bible verse lookup method`
- `fix(auth): resolve token refresh race condition`
- `docs: update installation instructions`

For breaking changes:
- `feat(api)!: redesign Bible content API`

See [CONTRIBUTING.md](../CONTRIBUTING.md#conventional-commits) for detailed guidelines.

## Related Issues

<!-- Link any related issues using keywords like "Closes", "Fixes", or "Resolves" -->

Closes #
Relates to #

## Additional Context

<!-- Add any other context about the PR here, such as: -->
<!-- - Screenshots (for UI changes) -->
<!-- - Performance benchmarks (for performance improvements) -->
<!-- - Links to external resources or discussions -->

## Reviewer Notes

<!-- Any specific areas you'd like reviewers to focus on? -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the book/chapter picker so it scrolls to and expands the currently-reading book when opened from the reader. The picker's list structure is refactored from `Section`-based rows to plain sibling rows, a `ScrollViewReader` is introduced for programmatic scroll positioning, and shared row styling is extracted into a clean `bookPickerRow` View extension (with the required tvOS compile guard).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused, well-structured fix with no regressions in error handling, state management, or platform guards.

Both files make straightforward, targeted changes. headerExpandedBookCode is set only on open (not close), cleared on dismiss, and the ScrollViewReader+onAppear scroll pattern follows the standard SwiftUI idiom. The tvOS guard on listRowSeparator is correctly placed in the shared bookPickerRow modifier, addressing the platform-availability concern.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift | Refactored from Section-header rows to plain bookRow + conditional chapterListView siblings; added ScrollViewReader to scroll the list to the expanded book on appear; extracted bookPickerRow view modifier (with correct tvOS guard) to remove duplication. |
| Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift | Small targeted fix: sets headerExpandedBookCode to the current reference book before toggling the picker open, so the list opens pre-scrolled to the reader's current position. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User taps book/chapter pill] --> B{showingBookPicker?}
    B -- false / opening --> C[Set headerExpandedBookCode = reference.bookUSFM]
    C --> D[Toggle showingBookPicker = true]
    B -- true / closing --> D2[Toggle showingBookPicker = false]
    D --> E[Sheet presents BibleReaderBookAndChapterPickerView]
    E --> F[ScrollViewReader wraps List]
    F --> G[List.onAppear]
    G --> H{expandedBookCode set?}
    H -- yes --> I[proxy.scrollTo expandedBookCode, anchor: .top]
    H -- no --> J[List shown at top]
    D2 --> K[onDismiss: headerExpandedBookCode = nil]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User taps book/chapter pill] --> B{showingBookPicker?}
    B -- false / opening --> C[Set headerExpandedBookCode = reference.bookUSFM]
    C --> D[Toggle showingBookPicker = true]
    B -- true / closing --> D2[Toggle showingBookPicker = false]
    D --> E[Sheet presents BibleReaderBookAndChapterPickerView]
    E --> F[ScrollViewReader wraps List]
    F --> G[List.onAppear]
    G --> H{expandedBookCode set?}
    H -- yes --> I[proxy.scrollTo expandedBookCode, anchor: .top]
    H -- no --> J[List shown at top]
    D2 --> K[onDismiss: headerExpandedBookCode = nil]
```

</a>

<sub>Reviews (3): Last reviewed commit: ["fix(reader): guard listRowSeparator for ..."](https://github.com/youversion/platform-sdk-swift/commit/798655f1325a310050d37f0be5f2fea8df465401) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40651340)</sub>

<!-- /greptile_comment -->