### PR TITLE
feat(reader): scroll to a verse within its chapter BL-1901

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ BibleReaderView(
 )
 ```
 
+When the reference names a verse, the reader shows only that verse range by default. Pass `showsFullChapter: true` to show the whole chapter scrolled to the verse instead:
+
+```swift
+BibleReaderView(
+    reference: BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16),
+    showsFullChapter: true
+)
+```
+
 To intercept verse taps instead of using the built-in sign-in flow:
 
 ```swift

--- a/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleReference.swift
@@ -62,7 +62,12 @@ public struct BibleReference: Comparable, Codable, Hashable, Sendable, CustomDeb
     public var isRange: Bool {
         verseEnd != nil && verseStart != verseEnd
     }
-    
+
+    /// The same reference with any verse dropped — the whole chapter.
+    public var chapterReference: BibleReference {
+        BibleReference(versionId: versionId, bookUSFM: bookUSFM, chapter: chapter)
+    }
+
     public static func compare(a: BibleReference, b: BibleReference) -> Int {
         // returns -1, 0, or 1
         if a.bookUSFM != b.bookUSFM {

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -172,17 +172,13 @@ private struct ReaderContent: View {
         .environment(\.colorScheme, viewModel.colorTheme?.colorScheme ?? .dark)
     }
 
-    private var renderedReference: BibleReference {
-        let reference = viewModel.reference
-        if viewModel.showsFullChapter {
-            // Drop the verse from the reference
-            return BibleReference(versionId: reference.versionId, bookUSFM: reference.bookUSFM, chapter: reference.chapter)
-        } else {
-            return reference
-        }
+    // MARK: - Helper views
+    private var progressView: some View {
+        ProgressView()
+            .tint(viewModel.readerTextMutedColor)
+            .padding(.vertical, 48)
     }
 
-    // MARK: - Helper views
     private var header: some View {
         HStack {
             if viewModel.version != nil {
@@ -287,7 +283,7 @@ private struct ReaderContent: View {
                             BibleReaderIntroView()
                         } else {
                             BibleTextView(
-                                renderedReference,
+                                viewModel.showsFullChapter ? viewModel.reference.chapterReference : viewModel.reference,
                                 textOptions: viewModel.textOptions,
                                 selectedVerses: $viewModel.selectedVerses,
                                 onVerseTap: { reference, actionType, footnotes, footnoteId in
@@ -307,15 +303,18 @@ private struct ReaderContent: View {
                     // Hide the content until the verse scroll lands
                     // to avoid flashing.
                     .opacity(verseScrollCoordinator.isScrollPending ? 0 : 1)
+                    .overlay(alignment: .top) {
+                        if verseScrollCoordinator.isScrollPending {
+                            progressView
+                        }
+                    }
                     .onGeometryChange(for: CGFloat.self) { proxy in
                         proxy.frame(in: .named("scrollView")).minY
                     } action: { newOffset in
                         viewModel.handleScroll(offset: newOffset)
                     }
                 } else {
-                    ProgressView()
-                        .tint(viewModel.readerTextMutedColor)
-                        .padding(.vertical, 48)
+                    progressView
                 }
             }
             .coordinateSpace(.named("scrollView"))

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -333,7 +333,7 @@ private struct ReaderContent: View {
             .onPreferenceChange(ChapterScrollAnchorsKey.self) { anchors in
                 verseScrollCoordinator.handleAnchors(anchors, proxy: scrollProxy)
             }
-            .onChange(of: viewModel.scrollTarget, initial: true) { _, target in
+            .onChange(of: viewModel.scrollTargetReference, initial: true) { _, target in
                 if target != nil {
                     verseScrollCoordinator.handleScrollTarget(proxy: scrollProxy)
                 }

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -7,6 +7,7 @@ public struct BibleReaderView: View {
     @State private var viewModel: BibleReaderViewModel?
 
     private let initialReference: BibleReference?
+    private let showsFullChapter: Bool
     private let verseSelectionStyle: VerseSelectionStyle
     private let onVerseTap: ((BibleReference) -> Void)?
 
@@ -25,15 +26,21 @@ public struct BibleReaderView: View {
     ///     sign-in is disabled via ``YouVersionPlatformConfiguration/isSignInEnabled``)
     ///     or opens the verse actions drawer for authenticated users. Footnote taps
     ///     are always handled by the reader regardless of this closure.
+    ///   - showsFullChapter: When `true`, the reader shows the full chapter and
+    ///     scrolls to `reference`'s verse. When `false` (the default), it shows only
+    ///     `reference`'s verse range — use this for passages that are just a
+    ///     few verses, such as a plan day.
     public init(reference: BibleReference? = nil,
                 verseSelectionStyle: VerseSelectionStyle = .solid,
-                onVerseTap: ((BibleReference) -> Void)? = nil
+                onVerseTap: ((BibleReference) -> Void)? = nil,
+                showsFullChapter: Bool = false
     ) {
         assert(
             onVerseTap != nil || YouVersionPlatformConfiguration.isSignInEnabled,
             "onVerseTap must be provided OR YouVersion sign-in must be enabled"
         )
         self.initialReference = reference
+        self.showsFullChapter = showsFullChapter
         self.verseSelectionStyle = verseSelectionStyle
         self.onVerseTap = onVerseTap
     }
@@ -68,6 +75,7 @@ public struct BibleReaderView: View {
             if viewModel == nil {
                 viewModel = BibleReaderViewModel(
                     reference: initialReference,
+                    showsFullChapter: showsFullChapter,
                     verseSelectionStyle: verseSelectionStyle,
                     onVerseTap: onVerseTap
                 )
@@ -90,6 +98,12 @@ private struct ReaderContent: View {
     private let fontListDetent = PresentationDetent.height(480)
     @State private var selectedDetent = PresentationDetent.height(360)
     @State private var detents: Set<PresentationDetent> = [.height(360), .height(480)]
+    @State private var verseScrollCoordinator: VerseScrollCoordinator
+
+    init(viewModel: BibleReaderViewModel) {
+        self.viewModel = viewModel
+        self._verseScrollCoordinator = State(initialValue: VerseScrollCoordinator(viewModel: viewModel))
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -156,6 +170,16 @@ private struct ReaderContent: View {
         }
         .environment(viewModel)
         .environment(\.colorScheme, viewModel.colorTheme?.colorScheme ?? .dark)
+    }
+
+    private var renderedReference: BibleReference {
+        let reference = viewModel.reference
+        if viewModel.showsFullChapter {
+            // Drop the verse from the reference
+            return BibleReference(versionId: reference.versionId, bookUSFM: reference.bookUSFM, chapter: reference.chapter)
+        } else {
+            return reference
+        }
     }
 
     // MARK: - Helper views
@@ -263,7 +287,7 @@ private struct ReaderContent: View {
                             BibleReaderIntroView()
                         } else {
                             BibleTextView(
-                                viewModel.reference,
+                                renderedReference,
                                 textOptions: viewModel.textOptions,
                                 selectedVerses: $viewModel.selectedVerses,
                                 onVerseTap: { reference, actionType, footnotes, footnoteId in
@@ -280,6 +304,9 @@ private struct ReaderContent: View {
                     .padding(.vertical)
                     .padding(.horizontal, 30)
                     .id("topOfContent")
+                    // Hide the content until the verse scroll lands
+                    // to avoid flashing.
+                    .opacity(verseScrollCoordinator.isScrollPending ? 0 : 1)
                     .onGeometryChange(for: CGFloat.self) { proxy in
                         proxy.frame(in: .named("scrollView")).minY
                     } action: { newOffset in
@@ -302,6 +329,14 @@ private struct ReaderContent: View {
                         try? await Task.sleep(for: .seconds(0.5))
                         viewModel.isChangingChapter = false
                     }
+                }
+            }
+            .onPreferenceChange(ChapterScrollAnchorsKey.self) { anchors in
+                verseScrollCoordinator.handleAnchors(anchors, proxy: scrollProxy)
+            }
+            .onChange(of: viewModel.scrollTarget, initial: true) { _, target in
+                if target != nil {
+                    verseScrollCoordinator.handleScrollTarget(proxy: scrollProxy)
                 }
             }
         }

--- a/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
+++ b/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
@@ -20,11 +20,6 @@ final class VerseScrollCoordinator {
     /// How long a scroll stays pending before it's abandoned, in case the requested
     /// chapter never lays out and the scroll would otherwise never complete.
     private let safetyTimeout: Duration = .seconds(2)
-    /// Roughly one 60Hz frame. The blocks are laid out in a single pass (the reader isn't
-    /// lazy), but a `scrollTo` issued in the same runloop tick the anchors arrive lands at
-    /// the chapter top — the layout isn't committed yet. Waiting one frame is enough for the
-    /// target block's position to resolve, for both short and long chapters.
-    private let settleDelay: Duration = .milliseconds(16)
 
     /// True while a verse is requested but not yet scrolled to.
     private(set) var isScrollPending = false
@@ -93,10 +88,12 @@ final class VerseScrollCoordinator {
         scrollToResolvedTarget(proxy: proxy)
     }
 
-    /// Scrolls to the resolved target, if there is one, after a one-frame settle so the
-    /// target block's position is committed (see ``settleDelay``). The scroll target and
-    /// pending state are held until the scroll completes — cleared together at the end — so a
-    /// repeat ``handleAnchors(_:proxy:)`` mid-scroll still sees the chapter it's scrolling to.
+    /// Scrolls to the resolved target, if there is one, on the next display frame — the
+    /// anchors arrive before SwiftUI commits the layout, so a `scrollTo` in the same
+    /// runloop tick lands at the chapter top; waiting one frame lets the target block's
+    /// position resolve. The scroll target and pending state are held
+    /// until the scroll completes — cleared together at the end — so a repeat
+    /// ``handleAnchors(_:proxy:)`` mid-scroll still sees the chapter it's scrolling to.
     /// Single-flight: a new scroll cancels any pending one.
     private func scrollToResolvedTarget(proxy: ScrollViewProxy) {
         guard let verseID = resolvedScrollTarget else {
@@ -105,9 +102,8 @@ final class VerseScrollCoordinator {
 
         safetyTask?.cancel()
         scrollTask?.cancel()
-        scrollTask = Task { @MainActor [weak self, settleDelay] in
-            // swiftlint:disable:next common_debug_statements
-            try? await Task.sleep(for: settleDelay)
+        scrollTask = Task { @MainActor [weak self] in
+            await DisplayFrame().nextFrame()
             if Task.isCancelled {
                 return
             }
@@ -123,5 +119,33 @@ final class VerseScrollCoordinator {
         scrollTask?.cancel()
         viewModel.clearScrollTarget()
         isScrollPending = false
+    }
+}
+
+/// Suspends until the next display frame (v-sync), so a scroll runs after SwiftUI has
+/// committed the current layout.
+@MainActor
+private final class DisplayFrame: NSObject {
+    private var displayLink: CADisplayLink?
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func nextFrame() async {
+        await withCheckedContinuation { continuation in
+#if os(macOS)
+            continuation.resume()
+#else
+            self.continuation = continuation
+            let displayLink = CADisplayLink(target: self, selector: #selector(fire))
+            displayLink.add(to: .main, forMode: .common)
+            self.displayLink = displayLink
+#endif
+        }
+    }
+
+    @objc private func fire() {
+        displayLink?.invalidate()
+        displayLink = nil
+        continuation?.resume()
+        continuation = nil
     }
 }

--- a/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
+++ b/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
@@ -1,0 +1,122 @@
+import Observation
+import SwiftUI
+import YouVersionPlatformCore
+import YouVersionPlatformUI
+
+/// Scrolls the reader to a requested verse, working around three SwiftUI limitations:
+/// - No "chapter finished laying out" signal, so readiness can't be observed directly.
+/// - No synchronous text geometry (UIKit exposes it via TextKit's `selectionRects`), so
+///   a verse's offset can't be measured before the first paint.
+/// - `scrollPosition(id:)` doesn't fit: it needs `.scrollTargetLayout()` on a lazy
+///   container, but our anchors live in the non-lazy `BibleTextView`.
+///
+/// So instead of waiting for a signal, it tries to scroll whenever either input
+/// arrives — the scroll target, or the chapter's ``ChapterScrollAnchors`` (published as
+/// the blocks render). Both are needed: a target can be on the chapter already on
+/// screen, which produces no new anchors to trigger on.
+@MainActor
+@Observable
+final class VerseScrollCoordinator {
+    /// How long a scroll stays pending before it's abandoned, in case the requested
+    /// chapter never lays out and the scroll would otherwise never complete.
+    private let safetyTimeout: Duration = .seconds(2)
+    /// Number of `scrollTo` attempts, one frame apart, since a large chapter's blocks
+    /// lay out over several frames and the target may not exist on the first tries.
+    private let scrollAttempts = 10
+    /// Roughly one 60Hz frame, between scroll attempts.
+    private let frameInterval: Duration = .milliseconds(16)
+
+    /// True while a verse is requested but not yet scrolled to.
+    private(set) var isScrollPending = false
+
+    private let viewModel: BibleReaderViewModel
+    private var anchors: ChapterScrollAnchors?
+    private var scrollTask: Task<Void, Never>?
+    private var safetyTask: Task<Void, Never>?
+
+    /// The verse id to scroll to, resolved from the scroll target against the held
+    /// anchors, or nil when not yet resolvable (no target, or the anchors aren't for the
+    /// target's chapter).
+    private var resolvedScrollTarget: Int? {
+        guard let target = viewModel.scrollTarget, let verse = target.verseStart,
+              let anchors, anchors.chapter == target.chapter else {
+            return nil
+        }
+        return anchors.blockFirstVerse(forTargetVerse: verse)
+    }
+
+    init(viewModel: BibleReaderViewModel) {
+        self.viewModel = viewModel
+    }
+
+    /// Marks the scroll as pending, arms the safety timeout, and scrolls if the target
+    /// is already on the on-screen chapter.
+    func handleScrollTarget(proxy: ScrollViewProxy) {
+        isScrollPending = true
+
+        safetyTask?.cancel()
+        safetyTask = Task { @MainActor [weak self, safetyTimeout] in
+            // swiftlint:disable:next common_debug_statements
+            try? await Task.sleep(for: safetyTimeout)
+            guard let self, !Task.isCancelled else {
+                return
+            }
+            viewModel.clearScrollTarget()
+            isScrollPending = false
+        }
+
+        scrollToResolvedTarget(proxy: proxy)
+    }
+
+    /// Records the latest chapter's anchors and scrolls if they're what the target was
+    /// waiting on. If they belong to a different chapter than the target — the reader
+    /// navigated away while a scroll was pending — the target will never lay out, so the
+    /// pending scroll is abandoned and the content revealed rather than left hidden until
+    /// the safety timeout.
+    func handleAnchors(_ newAnchors: ChapterScrollAnchors?, proxy: ScrollViewProxy) {
+        anchors = newAnchors
+        if isScrollPending, let newAnchors,
+           newAnchors.chapter != viewModel.scrollTarget?.chapter {
+            cancelPendingScroll()
+            return
+        }
+        scrollToResolvedTarget(proxy: proxy)
+    }
+
+    /// Scrolls to the resolved target, if there is one. Clears the scroll target, then
+    /// re-issues the scroll across several frames before clearing the pending state: the
+    /// target block may not exist on the first try (blocks lay out over frames), and
+    /// `scrollTo` is idempotent once it does. Single-flight: a new scroll cancels any
+    /// pending one.
+    private func scrollToResolvedTarget(proxy: ScrollViewProxy) {
+        guard let verseID = resolvedScrollTarget else {
+            return
+        }
+
+        viewModel.clearScrollTarget()
+
+        safetyTask?.cancel()
+        scrollTask?.cancel()
+        scrollTask = Task { @MainActor [weak self, scrollAttempts, frameInterval] in
+            for attempt in 0..<scrollAttempts {
+                if attempt > 0 {
+                    // swiftlint:disable:next common_debug_statements
+                    try? await Task.sleep(for: frameInterval)
+                    if Task.isCancelled {
+                        return
+                    }
+                }
+                proxy.scrollTo(verseID, anchor: .top)
+            }
+            self?.isScrollPending = false
+        }
+    }
+
+    /// Abandons the pending scroll and reveals the content, cancelling the safety timeout.
+    private func cancelPendingScroll() {
+        safetyTask?.cancel()
+        scrollTask?.cancel()
+        viewModel.clearScrollTarget()
+        isScrollPending = false
+    }
+}

--- a/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
+++ b/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
@@ -3,23 +3,15 @@ import SwiftUI
 import YouVersionPlatformCore
 import YouVersionPlatformUI
 
-/// Scrolls the reader to a requested verse, working around three SwiftUI limitations:
-/// - No "chapter finished laying out" signal, so readiness can't be observed directly.
-/// - No synchronous text geometry (UIKit exposes it via TextKit's `selectionRects`), so
-///   a verse's offset can't be measured before the first paint.
-/// - `scrollPosition(id:)` doesn't fit: it needs `.scrollTargetLayout()` on a lazy
-///   container, but our anchors live in the non-lazy `BibleTextView`.
-///
-/// So instead of waiting for a signal, it tries to scroll whenever either input
-/// arrives — the scroll target, or the chapter's ``ChapterScrollAnchors`` (published as
-/// the blocks render). Both are needed: a target can be on the chapter already on
-/// screen, which produces no new anchors to trigger on.
+/// Scrolls the reader to a requested verse. SwiftUI exposes no "chapter laid out" signal,
+/// so the scroll fires when either input arrives — the scroll target, or the chapter's
+/// ``ChapterScrollAnchors`` — since the target can already be on screen (no new anchors) or
+/// still loading (target set before anchors).
 @MainActor
 @Observable
 final class VerseScrollCoordinator {
-    /// How long a scroll stays pending before it's abandoned, in case the requested
-    /// chapter never lays out and the scroll would otherwise never complete.
-    private let safetyTimeout: Duration = .seconds(2)
+    /// How long a scroll stays pending before it's abandoned, if the chapter never lays out.
+    private let fallbackTimeout: Duration = .seconds(2)
 
     /// True while a verse is requested but not yet scrolled to.
     private(set) var isScrollPending = false
@@ -27,40 +19,33 @@ final class VerseScrollCoordinator {
     private let viewModel: BibleReaderViewModel
     private var anchors: ChapterScrollAnchors?
     private var scrollTask: Task<Void, Never>?
-    private var safetyTask: Task<Void, Never>?
+    private var fallbackTask: Task<Void, Never>?
 
-    /// The verse id to scroll to, resolved from the scroll target against the held
-    /// anchors, or nil when not yet resolvable (no target, or the anchors aren't for the
-    /// target's chapter).
-    private var resolvedScrollTarget: Int? {
-        guard let target = viewModel.scrollTarget, let verse = target.verseStart,
+    private var targetBlockID: Int? {
+        guard let target = viewModel.scrollTargetReference, let verse = target.verseStart,
               let anchors, anchors.chapter == target.chapter else {
             return nil
         }
         return anchors.blockFirstVerse(forTargetVerse: verse)
     }
 
-    /// True when the target's chapter is already rendered — its anchors are held. The scroll
-    /// can then run off the target's arrival, without waiting for anchors to fire. This is
-    /// the path a jump to a verse in the already-displayed chapter takes.
     private var isTargetChapterRendered: Bool {
-        viewModel.scrollTarget?.chapter == anchors?.chapter
+        viewModel.scrollTargetReference?.chapter == anchors?.chapter
     }
 
     init(viewModel: BibleReaderViewModel) {
         self.viewModel = viewModel
     }
 
-    /// Marks the scroll as pending and arms the safety timeout. If the target's chapter is
-    /// already rendered, scrolls immediately; otherwise the scroll waits for that chapter's
-    /// anchors to arrive via ``handleAnchors(_:proxy:)``.
+    /// Marks the scroll pending and arms the fallback. Scrolls now if the chapter is already
+    /// rendered; otherwise waits for its anchors via ``handleAnchors(_:proxy:)``.
     func handleScrollTarget(proxy: ScrollViewProxy) {
         isScrollPending = true
 
-        safetyTask?.cancel()
-        safetyTask = Task { @MainActor [weak self, safetyTimeout] in
+        fallbackTask?.cancel()
+        fallbackTask = Task { @MainActor [weak self, fallbackTimeout] in
             // swiftlint:disable:next common_debug_statements
-            try? await Task.sleep(for: safetyTimeout)
+            try? await Task.sleep(for: fallbackTimeout)
             guard let self, !Task.isCancelled else {
                 return
             }
@@ -69,53 +54,46 @@ final class VerseScrollCoordinator {
         }
 
         if isTargetChapterRendered {
-            scrollToResolvedTarget(proxy: proxy)
+            scrollToTargetBlock(proxy: proxy)
         }
     }
 
-    /// Records the latest chapter's anchors and scrolls if they're what the target was
-    /// waiting on. If they belong to a different chapter than the target — the reader
-    /// navigated away while a scroll was pending — the target will never lay out, so the
-    /// pending scroll is abandoned and the content revealed rather than left hidden until
-    /// the safety timeout.
+    /// Records the latest chapter's anchors and scrolls if they match the target.
     func handleAnchors(_ newAnchors: ChapterScrollAnchors?, proxy: ScrollViewProxy) {
         anchors = newAnchors
         if isScrollPending, let newAnchors,
-           newAnchors.chapter != viewModel.scrollTarget?.chapter {
+           newAnchors.chapter != viewModel.scrollTargetReference?.chapter {
             cancelPendingScroll()
             return
         }
-        scrollToResolvedTarget(proxy: proxy)
+        scrollToTargetBlock(proxy: proxy)
     }
 
-    /// Scrolls to the resolved target, if there is one, on the next display frame — the
-    /// anchors arrive before SwiftUI commits the layout, so a `scrollTo` in the same
-    /// runloop tick lands at the chapter top; waiting one frame lets the target block's
-    /// position resolve. The scroll target and pending state are held
-    /// until the scroll completes — cleared together at the end — so a repeat
-    /// ``handleAnchors(_:proxy:)`` mid-scroll still sees the chapter it's scrolling to.
-    /// Single-flight: a new scroll cancels any pending one.
-    private func scrollToResolvedTarget(proxy: ScrollViewProxy) {
-        guard let verseID = resolvedScrollTarget else {
+    /// Scrolls to the target block on the next display frame — the anchors arrive before
+    /// SwiftUI commits the layout, so scrolling in the same tick lands at the chapter top.
+    /// The target and pending state are held until the scroll completes so a repeat anchor
+    /// fire mid-scroll still resolves. Single-flight: a new scroll cancels any pending one.
+    private func scrollToTargetBlock(proxy: ScrollViewProxy) {
+        guard let blockID = targetBlockID else {
             return
         }
 
-        safetyTask?.cancel()
+        fallbackTask?.cancel()
         scrollTask?.cancel()
         scrollTask = Task { @MainActor [weak self] in
             await DisplayFrame().nextFrame()
             if Task.isCancelled {
                 return
             }
-            proxy.scrollTo(verseID, anchor: .top)
+            proxy.scrollTo(blockID, anchor: .top)
             self?.viewModel.clearScrollTarget()
             self?.isScrollPending = false
         }
     }
 
-    /// Abandons the pending scroll and reveals the content, cancelling the safety timeout.
+    /// Abandons the pending scroll and reveals the content, cancelling the fallback timeout.
     private func cancelPendingScroll() {
-        safetyTask?.cancel()
+        fallbackTask?.cancel()
         scrollTask?.cancel()
         viewModel.clearScrollTarget()
         isScrollPending = false

--- a/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
+++ b/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
@@ -20,11 +20,11 @@ final class VerseScrollCoordinator {
     /// How long a scroll stays pending before it's abandoned, in case the requested
     /// chapter never lays out and the scroll would otherwise never complete.
     private let safetyTimeout: Duration = .seconds(2)
-    /// Number of `scrollTo` attempts, one frame apart, since a large chapter's blocks
-    /// lay out over several frames and the target may not exist on the first tries.
-    private let scrollAttempts = 10
-    /// Roughly one 60Hz frame, between scroll attempts.
-    private let frameInterval: Duration = .milliseconds(16)
+    /// Roughly one 60Hz frame. The blocks are laid out in a single pass (the reader isn't
+    /// lazy), but a `scrollTo` issued in the same runloop tick the anchors arrive lands at
+    /// the chapter top — the layout isn't committed yet. Waiting one frame is enough for the
+    /// target block's position to resolve, for both short and long chapters.
+    private let settleDelay: Duration = .milliseconds(16)
 
     /// True while a verse is requested but not yet scrolled to.
     private(set) var isScrollPending = false
@@ -93,11 +93,10 @@ final class VerseScrollCoordinator {
         scrollToResolvedTarget(proxy: proxy)
     }
 
-    /// Scrolls to the resolved target, if there is one, re-issuing the scroll across several
-    /// frames since the target block may not exist on the first try (blocks lay out over
-    /// frames) and `scrollTo` is idempotent once it does. The scroll target and pending
-    /// state are held until the scroll completes — cleared together at the end — so a repeat
-    /// ``handleAnchors(_:proxy:)`` mid-scroll still sees the chapter it's scrolling to.
+    /// Scrolls to the resolved target, if there is one, after a one-frame settle so the
+    /// target block's position is committed (see ``settleDelay``). The scroll target and
+    /// pending state are held until the scroll completes — cleared together at the end — so a
+    /// repeat ``handleAnchors(_:proxy:)`` mid-scroll still sees the chapter it's scrolling to.
     /// Single-flight: a new scroll cancels any pending one.
     private func scrollToResolvedTarget(proxy: ScrollViewProxy) {
         guard let verseID = resolvedScrollTarget else {
@@ -106,17 +105,13 @@ final class VerseScrollCoordinator {
 
         safetyTask?.cancel()
         scrollTask?.cancel()
-        scrollTask = Task { @MainActor [weak self, scrollAttempts, frameInterval] in
-            for attempt in 0..<scrollAttempts {
-                if attempt > 0 {
-                    // swiftlint:disable:next common_debug_statements
-                    try? await Task.sleep(for: frameInterval)
-                    if Task.isCancelled {
-                        return
-                    }
-                }
-                proxy.scrollTo(verseID, anchor: .top)
+        scrollTask = Task { @MainActor [weak self, settleDelay] in
+            // swiftlint:disable:next common_debug_statements
+            try? await Task.sleep(for: settleDelay)
+            if Task.isCancelled {
+                return
             }
+            proxy.scrollTo(verseID, anchor: .top)
             self?.viewModel.clearScrollTarget()
             self?.isScrollPending = false
         }

--- a/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
+++ b/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
@@ -45,12 +45,20 @@ final class VerseScrollCoordinator {
         return anchors.blockFirstVerse(forTargetVerse: verse)
     }
 
+    /// True when the target's chapter is already rendered — its anchors are held. The scroll
+    /// can then run off the target's arrival, without waiting for anchors to fire. This is
+    /// the path a jump to a verse in the already-displayed chapter takes.
+    private var isTargetChapterRendered: Bool {
+        viewModel.scrollTarget?.chapter == anchors?.chapter
+    }
+
     init(viewModel: BibleReaderViewModel) {
         self.viewModel = viewModel
     }
 
-    /// Marks the scroll as pending, arms the safety timeout, and scrolls if the target
-    /// is already on the on-screen chapter.
+    /// Marks the scroll as pending and arms the safety timeout. If the target's chapter is
+    /// already rendered, scrolls immediately; otherwise the scroll waits for that chapter's
+    /// anchors to arrive via ``handleAnchors(_:proxy:)``.
     func handleScrollTarget(proxy: ScrollViewProxy) {
         isScrollPending = true
 
@@ -65,7 +73,9 @@ final class VerseScrollCoordinator {
             isScrollPending = false
         }
 
-        scrollToResolvedTarget(proxy: proxy)
+        if isTargetChapterRendered {
+            scrollToResolvedTarget(proxy: proxy)
+        }
     }
 
     /// Records the latest chapter's anchors and scrolls if they're what the target was
@@ -83,17 +93,16 @@ final class VerseScrollCoordinator {
         scrollToResolvedTarget(proxy: proxy)
     }
 
-    /// Scrolls to the resolved target, if there is one. Clears the scroll target, then
-    /// re-issues the scroll across several frames before clearing the pending state: the
-    /// target block may not exist on the first try (blocks lay out over frames), and
-    /// `scrollTo` is idempotent once it does. Single-flight: a new scroll cancels any
-    /// pending one.
+    /// Scrolls to the resolved target, if there is one, re-issuing the scroll across several
+    /// frames since the target block may not exist on the first try (blocks lay out over
+    /// frames) and `scrollTo` is idempotent once it does. The scroll target and pending
+    /// state are held until the scroll completes — cleared together at the end — so a repeat
+    /// ``handleAnchors(_:proxy:)`` mid-scroll still sees the chapter it's scrolling to.
+    /// Single-flight: a new scroll cancels any pending one.
     private func scrollToResolvedTarget(proxy: ScrollViewProxy) {
         guard let verseID = resolvedScrollTarget else {
             return
         }
-
-        viewModel.clearScrollTarget()
 
         safetyTask?.cancel()
         scrollTask?.cancel()
@@ -108,6 +117,7 @@ final class VerseScrollCoordinator {
                 }
                 proxy.scrollTo(verseID, anchor: .top)
             }
+            self?.viewModel.clearScrollTarget()
             self?.isScrollPending = false
         }
     }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -34,6 +34,8 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     var lastScrollOffset: CGFloat = 0
     var scrollToTop = false
     var isChangingChapter = false
+    private(set) var showsFullChapter: Bool
+    private(set) var scrollTarget: BibleReference?
     var showingSignInSheet = false
     var showingFontSettings = false
     var showingFontList = false // swiftlint:disable:this collection_suffix_property
@@ -83,6 +85,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
 
     init(
         reference: BibleReference? = nil,
+        showsFullChapter: Bool = false,
         highlightsViewModel: BibleHighlightsViewModel? = nil,
         verseSelectionStyle: VerseSelectionStyle = .solid,
         versionsViewModel: BibleVersionsViewModel? = nil,
@@ -106,6 +109,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
             }
         }
 
+        self.showsFullChapter = showsFullChapter
         self.onVerseTap = onVerseTap
         self.verseSelectionStyle = verseSelectionStyle
         self.authentication = authentication
@@ -130,6 +134,10 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         }
 
         observeCurrentVersion()
+
+        if reference != nil {
+            setScrollTarget()
+        }
     }
 
     // Reacts to BibleVersionsViewModel.currentVersion changes by updating
@@ -190,6 +198,21 @@ final class BibleReaderViewModel: ReaderThemeProviding {
 
     func onSignInRequired() {
         startSignInFlow = true
+    }
+
+    /// Sets the current ``reference``'s verse as the target the reader should scroll to
+    /// once its chapter lays out.
+    private func setScrollTarget() {
+        guard showsFullChapter, let verseStart = reference.verseStart, verseStart > 1 else {
+            return
+        }
+        scrollTarget = reference
+        scrollToTop = false
+    }
+
+    /// Clears the scroll target once the reader has brought it into view.
+    func clearScrollTarget() {
+        scrollTarget = nil
     }
 
     func loadUserSettingsFromStorage() {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -35,7 +35,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     var scrollToTop = false
     var isChangingChapter = false
     private(set) var showsFullChapter: Bool
-    private(set) var scrollTarget: BibleReference?
+    private(set) var scrollTargetReference: BibleReference?
     var showingSignInSheet = false
     var showingFontSettings = false
     var showingFontList = false // swiftlint:disable:this collection_suffix_property
@@ -206,13 +206,13 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         guard showsFullChapter, let verseStart = reference.verseStart, verseStart > 1 else {
             return
         }
-        scrollTarget = reference
+        scrollTargetReference = reference
         scrollToTop = false
     }
 
     /// Clears the scroll target once the reader has brought it into view.
     func clearScrollTarget() {
-        scrollTarget = nil
+        scrollTargetReference = nil
     }
 
     func loadUserSettingsFromStorage() {

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
@@ -5,9 +5,8 @@ extension BibleTextView {
     @ViewBuilder
     func view(for block: BibleTextBlock, textOptions: BibleTextOptions, ignoreMarginTop: Bool, previousMarginBottom: CGFloat) -> some View {
         if block.rows.isEmpty {
-            let theView = emitTextBlock(block, textOptions: textOptions, ignoreMarginTop: ignoreMarginTop, previousMarginBottom: previousMarginBottom)
-            let alignedView = applyAlignment(to: theView, alignment: block.alignment)
-            // Blocks with verses are tagged with their first verse as a scroll id.
+            let textBlockView = emitTextBlock(block, textOptions: textOptions, ignoreMarginTop: ignoreMarginTop, previousMarginBottom: previousMarginBottom)
+            let alignedView = aligned(textBlockView, for: block.alignment)
             if let firstVerse = block.firstVerse {
                 alignedView.id(firstVerse)
             } else {
@@ -19,13 +18,13 @@ extension BibleTextView {
     }
 
     @ViewBuilder
-    private func applyAlignment(to theView: some View, alignment: TextAlignment) -> some View {
+    private func aligned(_ view: some View, for alignment: TextAlignment) -> some View {
         if alignment == .leading {
-            theView
+            view
         } else {
             HStack {
                 Spacer()
-                theView
+                view
                 if alignment == .center {
                     Spacer()
                 }

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
@@ -6,19 +6,30 @@ extension BibleTextView {
     func view(for block: BibleTextBlock, textOptions: BibleTextOptions, ignoreMarginTop: Bool, previousMarginBottom: CGFloat) -> some View {
         if block.rows.isEmpty {
             let theView = emitTextBlock(block, textOptions: textOptions, ignoreMarginTop: ignoreMarginTop, previousMarginBottom: previousMarginBottom)
-            if block.alignment == .leading {
-                theView
+            let alignedView = applyAlignment(to: theView, alignment: block.alignment)
+            // Blocks with verses are tagged with their first verse as a scroll id.
+            if let firstVerse = block.firstVerse {
+                alignedView.id(firstVerse)
             } else {
-                HStack {
-                    Spacer()
-                    theView
-                    if block.alignment == .center {
-                        Spacer()
-                    }
-                }
+                alignedView
             }
         } else {
             emitTableRows(block.rows, textOptions: textOptions)
+        }
+    }
+
+    @ViewBuilder
+    private func applyAlignment(to theView: some View, alignment: TextAlignment) -> some View {
+        if alignment == .leading {
+            theView
+        } else {
+            HStack {
+                Spacer()
+                theView
+                if alignment == .center {
+                    Spacer()
+                }
+            }
         }
     }
 

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
@@ -120,6 +120,7 @@ public struct BibleTextView: View {
                 }
             }
         }
+        .preference(key: ChapterScrollAnchorsKey.self, value: chapterScrollAnchors)
         .environment(\.layoutDirection, isVersionRightToLeft ? .rightToLeft : .leftToRight)
         .environment(\.openURL, OpenURLAction(handler: { url in
             if let reference = parseReference(url: url) {
@@ -142,6 +143,17 @@ public struct BibleTextView: View {
         .task(id: reference) {
             BibleHighlightsViewModel.shared.ensureHighlightsForChapterLoaded(reference)
         }
+    }
+
+    /// The scroll anchors for the rendered chapter, or nil until blocks exist.
+    private var chapterScrollAnchors: ChapterScrollAnchors? {
+        guard let firstBlock = blocks.first else {
+            return nil
+        }
+        return ChapterScrollAnchors(
+            chapter: firstBlock.chapter,
+            blockFirstVerses: blocks.compactMap(\.firstVerse)
+        )
     }
 
     private func footnotesFor(reference: BibleReference) -> [BibleFootnote] {

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleTextBlock.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleTextBlock.swift
@@ -12,13 +12,7 @@ public struct BibleTextBlock: Identifiable {
     public let marginBottom: CGFloat
     public let alignment: TextAlignment
     public let footnotes: [BibleFootnote]
-
-    /// The first verse this block displays, or nil when it shows none.
-    public var firstVerse: Int? {
-        text.asAttributedString.runs[\.bibleTextCategory, \.bibleReference]
-            .first { category, _, _ in category == .scripture || category == .verseLabel }?
-            .1?.verseStart
-    }
+    public let firstVerse: Int? // The first verse this block displays, or nil when it shows none.
 
     public init(
         text: BibleAttributedString,
@@ -40,6 +34,7 @@ public struct BibleTextBlock: Identifiable {
         self.alignment = alignment
         self.footnotes = footnotes
         self.rows = rows
+        self.firstVerse = Self.firstVerse(in: text)
     }
 
     public init(
@@ -61,5 +56,12 @@ public struct BibleTextBlock: Identifiable {
         self.alignment = alignment
         self.footnotes = footnotes
         self.rows = rows
+        self.firstVerse = Self.firstVerse(in: text)
+    }
+
+    private static func firstVerse(in text: BibleAttributedString) -> Int? {
+        text.asAttributedString.runs[\.bibleTextCategory, \.bibleReference]
+            .first { category, _, _ in category == .scripture || category == .verseLabel }?
+            .1?.verseStart
     }
 }

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleTextBlock.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleTextBlock.swift
@@ -13,6 +13,13 @@ public struct BibleTextBlock: Identifiable {
     public let alignment: TextAlignment
     public let footnotes: [BibleFootnote]
 
+    /// The first verse this block displays, or nil when it shows none.
+    public var firstVerse: Int? {
+        text.asAttributedString.runs[\.bibleTextCategory, \.bibleReference]
+            .first { category, _, _ in category == .scripture || category == .verseLabel }?
+            .1?.verseStart
+    }
+
     public init(
         text: BibleAttributedString,
         chapter: Int,

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleTextBlock.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleTextBlock.swift
@@ -60,8 +60,11 @@ public struct BibleTextBlock: Identifiable {
     }
 
     private static func firstVerse(in text: BibleAttributedString) -> Int? {
-        text.asAttributedString.runs[\.bibleTextCategory, \.bibleReference]
-            .first { category, _, _ in category == .scripture || category == .verseLabel }?
-            .1?.verseStart
+        let runs = text.asAttributedString.runs[\.bibleTextCategory, \.bibleReference]
+        let firstScriptureRun = runs.first { category, _, _ in
+            category == .scripture || category == .verseLabel
+        }
+        let reference = firstScriptureRun?.1
+        return reference?.verseStart
     }
 }

--- a/Sources/YouVersionPlatformUI/Views/Rendering/ChapterScrollAnchors.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/ChapterScrollAnchors.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// The blocks a rendered chapter can scroll to, published up from
+/// `BibleTextView` so the reader can scroll to a verse once its block exists.
+public struct ChapterScrollAnchors: Equatable {
+    /// The chapter these blocks belong to.
+    public let chapter: Int
+
+    /// The first verse of each block, in render order. Each block is tagged with its
+    /// first verse as its `.id`.
+    public let blockFirstVerses: [Int]
+
+    public init(chapter: Int, blockFirstVerses: [Int]) {
+        self.chapter = chapter
+        self.blockFirstVerses = blockFirstVerses
+    }
+
+    /// The `.id` of the block containing `verse`.
+    public func blockFirstVerse(forTargetVerse verse: Int) -> Int? {
+        blockFirstVerses.last(where: { $0 <= verse })
+    }
+}
+
+public struct ChapterScrollAnchorsKey: PreferenceKey {
+    public static var defaultValue: ChapterScrollAnchors? { nil }
+
+    public static func reduce(value: inout ChapterScrollAnchors?, nextValue: () -> ChapterScrollAnchors?) {
+        value = nextValue() ?? value
+    }
+}

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
@@ -64,6 +64,7 @@ enum BibleReaderViewModelTestSupport {
     @MainActor
     static func makeViewModel(
         reference: BibleReference? = BibleReference(versionId: versionId, bookUSFM: "JHN", chapter: 1),
+        showsFullChapter: Bool = false,
         highlightsRepository: MockBibleHighlightsRepository = MockBibleHighlightsRepository(),
         versionRepository: any BibleVersionRepositoryProtocol = MockBibleVersionRepository(),
         onVerseTap: ((BibleReference) -> Void)? = nil,
@@ -83,6 +84,7 @@ enum BibleReaderViewModelTestSupport {
         )
         return BibleReaderViewModel(
             reference: reference,
+            showsFullChapter: showsFullChapter,
             highlightsViewModel: highlightsViewModel,
             versionsViewModel: versionsViewModel,
             onVerseTap: onVerseTap,

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
@@ -15,14 +15,14 @@ import Testing
     func chapterOnlyReferenceArmsNoScroll() {
         let viewModel = makeViewModel(verse: nil)
 
-        #expect(viewModel.scrollTarget == nil)
+        #expect(viewModel.scrollTargetReference == nil)
     }
 
     @Test
     func verseOneArmsNoScroll() {
         let viewModel = makeViewModel(verse: 1)
 
-        #expect(viewModel.scrollTarget == nil)
+        #expect(viewModel.scrollTargetReference == nil)
     }
 
     @Test
@@ -32,14 +32,14 @@ import Testing
 
         let viewModel = Support.makeViewModel(reference: nil, showsFullChapter: true)
 
-        #expect(viewModel.scrollTarget == nil)
+        #expect(viewModel.scrollTargetReference == nil)
     }
 
     @Test
     func verseRangeModeArmsNoScroll() {
         let viewModel = makeViewModel(verse: 14, showsFullChapter: false)
 
-        #expect(viewModel.scrollTarget == nil)
+        #expect(viewModel.scrollTargetReference == nil)
     }
 
     // A reader constructed fresh at a verse (the path loop-ios uses for VOTD and
@@ -50,7 +50,7 @@ import Testing
 
         let viewModel = Support.makeViewModel(reference: reference, showsFullChapter: true)
 
-        #expect(viewModel.scrollTarget?.verseStart == 16)
+        #expect(viewModel.scrollTargetReference?.verseStart == 16)
     }
 
     @Test
@@ -59,6 +59,6 @@ import Testing
 
         let viewModel = Support.makeViewModel(reference: reference, showsFullChapter: false)
 
-        #expect(viewModel.scrollTarget == nil)
+        #expect(viewModel.scrollTargetReference == nil)
     }
 }

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
@@ -1,0 +1,64 @@
+import Testing
+@testable import YouVersionPlatformCore
+@testable import YouVersionPlatformReader
+
+@MainActor
+@Suite(.serialized) struct BibleReaderViewModelVerseScrollTests {
+    private typealias Support = BibleReaderViewModelTestSupport
+
+    private func makeViewModel(verse: Int?, showsFullChapter: Bool = true) -> BibleReaderViewModel {
+        let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1, verse: verse)
+        return Support.makeViewModel(reference: reference, showsFullChapter: showsFullChapter)
+    }
+
+    @Test
+    func chapterOnlyReferenceArmsNoScroll() {
+        let viewModel = makeViewModel(verse: nil)
+
+        #expect(viewModel.scrollTarget == nil)
+    }
+
+    @Test
+    func verseOneArmsNoScroll() {
+        let viewModel = makeViewModel(verse: 1)
+
+        #expect(viewModel.scrollTarget == nil)
+    }
+
+    @Test
+    func restoredReferenceArmsNoScroll() {
+        Support.clearReaderDefaults()
+        defer { Support.clearReaderDefaults() }
+
+        let viewModel = Support.makeViewModel(reference: nil, showsFullChapter: true)
+
+        #expect(viewModel.scrollTarget == nil)
+    }
+
+    @Test
+    func verseRangeModeArmsNoScroll() {
+        let viewModel = makeViewModel(verse: 14, showsFullChapter: false)
+
+        #expect(viewModel.scrollTarget == nil)
+    }
+
+    // A reader constructed fresh at a verse (the path loop-ios uses for VOTD and
+    // bible stories) arms the scroll only when it opens in full-chapter mode.
+    @Test
+    func constructingFullChapterAtVerseArmsScroll() {
+        let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+
+        let viewModel = Support.makeViewModel(reference: reference, showsFullChapter: true)
+
+        #expect(viewModel.scrollTarget?.verseStart == 16)
+    }
+
+    @Test
+    func constructingVerseRangeAtVerseArmsNoScroll() {
+        let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+
+        let viewModel = Support.makeViewModel(reference: reference, showsFullChapter: false)
+
+        #expect(viewModel.scrollTarget == nil)
+    }
+}

--- a/Tests/YouVersionPlatformUITests/BibleVersionRenderingTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionRenderingTests.swift
@@ -232,4 +232,117 @@ import Testing
         #expect(!hasHeaderContaining(blocks, text: "Visible Header"))
         #expect(hasScriptureContaining(blocks, text: "First verse text."))
     }
+
+    // MARK: - firstVerse (scroll-to-verse support)
+
+    private func block(_ blocks: [BibleTextBlock], containingText text: String) throws -> BibleTextBlock {
+        try #require(blocks.first { $0.text.characters.contains(text) })
+    }
+
+    @Test func testFirstVerseReflectsBlockVerses() async throws {
+        let html = """
+        <div>
+            <div class="p">
+                <span class="yv-v" v="5"></span>
+                <span class="yv-vlbl">5</span>
+                Fifth verse text.
+            </div>
+            <div class="p">
+                <span class="yv-v" v="6"></span>
+                <span class="yv-vlbl">6</span>
+                Sixth verse text.
+            </div>
+        </div>
+        """
+
+        let reference = BibleReference(versionId: defaultVersionId, bookUSFM: "GEN", chapter: 1, verseStart: 5, verseEnd: 10)
+
+        let blocks = try await renderBlocks(html: html, reference: reference)
+        #expect(try block(blocks, containingText: "Fifth verse text.").firstVerse == 5)
+        #expect(try block(blocks, containingText: "Sixth verse text.").firstVerse == 6)
+    }
+
+    @Test func testFirstVerseIsNilForHeaderOnlyBlock() async throws {
+        let html = """
+        <div>
+            <div class="yv-h s1"><span>The List</span></div>
+            <div class="p">
+                <span class="yv-v" v="1"></span>
+                <span class="yv-vlbl">1</span>
+                First verse text.
+            </div>
+        </div>
+        """
+
+        let reference = BibleReference(versionId: defaultVersionId, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
+
+        let blocks = try await renderBlocks(html: html, reference: reference)
+        let headerBlock = try #require(blocks.first { block in
+            block.text.asAttributedString.runs[\.bibleTextCategory].contains { $0.0 == .header }
+                && block.text.characters.contains("The List")
+        })
+        #expect(headerBlock.firstVerse == nil)
+    }
+
+    @Test func testFirstVerseOfBlockSpanningMultipleVerses() async throws {
+        // A single paragraph carrying two verses reports the first, so a scroll
+        // request for either verse resolves to this block's start.
+        let html = """
+        <div>
+            <div class="p">
+                <span class="yv-v" v="1"></span>
+                <span class="yv-vlbl">1</span>
+                First verse text.
+                <span class="yv-v" v="2"></span>
+                <span class="yv-vlbl">2</span>
+                Second verse text.
+            </div>
+        </div>
+        """
+
+        let reference = BibleReference(versionId: defaultVersionId, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 5)
+
+        let blocks = try await renderBlocks(html: html, reference: reference)
+        let combined = try block(blocks, containingText: "Second verse text.")
+        #expect(combined.firstVerse == 1)
+
+        let firstVerses = blocks.compactMap { $0.firstVerse }
+        let layout = ChapterScrollAnchors(chapter: 1, blockFirstVerses: firstVerses)
+        #expect(layout.blockFirstVerse(forTargetVerse: 1) == 1)
+        #expect(layout.blockFirstVerse(forTargetVerse: 2) == 1)
+    }
+
+    @Test func testAcrosticChapterResolvesTargetVerseToOwningBlock() async throws {
+        // Mirrors Psalm 119's shape: stanzas of verses separated by letter
+        // headings, rendered as a full chapter. Verse 105 must resolve to its own
+        // block, not an earlier one — a regression where headings desynced the
+        // recorded verses from block identity landed scrolls on the wrong verse.
+        var html = "<div>"
+        let stanzas = [(letter: "MEM", start: 97), (letter: "NUN", start: 105), (letter: "SAMEKH", start: 113)]
+        for stanza in stanzas {
+            html += #"<div class="yv-h s1"><span>\#(stanza.letter)</span></div>"#
+            for verse in stanza.start..<(stanza.start + 8) {
+                html += #"""
+                <div class="p">
+                    <span class="yv-v" v="\#(verse)"></span>
+                    <span class="yv-vlbl">\#(verse)</span>
+                    Verse \#(verse) text.
+                </div>
+                """#
+            }
+        }
+        html += "</div>"
+
+        let reference = BibleReference(versionId: defaultVersionId, bookUSFM: "PSA", chapter: 119)
+        let blocks = try await renderBlocks(html: html, reference: reference)
+
+        let block105 = try block(blocks, containingText: "Verse 105 text.")
+        #expect(block105.firstVerse == 105)
+
+        let firstVerses = blocks.compactMap { $0.firstVerse }
+        let layout = ChapterScrollAnchors(chapter: 119, blockFirstVerses: firstVerses)
+        #expect(layout.blockFirstVerse(forTargetVerse: 105) == 105)
+        #expect(layout.blockFirstVerse(forTargetVerse: 100) == 100)
+        #expect(layout.blockFirstVerse(forTargetVerse: 113) == 113)
+    }
 }


### PR DESCRIPTION
## Description

Adds a `showsFullChapter` option to `BibleReaderView`. When a reference names a verse, the reader can now render the whole chapter and scroll to that verse, instead of rendering only the verse range (the existing default).

```swift
BibleReaderView(
    reference: BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16),
    showsFullChapter: true
)
```

**How it works**

SwiftUI gives no synchronous "chapter finished laying out" signal and no text geometry we can query, so verse → scroll position has to be bridged from the render layer:

- Each rendered `BibleTextBlock` derives its `firstVerse` from the attributed string it already carries (no new state on the low-level text types).
- `BibleTextView` publishes the chapter's blocks — chapter number + each block's first verse — up the view tree via a `ChapterScrollAnchors` preference.
- `VerseScrollCoordinator` (view-owned) receives those anchors, resolves the target verse to the block that contains it, and scrolls there, retrying across a few frames since there's no layout-complete callback to wait on.

The scroll is **armed at construction time**, so a reader opened directly at a verse (e.g. a VOTD deep-link) lands on that verse without any extra call.

_This PR is the foundation layer. A follow-up PR (`ss/drive-reader-from-outside-BL-1901`) stacks on it to add `BibleReaderNavigation` for driving an on-screen reader to a new passage from elsewhere in the app._

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] `feat:` New feature (non-breaking change which adds functionality)
- [ ] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

## Breaking Changes

<!-- If this PR contains breaking changes, mark this box and describe them below -->

- [ ] This PR contains **BREAKING CHANGES**

No breaking changes. `showsFullChapter` is a new parameter that defaults to `false`, preserving existing verse-range behavior.

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] All commit messages follow [conventional commits](https://www.conventionalcommits.org/) format

## Conventional Commits

<!-- Your commit messages should follow this format -->

✅ **All commits in this PR follow conventional commit format:**

```
feat(reader): scroll to a verse within its chapter
```

## Related Issues

BL-1901


## Validation

### Scrolls to verse:
```
BibleReaderView(
                    reference: BibleReference(versionId: 111, bookUSFM: "JHN", chapter: 3, verse: 16),
                    showsFullChapter: true
                )
```
https://github.com/user-attachments/assets/5138ec8f-c238-4f5b-a45d-c605ca040621

### Scrolls to verse in a long chapter:
```
BibleReaderView(
                    reference: BibleReference(versionId: 111, bookUSFM: "PSA", chapter: 119, verse: 105),
                    showsFullChapter: true
                )
```
https://github.com/user-attachments/assets/0df08353-5587-41a3-a12f-3998b317306f

### Shows full chapter when no verse provided:
```
BibleReaderView(
                    reference: BibleReference(versionId: 111,  bookUSFM: "PSA", chapter: 119)
                )
```
https://github.com/user-attachments/assets/e3a22160-b169-4e9d-921d-be138aee37fe

### Shows just the specified verse if `showsFullChapter` is false:
```
BibleReaderView(
                    reference: BibleReference(versionId: 111, bookUSFM: "PSA", chapter: 119, verse: 105)
                )
```
https://github.com/user-attachments/assets/ca0097a5-707b-4ff5-9888-d0bb40db60b1

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `showsFullChapter: true` to `BibleReaderView`, rendering the complete chapter and scrolling to the specified verse — wiring a new `VerseScrollCoordinator` and `ChapterScrollAnchors` preference key to bridge the SwiftUI layout timing gap. The feature is opt-in with `showsFullChapter: false` as the default, so all existing verse-range callers are unaffected.

- **`BibleTextBlock.firstVerse`** is derived from each block's attributed-string runs at init time and published upward via `ChapterScrollAnchors`/`ChapterScrollAnchorsKey`, giving the coordinator a stable integer ID for `ScrollViewProxy.scrollTo`.
- **`VerseScrollCoordinator`** arms on construction, waits for anchors or fires immediately if the chapter is already rendered, and has a 2-second fallback timeout to reveal content if the chapter never loads; previous review concerns about task retention and chapter-navigation blanking are addressed.
- **Tests** cover the view-model arming logic (verse 1, nil verse, wrong mode, verse-range mode) and the full anchor-resolution path including Psalm-119-style acrostic chapters.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the feature is fully opt-in behind a defaulted-false flag, all changed paths are well-tested, and the previously flagged task-retention and chapter-navigation issues were addressed in follow-up commits.

The coordinator, preference key, and view-model changes work together cleanly: weak-self captures prevent retention after dismissal, cancelPendingScroll unblocks content on chapter navigation, and the 2-second fallback ensures the opacity-zero state can never be permanent. Existing verse-range callers are untouched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift | New coordinator that manages verse-scroll lifecycle: arms pending state, waits for chapter anchors, defers scroll by one display frame via CADisplayLink, and cancels cleanly on chapter navigation. Weak-self capture and `cancelPendingScroll()` address the previously flagged issues. |
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Adds `showsFullChapter` parameter (defaults false, non-breaking), wires `VerseScrollCoordinator` as `@State`, applies `opacity(0)/overlay` while scroll is pending, and plumbs `onPreferenceChange`+`onChange(initial:)` handlers. Refactored `progressView` shared between loading and pending-scroll states. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Adds `showsFullChapter` (private(set)) and `scrollTargetReference` (private(set)), with `setScrollTarget()` gating on `showsFullChapter && verseStart > 1`. Previous review's setter-protection concern addressed. |
| Sources/YouVersionPlatformUI/Views/Rendering/ChapterScrollAnchors.swift | New preference key/value pair; `blockFirstVerse(forTargetVerse:)` uses `last(where:)` to correctly find the containing block for poetry/multi-verse paragraphs. `reduce` correctly lets child values (the rendered BibleTextView) win over default nil. |
| Sources/YouVersionPlatformUI/Views/Rendering/BibleTextBlock.swift | Adds `firstVerse: Int?` derived from attributed-string runs at init time; both public initializers updated. Header-only blocks yield nil, correctly excluding them from scroll anchoring. |
| Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift | Refactors alignment logic into `aligned(_:for:)` helper and applies `.id(firstVerse)` to blocks that carry a verse, enabling `ScrollViewProxy.scrollTo`. Table rows are unaffected. |
| Sources/YouVersionPlatformCore/Bible/BibleReference.swift | Adds `chapterReference` computed property (drops verse, keeps versionId/book/chapter); used by `ReaderContent` to pass a full-chapter reference to `BibleTextView` when `showsFullChapter` is true. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift | New test suite covering all arming conditions: nil verse, verse 1, restored reference, verse-range mode, full-chapter mode. Good coverage of the view-model contract. |
| Tests/YouVersionPlatformUITests/BibleVersionRenderingTests.swift | Adds four rendering tests for `firstVerse`: per-block verse extraction, nil for header-only blocks, multi-verse paragraphs, and the acrostic-chapter regression guard for Psalm-119-style layouts. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App
    participant BibleReaderView
    participant BibleReaderViewModel
    participant VerseScrollCoordinator
    participant BibleTextView
    participant ChapterScrollAnchorsKey

    App->>BibleReaderView: init(reference: JHN.3.16, showsFullChapter: true)
    BibleReaderView->>BibleReaderViewModel: init(reference:, showsFullChapter: true)
    BibleReaderViewModel->>BibleReaderViewModel: "setScrollTarget() -- scrollTargetReference = JHN.3.16"
    BibleReaderView->>VerseScrollCoordinator: "init(viewModel:) stored as @State"

    Note over BibleReaderView: View appears
    BibleReaderView->>VerseScrollCoordinator: onChange(scrollTargetReference, initial:true) -- handleScrollTarget
    VerseScrollCoordinator->>VerseScrollCoordinator: "isScrollPending = true, start 2s fallbackTask"

    BibleTextView->>BibleTextView: render blocks, compute firstVerse per block
    BibleTextView->>ChapterScrollAnchorsKey: publish ChapterScrollAnchors(chapter:3, blockFirstVerses:[1,...,16,...])

    ChapterScrollAnchorsKey->>BibleReaderView: onPreferenceChange -- handleAnchors
    BibleReaderView->>VerseScrollCoordinator: handleAnchors(anchors, proxy:)
    VerseScrollCoordinator->>VerseScrollCoordinator: "anchors.chapter(3) == target.chapter(3) -- match"
    VerseScrollCoordinator->>VerseScrollCoordinator: cancel fallbackTask, create scrollTask
    VerseScrollCoordinator->>VerseScrollCoordinator: await DisplayFrame().nextFrame()
    VerseScrollCoordinator->>BibleReaderView: proxy.scrollTo(16, anchor: .top)
    VerseScrollCoordinator->>BibleReaderViewModel: clearScrollTarget()
    VerseScrollCoordinator->>VerseScrollCoordinator: "isScrollPending = false -- content visible"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App
    participant BibleReaderView
    participant BibleReaderViewModel
    participant VerseScrollCoordinator
    participant BibleTextView
    participant ChapterScrollAnchorsKey

    App->>BibleReaderView: init(reference: JHN.3.16, showsFullChapter: true)
    BibleReaderView->>BibleReaderViewModel: init(reference:, showsFullChapter: true)
    BibleReaderViewModel->>BibleReaderViewModel: "setScrollTarget() -- scrollTargetReference = JHN.3.16"
    BibleReaderView->>VerseScrollCoordinator: "init(viewModel:) stored as @State"

    Note over BibleReaderView: View appears
    BibleReaderView->>VerseScrollCoordinator: onChange(scrollTargetReference, initial:true) -- handleScrollTarget
    VerseScrollCoordinator->>VerseScrollCoordinator: "isScrollPending = true, start 2s fallbackTask"

    BibleTextView->>BibleTextView: render blocks, compute firstVerse per block
    BibleTextView->>ChapterScrollAnchorsKey: publish ChapterScrollAnchors(chapter:3, blockFirstVerses:[1,...,16,...])

    ChapterScrollAnchorsKey->>BibleReaderView: onPreferenceChange -- handleAnchors
    BibleReaderView->>VerseScrollCoordinator: handleAnchors(anchors, proxy:)
    VerseScrollCoordinator->>VerseScrollCoordinator: "anchors.chapter(3) == target.chapter(3) -- match"
    VerseScrollCoordinator->>VerseScrollCoordinator: cancel fallbackTask, create scrollTask
    VerseScrollCoordinator->>VerseScrollCoordinator: await DisplayFrame().nextFrame()
    VerseScrollCoordinator->>BibleReaderView: proxy.scrollTo(16, anchor: .top)
    VerseScrollCoordinator->>BibleReaderViewModel: clearScrollTarget()
    VerseScrollCoordinator->>VerseScrollCoordinator: "isScrollPending = false -- content visible"
```

</a>

<sub>Reviews (6): Last reviewed commit: ["refactor(reader): apply PR review naming..."](https://github.com/youversion/platform-sdk-swift/commit/e3ade743f0c10a97c9996dafd3087394e99f0650) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41134694)</sub>

<!-- /greptile_comment -->