### PR TITLE
feat(reader): open the book picker expanded on the current book BL-1909

### DIFF
--- a/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift
@@ -92,7 +92,7 @@ public struct BibleReaderHeaderView: View {
             halfPillPickersView(
                 bookAndChapter: title,
                 versionAbbreviation: version.localizedAbbreviation ?? version.abbreviation ?? String(version.id),
-                handleChapterTap: { viewModel.showingBookPicker.toggle() },
+                handleChapterTap: { viewModel.toggleBookPicker() },
                 handleVersionTap: { viewModel.versionsViewModel.openVersionsStack(currentBibleLanguage: version.languageTag ?? "en") }
             )
         } else {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -89,6 +89,15 @@ extension BibleReaderViewModel {
         }
     }
 
+    /// Opens the picker with the current book already expanded, so its chapters are
+    /// visible without a second tap. Closing leaves the expanded book untouched.
+    func toggleBookPicker() {
+        if !showingBookPicker {
+            headerExpandedBookCode = reference.bookId
+        }
+        showingBookPicker.toggle()
+    }
+
     func handleScroll(offset: CGFloat) {
         let previousOffset = lastScrollOffset
         lastScrollOffset = offset

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
@@ -247,6 +247,34 @@ let previousChapterCases: [PreviousChapterCase] = [
         #expect(vm.showingVerseActionsDrawer == true)
     }
 
+    @Test
+    func toggleBookPickerFromClosedExpandsCurrentBookAndOpens() {
+        let vm = BibleReaderViewModel(
+            reference: BibleReference(versionId: Self.versionId, bookId: "JHN", chapter: 3)
+        )
+        vm.showingBookPicker = false
+        vm.headerExpandedBookCode = nil
+
+        vm.toggleBookPicker()
+
+        #expect(vm.showingBookPicker == true)
+        #expect(vm.headerExpandedBookCode == "JHN")
+    }
+
+    @Test
+    func toggleBookPickerFromOpenClosesWithoutChangingExpandedBook() {
+        let vm = BibleReaderViewModel(
+            reference: BibleReference(versionId: Self.versionId, bookId: "JHN", chapter: 3)
+        )
+        vm.showingBookPicker = true
+        vm.headerExpandedBookCode = "GEN"
+
+        vm.toggleBookPicker()
+
+        #expect(vm.showingBookPicker == false)
+        #expect(vm.headerExpandedBookCode == "GEN")
+    }
+
     @Test(arguments: [
         (BookFixture(id: "GEN", chapterCount: 3, hasIntro: true), true),
         (BookFixture(id: "JUD", chapterCount: 1, hasIntro: false), false),


### PR DESCRIPTION
https://github.com/user-attachments/assets/fff204de-4da5-43ac-89a6-e237cfdd261a


Rebased onto `main`. **This PR has been substantially reduced in scope** — see below.

## What changed since the last review

[#233](https://github.com/youversion/platform-sdk-swift/pull/233) (@davidfedor, merged to `main`)
rewrote the book/chapter picker: `List`/`Section` → `ScrollView` + `LazyVStack`, book rows as
plain `Button`s, `.scrollPosition(id:anchor:.center)` seeded from a new `initialBookCode`, a
current-book highlight, and refreshed visuals.

That **supersedes the original fix in this PR**. The BL-1909 acceptance criterion — "Chapter
selection is visible when tapping on Book Name in Reader" — is already satisfied on `main`,
because #233's flat `LazyVStack` rows no longer swallow the tap the way the old
`List` section headers did.

So this PR's entire picker rewrite has been **dropped**.
`BibleReaderBookAndChapterPickerView.swift` is now byte-identical to `main`.

## What remains (38 lines, 3 files)

Only the behavior `main` does not yet have: **the picker opens with the current book already
expanded**, so the chapter grid is visible without a second tap.

- `BibleReaderViewModel+Navigation.swift` — new `toggleBookPicker()` that seeds
  `headerExpandedBookCode = reference.bookId` when opening, alongside the other intent
  methods (`goToNextChapter()`, `handleVerseTap(...)`).
- `BibleReaderHeaderView.swift` — one line: `handleChapterTap: { viewModel.toggleBookPicker() }`.
  #233's `initialBookCode:` argument is left untouched.
- `BibleReaderViewModel+NavigationTests.swift` — two tests covering open (seeds + expands) and
  close (leaves the expanded book alone).

## ⚠️ Design interaction for @davidfedor

`main` paints the current-book highlight only while that book is **collapsed**:

```swift
.background(viewModel.reference.bookId == bookCode && (expandedBookCode != bookCode)
            ? viewModel.readerSurfaceTertiaryColor : .clear)
```

Auto-expanding the current book therefore **suppresses that highlight on open** — you get the
expanded chapter grid instead of the highlighted row. If the scroll-to + highlight behavior
from #233 was the intended final UX, say so and I'll drop the auto-expand entirely (the ticket
is satisfied by #233 either way).

## Checks

Build ✅ · SwiftLint ✅ · 542 tests ✅ · public-API stability ✅ (change is internal only)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR routes reader-header taps through a view-model helper so the current book is expanded whenever the book picker opens.
- Adds centralized book-picker toggle behavior while preserving expanded state on close.
- Adds navigation tests covering both opening and closing behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/Components/BibleReaderHeaderView.swift | Routes chapter-picker taps through the new view-model toggle helper. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift | Expands the current book before opening the picker and preserves expansion when closing. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift | Covers the new picker behavior for both closed and open states. |

<sub>Reviews (5): Last reviewed commit: ["feat(reader): open the book picker expan..."](https://github.com/youversion/platform-sdk-swift/commit/db5f8fcc45a602cfbce7dfab6096a044ab6e14dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40953092)</sub>

<!-- /greptile_comment -->