### PR TITLE
chore: make highlights flows smoother

### DIFF
--- a/.api-baseline/YouVersionPlatformCore.json
+++ b/.api-baseline/YouVersionPlatformCore.json
@@ -4636,17 +4636,9 @@
             "children": [
               {
                 "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SignInWithYouVersionPermission",
-                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
-                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
-                  }
-                ],
-                "usr": "s:Sq"
+                "name": "SignInWithYouVersionPermission",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
               },
               {
                 "kind": "TypeNominal",
@@ -4656,8 +4648,8 @@
               }
             ],
             "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueACSgSS_tcfc",
-            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueACSgSS_tcfc",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueACSS_tcfc",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueACSS_tcfc",
             "moduleName": "YouVersionPlatformCore",
             "init_kind": "Designated"
           },
@@ -21481,6 +21473,69 @@
             ]
           },
           {
+            "kind": "Var",
+            "name": "authStateDidChangeNotification",
+            "printedName": "authStateDidChangeNotification",
+            "children": [
+              {
+                "kind": "TypeNameAlias",
+                "name": "Name",
+                "printedName": "Foundation.Notification.Name",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Name",
+                    "printedName": "Foundation.NSNotification.Name",
+                    "usr": "c:@T@NSNotificationName"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV30authStateDidChangeNotificationSo18NSNotificationNameavpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV30authStateDidChangeNotificationSo18NSNotificationNameavpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Name",
+                    "printedName": "Foundation.Notification.Name",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Name",
+                        "printedName": "Foundation.NSNotification.Name",
+                        "usr": "c:@T@NSNotificationName"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV30authStateDidChangeNotificationSo18NSNotificationNameavgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV30authStateDidChangeNotificationSo18NSNotificationNameavgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
             "kind": "Function",
             "name": "configure",
             "printedName": "configure(appKey:apiHost:appName:isSignInEnabled:signInPromptMessage:permittedLanguageTags:permittedVersionIds:)",
@@ -21891,6 +21946,31 @@
             "declKind": "Func",
             "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV15savePermissionsyySayAA010SignInWithaB10PermissionOGFZ",
             "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV15savePermissionsyySayAA010SignInWithaB10PermissionOGFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hasPermission",
+            "printedName": "hasPermission(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionPermission",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV13hasPermissionySbAA010SignInWithabG0OFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV13hasPermissionySbAA010SignInWithabG0OFZ",
             "moduleName": "YouVersionPlatformCore",
             "static": true,
             "funcSelfKind": "NonMutating"

--- a/Examples/SampleApp/ProfileView.swift
+++ b/Examples/SampleApp/ProfileView.swift
@@ -53,9 +53,6 @@ struct ProfileView: View {
                 // The user is signed in! Their accessToken will automatically be saved
                 // to UserDefaults on this device, so they don't have to log in again next time.
                 // Now you may use accessors like YouVersionAPI.Users.currentUserName.
-                
-                // To prove out the UX: immediately request the highlights permission
-                requestHighlightsPermission()
             } catch {
                 print("Sign In failed: \(error.localizedDescription)")
             }

--- a/Sources/YouVersionPlatformCore/APIs/Users/SignInWithYouVersionPermission.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Users/SignInWithYouVersionPermission.swift
@@ -14,11 +14,8 @@ public enum SignInWithYouVersionPermission: RawRepresentable, CaseIterable, Hash
         .highlights
     ]
 
-    public init?(rawValue: String) {
-        self.init(permissionRawValue: rawValue)
-    }
-
-    init(permissionRawValue rawValue: String) {
+    /// Creates a permission from a raw permission value, preserving unrecognized values as ``unknown(_:)``.
+    public init(rawValue: String) {
         switch rawValue {
         case "openid":
             self = .openid
@@ -52,7 +49,7 @@ public enum SignInWithYouVersionPermission: RawRepresentable, CaseIterable, Hash
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self = SignInWithYouVersionPermission(permissionRawValue: try container.decode(String.self))
+        self = SignInWithYouVersionPermission(rawValue: try container.decode(String.self))
     }
 
     public func encode(to encoder: any Encoder) throws {

--- a/Sources/YouVersionPlatformCore/APIs/Users/Users.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Users/Users.swift
@@ -269,7 +269,7 @@ public extension YouVersionAPI {
         private static func permissions(from value: String) -> [SignInWithYouVersionPermission] {
             value
                 .split { $0 == "," || $0 == " " }
-                .map { SignInWithYouVersionPermission(permissionRawValue: String($0)) }
+                .map { SignInWithYouVersionPermission(rawValue: String($0)) }
         }
 
         // MARK: - Public Accessors

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
@@ -15,15 +15,24 @@ public class BibleHighlightsViewModel: ObservableObject {
     private let cache: BibleHighlightsCache
     private let repository: any BibleHighlightsRepositoryProtocol
     private var loadTasks: [BibleReference: Task<Void, Never>] = [:]
-    
+
     // MARK: - Initialization
-    
+
     public init(
         cache: BibleHighlightsCache = BibleHighlightsCache.shared,
         repository: any BibleHighlightsRepositoryProtocol = BibleHighlightsRepository()
     ) {
         self.cache = cache
         self.repository = repository
+        NotificationCenter.default.addObserver(
+            forName: YouVersionPlatformConfiguration.authStateDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.reset()
+            }
+        }
     }
 
     // Called e.g. when the user signs out

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
@@ -14,6 +14,7 @@ public class BibleHighlightsViewModel: ObservableObject {
 
     private let cache: BibleHighlightsCache
     private let repository: any BibleHighlightsRepositoryProtocol
+    nonisolated(unsafe) private var authStateObserver: NSObjectProtocol?
     private var loadTasks: [BibleReference: Task<Void, Never>] = [:]
 
     // MARK: - Initialization
@@ -24,7 +25,7 @@ public class BibleHighlightsViewModel: ObservableObject {
     ) {
         self.cache = cache
         self.repository = repository
-        NotificationCenter.default.addObserver(
+        self.authStateObserver = NotificationCenter.default.addObserver(
             forName: YouVersionPlatformConfiguration.authStateDidChangeNotification,
             object: nil,
             queue: nil
@@ -32,6 +33,12 @@ public class BibleHighlightsViewModel: ObservableObject {
             Task { @MainActor in
                 self?.reset()
             }
+        }
+    }
+
+    deinit {
+        if let authStateObserver {
+            NotificationCenter.default.removeObserver(authStateObserver)
         }
     }
 

--- a/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
+++ b/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
@@ -39,7 +39,7 @@ public struct YouVersionPlatformConfiguration {
     static var permissions: [SignInWithYouVersionPermission] {
         UserDefaults.standard
             .stringArray(forKey: permissionsKey)?
-            .map { SignInWithYouVersionPermission(permissionRawValue: $0) } ?? []
+            .map { SignInWithYouVersionPermission(rawValue: $0) } ?? []
     }
 
     @MainActor
@@ -129,6 +129,10 @@ public struct YouVersionPlatformConfiguration {
             .map(\.rawValue)
             .sorted()
         UserDefaults.standard.set(rawValues, forKey: permissionsKey)
+    }
+    
+    public static func hasPermission(_ permission: SignInWithYouVersionPermission) -> Bool {
+        permissions.contains(permission)
     }
 
     private static func postAuthStateDidChangeNotificationIfNeeded(wasSignedIn: Bool) {

--- a/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
+++ b/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
@@ -34,6 +34,8 @@ public struct YouVersionPlatformConfiguration {
     private static let expiryDateKey = "YouVersionPlatformExpiryDate"
     private static let permissionsKey = "YouVersionPlatformDataExchangePermissions"
 
+    public static let authStateDidChangeNotification = Notification.Name("YouVersionPlatformAuthStateDidChange")
+
     static var permissions: [SignInWithYouVersionPermission] {
         UserDefaults.standard
             .stringArray(forKey: permissionsKey)?
@@ -84,10 +86,12 @@ public struct YouVersionPlatformConfiguration {
 
     @MainActor
     public static func saveAuthData(accessToken: String?, refreshToken: String?, idToken: String?, expiryDate: Date?) {
+        let wasSignedIn = Self.accessToken != nil
         UserDefaults.standard.set(accessToken, forKey: accessTokenKey)
         UserDefaults.standard.set(refreshToken, forKey: refreshTokenKey)
         UserDefaults.standard.set(idToken, forKey: idTokenKey)
         UserDefaults.standard.set(expiryDate, forKey: expiryDateKey)
+        postAuthStateDidChangeNotificationIfNeeded(wasSignedIn: wasSignedIn)
     }
 
     @MainActor
@@ -125,6 +129,13 @@ public struct YouVersionPlatformConfiguration {
             .map(\.rawValue)
             .sorted()
         UserDefaults.standard.set(rawValues, forKey: permissionsKey)
+    }
+
+    private static func postAuthStateDidChangeNotificationIfNeeded(wasSignedIn: Bool) {
+        guard wasSignedIn != (accessToken != nil) else {
+            return
+        }
+        NotificationCenter.default.post(name: authStateDidChangeNotification, object: nil)
     }
 
 }

--- a/Sources/YouVersionPlatformUI/APIs/DataExchangeSession.swift
+++ b/Sources/YouVersionPlatformUI/APIs/DataExchangeSession.swift
@@ -120,7 +120,7 @@ public struct DataExchangeSession {
     private static func permissions(from value: String) -> [SignInWithYouVersionPermission] {
         value
             .split { $0 == "," || $0 == " " }
-            .compactMap { SignInWithYouVersionPermission(rawValue: String($0)) }
+            .map { SignInWithYouVersionPermission(rawValue: String($0)) }
     }
 
     private func dataExchangeSession(

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
@@ -128,6 +128,9 @@ public struct BibleTextView: View {
             }
             return .handled
         }))
+        .onReceive(NotificationCenter.default.publisher(for: YouVersionPlatformConfiguration.authStateDidChangeNotification)) { _ in
+            BibleHighlightsViewModel.shared.ensureHighlightsForChapterLoaded(reference, forceReload: true)
+        }
         .task(id: LoadKey(
             reference: reference,
             fontSize: textOptions.fontSize,

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
@@ -119,6 +119,7 @@ public struct BibleTextView: View {
                 }
             }
         }
+        .coordinateSpace(.named("BibleTextView"))
         .environment(\.layoutDirection, isVersionRightToLeft ? .rightToLeft : .leftToRight)
         .environment(\.openURL, OpenURLAction(handler: { url in
             if let reference = parseReference(url: url) {
@@ -128,9 +129,6 @@ public struct BibleTextView: View {
             }
             return .handled
         }))
-        .onReceive(NotificationCenter.default.publisher(for: YouVersionPlatformConfiguration.authStateDidChangeNotification)) { _ in
-            BibleHighlightsViewModel.shared.ensureHighlightsForChapterLoaded(reference, forceReload: true)
-        }
         .task(id: LoadKey(
             reference: reference,
             fontSize: textOptions.fontSize,
@@ -140,9 +138,15 @@ public struct BibleTextView: View {
         )) {
             await loadBlocks()
         }
-        .coordinateSpace(.named("BibleTextView"))
         .task(id: reference) {
-            BibleHighlightsViewModel.shared.ensureHighlightsForChapterLoaded(reference)
+            if YouVersionAPI.isSignedIn && YouVersionPlatformConfiguration.hasPermission(.highlights) {
+                BibleHighlightsViewModel.shared.ensureHighlightsForChapterLoaded(reference)
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: YouVersionPlatformConfiguration.authStateDidChangeNotification)) { _ in
+            if YouVersionAPI.isSignedIn && YouVersionPlatformConfiguration.hasPermission(.highlights) {
+                BibleHighlightsViewModel.shared.ensureHighlightsForChapterLoaded(reference, forceReload: true)
+            }
         }
     }
 

--- a/Tests/YouVersionPlatformCoreTests/DataExchangeAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/DataExchangeAPITests.swift
@@ -11,7 +11,7 @@ extension ConfigurationStateTests {
         @Test func permissionRawValueAndDescription() throws {
             #expect(SignInWithYouVersionPermission.highlights.rawValue == "highlights")
             #expect(SignInWithYouVersionPermission.highlights.description == "highlights")
-            let permission = try #require(SignInWithYouVersionPermission(rawValue: "notes"))
+            let permission = SignInWithYouVersionPermission(rawValue: "notes")
             #expect(permission == .unknown("notes"))
             #expect(permission.rawValue == "notes")
         }

--- a/Tests/YouVersionPlatformCoreTests/UsersModelsTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/UsersModelsTests.swift
@@ -9,7 +9,7 @@ import Testing
         #expect(SignInWithYouVersionPermission.profile.rawValue == "profile")
         #expect(SignInWithYouVersionPermission.email.rawValue == "email")
         #expect(SignInWithYouVersionPermission.highlights.rawValue == "highlights")
-        let permission = try #require(SignInWithYouVersionPermission(rawValue: "notes"))
+        let permission = SignInWithYouVersionPermission(rawValue: "notes")
         #expect(permission == .unknown("notes"))
         #expect(permission.rawValue == "notes")
         #expect(SignInWithYouVersionPermission.allCases == [.openid, .profile, .email, .highlights])

--- a/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
@@ -177,34 +177,44 @@ extension ConfigurationStateTests {
             #expect(YouVersionPlatformConfiguration.accessToken == nil)
         }
 
-        @Test func authStateDidChangeNotificationPostsWhenSignInStateChanges() async {
-            await YouVersionPlatformConfiguration.clearAuthTokens()
+        @Test @MainActor func authStateDidChangeNotificationPostsWhenSignInStateChanges() async {
+            @MainActor final class NotificationCounter {
+                private(set) var count = 0
+
+                func increment() {
+                    count += 1
+                }
+            }
+
+            YouVersionPlatformConfiguration.clearAuthTokens()
             let counter = NotificationCounter()
             let observer = NotificationCenter.default.addObserver(
                 forName: YouVersionPlatformConfiguration.authStateDidChangeNotification,
                 object: nil,
                 queue: nil
             ) { _ in
-                counter.increment()
+                MainActor.assumeIsolated {
+                    counter.increment()
+                }
             }
             defer {
                 NotificationCenter.default.removeObserver(observer)
             }
 
             let expiry = Date(timeIntervalSinceNow: 3600)
-            await YouVersionPlatformConfiguration.saveAuthData(
+            YouVersionPlatformConfiguration.saveAuthData(
                 accessToken: "access-1",
                 refreshToken: "refresh-1",
                 idToken: nil,
                 expiryDate: expiry
             )
-            await YouVersionPlatformConfiguration.saveAuthData(
+            YouVersionPlatformConfiguration.saveAuthData(
                 accessToken: "access-2",
                 refreshToken: "refresh-2",
                 idToken: nil,
                 expiryDate: expiry
             )
-            await YouVersionPlatformConfiguration.clearAuthTokens()
+            YouVersionPlatformConfiguration.clearAuthTokens()
 
             #expect(counter.count == 2)
         }
@@ -271,11 +281,3 @@ extension ConfigurationStateTests {
 }
 
 private let permissionsKey = "YouVersionPlatformDataExchangePermissions"
-
-private final class NotificationCounter: @unchecked Sendable {
-    nonisolated(unsafe) private(set) var count = 0
-
-    func increment() {
-        count += 1
-    }
-}

--- a/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
@@ -177,6 +177,38 @@ extension ConfigurationStateTests {
             #expect(YouVersionPlatformConfiguration.accessToken == nil)
         }
 
+        @Test func authStateDidChangeNotificationPostsWhenSignInStateChanges() async {
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+            let counter = NotificationCounter()
+            let observer = NotificationCenter.default.addObserver(
+                forName: YouVersionPlatformConfiguration.authStateDidChangeNotification,
+                object: nil,
+                queue: nil
+            ) { _ in
+                counter.increment()
+            }
+            defer {
+                NotificationCenter.default.removeObserver(observer)
+            }
+
+            let expiry = Date(timeIntervalSinceNow: 3600)
+            await YouVersionPlatformConfiguration.saveAuthData(
+                accessToken: "access-1",
+                refreshToken: "refresh-1",
+                idToken: nil,
+                expiryDate: expiry
+            )
+            await YouVersionPlatformConfiguration.saveAuthData(
+                accessToken: "access-2",
+                refreshToken: "refresh-2",
+                idToken: nil,
+                expiryDate: expiry
+            )
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+
+            #expect(counter.count == 2)
+        }
+
         // MARK: - Permissions
 
         @Test func savePermissionsPersistsPermission() async {
@@ -239,3 +271,11 @@ extension ConfigurationStateTests {
 }
 
 private let permissionsKey = "YouVersionPlatformDataExchangePermissions"
+
+private final class NotificationCounter: @unchecked Sendable {
+    nonisolated(unsafe) private(set) var count = 0
+
+    func increment() {
+        count += 1
+    }
+}

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelDataExchangeTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelDataExchangeTests.swift
@@ -162,7 +162,7 @@ import Testing
     }
 
     @Test
-    func pendingHighlightShowsDataExchangeConfirmationAfterSignInSucceeds() async {
+    func pendingHighlightStartsDataExchangeFlowDirectlyAfterSignInSucceeds() async {
         YouVersionPlatformConfiguration.configure(appKey: "test-app", isSignInEnabled: true)
         let highlightsRepository = MockBibleHighlightsRepository()
         let viewModel = Support.makeViewModel(


### PR DESCRIPTION
chore: make highlights flows smoother

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR polishes the highlights feature by introducing an `authStateDidChangeNotification` on `YouVersionPlatformConfiguration` so that `BibleHighlightsViewModel` and `BibleTextView` can react automatically to sign-in/sign-out events, rather than requiring callers to manually trigger flows. It also promotes `init(rawValue:)` on `SignInWithYouVersionPermission` from failable to non-failable (since the `unknown(_:)` case already captures all unrecognized values), and adds a public `hasPermission(_:)` convenience to `YouVersionPlatformConfiguration`.

- **Auth state notification** (`authStateDidChangeNotification`) is posted only when the sign-in state actually changes (nil ↔ non-nil access token), correctly excluding mid-session token refreshes; `BibleHighlightsViewModel` now stores and removes the observer token in `deinit`, directly addressing the previous review comment.
- **`BibleTextView`** gates highlights loading behind `isSignedIn && hasPermission(.highlights)` and re-triggers on auth state changes via `onReceive`, replacing the manual `requestHighlightsPermission()` call in `ProfileView`.
- **`init(rawValue:)` non-failable change** is consistently applied across `Users.swift`, `DataExchangeSession.swift`, and all affected tests (`compactMap` → `map`, `try #require` removed).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the auth state notification is correctly gated on actual sign-in transitions, the observer lifecycle is properly managed, and the non-failable init change is applied consistently everywhere

The auth-state notification fires only on nil to non-nil access token transitions, deduplication in ensureHighlightsForChapterLoaded prevents redundant server requests, and the observer token is now retained and cleaned up in deinit. No logic errors found.

BibleTextView.swift — the onReceive block fires on every live instance simultaneously on auth change; worth a confirming look if the app can display many chapters at once

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/APIs/Users/SignInWithYouVersionPermission.swift | init?(rawValue:) replaced with non-failable init(rawValue:); clean change since unknown(_:) preserves all input values |
| Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift | Added authStateDidChangeNotification, hasPermission(_:), and postAuthStateDidChangeNotificationIfNeeded; notification is correctly gated on actual sign-in state transitions |
| Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift | Observer token now stored in nonisolated(unsafe) authStateObserver and removed in deinit, addressing previous PR feedback about leaked observers |
| Sources/YouVersionPlatformUI/Views/BibleTextView.swift | Highlights loading now gated on isSignedIn + hasPermission; onReceive triggers forceReload on auth state change, but all BibleTextView instances on screen will each independently call ensureHighlightsForChapterLoaded on the same auth event |
| Sources/YouVersionPlatformUI/APIs/DataExchangeSession.swift | compactMap changed to map to match the now non-failable init(rawValue:); consistent with changes in Users.swift |
| Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift | New test correctly verifies that the notification fires exactly twice (sign-in + sign-out) and not on mid-session token refresh; MainActor.assumeIsolated usage is correct since saveAuthData always posts from the main actor |
| Tests/YouVersionPlatformCoreTests/DataExchangeAPITests.swift | try #require removed to match non-failable init(rawValue:); test logic unchanged |
| Tests/YouVersionPlatformCoreTests/UsersModelsTests.swift | try #require removed to match non-failable init(rawValue:); test logic unchanged |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelDataExchangeTests.swift | Test renamed to reflect updated behavior: data exchange flow now starts directly after sign-in rather than showing a confirmation sheet |
| Examples/SampleApp/ProfileView.swift | Removed the immediate requestHighlightsPermission() call after sign-in; now handled automatically via the auth state notification |
| .api-baseline/YouVersionPlatformCore.json | Baseline updated to reflect init(rawValue:) becoming non-failable and two new public APIs: authStateDidChangeNotification and hasPermission(_:) |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App
    participant Config as YouVersionPlatformConfiguration
    participant NC as NotificationCenter
    participant BHVM as BibleHighlightsViewModel
    participant BTV as BibleTextView

    App->>Config: saveAuthData(accessToken: "token", ...)
    Config->>Config: "wasSignedIn = (accessToken != nil)"
    Config->>Config: store tokens in UserDefaults
    Config->>Config: postAuthStateDidChangeNotificationIfNeeded()
    Config->>NC: post(authStateDidChangeNotification)

    NC-->>BHVM: "observer fires (queue: nil = posting thread)"
    BHVM->>BHVM: "Task { @MainActor in reset() }"
    Note over BHVM: Clears highlights cache async

    NC-->>BTV: onReceive fires
    BTV->>BTV: "isSignedIn && hasPermission(.highlights)?"
    alt signed in with highlights permission
        BTV->>BHVM: ensureHighlightsForChapterLoaded(reference, forceReload: true)
        BHVM->>BHVM: markChapterAsLoading()
        BHVM->>BHVM: "Task -> loadChapterFromServer()"
        BHVM-->>BTV: cache updated, view re-renders
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App
    participant Config as YouVersionPlatformConfiguration
    participant NC as NotificationCenter
    participant BHVM as BibleHighlightsViewModel
    participant BTV as BibleTextView

    App->>Config: saveAuthData(accessToken: "token", ...)
    Config->>Config: "wasSignedIn = (accessToken != nil)"
    Config->>Config: store tokens in UserDefaults
    Config->>Config: postAuthStateDidChangeNotificationIfNeeded()
    Config->>NC: post(authStateDidChangeNotification)

    NC-->>BHVM: "observer fires (queue: nil = posting thread)"
    BHVM->>BHVM: "Task { @MainActor in reset() }"
    Note over BHVM: Clears highlights cache async

    NC-->>BTV: onReceive fires
    BTV->>BTV: "isSignedIn && hasPermission(.highlights)?"
    alt signed in with highlights permission
        BTV->>BHVM: ensureHighlightsForChapterLoaded(reference, forceReload: true)
        BHVM->>BHVM: markChapterAsLoading()
        BHVM->>BHVM: "Task -> loadChapterFromServer()"
        BHVM-->>BTV: cache updated, view re-renders
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["chore: cleanup per review comments"](https://github.com/youversion/platform-sdk-swift/commit/2fbc4bbbbdaceef85e8fb44cf4d18bc7eb5e801c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41396108)</sub>

<!-- /greptile_comment -->