### PR TITLE
feat(reader): drive the reader to a passage via BibleReaderNavigation

### DIFF
--- a/Examples/SampleApp/NavigateView.swift
+++ b/Examples/SampleApp/NavigateView.swift
@@ -4,7 +4,7 @@ import YouVersionPlatform
 /// Demonstrates driving the Bible reader from another tab via
 /// ``BibleReaderNavigation``: each button requests a passage and switches to the
 /// Bible tab, where the shared reader moves to it in place.
-struct NavigationDemoView: View {
+struct NavigateView: View {
     let navigation: BibleReaderNavigation
     let onNavigate: () -> Void
 

--- a/Examples/SampleApp/NavigationDemoView.swift
+++ b/Examples/SampleApp/NavigationDemoView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import YouVersionPlatform
+
+/// Demonstrates driving the Bible reader from another tab via
+/// ``BibleReaderNavigation``: each button requests a passage and switches to the
+/// Bible tab, where the shared reader moves to it in place.
+struct NavigationDemoView: View {
+    let navigation: BibleReaderNavigation
+    let onNavigate: () -> Void
+
+    private let examples: [(title: String, reference: BibleReference, showsFullChapter: Bool)] = [
+        (
+            "John 3:16 — full chapter, scrolled to the verse",
+            BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16),
+            true
+        ),
+        (
+            "Psalm 119:105 — full chapter, scrolled to the verse",
+            BibleReference(versionId: 3034, bookUSFM: "PSA", chapter: 119, verse: 105),
+            true
+        ),
+        (
+            "Romans 8:28 — just the verse range",
+            BibleReference(versionId: 3034, bookUSFM: "ROM", chapter: 8, verse: 28),
+            false
+        ),
+        (
+            "Genesis 1 — whole chapter",
+            BibleReference(versionId: 3034, bookUSFM: "GEN", chapter: 1),
+            true
+        )
+    ]
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    ForEach(examples, id: \.title) { example in
+                        Button(example.title) {
+                            navigation.request(example.reference, showsFullChapter: example.showsFullChapter)
+                            onNavigate()
+                        }
+                    }
+                } footer: {
+                    Text("Tapping a passage drives the reader in the Bible tab — it isn't recreated.")
+                }
+            }
+            .navigationTitle("Navigate")
+        }
+    }
+}

--- a/Examples/SampleApp/SampleApp.swift
+++ b/Examples/SampleApp/SampleApp.swift
@@ -19,7 +19,7 @@ struct SampleApp: App {
     var body: some Scene {
         WindowGroup {
             TabView(selection: $selectedTab) {
-                BibleReaderView(readerNavigation: readerNavigation)
+                BibleReaderView.restoringLastPassage(readerNavigation: readerNavigation)
                 .tabItem {
                     Label("Bible", systemImage: "book.closed.fill")
                 }

--- a/Examples/SampleApp/SampleApp.swift
+++ b/Examples/SampleApp/SampleApp.swift
@@ -25,7 +25,7 @@ struct SampleApp: App {
                 }
                 .tag(0)
 
-                NavigationDemoView(navigation: readerNavigation, onNavigate: { selectedTab = 0 })
+                NavigateView(navigation: readerNavigation, onNavigate: { selectedTab = 0 })
                     .tabItem {
                         Label("Navigate", systemImage: "arrow.uturn.right")
                     }

--- a/Examples/SampleApp/SampleApp.swift
+++ b/Examples/SampleApp/SampleApp.swift
@@ -5,6 +5,7 @@ import YouVersionPlatform
 struct SampleApp: App {
 
     @State private var selectedTab = 0
+    @State private var readerNavigation = BibleReaderNavigation()
 
     init() {
         // Get your app key from https://platform.youversion.com/
@@ -18,29 +19,35 @@ struct SampleApp: App {
     var body: some Scene {
         WindowGroup {
             TabView(selection: $selectedTab) {
-                BibleReaderView()
+                BibleReaderView(readerNavigation: readerNavigation)
                 .tabItem {
                     Label("Bible", systemImage: "book.closed.fill")
                 }
                 .tag(0)
 
+                NavigationDemoView(navigation: readerNavigation, onNavigate: { selectedTab = 0 })
+                    .tabItem {
+                        Label("Navigate", systemImage: "arrow.uturn.right")
+                    }
+                    .tag(1)
+
                 VotdContainerView()
                     .tabItem {
                         Label("VOTD", systemImage: "sun.max.fill")
                     }
-                    .tag(1)
+                    .tag(2)
 
                 CardView()
                     .tabItem {
                         Label("Card", systemImage: "doc.plaintext")
                     }
-                    .tag(2)
+                    .tag(3)
 
                 ProfileView()
                     .tabItem {
                         Label("Profile", systemImage: "person.fill")
                     }
-                    .tag(3)
+                    .tag(4)
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -144,8 +144,10 @@ The SDK automatically fetches Scripture from YouVersion servers and maintains a 
 
 Displays a full Bible reading experience, very similar to the YouVersion Bible app, ready to be added as a tab in your app.
 
+To restore the passage the user was last viewing (or open to John 1 the first time):
+
 ```swift
-BibleReaderView()
+BibleReaderView.restoringLastPassage()
 ```
 
 To open to a specific passage:
@@ -182,7 +184,7 @@ var body: some View {
         .tabItem { Label("Home", systemImage: "house") }
         .tag(Tab.home)
 
-        BibleReaderView(readerNavigation: readerNavigation)
+        BibleReaderView.restoringLastPassage(readerNavigation: readerNavigation)
             .tabItem { Label("Bible", systemImage: "book.closed") }
             .tag(Tab.bible)
     }
@@ -192,7 +194,7 @@ var body: some View {
 To intercept verse taps instead of using the built-in sign-in flow:
 
 ```swift
-BibleReaderView(
+BibleReaderView.restoringLastPassage(
     onVerseTap: { reference in
         // Handle the tapped verse reference
     }

--- a/README.md
+++ b/README.md
@@ -165,6 +165,30 @@ BibleReaderView(
 )
 ```
 
+#### Navigating the reader from elsewhere in your app
+
+To move the reader to a new passage from another screen — for example, a "Read" button in a different tab — share a `BibleReaderNavigation` object and call `request(_:showsFullChapter:)`. This sets the passage the reader moves to; bringing the reader on screen (switching tabs, pushing it) is still up to your app. The reader moves in place; you don't recreate it.
+
+```swift
+@State private var readerNavigation = BibleReaderNavigation()
+@State private var selectedTab = Tab.home
+
+var body: some View {
+    TabView(selection: $selectedTab) {
+        HomeView(onReadTap: { reference in
+            readerNavigation.request(reference, showsFullChapter: true)
+            selectedTab = .bible            // bring the reader on screen
+        })
+        .tabItem { Label("Home", systemImage: "house") }
+        .tag(Tab.home)
+
+        BibleReaderView(navigation: readerNavigation)
+            .tabItem { Label("Bible", systemImage: "book.closed") }
+            .tag(Tab.bible)
+    }
+}
+```
+
 To intercept verse taps instead of using the built-in sign-in flow:
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ var body: some View {
         .tabItem { Label("Home", systemImage: "house") }
         .tag(Tab.home)
 
-        BibleReaderView(navigation: readerNavigation)
+        BibleReaderView(readerNavigation: readerNavigation)
             .tabItem { Label("Bible", systemImage: "book.closed") }
             .tag(Tab.bible)
     }

--- a/Sources/YouVersionPlatformReader/BibleReaderNavigation.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderNavigation.swift
@@ -24,7 +24,7 @@ public final class BibleReaderNavigation {
     }
 
     /// Called by the reader once it has begun acting on the request.
-    func consumePendingRequest() {
+    func clearPendingRequest() {
         pendingRequest = nil
     }
 }

--- a/Sources/YouVersionPlatformReader/BibleReaderNavigation.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderNavigation.swift
@@ -1,0 +1,30 @@
+import Observation
+import YouVersionPlatformCore
+
+@MainActor
+@Observable
+public final class BibleReaderNavigation {
+    /// A request for the reader: which reference to move to, and whether to
+    /// show its full chapter or only its verse range.
+    public struct Request: Equatable, Sendable {
+        public let reference: BibleReference
+        public let showsFullChapter: Bool
+    }
+
+    /// The request the reader should act on next.
+    public private(set) var pendingRequest: Request?
+
+    public init() {}
+
+    /// Requests that the connected reader move to `reference`. Safe to call from
+    /// any view that shares this object — the reader need not be on screen yet; it
+    /// picks up the pending reference when it appears.
+    public func request(_ reference: BibleReference, showsFullChapter: Bool = false) {
+        pendingRequest = Request(reference: reference, showsFullChapter: showsFullChapter)
+    }
+
+    /// Called by the reader once it has begun acting on the request.
+    func consumePendingRequest() {
+        pendingRequest = nil
+    }
+}

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -7,6 +7,7 @@ public struct BibleReaderView: View {
     @State private var viewModel: BibleReaderViewModel?
 
     private let initialReference: BibleReference?
+    private let readerNavigation: BibleReaderNavigation?
     private let showsFullChapter: Bool
     private let verseSelectionStyle: VerseSelectionStyle
     private let onVerseTap: ((BibleReference) -> Void)?
@@ -30,16 +31,21 @@ public struct BibleReaderView: View {
     ///     scrolls to `reference`'s verse. When `false` (the default), it shows only
     ///     `reference`'s verse range — use this for passages that are just a
     ///     few verses, such as a plan day.
+    ///   - readerNavigation: An optional ``BibleReaderNavigation`` used to move the reader
+    ///     to a new passage from elsewhere in the app (for example, a "Read" button in
+    ///     another tab).
     public init(reference: BibleReference? = nil,
                 verseSelectionStyle: VerseSelectionStyle = .solid,
                 onVerseTap: ((BibleReference) -> Void)? = nil,
-                showsFullChapter: Bool = false
+                showsFullChapter: Bool = false,
+                readerNavigation: BibleReaderNavigation? = nil
     ) {
         assert(
             onVerseTap != nil || YouVersionPlatformConfiguration.isSignInEnabled,
             "onVerseTap must be provided OR YouVersion sign-in must be enabled"
         )
         self.initialReference = reference
+        self.readerNavigation = readerNavigation
         self.showsFullChapter = showsFullChapter
         self.verseSelectionStyle = verseSelectionStyle
         self.onVerseTap = onVerseTap
@@ -66,7 +72,7 @@ public struct BibleReaderView: View {
     public var body: some View {
         Group {
             if let viewModel {
-                ReaderContent(viewModel: viewModel)
+                ReaderContent(viewModel: viewModel, readerNavigation: readerNavigation)
             } else {
                 Color.clear
             }
@@ -86,6 +92,7 @@ public struct BibleReaderView: View {
 
 private struct ReaderContent: View {
     @Bindable var viewModel: BibleReaderViewModel
+    let readerNavigation: BibleReaderNavigation?
 #if !os(tvOS)
     @State private var contextProvider = ContextProvider()
 #endif
@@ -100,8 +107,9 @@ private struct ReaderContent: View {
     @State private var detents: Set<PresentationDetent> = [.height(360), .height(480)]
     @State private var verseScrollCoordinator: VerseScrollCoordinator
 
-    init(viewModel: BibleReaderViewModel) {
+    init(viewModel: BibleReaderViewModel, readerNavigation: BibleReaderNavigation?) {
         self.viewModel = viewModel
+        self.readerNavigation = readerNavigation
         self._verseScrollCoordinator = State(initialValue: VerseScrollCoordinator(viewModel: viewModel))
     }
 
@@ -199,6 +207,12 @@ private struct ReaderContent: View {
         }
         .onChange(of: colorScheme, initial: true) { _, newValue in
             viewModel.colorScheme = newValue
+        }
+        .onChange(of: readerNavigation?.pendingRequest) { _, _ in
+            handleNavigationRequest()
+        }
+        .onAppear {
+            handleNavigationRequest()
         }
         .environment(viewModel)
         .environment(\.colorScheme, viewModel.colorTheme?.colorScheme ?? .dark)
@@ -389,6 +403,16 @@ private struct ReaderContent: View {
         }
     }
 #endif
+
+    private func handleNavigationRequest() {
+        guard let readerNavigation, let request = readerNavigation.pendingRequest else {
+            return
+        }
+        readerNavigation.consumePendingRequest()
+        Task {
+            await viewModel.goToReference(request.reference, showsFullChapter: request.showsFullChapter)
+        }
+    }
 
 }
 

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -364,24 +364,26 @@ private struct ReaderContent: View {
                 }
             }
             .coordinateSpace(.named("scrollView"))
-            .onChange(of: viewModel.scrollToTop) { _, shouldScroll in
-                if shouldScroll {
-                    scrollProxy.scrollTo("topOfContent", anchor: .top)
-                    viewModel.scrollToTop = false
-                    // Wait for scroll animation before clearing the flag.
-                    Task { @MainActor in
-                        // swiftlint:disable:next common_debug_statements
-                        try? await Task.sleep(for: .seconds(0.5))
-                        viewModel.isChangingChapter = false
-                    }
-                }
-            }
             .onPreferenceChange(ChapterScrollAnchorsKey.self) { anchors in
                 verseScrollCoordinator.handleAnchors(anchors, proxy: scrollProxy)
             }
-            .onChange(of: viewModel.scrollTargetReference, initial: true) { _, target in
-                if target != nil {
+            .onChange(of: viewModel.scrollAction, initial: true) { _, action in
+                switch action {
+                case .top:
+                    scrollProxy.scrollTo("topOfContent", anchor: .top)
+                    // Mark the scroll consumed so a later navigation can re-arm it, but keep
+                    // chrome suppressed until the scroll animation settles before finishing.
+                    viewModel.clearScrollAction()
+                    Task { @MainActor in
+                        // swiftlint:disable:next common_debug_statements
+                        try? await Task.sleep(for: .seconds(0.5))
+                        // Scroll already consumed above; only end the chapter change.
+                        viewModel.finishChapterChange(clearingScroll: false)
+                    }
+                case .toVerse:
                     verseScrollCoordinator.handleScrollTarget(proxy: scrollProxy)
+                case .none:
+                    break
                 }
             }
         }

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -12,11 +12,13 @@ public struct BibleReaderView: View {
     private let verseSelectionStyle: VerseSelectionStyle
     private let onVerseTap: ((BibleReference) -> Void)?
 
-    /// Creates a Bible reader view.
+    /// Creates a Bible reader view displaying `reference`.
+    ///
+    /// To restore the passage the user was last viewing instead, use
+    /// ``restoringLastPassage(verseSelectionStyle:onVerseTap:readerNavigation:)``.
     ///
     /// - Parameters:
-    ///   - reference: The Bible reference to display initially. When `nil`, the reader
-    ///     restores the last-viewed reference or defaults to John 1.
+    ///   - reference: The Bible reference to display initially.
     ///   - verseSelectionStyle: Controls the visual style of the underline drawn
     ///     beneath selected verses. Defaults to ``VerseSelectionStyle/solid``.
     ///   - onVerseTap: An optional closure called when the user taps a verse.
@@ -34,17 +36,58 @@ public struct BibleReaderView: View {
     ///   - readerNavigation: An optional ``BibleReaderNavigation`` used to move the reader
     ///     to a new passage from elsewhere in the app (for example, a "Read" button in
     ///     another tab).
-    public init(reference: BibleReference? = nil,
+    public init(reference: BibleReference,
                 verseSelectionStyle: VerseSelectionStyle = .solid,
                 onVerseTap: ((BibleReference) -> Void)? = nil,
                 showsFullChapter: Bool = false,
                 readerNavigation: BibleReaderNavigation? = nil
     ) {
+        self.init(
+            initialReference: reference,
+            verseSelectionStyle: verseSelectionStyle,
+            onVerseTap: onVerseTap,
+            showsFullChapter: showsFullChapter,
+            readerNavigation: readerNavigation
+        )
+    }
+
+    /// Creates a Bible reader view that restores the passage the user was last
+    /// viewing — the reference and its display mode — or shows John 1 when
+    /// nothing has been saved yet.
+    ///
+    /// - Parameters:
+    ///   - verseSelectionStyle: Controls the visual style of the underline drawn
+    ///     beneath selected verses. Defaults to ``VerseSelectionStyle/solid``.
+    ///   - onVerseTap: An optional closure called when the user taps a verse.
+    ///     See ``init(reference:verseSelectionStyle:onVerseTap:showsFullChapter:readerNavigation:)``.
+    ///   - readerNavigation: An optional ``BibleReaderNavigation`` used to move the reader
+    ///     to a new passage from elsewhere in the app (for example, a "Read" button in
+    ///     another tab).
+    public static func restoringLastPassage(
+        verseSelectionStyle: VerseSelectionStyle = .solid,
+        onVerseTap: ((BibleReference) -> Void)? = nil,
+        readerNavigation: BibleReaderNavigation? = nil
+    ) -> BibleReaderView {
+        BibleReaderView(
+            initialReference: nil,
+            verseSelectionStyle: verseSelectionStyle,
+            onVerseTap: onVerseTap,
+            showsFullChapter: false,
+            readerNavigation: readerNavigation
+        )
+    }
+
+    private init(initialReference: BibleReference?,
+                 verseSelectionStyle: VerseSelectionStyle,
+                 onVerseTap: ((BibleReference) -> Void)?,
+                 showsFullChapter: Bool,
+                 readerNavigation: BibleReaderNavigation?
+    ) {
         assert(
             onVerseTap != nil || YouVersionPlatformConfiguration.isSignInEnabled,
             "onVerseTap must be provided OR YouVersion sign-in must be enabled"
         )
-        self.initialReference = reference
+        self.initialReference = initialReference
         self.readerNavigation = readerNavigation
         self.showsFullChapter = showsFullChapter
         self.verseSelectionStyle = verseSelectionStyle
@@ -66,7 +109,13 @@ public struct BibleReaderView: View {
                 onVerseTap: ((BibleReference) -> Void)? = nil
     ) {
         YouVersionPlatformConfiguration.configureSignIn(appName: appName, signInPromptMessage: signInMessage)
-        self.init(reference: reference, verseSelectionStyle: verseSelectionStyle, onVerseTap: onVerseTap)
+        self.init(
+            initialReference: reference,
+            verseSelectionStyle: verseSelectionStyle,
+            onVerseTap: onVerseTap,
+            showsFullChapter: false,
+            readerNavigation: nil
+        )
     }
 
     public var body: some View {
@@ -79,12 +128,19 @@ public struct BibleReaderView: View {
         }
         .task {
             if viewModel == nil {
-                viewModel = BibleReaderViewModel(
-                    reference: initialReference,
-                    showsFullChapter: showsFullChapter,
-                    verseSelectionStyle: verseSelectionStyle,
-                    onVerseTap: onVerseTap
-                )
+                viewModel = if let initialReference {
+                    BibleReaderViewModel(
+                        reference: initialReference,
+                        showsFullChapter: showsFullChapter,
+                        verseSelectionStyle: verseSelectionStyle,
+                        onVerseTap: onVerseTap
+                    )
+                } else {
+                    BibleReaderViewModel(
+                        verseSelectionStyle: verseSelectionStyle,
+                        onVerseTap: onVerseTap
+                    )
+                }
             }
         }
     }

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -380,7 +380,7 @@ private struct ReaderContent: View {
                         // Scroll already consumed above; only end the chapter change.
                         viewModel.finishChapterChange(clearingScroll: false)
                     }
-                case .toVerse:
+                case .reference:
                     verseScrollCoordinator.handleScrollTarget(proxy: scrollProxy)
                 case .none:
                     break

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -209,10 +209,14 @@ private struct ReaderContent: View {
             viewModel.colorScheme = newValue
         }
         .onChange(of: readerNavigation?.pendingRequest) { _, _ in
-            handleNavigationRequest()
+            if let readerNavigation {
+                viewModel.handleNavigationRequest(from: readerNavigation)
+            }
         }
         .onAppear {
-            handleNavigationRequest()
+            if let readerNavigation {
+                viewModel.handleNavigationRequest(from: readerNavigation)
+            }
         }
         .environment(viewModel)
         .environment(\.colorScheme, viewModel.colorTheme?.colorScheme ?? .dark)
@@ -405,16 +409,6 @@ private struct ReaderContent: View {
         }
     }
 #endif
-
-    private func handleNavigationRequest() {
-        guard let readerNavigation, let request = readerNavigation.pendingRequest else {
-            return
-        }
-        readerNavigation.consumePendingRequest()
-        Task {
-            await viewModel.goToReference(request.reference, showsFullChapter: request.showsFullChapter)
-        }
-    }
 
 }
 

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -77,6 +77,40 @@ public struct BibleReaderView: View {
         )
     }
 
+    /// Creates a Bible reader view.
+    ///
+    /// - Parameters:
+    ///   - reference: The Bible reference to display initially. When `nil`, the reader
+    ///     restores the last-viewed reference or defaults to John 1.
+    ///   - verseSelectionStyle: Controls the visual style of the underline drawn
+    ///     beneath selected verses. Defaults to ``VerseSelectionStyle/solid``.
+    ///   - onVerseTap: An optional closure called when the user taps a verse.
+    ///     When provided, the closure receives the tapped ``BibleReference`` and
+    ///     the reader takes no further action — the host app is responsible for
+    ///     handling the interaction. When `nil` (the default), tapping a verse
+    ///     triggers the built-in sign-in prompt for unauthenticated users (unless
+    ///     sign-in is disabled via ``YouVersionPlatformConfiguration/isSignInEnabled``)
+    ///     or opens the verse actions drawer for authenticated users. Footnote taps
+    ///     are always handled by the reader regardless of this closure.
+    ///   - showsFullChapter: When `true`, the reader shows the full chapter and
+    ///     scrolls to `reference`'s verse. When `false` (the default), it shows only
+    ///     `reference`'s verse range — use this for passages that are just a
+    ///     few verses, such as a plan day.
+    @available(*, deprecated, message: "Pass a non-optional reference, or use BibleReaderView.restoringLastPassage() to restore the last-viewed passage.")
+    public init(reference: BibleReference? = nil,
+                verseSelectionStyle: VerseSelectionStyle = .solid,
+                onVerseTap: ((BibleReference) -> Void)? = nil,
+                showsFullChapter: Bool = false
+    ) {
+        self.init(
+            initialReference: reference,
+            verseSelectionStyle: verseSelectionStyle,
+            onVerseTap: onVerseTap,
+            showsFullChapter: showsFullChapter,
+            readerNavigation: nil
+        )
+    }
+
     private init(initialReference: BibleReference?,
                  verseSelectionStyle: VerseSelectionStyle,
                  onVerseTap: ((BibleReference) -> Void)?,

--- a/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
+++ b/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
@@ -49,8 +49,7 @@ final class VerseScrollCoordinator {
             guard let self, !Task.isCancelled else {
                 return
             }
-            viewModel.clearScrollTarget()
-            isScrollPending = false
+            clearScrollState()
         }
 
         if isTargetChapterRendered {
@@ -63,7 +62,8 @@ final class VerseScrollCoordinator {
         anchors = newAnchors
         if isScrollPending, let newAnchors,
            newAnchors.chapter != viewModel.scrollTargetReference?.chapter {
-            cancelPendingScroll()
+            scrollTask?.cancel()
+            clearScrollState()
             return
         }
         scrollToTargetBlock(proxy: proxy)
@@ -86,16 +86,14 @@ final class VerseScrollCoordinator {
                 return
             }
             proxy.scrollTo(blockID, anchor: .top)
-            self?.viewModel.clearScrollTarget()
-            self?.isScrollPending = false
+            self?.clearScrollState()
         }
     }
 
-    /// Abandons the pending scroll and reveals the content, cancelling the fallback timeout.
-    private func cancelPendingScroll() {
+    private func clearScrollState() {
         fallbackTask?.cancel()
-        scrollTask?.cancel()
         viewModel.clearScrollTarget()
+        viewModel.isChangingChapter = false
         isScrollPending = false
     }
 }

--- a/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
+++ b/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
@@ -92,8 +92,7 @@ final class VerseScrollCoordinator {
 
     private func clearScrollState() {
         fallbackTask?.cancel()
-        viewModel.clearScrollTarget()
-        viewModel.isChangingChapter = false
+        viewModel.finishChapterChange()
         isScrollPending = false
     }
 }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -30,7 +30,7 @@ extension BibleReaderViewModel {
         // back to minY = 0, since onGeometryChange won't fire again.
         lastScrollOffset = 0
         showChrome = true
-        scrollToTop = true
+        scrollAction = .top
     }
 
     func goToNextChapter() {
@@ -62,13 +62,13 @@ extension BibleReaderViewModel {
         // back to minY = 0, since onGeometryChange won't fire again.
         lastScrollOffset = 0
         showChrome = true
-        scrollToTop = true
+        scrollAction = .top
     }
 
     func goToReference(_ reference: BibleReference, showsFullChapter: Bool) async {
         await onHeaderSelectionChange(reference, showIntro: false)
         guard reference == self.reference else {
-            isChangingChapter = false
+            finishChapterChange()
             return
         }
         self.showsFullChapter = showsFullChapter
@@ -251,7 +251,7 @@ extension BibleReaderViewModel {
             // back to minY = 0, since onGeometryChange won't fire again.
             lastScrollOffset = 0
             showChrome = true
-            scrollToTop = true
+            scrollAction = .top
         } catch {
             YouVersionPlatformLogger.error("Error loading version/chapter: \(error)", category: "Reader")
         }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -65,6 +65,12 @@ extension BibleReaderViewModel {
         scrollToTop = true
     }
 
+    func goToReference(_ reference: BibleReference, showsFullChapter: Bool) async {
+        self.showsFullChapter = showsFullChapter
+        await onHeaderSelectionChange(reference, showIntro: false)
+        setScrollTarget()
+    }
+
     func removeVerseSelection() {
         selectedVerses.removeAll()
         withAnimation(verseActionsDrawerAnimation) {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -66,8 +66,12 @@ extension BibleReaderViewModel {
     }
 
     func goToReference(_ reference: BibleReference, showsFullChapter: Bool) async {
-        self.showsFullChapter = showsFullChapter
         await onHeaderSelectionChange(reference, showIntro: false)
+        guard reference == self.reference else {
+            isChangingChapter = false
+            return
+        }
+        self.showsFullChapter = showsFullChapter
         setScrollTarget()
     }
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -24,13 +24,7 @@ extension BibleReaderViewModel {
             }
         }
 
-        // Reset scroll tracking and restore chrome so the new chapter lands
-        // in the same initial state as a fresh open. Without this, chrome
-        // stays hidden after a navigation tap that scrolls cached content
-        // back to minY = 0, since onGeometryChange won't fire again.
-        lastScrollOffset = 0
-        showChrome = true
-        scrollAction = .top
+        resetScrollStateForNewChapter()
     }
 
     func goToNextChapter() {
@@ -56,23 +50,29 @@ extension BibleReaderViewModel {
             }
         }
 
-        // Reset scroll tracking and restore chrome so the new chapter lands
-        // in the same initial state as a fresh open. Without this, chrome
-        // stays hidden after a navigation tap that scrolls cached content
-        // back to minY = 0, since onGeometryChange won't fire again.
-        lastScrollOffset = 0
-        showChrome = true
-        scrollAction = .top
+        resetScrollStateForNewChapter()
     }
 
-    func goToReference(_ reference: BibleReference, showsFullChapter: Bool) async {
-        await onHeaderSelectionChange(reference, showIntro: false)
-        guard reference == self.reference else {
-            finishChapterChange()
+    /// Acts on any pending request from `readerNavigation`, moving the reader to the
+    /// requested passage.
+    func handleNavigationRequest(from readerNavigation: BibleReaderNavigation) {
+        guard let request = readerNavigation.pendingRequest else {
             return
         }
-        self.showsFullChapter = showsFullChapter
-        setScrollTarget()
+        readerNavigation.clearPendingRequest()
+        Task {
+            await goToReference(request.reference, showsFullChapter: request.showsFullChapter)
+        }
+    }
+
+    func goToReference(_ reference: BibleReference, showsFullChapter: Bool = false) async {
+        await onHeaderSelectionChange(reference, showIntro: false)
+        if reference == self.reference {
+            self.showsFullChapter = showsFullChapter
+            setScrollTarget()
+        } else {
+            finishChapterChange()
+        }
     }
 
     func removeVerseSelection() {
@@ -244,14 +244,7 @@ extension BibleReaderViewModel {
             }
             self.reference = reference
             self.showBookIntro = showIntro
-
-            // Reset scroll tracking and restore chrome so the new chapter lands
-            // in the same initial state as a fresh open. Without this, chrome
-            // stays hidden after a navigation tap that scrolls cached content
-            // back to minY = 0, since onGeometryChange won't fire again.
-            lastScrollOffset = 0
-            showChrome = true
-            scrollAction = .top
+            resetScrollStateForNewChapter()
         } catch {
             YouVersionPlatformLogger.error("Error loading version/chapter: \(error)", category: "Reader")
         }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -115,8 +115,9 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         authentication.isSignedIn
     }
 
-    init(
-        reference: BibleReference? = nil,
+    /// Creates a view model displaying `reference`.
+    convenience init(
+        reference: BibleReference,
         showsFullChapter: Bool = false,
         highlightsViewModel: BibleHighlightsViewModel? = nil,
         verseSelectionStyle: VerseSelectionStyle = .solid,
@@ -124,9 +125,51 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         onVerseTap: ((BibleReference) -> Void)? = nil,
         authentication: BibleReaderAuthentication? = nil
     ) {
+        self.init(
+            initialReference: reference,
+            showsFullChapter: showsFullChapter,
+            highlightsViewModel: highlightsViewModel,
+            verseSelectionStyle: verseSelectionStyle,
+            versionsViewModel: versionsViewModel,
+            onVerseTap: onVerseTap,
+            authentication: authentication
+        )
+    }
+
+    /// Creates a view model that restores the last-viewed passage — the reference,
+    /// intro visibility, and full-chapter display mode — or falls back to John 1
+    /// when nothing has been saved. No verse scroll is armed on restore, so a user
+    /// who had scrolled within the chapter isn't pulled back to the saved verse.
+    convenience init(
+        highlightsViewModel: BibleHighlightsViewModel? = nil,
+        verseSelectionStyle: VerseSelectionStyle = .solid,
+        versionsViewModel: BibleVersionsViewModel? = nil,
+        onVerseTap: ((BibleReference) -> Void)? = nil,
+        authentication: BibleReaderAuthentication? = nil
+    ) {
+        self.init(
+            initialReference: nil,
+            showsFullChapter: false,
+            highlightsViewModel: highlightsViewModel,
+            verseSelectionStyle: verseSelectionStyle,
+            versionsViewModel: versionsViewModel,
+            onVerseTap: onVerseTap,
+            authentication: authentication
+        )
+    }
+
+    private init(
+        initialReference: BibleReference?,
+        showsFullChapter: Bool,
+        highlightsViewModel: BibleHighlightsViewModel?,
+        verseSelectionStyle: VerseSelectionStyle,
+        versionsViewModel: BibleVersionsViewModel?,
+        onVerseTap: ((BibleReference) -> Void)?,
+        authentication: BibleReaderAuthentication?
+    ) {
         let authentication = authentication ?? .default
-        if let reference {
-            self.reference = reference
+        if let initialReference {
+            self.reference = initialReference
             self.showBookIntro = false
             self.showsFullChapter = showsFullChapter
         } else {
@@ -136,8 +179,8 @@ final class BibleReaderViewModel: ReaderThemeProviding {
                 self.showBookIntro = UserDefaults.standard.bool(forKey: userDefaultsKeyForBibleDisplayIntro)
                 self.showsFullChapter = UserDefaults.standard.bool(forKey: userDefaultsKeyForShowsFullChapter)
             } else {
-                // no specified or saved version, so, pick a downloaded one, else a safe default.
-                let versionId = reference?.versionId ?? BibleVersionRepository.shared.downloadedVersionIds.first ?? 3034
+                // no saved reference, so, pick a downloaded version, else a safe default.
+                let versionId = BibleVersionRepository.shared.downloadedVersionIds.first ?? 3034
                 self.reference = BibleReference(versionId: versionId, bookUSFM: "JHN", chapter: 1)
                 self.showBookIntro = false
                 self.showsFullChapter = showsFullChapter
@@ -167,7 +210,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
 
         observeCurrentVersion()
 
-        if reference != nil {
+        if initialReference != nil {
             setScrollTarget()
         }
     }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -8,17 +8,11 @@ import YouVersionPlatformCore
 import YouVersionPlatformUI
 
 /// The single scroll intent a navigation produces. The reader observes this and
-/// performs exactly one of: nothing, scroll to the top, or scroll to a verse.
-///
-/// Modeling the two outcomes as one value (rather than a `scrollToTop` flag plus a
-/// `scrollTargetReference`) means a navigation can't arm both or neither, and there's
-/// no window where a `scrollToTop = true` write is immediately overwritten by a
-/// verse-scroll arm in the same run-loop tick — which SwiftUI would coalesce, dropping
-/// the intermediate value and the reset that depends on observing it.
+/// performs exactly one of: nothing, scroll to the top, or scroll to a reference.
 enum ScrollAction: Equatable {
     case none
     case top
-    case toVerse(BibleReference)
+    case reference(BibleReference)
 }
 
 @MainActor
@@ -59,9 +53,9 @@ final class BibleReaderViewModel: ReaderThemeProviding {
             UserDefaults.standard.set(showsFullChapter, forKey: userDefaultsKeyForShowsFullChapter)
         }
     }
-    /// The verse the reader should scroll to, if the current ``scrollAction`` is a verse scroll.
+    /// The reference the reader should scroll to, if the current ``scrollAction`` is a verse scroll.
     var scrollTargetReference: BibleReference? {
-        if case .toVerse(let reference) = scrollAction {
+        if case .reference(let reference) = scrollAction {
             reference
         } else {
             nil
@@ -244,7 +238,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         guard showsFullChapter, let verseStart = reference.verseStart, verseStart > 1 else {
             return
         }
-        scrollAction = .toVerse(reference)
+        scrollAction = .reference(reference)
     }
 
     /// Marks the current ``scrollAction`` as consumed once the reader has begun acting on it,

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -7,6 +7,20 @@ import SwiftUI
 import YouVersionPlatformCore
 import YouVersionPlatformUI
 
+/// The single scroll intent a navigation produces. The reader observes this and
+/// performs exactly one of: nothing, scroll to the top, or scroll to a verse.
+///
+/// Modeling the two outcomes as one value (rather than a `scrollToTop` flag plus a
+/// `scrollTargetReference`) means a navigation can't arm both or neither, and there's
+/// no window where a `scrollToTop = true` write is immediately overwritten by a
+/// verse-scroll arm in the same run-loop tick — which SwiftUI would coalesce, dropping
+/// the intermediate value and the reset that depends on observing it.
+enum ScrollAction: Equatable {
+    case none
+    case top
+    case toVerse(BibleReference)
+}
+
 @MainActor
 @Observable
 final class BibleReaderViewModel: ReaderThemeProviding {
@@ -38,14 +52,21 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     // MARK: - UI state of the Reader itself
     var showChrome = true
     var lastScrollOffset: CGFloat = 0
-    var scrollToTop = false
     var isChangingChapter = false
+    var scrollAction: ScrollAction = .none
     var showsFullChapter: Bool {
         didSet {
             UserDefaults.standard.set(showsFullChapter, forKey: userDefaultsKeyForShowsFullChapter)
         }
     }
-    private(set) var scrollTargetReference: BibleReference?
+    /// The verse the reader should scroll to, if the current ``scrollAction`` is a verse scroll.
+    var scrollTargetReference: BibleReference? {
+        if case .toVerse(let reference) = scrollAction {
+            reference
+        } else {
+            nil
+        }
+    }
     var showingSignInSheet = false
     var showingFontSettings = false
     var showingFontList = false // swiftlint:disable:this collection_suffix_property
@@ -223,13 +244,26 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         guard showsFullChapter, let verseStart = reference.verseStart, verseStart > 1 else {
             return
         }
-        scrollTargetReference = reference
-        scrollToTop = false
+        scrollAction = .toVerse(reference)
     }
 
-    /// Clears the scroll target once the reader has brought it into view.
-    func clearScrollTarget() {
-        scrollTargetReference = nil
+    /// Marks the current ``scrollAction`` as consumed once the reader has begun acting on it,
+    /// without ending the chapter change (chrome stays suppressed until the scroll settles).
+    func clearScrollAction() {
+        scrollAction = .none
+    }
+
+    /// Ends an in-flight chapter change by re-enabling scroll-driven chrome, and — unless the
+    /// scroll was already consumed via ``clearScrollAction()`` — clearing any armed scroll. This
+    /// is the single place a navigation returns the reader to its resting state.
+    ///
+    /// Pass `clearingScroll: false` from a delayed settle where the scroll has already been
+    /// consumed, so a navigation that re-armed a scroll during the delay isn't clobbered.
+    func finishChapterChange(clearingScroll: Bool = true) {
+        if clearingScroll {
+            scrollAction = .none
+        }
+        isChangingChapter = false
     }
 
     func loadUserSettingsFromStorage() {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -247,12 +247,15 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         scrollAction = .none
     }
 
-    /// Ends an in-flight chapter change by re-enabling scroll-driven chrome, and — unless the
-    /// scroll was already consumed via ``clearScrollAction()`` — clearing any armed scroll. This
-    /// is the single place a navigation returns the reader to its resting state.
-    ///
-    /// Pass `clearingScroll: false` from a delayed settle where the scroll has already been
-    /// consumed, so a navigation that re-armed a scroll during the delay isn't clobbered.
+    /// Puts the reader into the same state a freshly opened chapter would be in.
+    func resetScrollStateForNewChapter() {
+        lastScrollOffset = 0
+        showChrome = true
+        scrollAction = .top
+    }
+
+    /// Ends an in-flight chapter change by optionally clearing any armed scroll
+    /// and resetting the isChangingChapter flag.
     func finishChapterChange(clearingScroll: Bool = true) {
         if clearingScroll {
             scrollAction = .none

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -14,6 +14,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
 
     private let userDefaultsKeyForBibleReference = "bible-reader-view--reference"
     private let userDefaultsKeyForBibleDisplayIntro = "bible-reader-view--displayintro"
+    private let userDefaultsKeyForShowsFullChapter = "bible-reader-view--showsfullchapter"
     private let userDefaultsKeyForReaderSettings = "bible-reader-view--readersettings"
     var reference: BibleReference {
         didSet {
@@ -39,7 +40,11 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     var lastScrollOffset: CGFloat = 0
     var scrollToTop = false
     var isChangingChapter = false
-    var showsFullChapter: Bool
+    var showsFullChapter: Bool {
+        didSet {
+            UserDefaults.standard.set(showsFullChapter, forKey: userDefaultsKeyForShowsFullChapter)
+        }
+    }
     private(set) var scrollTargetReference: BibleReference?
     var showingSignInSheet = false
     var showingFontSettings = false
@@ -108,20 +113,21 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         if let reference {
             self.reference = reference
             self.showBookIntro = false
+            self.showsFullChapter = showsFullChapter
         } else {
             if let data = UserDefaults.standard.data(forKey: userDefaultsKeyForBibleReference),
                let savedValue = try? JSONDecoder().decode(BibleReference.self, from: data) {
                 self.reference = savedValue
                 self.showBookIntro = UserDefaults.standard.bool(forKey: userDefaultsKeyForBibleDisplayIntro)
+                self.showsFullChapter = UserDefaults.standard.bool(forKey: userDefaultsKeyForShowsFullChapter)
             } else {
                 // no specified or saved version, so, pick a downloaded one, else a safe default.
                 let versionId = reference?.versionId ?? BibleVersionRepository.shared.downloadedVersionIds.first ?? 3034
                 self.reference = BibleReference(versionId: versionId, bookUSFM: "JHN", chapter: 1)
                 self.showBookIntro = false
+                self.showsFullChapter = showsFullChapter
             }
         }
-
-        self.showsFullChapter = showsFullChapter
         self.onVerseTap = onVerseTap
         self.verseSelectionStyle = verseSelectionStyle
         self.authentication = authentication

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -39,7 +39,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     var lastScrollOffset: CGFloat = 0
     var scrollToTop = false
     var isChangingChapter = false
-    private(set) var showsFullChapter: Bool
+    var showsFullChapter: Bool
     private(set) var scrollTargetReference: BibleReference?
     var showingSignInSheet = false
     var showingFontSettings = false
@@ -213,7 +213,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
 
     /// Sets the current ``reference``'s verse as the target the reader should scroll to
     /// once its chapter lays out.
-    private func setScrollTarget() {
+    func setScrollTarget() {
         guard showsFullChapter, let verseStart = reference.verseStart, verseStart > 1 else {
             return
         }

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
@@ -209,7 +209,6 @@ let previousChapterCases: [PreviousChapterCase] = [
         // currentVersion is nil by default — the "no loaded version" state.
         vm.isChangingChapter = false
         vm.lastScrollOffset = 123
-        vm.scrollToTop = false
         vm.selectedVerses = [selectedReference]
         vm.showingVerseActionsDrawer = true
 
@@ -219,7 +218,7 @@ let previousChapterCases: [PreviousChapterCase] = [
         #expect(vm.showBookIntro == showIntro)
         #expect(vm.isChangingChapter == false)
         #expect(vm.lastScrollOffset == 123)
-        #expect(vm.scrollToTop == false)
+        #expect(vm.scrollAction == .none)
         #expect(vm.selectedVerses == [selectedReference])
         #expect(vm.showingVerseActionsDrawer == true)
     }
@@ -234,7 +233,6 @@ let previousChapterCases: [PreviousChapterCase] = [
         // currentVersion is nil by default — the "no loaded version" state.
         vm.isChangingChapter = false
         vm.lastScrollOffset = 123
-        vm.scrollToTop = false
         vm.selectedVerses = [selectedReference]
         vm.showingVerseActionsDrawer = true
 
@@ -244,7 +242,7 @@ let previousChapterCases: [PreviousChapterCase] = [
         #expect(vm.showBookIntro == showIntro)
         #expect(vm.isChangingChapter == false)
         #expect(vm.lastScrollOffset == 123)
-        #expect(vm.scrollToTop == false)
+        #expect(vm.scrollAction == .none)
         #expect(vm.selectedVerses == [selectedReference])
         #expect(vm.showingVerseActionsDrawer == true)
     }
@@ -468,7 +466,7 @@ let previousChapterCases: [PreviousChapterCase] = [
     private func assertNavigationSideEffects(on vm: BibleReaderViewModel) {
         #expect(vm.isChangingChapter == true)
         #expect(vm.lastScrollOffset == 0)
-        #expect(vm.scrollToTop == true)
+        #expect(vm.scrollAction == .top)
         #expect(vm.selectedVerses.isEmpty)
         #expect(vm.showingVerseActionsDrawer == false)
     }
@@ -491,7 +489,6 @@ let previousChapterCases: [PreviousChapterCase] = [
         vm.showBookIntro = showBookIntro
         vm.isChangingChapter = false
         vm.lastScrollOffset = 321
-        vm.scrollToTop = false
         vm.selectedVerses = [selectedReference]
         vm.showingVerseActionsDrawer = true
         return vm

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelNavigationStateTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelNavigationStateTests.swift
@@ -28,7 +28,7 @@ import Testing
         #expect(viewModel.showingVerseActionsDrawer == false)
         #expect(viewModel.showChrome)
         #expect(viewModel.lastScrollOffset == 0)
-        #expect(viewModel.scrollToTop)
+        #expect(viewModel.scrollAction == .top)
         #expect(await repository.requestedIds() == [111])
     }
 

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelPersistenceTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelPersistenceTests.swift
@@ -37,6 +37,44 @@ import Testing
     }
 
     @Test
+    func initWithoutExplicitReferenceRestoresSavedShowsFullChapter() {
+        Support.clearReaderDefaults()
+        let savedReference = BibleReference(versionId: 111, bookUSFM: "JHN", chapter: 3, verse: 16)
+        UserDefaults.standard.set(try? JSONEncoder().encode(savedReference), forKey: Support.referenceKey)
+        UserDefaults.standard.set(true, forKey: Support.showsFullChapterKey)
+
+        let viewModel = Support.makeViewModel(reference: nil)
+
+        #expect(viewModel.reference == savedReference)
+        #expect(viewModel.showsFullChapter)
+    }
+
+    @Test
+    func initWithExplicitReferenceIgnoresSavedShowsFullChapter() {
+        Support.clearReaderDefaults()
+        UserDefaults.standard.set(true, forKey: Support.showsFullChapterKey)
+
+        let viewModel = Support.makeViewModel(
+            reference: BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1),
+            showsFullChapter: false
+        )
+
+        #expect(viewModel.showsFullChapter == false)
+    }
+
+    @Test
+    func showsFullChapterPersistsWhenChanged() {
+        Support.clearReaderDefaults()
+        let viewModel = Support.makeViewModel(
+            reference: BibleReference(versionId: Support.versionId, bookUSFM: "GEN", chapter: 1)
+        )
+
+        viewModel.showsFullChapter = true
+
+        #expect(UserDefaults.standard.bool(forKey: Support.showsFullChapterKey))
+    }
+
+    @Test
     func initWithoutSavedReferenceUsesDefaultJohnOneReference() {
         Support.clearReaderDefaults()
 

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
@@ -112,14 +112,23 @@ enum BibleReaderViewModelTestSupport {
             signOut: signOut,
             hasPermission: hasPermission
         )
-        return BibleReaderViewModel(
-            reference: reference,
-            showsFullChapter: showsFullChapter,
-            highlightsViewModel: highlightsViewModel,
-            versionsViewModel: versionsViewModel,
-            onVerseTap: onVerseTap,
-            authentication: authentication
-        )
+        return if let reference {
+            BibleReaderViewModel(
+                reference: reference,
+                showsFullChapter: showsFullChapter,
+                highlightsViewModel: highlightsViewModel,
+                versionsViewModel: versionsViewModel,
+                onVerseTap: onVerseTap,
+                authentication: authentication
+            )
+        } else {
+            BibleReaderViewModel(
+                highlightsViewModel: highlightsViewModel,
+                versionsViewModel: versionsViewModel,
+                onVerseTap: onVerseTap,
+                authentication: authentication
+            )
+        }
     }
 
     static func makeBibleVersion(id: Int) -> BibleVersion {

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
@@ -79,6 +79,7 @@ enum BibleReaderViewModelTestSupport {
     static let versionId = 3034
     static let referenceKey = "bible-reader-view--reference"
     static let displayIntroKey = "bible-reader-view--displayintro"
+    static let showsFullChapterKey = "bible-reader-view--showsfullchapter"
     static let readerSettingsKey = "bible-reader-view--readersettings"
 
     @MainActor
@@ -155,6 +156,7 @@ enum BibleReaderViewModelTestSupport {
     static func clearReaderDefaults() {
         UserDefaults.standard.removeObject(forKey: referenceKey)
         UserDefaults.standard.removeObject(forKey: displayIntroKey)
+        UserDefaults.standard.removeObject(forKey: showsFullChapterKey)
         UserDefaults.standard.removeObject(forKey: readerSettingsKey)
     }
 

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
@@ -143,11 +143,11 @@ import Testing
     }
 
     @Test
-    func consumeClearsPendingRequest() {
+    func clearsPendingRequest() {
         let navigation = BibleReaderNavigation()
         navigation.request(BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16))
 
-        navigation.consumePendingRequest()
+        navigation.clearPendingRequest()
 
         #expect(navigation.pendingRequest == nil)
     }

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
@@ -89,6 +89,23 @@ import Testing
     }
 
     @Test
+    func goToReferenceArmsNoScrollWhenVersionLoadFails() async {
+        let repository = MockBibleVersionRepository()
+        let viewModel = Support.makeViewModel(versionRepository: repository)
+        viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
+        await repository.setThrownError(TestError())
+
+        // A different version forces the cross-version load path, which throws.
+        let target = BibleReference(versionId: Support.versionId + 1, bookUSFM: "JHN", chapter: 3, verse: 16)
+        await viewModel.goToReference(target, showsFullChapter: true)
+
+        #expect(viewModel.reference.chapter != 3)
+        #expect(viewModel.scrollTargetReference == nil)
+        #expect(viewModel.showsFullChapter == false)
+        #expect(viewModel.isChangingChapter == false)
+    }
+
+    @Test
     func goToChapterReferenceArmsNoScroll() async {
         let viewModel = Support.makeViewModel()
         viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
@@ -73,6 +73,7 @@ import Testing
         #expect(viewModel.reference.bookUSFM == "JHN")
         #expect(viewModel.reference.chapter == 3)
         #expect(viewModel.scrollTargetReference?.verseStart == 16)
+        #expect(viewModel.isChangingChapter)
     }
 
     @Test

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
@@ -143,7 +143,7 @@ import Testing
     }
 
     @Test
-    func clearsPendingRequest() {
+    func clearPendingRequestSetsItToNil() {
         let navigation = BibleReaderNavigation()
         navigation.request(BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16))
 

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
@@ -61,4 +61,76 @@ import Testing
 
         #expect(viewModel.scrollTargetReference == nil)
     }
+
+    @Test
+    func goToReferenceFullChapterLoadsChapterAndArmsScroll() async {
+        let viewModel = Support.makeViewModel()
+        viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
+
+        let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        await viewModel.goToReference(target, showsFullChapter: true)
+
+        #expect(viewModel.reference.bookUSFM == "JHN")
+        #expect(viewModel.reference.chapter == 3)
+        #expect(viewModel.scrollTargetReference?.verseStart == 16)
+    }
+
+    @Test
+    func goToReferenceVerseRangeArmsNoScroll() async {
+        let viewModel = Support.makeViewModel()
+        viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
+
+        let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        await viewModel.goToReference(target, showsFullChapter: false)
+
+        #expect(viewModel.reference.chapter == 3)
+        #expect(viewModel.scrollTargetReference == nil)
+    }
+
+    @Test
+    func goToChapterReferenceArmsNoScroll() async {
+        let viewModel = Support.makeViewModel()
+        viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
+
+        await viewModel.goToReference(
+            BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3),
+            showsFullChapter: true
+        )
+
+        #expect(viewModel.reference.chapter == 3)
+        #expect(viewModel.scrollTargetReference == nil)
+    }
+}
+
+@MainActor
+@Suite struct BibleReaderNavigationTests {
+    @Test
+    func requestSetsPendingRequest() {
+        let navigation = BibleReaderNavigation()
+        let reference = BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16)
+
+        navigation.request(reference, showsFullChapter: true)
+
+        #expect(navigation.pendingRequest?.reference == reference)
+        #expect(navigation.pendingRequest?.showsFullChapter == true)
+    }
+
+    @Test
+    func requestDefaultsToVerseRange() {
+        let navigation = BibleReaderNavigation()
+
+        navigation.request(BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16))
+
+        #expect(navigation.pendingRequest?.showsFullChapter == false)
+    }
+
+    @Test
+    func consumeClearsPendingRequest() {
+        let navigation = BibleReaderNavigation()
+        navigation.request(BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16))
+
+        navigation.consumePendingRequest()
+
+        #expect(navigation.pendingRequest == nil)
+    }
 }


### PR DESCRIPTION
## Description

Adds `BibleReaderNavigation`, a shared `@Observable` a host app uses to move an on-screen reader to a new passage from elsewhere in the app — e.g. a "Read" button in another tab. A caller does `navigation.request(reference, showsFullChapter:)`; the reader picks up the pending request, loads that chapter in place via `goToReference`, and (for a full chapter) scrolls to the verse. This builds on the verse-scroll support merged in #173.

**What's included:**
- **`BibleReaderNavigation`** — a public observable with `request(_:showsFullChapter:)` and a `pendingRequest` the reader observes. The reader need not be on screen when `request` is called; it picks up the pending request when it appears. Read-and-clear is a single `clearPendingRequest()` on the object, and the reader drains the request from the view model (not the view).
- **`BibleReaderView` init split** — `init(reference:)` now takes a **required** reference, and a new `BibleReaderView.restoringLastPassage(...)` factory restores the last-viewed passage (or John 1 the first time). This is the recommended shape going forward — a `showsFullChapter` flag can no longer be silently overridden by the persisted value. The old optional-reference `init(reference:)` is retained as a **deprecated** overload, so existing callers keep compiling (see **Breaking Changes**).
- **`goToReference`** — a view-model navigation operation that loads the chapter, then (only once it actually loaded) commits the display mode and arms the scroll. Lives alongside the other `goTo*` methods.
- **`ScrollAction` model** — navigation intent is a single `ScrollAction` value (`.none` / `.top` / `.reference`) rather than a separate `scrollToTop` flag and scroll-target pair. This makes conflicting or empty scroll intent unrepresentable and removes the same-run-loop coalescing hazard that left the header chrome stuck after a verse navigation.
- **Cold-launch fix** — `showsFullChapter` is now persisted and restored, so a passage last viewed as a full chapter comes back as a full chapter after the app is force-quit and relaunched (previously it came back as just the verse range). No verse scroll is armed on restore, so a user who had scrolled within the chapter isn't pulled back to the saved verse.
- **Failed-load handling** — a cross-version navigation whose version fetch fails no longer commits the new display mode, arms a stale scroll, or leaves the header wedged.
- **Sample app** — a "Navigate" tab demonstrating driving the reader from another tab.
- **README** — docs for the navigation API and the `restoringLastPassage()` entry point.

## Type of Change

- [x] `feat:` New feature (non-breaking change which adds functionality)
- [x] `fix:` Bug fix (non-breaking change which fixes an issue)
- [x] `docs:` Documentation update
- [x] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [ ] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

- [ ] This PR contains **BREAKING CHANGES**

No breaking changes. Bryan's init split originally made `BibleReaderView(reference:)` non-optional, which would have broken existing callers relying on the `nil` default (`BibleReaderView()`, `BibleReaderView(onVerseTap:)`, `BibleReaderView(showsFullChapter:)`). To avoid that, the original `init(reference: BibleReference? = nil, ...)` is retained as a **deprecated** overload that forwards to the designated init; its deprecation message steers callers to pass a non-optional reference or use `BibleReaderView.restoringLastPassage()`.

Verified with `swift-api-digester`: **0 breaking changes** against the shipped `v5.3.0` baseline (raw, unfiltered). The public API baseline has been regenerated to the additive surface — the required-reference init, the `restoringLastPassage()` factory, and `BibleReaderNavigation` — with no removed symbols. This ships as a **minor** release (`v5.4.0`).

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] All commit messages follow [conventional commits](https://www.conventionalcommits.org/) format

## Conventional Commits

✅ **All commits in this PR follow conventional commit format:**

- `feat(reader): drive the reader to a passage via BibleReaderNavigation`
- `fix(reader): persist showsFullChapter across cold launch BL-1901`
- `docs(reader): fix navigation param label in README BL-1901`
- `fix(reader): release isChangingChapter after a verse scroll BL-1901`
- `fix(reader): handle failed chapter load in goToReference BL-1901`
- `refactor(reader): model scroll intent as a single ScrollAction BL-1901`
- `refactor(reader): split reader init into explicit and restore paths BL-1901`
- `docs(reader): keep BibleReaderView(reference:) source-compatible BL-1901`
- `test(reader): rename clear-request test to a verb phrase BL-1901`

## Related Issues

Relates to BL-1901

## Additional Context

Depends on / builds atop #173 (verse-scroll support), now merged to `main`.

Verified end-to-end in the sample app on the simulator:
- Navigate to John 3:16 (full chapter) → background → reopen → still shows the full chapter ✅
- Navigate to John 3:16 (full chapter) → force-quit → cold launch → shows the full chapter (previously regressed to the verse range) ✅
- After a full-chapter verse navigation, the header still hides/shows on scroll (no stuck chrome) ✅

## Reviewer Notes

Incorporates review feedback from @bryanmontz:
- **Init split** (`init(reference:)` required + `restoringLastPassage()` factory) resolves the "why persist / caller value overridden" thread: a display mode can no longer be passed without the reference it describes, and the restore path has no `showsFullChapter` parameter to conflict with the restored state. The original optional-reference `init` is kept as a **deprecated** overload so no existing caller breaks — `swift-api-digester` reports 0 breakages vs the shipped baseline.
- **`goToReference`** uses `if/else` (not `guard`) to route load-success vs. load-failure, and `showsFullChapter` gained a default.
- **Navigation handling moved out of the view** into `viewModel.handleNavigationRequest(from:)`; the view just observes `pendingRequest` and forwards. The parameter is a required `BibleReaderNavigation` (the nil-check lives at the call site).
- **`resetScrollStateForNewChapter()`** extracts the previously-duplicated chrome/scroll reset and replaces the hard-to-parse inline comment with an intent-first explanation.
- **`NavigationDemoView` → `NavigateView`** in the sample app.

Design notes:
- **`ScrollAction`** — replaces the `scrollToTop` flag + scroll-target pair as the single source of truth for scroll intent. `scrollTargetReference` is now a computed projection of `.reference`, so `VerseScrollCoordinator` reads it unchanged. `finishChapterChange()` is the one place a navigation returns the reader to rest.
- **`goToReference` ordering** — loads the chapter first, then commits `showsFullChapter` and arms the scroll only if the requested reference actually loaded; the failure branch resets `isChangingChapter` so the header stays responsive.

## Validation

Validated via the new page in the sample app:

https://github.com/user-attachments/assets/8d2c3e04-6565-4996-b3d8-1786d45d6681

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `BibleReaderNavigation`, a shared `@Observable` class that lets a host app drive the reader to a new passage from another tab without recreating it. It also refactors scroll intent into a `ScrollAction` enum (fixing a coalescing hazard), persists `showsFullChapter` across cold-launch, splits `BibleReaderView.init` into explicit and restore paths while keeping a deprecated overload for source compatibility, and adds `goToReference` for cross-tab navigation.

- **`BibleReaderNavigation`** introduces `request(_:showsFullChapter:)` / `pendingRequest` / `clearPendingRequest()` with `onAppear` + `onChange` in `ReaderContent` covering both the "reader not yet on screen" and "reader already visible" cases.
- **`ScrollAction` enum** replaces the `scrollToTop` flag + `scrollTargetReference` pair, making conflicting or empty scroll intent unrepresentable and resolving the same-run-loop coalescing hazard reported in previous review threads.
- **`goToReference`** routes load-success vs. failure through an `if/else` keyed on `reference == self.reference` post-await, fixing the silent `showsFullChapter` persistence and stuck `isChangingChapter` bugs from the previous review cycle.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the previous review's isChangingChapter-stuck and silent-persistence bugs are both resolved, and the new navigation flow is covered by tests.

The ScrollAction enum cleanly replaces the two-flag approach, goToReference correctly routes success vs. failure via reference == self.reference post-await (fixing both old stuck-chrome and premature-persist issues), and showsFullChapter is now only written after a confirmed successful load. The one open concern — an unstructured Task in handleNavigationRequest that can't be cancelled if a second request arrives mid-flight — is an unlikely edge case for cross-tab navigation and does not leave state permanently wedged.

No files require special attention. BibleReaderViewModel+Navigation.swift is the place to revisit if rapid concurrent navigation ever becomes a reported issue.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/BibleReaderNavigation.swift | New public observable class providing request(_:showsFullChapter:) and pendingRequest. Clean design; clearPendingRequest() is correctly internal-only. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift | Adds handleNavigationRequest and goToReference. The unstructured Task in handleNavigationRequest has no cancellation, so rapid concurrent navigations can race; otherwise the success/failure routing via reference == self.reference is correct. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Replaces scrollToTop + scrollTargetReference with ScrollAction enum; adds showsFullChapter persistence and the finishChapterChange/resetScrollStateForNewChapter helpers. Logic is sound. |
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Splits init into explicit init(reference:), restoringLastPassage() factory, and deprecated optional-reference overload. Navigation handling in ReaderContent correctly uses both onAppear and onChange. |
| Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift | Extracts duplicated cleanup into clearScrollState() which now calls finishChapterChange() — consistent with the new lifecycle model. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift | Good coverage of goToReference paths: full-chapter verse scroll, verse-range (no scroll), failed cross-version load, and chapter-level reference. Also adds BibleReaderNavigationTests. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelPersistenceTests.swift | Three new tests confirm showsFullChapter is restored from defaults when no explicit reference is given, ignored when an explicit reference is given, and persisted on assignment. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift | Adds showsFullChapterKey constant and updates makeViewModel to branch on optional reference, matching the new designated init split. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift | Updates assertions from scrollToTop == true/false to scrollAction == .top/.none — straightforward mechanical update, all assertions remain correct. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelNavigationStateTests.swift | Single assertion updated from scrollToTop to scrollAction == .top. No logic change. |
| Examples/SampleApp/NavigateView.swift | New sample-app view demonstrating the navigation API with four passage examples and a tab-switch callback. |
| Examples/SampleApp/SampleApp.swift | Migrates BibleReaderView() to BibleReaderView.restoringLastPassage(readerNavigation:), adds the Navigate tab, and renumbers existing tab tags. |
| README.md | Adds navigation API docs and restoringLastPassage() example. Code examples use readerNavigation: label consistently. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Host as Host App (NavigateView)
    participant Nav as BibleReaderNavigation
    participant View as ReaderContent (BibleReaderView)
    participant VM as BibleReaderViewModel
    participant VSC as VerseScrollCoordinator

    Host->>Nav: request(reference, showsFullChapter: true)
    Note over Nav: pendingRequest = Request(...)
    Host->>Host: "selectedTab = .bible"

    alt Reader already on screen
        Note over View: onChange(pendingRequest) fires
    else Reader just appeared
        Note over View: onAppear fires
    end

    View->>VM: handleNavigationRequest(from: nav)
    VM->>Nav: clearPendingRequest()
    Note over Nav: pendingRequest = nil

    VM->>VM: "Task { await goToReference(reference, showsFullChapter) }"

    VM->>VM: onHeaderSelectionChange(reference)
    Note over VM: isChangingChapter = true
    Note over VM: (load version if needed)
    Note over VM: self.reference = reference
    Note over VM: resetScrollStateForNewChapter() → scrollAction = .top

    alt "Load succeeded (reference == self.reference)"
        VM->>VM: "showsFullChapter = true (persisted)"
        VM->>VM: "setScrollTarget() → scrollAction = .reference(JHN 3:16)"
        View->>VSC: handleScrollTarget(proxy)
        VSC->>VSC: scroll to verse block
        VSC->>VM: "finishChapterChange() → isChangingChapter = false"
    else "Load failed (reference != self.reference)"
        VM->>VM: "finishChapterChange() → scrollAction = .none, isChangingChapter = false"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Host as Host App (NavigateView)
    participant Nav as BibleReaderNavigation
    participant View as ReaderContent (BibleReaderView)
    participant VM as BibleReaderViewModel
    participant VSC as VerseScrollCoordinator

    Host->>Nav: request(reference, showsFullChapter: true)
    Note over Nav: pendingRequest = Request(...)
    Host->>Host: "selectedTab = .bible"

    alt Reader already on screen
        Note over View: onChange(pendingRequest) fires
    else Reader just appeared
        Note over View: onAppear fires
    end

    View->>VM: handleNavigationRequest(from: nav)
    VM->>Nav: clearPendingRequest()
    Note over Nav: pendingRequest = nil

    VM->>VM: "Task { await goToReference(reference, showsFullChapter) }"

    VM->>VM: onHeaderSelectionChange(reference)
    Note over VM: isChangingChapter = true
    Note over VM: (load version if needed)
    Note over VM: self.reference = reference
    Note over VM: resetScrollStateForNewChapter() → scrollAction = .top

    alt "Load succeeded (reference == self.reference)"
        VM->>VM: "showsFullChapter = true (persisted)"
        VM->>VM: "setScrollTarget() → scrollAction = .reference(JHN 3:16)"
        View->>VSC: handleScrollTarget(proxy)
        VSC->>VSC: scroll to verse block
        VSC->>VM: "finishChapterChange() → isChangingChapter = false"
    else "Load failed (reference != self.reference)"
        VM->>VM: "finishChapterChange() → scrollAction = .none, isChangingChapter = false"
    end
```

</a>

<sub>Reviews (16): Last reviewed commit: ["test(reader): rename clear-request test ..."](https://github.com/youversion/platform-sdk-swift/commit/82b9d2520ca3a7b93dc35f6e14e1fbf09a79b885) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42805219)</sub>

<!-- /greptile_comment -->