### PR TITLE
chore: save permissions at the same time as auth data

### DIFF
--- a/.api-baseline/YouVersionPlatformCore.json
+++ b/.api-baseline/YouVersionPlatformCore.json
@@ -21713,7 +21713,7 @@
           {
             "kind": "Function",
             "name": "saveAuthData",
-            "printedName": "saveAuthData(accessToken:refreshToken:idToken:expiryDate:)",
+            "printedName": "saveAuthData(accessToken:refreshToken:idToken:expiryDate:permissions:)",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -21775,11 +21775,34 @@
                   }
                 ],
                 "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SignInWithYouVersionPermission",
+                        "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                        "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
               }
             ],
             "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV12saveAuthData11accessToken07refreshJ002idJ010expiryDateySSSg_A2I10Foundation0N0VSgtFZ",
-            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV12saveAuthData11accessToken07refreshJ002idJ010expiryDateySSSg_A2I10Foundation0N0VSgtFZ",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV12saveAuthData11accessToken07refreshJ002idJ010expiryDate11permissionsySSSg_A2J10Foundation0N0VSgSayAA010SignInWithaB10PermissionOGSgtFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV12saveAuthData11accessToken07refreshJ002idJ010expiryDate11permissionsySSSg_A2J10Foundation0N0VSgSayAA010SignInWithaB10PermissionOGSgtFZ",
             "moduleName": "YouVersionPlatformCore",
             "static": true,
             "declAttributes": [
@@ -21917,38 +21940,6 @@
                 "accessorKind": "get"
               }
             ]
-          },
-          {
-            "kind": "Function",
-            "name": "savePermissions",
-            "printedName": "savePermissions(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Array",
-                "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SignInWithYouVersionPermission",
-                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
-                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
-                  }
-                ],
-                "usr": "s:Sa"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV15savePermissionsyySayAA010SignInWithaB10PermissionOGFZ",
-            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV15savePermissionsyySayAA010SignInWithaB10PermissionOGFZ",
-            "moduleName": "YouVersionPlatformCore",
-            "static": true,
-            "funcSelfKind": "NonMutating"
           },
           {
             "kind": "Function",

--- a/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
@@ -30,11 +30,9 @@ public enum YouVersionAPI {
                 accessToken: result.accessToken,
                 refreshToken: result.refreshToken,
                 idToken: result.idToken,
-                expiryDate: result.expiryDate
+                expiryDate: result.expiryDate,
+                permissions: result.permissions
             )
-            if let permissions = result.permissions {
-                YouVersionPlatformConfiguration.savePermissions(permissions)
-            }
         }
         return true
     }

--- a/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
+++ b/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
@@ -85,12 +85,15 @@ public struct YouVersionPlatformConfiguration {
     }
 
     @MainActor
-    public static func saveAuthData(accessToken: String?, refreshToken: String?, idToken: String?, expiryDate: Date?) {
+    public static func saveAuthData(accessToken: String?, refreshToken: String?, idToken: String?, expiryDate: Date?, permissions: [SignInWithYouVersionPermission]? = nil) {
         let wasSignedIn = Self.accessToken != nil
         UserDefaults.standard.set(accessToken, forKey: accessTokenKey)
         UserDefaults.standard.set(refreshToken, forKey: refreshTokenKey)
         UserDefaults.standard.set(idToken, forKey: idTokenKey)
         UserDefaults.standard.set(expiryDate, forKey: expiryDateKey)
+        if let permissions {
+            savePermissions(permissions)
+        }
         postAuthStateDidChangeNotificationIfNeeded(wasSignedIn: wasSignedIn)
     }
 
@@ -124,7 +127,7 @@ public struct YouVersionPlatformConfiguration {
         )
     }
 
-    public static func savePermissions(_ permissions: [SignInWithYouVersionPermission]) {
+    private static func savePermissions(_ permissions: [SignInWithYouVersionPermission]) {
         let rawValues = Set(Self.permissions + permissions)
             .map(\.rawValue)
             .sorted()

--- a/Sources/YouVersionPlatformUI/APIs/DataExchangeSession.swift
+++ b/Sources/YouVersionPlatformUI/APIs/DataExchangeSession.swift
@@ -98,8 +98,14 @@ public struct DataExchangeSession {
             session.start()
         }
 
-        if result.isGranted {
-            YouVersionPlatformConfiguration.savePermissions(result.grantedPermissions)
+        if result.isGranted, let authdata = YouVersionPlatformConfiguration.authData {
+            YouVersionPlatformConfiguration.saveAuthData(
+                accessToken: authdata.accessToken,
+                refreshToken: authdata.refreshToken,
+                idToken: authdata.idToken,
+                expiryDate: authdata.expiryDate,
+                permissions: result.grantedPermissions
+            )
         }
 
         return result

--- a/Sources/YouVersionPlatformUI/APIs/Users+SignIn.swift
+++ b/Sources/YouVersionPlatformUI/APIs/Users+SignIn.swift
@@ -88,9 +88,9 @@ public extension YouVersionAPI.Users {
                             accessToken: result.accessToken,
                             refreshToken: result.refreshToken,
                             idToken: result.idToken,
-                            expiryDate: result.expiryDate
+                            expiryDate: result.expiryDate,
+                            permissions: result.permissions
                         )
-                        YouVersionPlatformConfiguration.savePermissions(result.permissions ?? [])
                         continuation.resume(returning: result)
                     } catch {
                         continuation.resume(throwing: error)

--- a/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
@@ -222,9 +222,16 @@ extension ConfigurationStateTests {
         // MARK: - Permissions
 
         @Test func savePermissionsPersistsPermission() async {
+            let expiry = Date(timeIntervalSinceNow: 3600)
             await YouVersionPlatformConfiguration.clearAuthTokens()
 
-            YouVersionPlatformConfiguration.savePermissions([.highlights])
+            await YouVersionPlatformConfiguration.saveAuthData(
+                accessToken: "access-1",
+                refreshToken: "refresh-1",
+                idToken: nil,
+                expiryDate: expiry,
+                permissions: [.highlights]
+            )
 
             #expect(YouVersionAPI.hasPermission(.highlights))
             await YouVersionPlatformConfiguration.clearAuthTokens()
@@ -237,9 +244,9 @@ extension ConfigurationStateTests {
                 accessToken: "access-1",
                 refreshToken: "refresh-1",
                 idToken: nil,
-                expiryDate: expiry
+                expiryDate: expiry,
+                permissions: [.profile, .highlights, .unknown("notes")]
             )
-            YouVersionPlatformConfiguration.savePermissions([.profile, .highlights, .unknown("notes")])
 
             let authData = try #require(YouVersionPlatformConfiguration.authData)
             #expect(authData.permissions == [.highlights, .unknown("notes"), .profile])
@@ -262,7 +269,14 @@ extension ConfigurationStateTests {
         }
 
         @Test func clearAuthTokensClearsPermissions() async {
-            YouVersionPlatformConfiguration.savePermissions([.highlights])
+            let expiry = Date(timeIntervalSinceNow: 3600)
+            await YouVersionPlatformConfiguration.saveAuthData(
+                accessToken: "access-1",
+                refreshToken: "refresh-1",
+                idToken: nil,
+                expiryDate: expiry,
+                permissions: [.highlights]
+            )
 
             await YouVersionPlatformConfiguration.clearAuthTokens()
 


### PR DESCRIPTION
chore: save permissions at the same time as auth data to avoid race conditions

This also let us make savePermissions() private.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates auth data and permissions into a single atomic write by adding an optional `permissions` parameter to `saveAuthData`, then making `savePermissions` private. All three call sites (sign-in, token refresh, data exchange) are updated accordingly.

- `YouVersionPlatformConfiguration.saveAuthData` gains `permissions: [SignInWithYouVersionPermission]? = nil`, and the standalone public `savePermissions` is now private, preventing callers from writing permissions without a corresponding auth write.
- `DataExchangeSession.requestDataExchange` reads back the current `authData` and re-saves it together with the newly granted permissions — but silently skips the save if `authData` is nil at that point, which could leave a successful grant unrecorded.
- Tests and the API baseline are fully updated to match the new signature.

<h3>Confidence Score: 4/5</h3>

The consolidation of auth and permission writes is a good improvement. One edge case in DataExchangeSession — silently dropping granted permissions when authData becomes nil mid-flow — warrants a look before merging.

The sign-in and token-refresh paths are clean and correct. The data exchange path introduces a conditional save where a successful grant can silently produce no observable effect if auth state was cleared between the start and completion of the browser session — the caller gets isGranted == true but hasPermission still returns false. This case is unlikely in practice but has no logging or error path to make it discoverable.

Sources/YouVersionPlatformUI/APIs/DataExchangeSession.swift — specifically the `if result.isGranted, let authdata` guard that can silently drop permissions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .api-baseline/YouVersionPlatformCore.json | API baseline updated to reflect the new `permissions` parameter on `saveAuthData` and the removal of the public `savePermissions` function — consistent with source changes. |
| Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift | Token refresh now forwards `result.permissions` to `saveAuthData`, consolidating the two calls into one; straightforward and correct. |
| Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift | `saveAuthData` gains an optional `permissions` parameter; `savePermissions` is correctly made private; accumulation logic is unchanged. |
| Sources/YouVersionPlatformUI/APIs/DataExchangeSession.swift | Replaces direct `savePermissions` with `saveAuthData` + auth data read-back. Has a silent permission drop if `authData` is nil when the grant completes. |
| Sources/YouVersionPlatformUI/APIs/Users+SignIn.swift | Previous two-step save (auth + separate permissions) collapsed into a single `saveAuthData` call; correct and clean. |
| Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift | Tests updated to use the new `saveAuthData` API; coverage is maintained across the permission-persistence scenarios. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant DataExchangeSession
    participant YouVersionAPI
    participant Config as YouVersionPlatformConfiguration

    Note over Caller,Config: Sign-in flow (Users+SignIn.swift)
    Caller->>YouVersionAPI: signIn(permissions:)
    YouVersionAPI->>Config: saveAuthData(accessToken:refreshToken:idToken:expiryDate:permissions:)
    Config->>Config: savePermissions (private)
    Config->>Config: postAuthStateDidChangeNotificationIfNeeded

    Note over Caller,Config: Token refresh flow (YouVersionAPI.swift)
    YouVersionAPI->>YouVersionAPI: refreshSignIn(withToken:)
    YouVersionAPI->>Config: saveAuthData(..., permissions: result.permissions)

    Note over Caller,Config: Data exchange flow (DataExchangeSession.swift)
    Caller->>DataExchangeSession: requestDataExchange(permissions:)
    DataExchangeSession->>YouVersionAPI: DataExchange.updateToken
    DataExchangeSession->>DataExchangeSession: ASWebAuthenticationSession (browser)
    DataExchangeSession->>Config: authData (read)
    alt "authData != nil"
        DataExchangeSession->>Config: saveAuthData(..., permissions: grantedPermissions)
    else "authData == nil"
        DataExchangeSession-->>Caller: "result.isGranted == true (permissions NOT saved)"
    end
    DataExchangeSession->>Caller: return result
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant DataExchangeSession
    participant YouVersionAPI
    participant Config as YouVersionPlatformConfiguration

    Note over Caller,Config: Sign-in flow (Users+SignIn.swift)
    Caller->>YouVersionAPI: signIn(permissions:)
    YouVersionAPI->>Config: saveAuthData(accessToken:refreshToken:idToken:expiryDate:permissions:)
    Config->>Config: savePermissions (private)
    Config->>Config: postAuthStateDidChangeNotificationIfNeeded

    Note over Caller,Config: Token refresh flow (YouVersionAPI.swift)
    YouVersionAPI->>YouVersionAPI: refreshSignIn(withToken:)
    YouVersionAPI->>Config: saveAuthData(..., permissions: result.permissions)

    Note over Caller,Config: Data exchange flow (DataExchangeSession.swift)
    Caller->>DataExchangeSession: requestDataExchange(permissions:)
    DataExchangeSession->>YouVersionAPI: DataExchange.updateToken
    DataExchangeSession->>DataExchangeSession: ASWebAuthenticationSession (browser)
    DataExchangeSession->>Config: authData (read)
    alt "authData != nil"
        DataExchangeSession->>Config: saveAuthData(..., permissions: grantedPermissions)
    else "authData == nil"
        DataExchangeSession-->>Caller: "result.isGranted == true (permissions NOT saved)"
    end
    DataExchangeSession->>Caller: return result
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformUI%2FAPIs%2FDataExchangeSession.swift%3A101-109%0A**Silent%20permission%20drop%20when%20%60authData%60%20is%20nil**%0A%0AThe%20new%20guard%20%60let%20authdata%20%3D%20YouVersionPlatformConfiguration.authData%60%20silently%20swallows%20a%20successful%20data%20exchange%20grant%20if%20auth%20data%20has%20been%20cleared%20between%20the%20start%20and%20completion%20of%20the%20flow.%20The%20caller%20still%20receives%20a%20%60DataExchangeRequestResult%60%20with%20%60isGranted%20%3D%3D%20true%60%2C%20but%20%60hasPermission%28_%3A%29%60%20will%20continue%20returning%20%60false%60%20for%20the%20newly%20granted%20permissions%20%E2%80%94%20a%20silent%20inconsistency%20that%20is%20difficult%20to%20diagnose.%20The%20old%20code%20called%20%60savePermissions%60%20unconditionally%20on%20grant.%20Consider%20logging%20a%20warning%20%28or%20asserting%29%20in%20the%20%60else%60%20branch%20so%20the%20dropped-permission%20case%20is%20at%20least%20observable.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=178&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformUI%2FAPIs%2FDataExchangeSession.swift%3A101-109%0A**Silent%20permission%20drop%20when%20%60authData%60%20is%20nil**%0A%0AThe%20new%20guard%20%60let%20authdata%20%3D%20YouVersionPlatformConfiguration.authData%60%20silently%20swallows%20a%20successful%20data%20exchange%20grant%20if%20auth%20data%20has%20been%20cleared%20between%20the%20start%20and%20completion%20of%20the%20flow.%20The%20caller%20still%20receives%20a%20%60DataExchangeRequestResult%60%20with%20%60isGranted%20%3D%3D%20true%60%2C%20but%20%60hasPermission%28_%3A%29%60%20will%20continue%20returning%20%60false%60%20for%20the%20newly%20granted%20permissions%20%E2%80%94%20a%20silent%20inconsistency%20that%20is%20difficult%20to%20diagnose.%20The%20old%20code%20called%20%60savePermissions%60%20unconditionally%20on%20grant.%20Consider%20logging%20a%20warning%20%28or%20asserting%29%20in%20the%20%60else%60%20branch%20so%20the%20dropped-permission%20case%20is%20at%20least%20observable.%0A%0A&pr=178&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22combine-defaults-saving%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22combine-defaults-saving%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformUI%2FAPIs%2FDataExchangeSession.swift%3A101-109%0A**Silent%20permission%20drop%20when%20%60authData%60%20is%20nil**%0A%0AThe%20new%20guard%20%60let%20authdata%20%3D%20YouVersionPlatformConfiguration.authData%60%20silently%20swallows%20a%20successful%20data%20exchange%20grant%20if%20auth%20data%20has%20been%20cleared%20between%20the%20start%20and%20completion%20of%20the%20flow.%20The%20caller%20still%20receives%20a%20%60DataExchangeRequestResult%60%20with%20%60isGranted%20%3D%3D%20true%60%2C%20but%20%60hasPermission%28_%3A%29%60%20will%20continue%20returning%20%60false%60%20for%20the%20newly%20granted%20permissions%20%E2%80%94%20a%20silent%20inconsistency%20that%20is%20difficult%20to%20diagnose.%20The%20old%20code%20called%20%60savePermissions%60%20unconditionally%20on%20grant.%20Consider%20logging%20a%20warning%20%28or%20asserting%29%20in%20the%20%60else%60%20branch%20so%20the%20dropped-permission%20case%20is%20at%20least%20observable.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=178&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/YouVersionPlatformUI/APIs/DataExchangeSession.swift:101-109
**Silent permission drop when `authData` is nil**

The new guard `let authdata = YouVersionPlatformConfiguration.authData` silently swallows a successful data exchange grant if auth data has been cleared between the start and completion of the flow. The caller still receives a `DataExchangeRequestResult` with `isGranted == true`, but `hasPermission(_:)` will continue returning `false` for the newly granted permissions — a silent inconsistency that is difficult to diagnose. The old code called `savePermissions` unconditionally on grant. Consider logging a warning (or asserting) in the `else` branch so the dropped-permission case is at least observable.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: save permissions at the same time..."](https://github.com/youversion/platform-sdk-swift/commit/5a201cda039b09428a662a26db780010f9aa095c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41471733)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->