### PR TITLE
chore: when signing out, if there are pending highlights, confirm with the user

### DIFF
--- a/Sources/YouVersionPlatformCore/APIs/URLRequest+YouVersion.swift
+++ b/Sources/YouVersionPlatformCore/APIs/URLRequest+YouVersion.swift
@@ -11,7 +11,8 @@ public extension URLRequest {
     static func youVersion(
         _ url: URL,
         accessToken providedToken: String? = nil,
-        cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy
+        cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
+        omitAccessToken: Bool = false
     ) -> URLRequest {
         var request = URLRequest(url: url, cachePolicy: cachePolicy)
         if let appKey = YouVersionPlatformConfiguration.appKey {
@@ -21,7 +22,7 @@ public extension URLRequest {
         if let installId = YouVersionPlatformConfiguration.installId {
             request.setValue(installId, forHTTPHeaderField: "x-yvp-installation-id")
         }
-        if let accessToken = providedToken ?? YouVersionPlatformConfiguration.accessToken {
+        if !omitAccessToken, let accessToken = providedToken ?? YouVersionPlatformConfiguration.accessToken {
             request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         }
         return request

--- a/Sources/YouVersionPlatformCore/APIs/Users/Users.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Users/Users.swift
@@ -216,7 +216,7 @@ public extension YouVersionAPI {
                 "refresh_token": refreshToken
             ])
 
-            var request = YouVersionAPI.urlRequest(with: url, accessToken: nil, session: session)
+            var request = YouVersionAPI.urlRequest(with: url, accessToken: nil, session: session, omitAccessToken: true)
             request.httpMethod = "POST"
             request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
             request.httpBody = bodyData

--- a/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
@@ -62,9 +62,10 @@ public enum YouVersionAPI {
         with url: URL,
         accessToken: String?,
         session: URLSession,
-        cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy
+        cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
+        omitAccessToken: Bool = false
     ) -> URLRequest {
-        var request = URLRequest.youVersion(url, accessToken: accessToken, cachePolicy: cachePolicy)
+        var request = URLRequest.youVersion(url, accessToken: accessToken, cachePolicy: cachePolicy, omitAccessToken: omitAccessToken)
 
         if let additionalHeaders = session.configuration.httpAdditionalHeaders {
             for (key, value) in additionalHeaders {

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift
@@ -38,7 +38,13 @@ public struct BibleHighlightsAPI: BibleHighlightsAPIProtocol {
 public protocol BibleHighlightsRepositoryProtocol {
     @MainActor func highlights(for references: [BibleReference]) async throws -> [String: [BibleHighlight]]
     @MainActor func queueOperation(_ operation: PendingHighlightOperation)
+}
+
+public protocol BibleHighlightsPendingOperationsReporting: BibleHighlightsRepositoryProtocol {
     @MainActor var hasPendingOperations: Bool { get }
+}
+
+public protocol BibleHighlightsPendingOperationsClearing: BibleHighlightsRepositoryProtocol {
     @MainActor func clearPendingOperations()
 }
 
@@ -57,7 +63,7 @@ public struct OperationResult {
 }
 
 @MainActor
-public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
+public class BibleHighlightsRepository: BibleHighlightsPendingOperationsReporting, BibleHighlightsPendingOperationsClearing {
     
     // MARK: - Private Properties
     
@@ -370,6 +376,10 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
     
     public var hasPendingOperations: Bool {
         processingQueue || !pendingServerOperations.isEmpty
+    }
+
+    public var pendingOperationCount: Int {
+        pendingServerOperations.count
     }
     
     public func clearPendingOperations() {

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift
@@ -38,7 +38,7 @@ public struct BibleHighlightsAPI: BibleHighlightsAPIProtocol {
 public protocol BibleHighlightsRepositoryProtocol {
     @MainActor func highlights(for references: [BibleReference]) async throws -> [String: [BibleHighlight]]
     @MainActor func queueOperation(_ operation: PendingHighlightOperation)
-    @MainActor var pendingOperationCount: Int { get }
+    @MainActor var hasPendingOperations: Bool { get }
     @MainActor func clearPendingOperations()
 }
 
@@ -62,14 +62,22 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
     // MARK: - Private Properties
     
     private let api: BibleHighlightsAPIProtocol
+    private let retryDelayNanoseconds: UInt64
     private var pendingServerOperations: [PendingHighlightOperation] = []
     private var operationResults: [UUID: OperationResult] = [:]
     private var processingQueue = false
+    private var operationGeneration = 0
     
     // MARK: - Initialization
     
     public init(api: BibleHighlightsAPIProtocol = BibleHighlightsAPI()) {
         self.api = api
+        self.retryDelayNanoseconds = 2_000_000_000
+    }
+
+    init(api: BibleHighlightsAPIProtocol, retryDelayNanoseconds: UInt64) {
+        self.api = api
+        self.retryDelayNanoseconds = retryDelayNanoseconds
     }
     
     // MARK: - Public Methods
@@ -271,14 +279,22 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
         }
         
         processingQueue = true
-        defer { processingQueue = false }
+        var nextProcessingDelayNanoseconds: UInt64?
+        defer {
+            processingQueue = false
+            if let nextProcessingDelayNanoseconds, !pendingServerOperations.isEmpty {
+                scheduleQueueProcessing(after: nextProcessingDelayNanoseconds)
+            }
+        }
         
         // Get current batch of operations
+        let operationGenerationAtStart = operationGeneration
         let operationsToProcess = pendingServerOperations
         pendingServerOperations.removeAll()
         
         do {
             let results = try await saveOperations(operationsToProcess)
+            var failedOperationCount = 0
             
             // Update operation results
             for operation in operationsToProcess {
@@ -291,23 +307,18 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
                 )
                 operationResults[operation.id] = result
                 
-                if !success {
+                if !success && operationGeneration == operationGenerationAtStart {
                     // Re-queue failed operations
                     pendingServerOperations.append(operation)
+                    failedOperationCount += 1
                 }
             }
             
-            // If there are still pending operations (failed ones), try again
             if !pendingServerOperations.isEmpty {
-                // swiftlint:disable:next common_debug_statements
-                try await Task.sleep(nanoseconds: 2_000_000_000) // 2 second delay before retry
-                await processQueue()
+                nextProcessingDelayNanoseconds = failedOperationCount > 0 ? retryDelayNanoseconds : 0
             }
             
         } catch {
-            // Re-queue all operations on error
-            pendingServerOperations.insert(contentsOf: operationsToProcess, at: 0)
-            
             // Calculate the maximum retry count from all operations
             let maxRetryCount = operationsToProcess.compactMap { operation in
                 operationResults[operation.id]?.retryCount
@@ -326,12 +337,15 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
                 )
                 operationResults[operation.id] = result
             }
-            
-            // Retry after delay (with exponential backoff)
-            let delay = min(UInt64(pow(2.0, Double(min(newRetryCount, 5)))) * 1_000_000_000, 30_000_000_000) // Max 30 seconds
-            // swiftlint:disable:next common_debug_statements
-            try? await Task.sleep(nanoseconds: delay)
-            await processQueue()
+
+            if operationGeneration == operationGenerationAtStart {
+                // Re-queue all operations on error
+                pendingServerOperations.insert(contentsOf: operationsToProcess, at: 0)
+            }
+
+            if !pendingServerOperations.isEmpty {
+                nextProcessingDelayNanoseconds = retryDelay(forRetryCount: newRetryCount)
+            }
         }
     }
     
@@ -354,12 +368,13 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
         operationResults.removeAll()
     }
     
-    public var pendingOperationCount: Int {
-        pendingServerOperations.count
+    public var hasPendingOperations: Bool {
+        processingQueue || !pendingServerOperations.isEmpty
     }
     
     public func clearPendingOperations() {
         pendingServerOperations.removeAll()
+        operationGeneration += 1
     }
     
     public var failedOperationCount: Int {
@@ -367,5 +382,21 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
             let result = operationResults[operation.id]
             return result?.success == false
         }.count
+    }
+
+    private func scheduleQueueProcessing(after delayNanoseconds: UInt64) {
+        Task { [weak self] in
+            if delayNanoseconds > 0 {
+                // swiftlint:disable:next common_debug_statements
+                try? await Task.sleep(nanoseconds: delayNanoseconds)
+            }
+            await self?.processQueue()
+        }
+    }
+
+    private func retryDelay(forRetryCount retryCount: Int) -> UInt64 {
+        let cappedRetryCount = max(1, min(retryCount, 5))
+        let retryMultiplier = UInt64(pow(2.0, Double(cappedRetryCount - 1)))
+        return min(retryMultiplier * retryDelayNanoseconds, 30_000_000_000)
     }
 } 

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift
@@ -38,6 +38,7 @@ public struct BibleHighlightsAPI: BibleHighlightsAPIProtocol {
 public protocol BibleHighlightsRepositoryProtocol {
     @MainActor func highlights(for references: [BibleReference]) async throws -> [String: [BibleHighlight]]
     @MainActor func queueOperation(_ operation: PendingHighlightOperation)
+    @MainActor var pendingOperationCount: Int { get }
 }
 
 public struct OperationResult {

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift
@@ -39,6 +39,7 @@ public protocol BibleHighlightsRepositoryProtocol {
     @MainActor func highlights(for references: [BibleReference]) async throws -> [String: [BibleHighlight]]
     @MainActor func queueOperation(_ operation: PendingHighlightOperation)
     @MainActor var pendingOperationCount: Int { get }
+    @MainActor func clearPendingOperations()
 }
 
 public struct OperationResult {
@@ -355,6 +356,10 @@ public class BibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
     
     public var pendingOperationCount: Int {
         pendingServerOperations.count
+    }
+    
+    public func clearPendingOperations() {
+        pendingServerOperations.removeAll()
     }
     
     public var failedOperationCount: Int {

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
@@ -47,6 +47,10 @@ public class BibleHighlightsViewModel: ObservableObject {
         cache.reset()
     }
     
+    public var pendingOperationCount: Int {
+        repository.pendingOperationCount
+    }
+    
     // MARK: - Data Retrieval
     
     /// Synchronous method for getting highlights (views should observe cache directly and filter as needed)

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
@@ -48,8 +48,8 @@ public class BibleHighlightsViewModel: ObservableObject {
         repository.clearPendingOperations()
     }
     
-    public var pendingOperationCount: Int {
-        repository.pendingOperationCount
+    public var hasPendingOperations: Bool {
+        repository.hasPendingOperations
     }
     
     // MARK: - Data Retrieval

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
@@ -45,6 +45,7 @@ public class BibleHighlightsViewModel: ObservableObject {
     // Called e.g. when the user signs out
     public func reset() {
         cache.reset()
+        repository.clearPendingOperations()
     }
     
     public var pendingOperationCount: Int {

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
@@ -45,11 +45,11 @@ public class BibleHighlightsViewModel: ObservableObject {
     // Called e.g. when the user signs out
     public func reset() {
         cache.reset()
-        repository.clearPendingOperations()
+        (repository as? any BibleHighlightsPendingOperationsClearing)?.clearPendingOperations()
     }
     
     public var hasPendingOperations: Bool {
-        repository.hasPendingOperations
+        (repository as? any BibleHighlightsPendingOperationsReporting)?.hasPendingOperations ?? false
     }
     
     // MARK: - Data Retrieval

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -124,6 +124,15 @@ private struct ReaderContent: View {
             Text(String.localized("signOut.explanation"))
         }
         .alert(
+            String.localized("signOut.pendinghighlights.question"),
+            isPresented: $viewModel.showSignOutWithPendingHighlightsConfirmation
+        ) {
+            Button(String.localized("signOut.pendinghighlights.confirm"), role: .destructive) { viewModel.confirmPendingHighlightsSignOut() }
+            Button(String.localized("generic.cancel"), role: .cancel) { }
+        } message: {
+            Text(String.localized("signOut.pendinghighlights.explanation"))
+        }
+        .alert(
             String.localized("dataExchange.highlights.question"),
             isPresented: $viewModel.showingDataExchangeConfirmation
         ) {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderAuthentication.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderAuthentication.swift
@@ -2,11 +2,10 @@ import YouVersionPlatformCore
 
 /// The authentication behavior used by `BibleReaderViewModel`.
 ///
-/// The reader keeps customer-facing state on `BibleReaderViewModel.isSignedIn`,
-/// but the work of reading, validating, and clearing YouVersion authentication
-/// lives here. Production uses `default`; tests can supply a deterministic
-/// instance so view model tests do not read or mutate the process-wide token
-/// store shared by other test suites.
+/// Reads, validates, and clears YouVersion authentication for `BibleReaderViewModel`.
+/// Production uses `default`; tests can supply a deterministic instance so view
+/// model tests do not read or mutate the process-wide token store shared by
+/// other test suites.
 struct BibleReaderAuthentication {
     static let `default` = BibleReaderAuthentication(
         isSignedIn: { YouVersionAPI.isSignedIn },

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -83,9 +83,13 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     var startSignInFlow = false
     var showingDataExchangeConfirmation = false
     var startDataExchangeFlow = false
-    private(set) var isSignedIn: Bool
     var showSignOutConfirmation = false
+    var showSignOutWithPendingHighlightsConfirmation = false
     private var pendingHighlight: PendingHighlight?
+
+    var isSignedIn: Bool {
+        authentication.isSignedIn
+    }
 
     init(
         reference: BibleReference? = nil,
@@ -115,7 +119,6 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         self.onVerseTap = onVerseTap
         self.verseSelectionStyle = verseSelectionStyle
         self.authentication = authentication
-        self.isSignedIn = authentication.isSignedIn
         self.highlightsViewModel = highlightsViewModel ?? BibleHighlightsViewModel()
         let shouldLoadVersionsViewModel = versionsViewModel == nil
         self.versionsViewModel = versionsViewModel ?? BibleVersionsViewModel()
@@ -267,7 +270,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     }
 
     func updateSignInState() async {
-        isSignedIn = await authentication.hasValidToken()
+        _ = await authentication.hasValidToken()
     }
 
     /// Continues a pending highlight action after the user has completed sign-in.
@@ -355,14 +358,22 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     }
 
     func signOut() {
-        showSignOutConfirmation = true
+        if highlightsViewModel.pendingOperationCount > 0 {
+            showSignOutWithPendingHighlightsConfirmation = true
+        } else {
+            showSignOutConfirmation = true
+        }
     }
 
     func confirmSignOut() {
         authentication.signOut()
         highlightsViewModel.reset()
-        isSignedIn = false
         clearPendingHighlight()
+    }
+
+    func confirmPendingHighlightsSignOut() {
+        highlightsViewModel.reset()
+        confirmSignOut()
     }
 
     private struct ReaderSettings: Codable {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -280,6 +280,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         }
         if authentication.hasPermission(.highlights) {
             applyPendingHighlight()
+            reloadCurrentChapterHighlights()
         } else {
             startDataExchangeFlow = true
         }
@@ -323,6 +324,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         showingDataExchangeConfirmation = false
         if result.isGranted && result.grantedPermissions.contains(.highlights) {
             applyPendingHighlight()
+            reloadCurrentChapterHighlights()
         } else {
             clearPendingHighlight()
         }
@@ -421,6 +423,10 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     private func applyHighlight(references: Set<BibleReference>, color: String) {
         highlightsViewModel.addHighlights(references: Array(references), color: color)
         removeVerseSelection()
+    }
+
+    private func reloadCurrentChapterHighlights() {
+        highlightsViewModel.ensureHighlightsForChapterLoaded(reference, forceReload: true)
     }
 
     private func clearPendingHighlight() {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -358,7 +358,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     }
 
     func signOut() {
-        if highlightsViewModel.pendingOperationCount > 0 {
+        if highlightsViewModel.hasPendingOperations {
             showSignOutWithPendingHighlightsConfirmation = true
         } else {
             showSignOutConfirmation = true

--- a/Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings
+++ b/Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings
@@ -1558,6 +1558,39 @@
         }
       }
     },
+    "signOut.pendinghighlights.confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign out anyway"
+          }
+        }
+      }
+    },
+    "signOut.pendinghighlights.explanation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Some of your highlights haven’t been saved yet, and they will be lost if you sign out. Do you want to sign out anyway?"
+          }
+        }
+      }
+    },
+    "signOut.pendinghighlights.question" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save your highlights?"
+          }
+        }
+      }
+    },
     "tab.bible": {
       "extractionState": "manual",
       "localizations": {

--- a/Tests/YouVersionPlatformCoreTests/BibleHighlightsRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleHighlightsRepositoryTests.swift
@@ -12,10 +12,12 @@ class MockBibleHighlightsAPI: BibleHighlightsAPIProtocol {
     var deleteHighlightCallCount = 0
     
     var shouldThrowError = false
+    var shouldSuspendCreateHighlight = false
     var mockCreateHighlightResult = true
     var mockGetHighlightsResult: [HighlightResponse] = []
     var mockUpdateHighlightResult = true
     var mockDeleteHighlightResult = true
+    private var createHighlightContinuation: CheckedContinuation<Void, Never>?
     
     func reset() {
         createHighlightCallCount = 0
@@ -23,10 +25,23 @@ class MockBibleHighlightsAPI: BibleHighlightsAPIProtocol {
         updateHighlightCallCount = 0
         deleteHighlightCallCount = 0
         shouldThrowError = false
+        shouldSuspendCreateHighlight = false
         mockCreateHighlightResult = true
         mockGetHighlightsResult = []
         mockUpdateHighlightResult = true
         mockDeleteHighlightResult = true
+    }
+
+    func waitForCreateHighlightToStart() async {
+        while shouldSuspendCreateHighlight && createHighlightContinuation == nil {
+            await Task.yield()
+        }
+    }
+
+    func resumeCreateHighlight() {
+        shouldSuspendCreateHighlight = false
+        createHighlightContinuation?.resume()
+        createHighlightContinuation = nil
     }
     
     func highlights(bibleId: Int, passageId: String) async throws -> [HighlightResponse] {
@@ -41,6 +56,12 @@ class MockBibleHighlightsAPI: BibleHighlightsAPIProtocol {
     
     func createHighlight(bibleId: Int, passageId: String, color: String) async throws -> Bool {
         createHighlightCallCount += 1
+
+        if shouldSuspendCreateHighlight {
+            await withCheckedContinuation { continuation in
+                createHighlightContinuation = continuation
+            }
+        }
         
         if shouldThrowError {
             throw NSError(domain: "TestError", code: 1, userInfo: nil)
@@ -291,15 +312,15 @@ struct BibleHighlightsRepositoryTests {
         let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
         let operation = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
         
-        #expect(repository.pendingOperationCount == 0)
+        #expect(!repository.hasPendingOperations)
         
         repository.queueOperation(operation)
         
-        #expect(repository.pendingOperationCount == 1)
+        #expect(repository.hasPendingOperations)
     }
     
     @Test
-    func testQueueOperationMaintainsOrder() async {
+    func testMultipleQueueOperationsArePending() async {
         let mockAPI = setUp()
         let repository = BibleHighlightsRepository(api: mockAPI)
         
@@ -316,7 +337,7 @@ struct BibleHighlightsRepositoryTests {
         repository.queueOperation(operation2)
         repository.queueOperation(operation1)
         
-        #expect(repository.pendingOperationCount == 2)
+        #expect(repository.hasPendingOperations)
     }
 
     @Test
@@ -331,11 +352,60 @@ struct BibleHighlightsRepositoryTests {
         repository.queueOperation(firstOperation)
         repository.queueOperation(secondOperation)
 
-        #expect(repository.pendingOperationCount == 2)
+        #expect(repository.hasPendingOperations)
 
         repository.clearPendingOperations()
 
-        #expect(repository.pendingOperationCount == 0)
+        #expect(!repository.hasPendingOperations)
+    }
+
+    @Test
+    func testClearPendingOperationsDoesNotRequeueProcessingOperation() async {
+        let mockAPI = setUp()
+        mockAPI.shouldSuspendCreateHighlight = true
+        mockAPI.mockCreateHighlightResult = false
+        let repository = BibleHighlightsRepository(api: mockAPI)
+
+        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let operation = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
+
+        repository.queueOperation(operation)
+        await mockAPI.waitForCreateHighlightToStart()
+
+        repository.clearPendingOperations()
+
+        #expect(repository.hasPendingOperations)
+
+        mockAPI.resumeCreateHighlight()
+
+        while repository.hasPendingOperations {
+            await Task.yield()
+        }
+
+        #expect(repository.failedOperationCount == 0)
+    }
+
+    @Test
+    func testHasPendingOperationsWhileQueueIsProcessing() async {
+        let mockAPI = setUp()
+        mockAPI.shouldSuspendCreateHighlight = true
+        let repository = BibleHighlightsRepository(api: mockAPI)
+
+        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let operation = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
+
+        repository.queueOperation(operation)
+        await mockAPI.waitForCreateHighlightToStart()
+
+        #expect(repository.hasPendingOperations)
+
+        mockAPI.resumeCreateHighlight()
+
+        while repository.hasPendingOperations {
+            await Task.yield()
+        }
+
+        #expect(mockAPI.createHighlightCallCount == 1)
     }
     
     @Test
@@ -348,12 +418,12 @@ struct BibleHighlightsRepositoryTests {
         
         repository.queueOperation(operation)
         
-        #expect(repository.pendingOperationCount == 1)
+        #expect(repository.hasPendingOperations)
         
         await repository.processQueue()
         
         #expect(mockAPI.createHighlightCallCount == 1)
-        #expect(repository.pendingOperationCount == 0)
+        #expect(!repository.hasPendingOperations)
     }
     
     @Test
@@ -369,14 +439,17 @@ struct BibleHighlightsRepositoryTests {
         
         repository.queueOperation(operation)
         
-        #expect(repository.pendingOperationCount == 1)
+        #expect(repository.hasPendingOperations)
         
         await repository.processQueue()
         
         // The operation will be retried automatically, so we expect at least 1 call
         #expect(mockAPI.createHighlightCallCount >= 1)
-        #expect(repository.pendingOperationCount == 1) // Should be re-queued
+        #expect(repository.hasPendingOperations)
         #expect(repository.failedOperationCount == 1)
+
+        mockAPI.mockCreateHighlightResult = true
+        await repository.retryFailedOperations()
     }
     
     @Test
@@ -392,14 +465,41 @@ struct BibleHighlightsRepositoryTests {
         
         repository.queueOperation(operation)
         
-        #expect(repository.pendingOperationCount == 1)
+        #expect(repository.hasPendingOperations)
         
         await repository.processQueue()
         
         // The operation will be retried automatically, so we expect at least 1 call
         #expect(mockAPI.createHighlightCallCount >= 1)
-        #expect(repository.pendingOperationCount == 1) // Should be re-queued
+        #expect(repository.hasPendingOperations)
         #expect(repository.failedOperationCount == 1)
+
+        mockAPI.shouldThrowError = false
+        await repository.retryFailedOperations()
+    }
+
+    @Test
+    func testFailedOperationsAreRetriedWithDelayedProcessing() async {
+        let mockAPI = setUp()
+        mockAPI.mockCreateHighlightResult = false
+        let repository = BibleHighlightsRepository(api: mockAPI, retryDelayNanoseconds: 50_000_000)
+
+        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let operation = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
+
+        repository.queueOperation(operation)
+
+        while mockAPI.createHighlightCallCount == 0 {
+            await Task.yield()
+        }
+
+        #expect(repository.hasPendingOperations)
+
+        mockAPI.mockCreateHighlightResult = true
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(mockAPI.createHighlightCallCount >= 2)
+        #expect(!repository.hasPendingOperations)
     }
     
     // MARK: - Test Operation Results
@@ -466,6 +566,6 @@ struct BibleHighlightsRepositoryTests {
         
         // The operation will be retried, so we expect at least 2 calls (original + retry)
         #expect(mockAPI.createHighlightCallCount >= 2)
-        #expect(repository.pendingOperationCount == 0)
+        #expect(!repository.hasPendingOperations)
     }
 } 

--- a/Tests/YouVersionPlatformCoreTests/BibleHighlightsRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleHighlightsRepositoryTests.swift
@@ -318,6 +318,25 @@ struct BibleHighlightsRepositoryTests {
         
         #expect(repository.pendingOperationCount == 2)
     }
+
+    @Test
+    func testClearPendingOperations() {
+        let mockAPI = setUp()
+        let repository = BibleHighlightsRepository(api: mockAPI)
+
+        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let firstOperation = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
+        let secondOperation = PendingHighlightOperation(references: [reference], color: nil, operationType: .remove)
+
+        repository.queueOperation(firstOperation)
+        repository.queueOperation(secondOperation)
+
+        #expect(repository.pendingOperationCount == 2)
+
+        repository.clearPendingOperations()
+
+        #expect(repository.pendingOperationCount == 0)
+    }
     
     @Test
     func testProcessQueue() async {

--- a/Tests/YouVersionPlatformCoreTests/BibleHighlightsViewModelTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleHighlightsViewModelTests.swift
@@ -120,12 +120,12 @@ struct BibleHighlightsViewModelTests {
 
         viewModel.addHighlights(references: [reference], color: "eefeef")
 
-        #expect(viewModel.pendingOperationCount == 1)
+        #expect(viewModel.hasPendingOperations)
 
         viewModel.reset()
 
         #expect(mockRepository.clearPendingOperationsCallCount == 1)
-        #expect(viewModel.pendingOperationCount == 0)
+        #expect(!viewModel.hasPendingOperations)
     }
     
     // Publisher-based APIs removed; tests adjusted accordingly

--- a/Tests/YouVersionPlatformCoreTests/BibleHighlightsViewModelTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleHighlightsViewModelTests.swift
@@ -80,6 +80,16 @@ class MockBibleHighlightsRepository: BibleHighlightsRepository {
     }
 }
 
+@MainActor
+final class MinimalBibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
+    func highlights(for references: [BibleReference]) async throws -> [String: [BibleHighlight]] {
+        [:]
+    }
+
+    func queueOperation(_ operation: PendingHighlightOperation) {
+    }
+}
+
 // MARK: - Tests
 
 @MainActor
@@ -125,6 +135,17 @@ struct BibleHighlightsViewModelTests {
         viewModel.reset()
 
         #expect(mockRepository.clearPendingOperationsCallCount == 1)
+        #expect(!viewModel.hasPendingOperations)
+    }
+
+    @Test
+    func testRepositoryProtocolDoesNotRequirePendingOperationsState() {
+        let cache = BibleHighlightsCache()
+        let repository = MinimalBibleHighlightsRepository()
+        let viewModel = BibleHighlightsViewModel(cache: cache, repository: repository)
+
+        viewModel.reset()
+
         #expect(!viewModel.hasPendingOperations)
     }
     

--- a/Tests/YouVersionPlatformCoreTests/BibleHighlightsViewModelTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleHighlightsViewModelTests.swift
@@ -51,6 +51,7 @@ class MockBibleHighlightsAPIVM: BibleHighlightsAPIProtocol {
 
 class MockBibleHighlightsRepository: BibleHighlightsRepository {
     var queueOperationCallCount = 0
+    var clearPendingOperationsCallCount = 0
     var highlightsCallCount = 0
     var shouldThrowError = false
     var mockServerData: [String: [BibleHighlight]] = [:]
@@ -71,6 +72,11 @@ class MockBibleHighlightsRepository: BibleHighlightsRepository {
     override func queueOperation(_ operation: PendingHighlightOperation) {
         queueOperationCallCount += 1
         super.queueOperation(operation)
+    }
+
+    override func clearPendingOperations() {
+        clearPendingOperationsCallCount += 1
+        super.clearPendingOperations()
     }
 }
 
@@ -103,6 +109,23 @@ struct BibleHighlightsViewModelTests {
         let highlights = viewModel.highlights(for: BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 10))
         
         #expect(highlights.isEmpty)
+    }
+
+    @Test
+    func testResetClearsPendingOperations() {
+        let cache = BibleHighlightsCache()
+        let mockRepository = MockBibleHighlightsRepository()
+        let viewModel = BibleHighlightsViewModel(cache: cache, repository: mockRepository)
+        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+
+        viewModel.addHighlights(references: [reference], color: "eefeef")
+
+        #expect(viewModel.pendingOperationCount == 1)
+
+        viewModel.reset()
+
+        #expect(mockRepository.clearPendingOperationsCallCount == 1)
+        #expect(viewModel.pendingOperationCount == 0)
     }
     
     // Publisher-based APIs removed; tests adjusted accordingly

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelDataExchangeTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelDataExchangeTests.swift
@@ -165,15 +165,17 @@ import Testing
     func pendingHighlightStartsDataExchangeFlowDirectlyAfterSignInSucceeds() async {
         YouVersionPlatformConfiguration.configure(appKey: "test-app", isSignInEnabled: true)
         let highlightsRepository = MockBibleHighlightsRepository()
+        let authenticationState = MockBibleReaderAuthenticationState(isSignedIn: false)
         let viewModel = Support.makeViewModel(
             highlightsRepository: highlightsRepository,
-            isSignedIn: false,
+            readIsSignedIn: { authenticationState.isSignedIn },
             hasValidToken: true
         )
         let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
         viewModel.selectedVerses = [reference]
         viewModel.addHighlightOrStartPermissionFlow(references: [reference], color: "DDAAFF")
 
+        authenticationState.isSignedIn = true
         await viewModel.updateSignInState()
         viewModel.continuePendingHighlightAfterSignIn()
 

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelDataExchangeTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelDataExchangeTests.swift
@@ -94,6 +94,36 @@ import Testing
     }
 
     @Test
+    func signedInUserGrantingHighlightPermissionLoadsCurrentChapterHighlights() async {
+        let highlightsRepository = MockBibleHighlightsRepository()
+        let localReference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        let serverReference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 17)
+        let chapterReference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3)
+        let viewModel = Support.makeViewModel(
+            reference: chapterReference,
+            highlightsRepository: highlightsRepository,
+            isSignedIn: true
+        )
+        let chapterKey = "\(Support.versionId)_JHN_3"
+        highlightsRepository.serverHighlights = [
+            chapterKey: [BibleHighlight(serverReference, color: "FFD700")]
+        ]
+        viewModel.selectedVerses = [localReference]
+        viewModel.showingVerseActionsDrawer = true
+        viewModel.addHighlightOrStartPermissionFlow(references: [localReference], color: "DDAAFF")
+        viewModel.confirmDataExchangePrompt()
+
+        viewModel.completeDataExchangeFlow(with: DataExchangeRequestResult(status: .granted, grantedPermissions: [.highlights]))
+        for _ in 0..<100 where viewModel.highlightsViewModel.highlights(for: serverReference).isEmpty {
+            await Task.yield()
+        }
+
+        #expect(highlightsRepository.requestedReferences == [[chapterReference]])
+        #expect(viewModel.highlightsViewModel.highlights(for: localReference) == [BibleHighlight(localReference, color: "DDAAFF")])
+        #expect(viewModel.highlightsViewModel.highlights(for: serverReference) == [BibleHighlight(serverReference, color: "FFD700")])
+    }
+
+    @Test
     func cancelledDataExchangeFlowDoesNotApplyPendingHighlight() {
         let highlightsRepository = MockBibleHighlightsRepository()
         let viewModel = Support.makeViewModel(highlightsRepository: highlightsRepository, isSignedIn: true)

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelSignInTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelSignInTests.swift
@@ -73,7 +73,7 @@ import Testing
     }
 
     @Test
-    func signOutShowsConfirmationAndConfirmSignOutClearsStateAndHighlights() {
+    func signOutShowsPendingHighlightsConfirmationAndConfirmClearsStateAndHighlights() {
         Support.clearReaderDefaults()
         let authenticationState = MockBibleReaderAuthenticationState(isSignedIn: true)
         var didSignOut = false
@@ -92,7 +92,7 @@ import Testing
         viewModel.signOut()
         #expect(viewModel.showSignOutWithPendingHighlightsConfirmation)
 
-        viewModel.confirmSignOut()
+        viewModel.confirmPendingHighlightsSignOut()
 
         #expect(didSignOut)
         #expect(viewModel.isSignedIn == false)

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelSignInTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelSignInTests.swift
@@ -60,19 +60,37 @@ import Testing
     }
 
     @Test
+    func signInReadsCurrentAuthenticationState() {
+        Support.clearReaderDefaults()
+        let authenticationState = MockBibleReaderAuthenticationState(isSignedIn: false)
+        let viewModel = Support.makeViewModel(readIsSignedIn: { authenticationState.isSignedIn })
+        authenticationState.isSignedIn = true
+
+        viewModel.signIn()
+
+        #expect(viewModel.startSignInFlow == false)
+        #expect(viewModel.isSignedIn)
+    }
+
+    @Test
     func signOutShowsConfirmationAndConfirmSignOutClearsStateAndHighlights() {
         Support.clearReaderDefaults()
+        let authenticationState = MockBibleReaderAuthenticationState(isSignedIn: true)
         var didSignOut = false
-        let viewModel = Support.makeViewModel(isSignedIn: true) {
-            didSignOut = true
-        }
+        let viewModel = Support.makeViewModel(
+            readIsSignedIn: { authenticationState.isSignedIn },
+            signOut: {
+                didSignOut = true
+                authenticationState.isSignedIn = false
+            }
+        )
         let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
         viewModel.highlightsViewModel.addHighlights(references: [reference], color: "DDAAFF")
 
         #expect(viewModel.isSignedIn)
 
         viewModel.signOut()
-        #expect(viewModel.showSignOutConfirmation)
+        #expect(viewModel.showSignOutWithPendingHighlightsConfirmation)
 
         viewModel.confirmSignOut()
 
@@ -84,10 +102,14 @@ import Testing
     @Test
     func updateSignInStateUsesAuthenticationState() async {
         Support.clearReaderDefaults()
-        let viewModel = Support.makeViewModel(hasValidToken: true)
+        var didValidateToken = false
+        let viewModel = Support.makeViewModel(validateToken: {
+            didValidateToken = true
+            return true
+        })
 
         await viewModel.updateSignInState()
 
-        #expect(viewModel.isSignedIn)
+        #expect(didValidateToken)
     }
 }

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
@@ -43,7 +43,7 @@ actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
 }
 
 @MainActor
-final class MockBibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
+final class MockBibleHighlightsRepository: BibleHighlightsPendingOperationsReporting, BibleHighlightsPendingOperationsClearing {
     private(set) var queuedOperations: [PendingHighlightOperation] = []
     private(set) var requestedReferences: [[BibleReference]] = []
     var serverHighlights: [String: [BibleHighlight]] = [:]

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
@@ -46,12 +46,25 @@ actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
 final class MockBibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
     private(set) var queuedOperations: [PendingHighlightOperation] = []
 
+    var pendingOperationCount: Int {
+        queuedOperations.count
+    }
+
     func highlights(for references: [BibleReference]) async throws -> [String: [BibleHighlight]] {
         [:]
     }
 
     func queueOperation(_ operation: PendingHighlightOperation) {
         queuedOperations.append(operation)
+    }
+}
+
+@MainActor
+final class MockBibleReaderAuthenticationState {
+    var isSignedIn: Bool
+
+    init(isSignedIn: Bool) {
+        self.isSignedIn = isSignedIn
     }
 }
 
@@ -68,7 +81,9 @@ enum BibleReaderViewModelTestSupport {
         versionRepository: any BibleVersionRepositoryProtocol = MockBibleVersionRepository(),
         onVerseTap: ((BibleReference) -> Void)? = nil,
         isSignedIn: Bool = false,
+        readIsSignedIn: (@MainActor () -> Bool)? = nil,
         hasValidToken: Bool? = nil,
+        validateToken: (@MainActor () async -> Bool)? = nil,
         signOut: @escaping @MainActor () -> Void = {},
         hasPermission: @escaping @MainActor (SignInWithYouVersionPermission) -> Bool = { _ in false }
     ) -> BibleReaderViewModel {
@@ -78,8 +93,13 @@ enum BibleReaderViewModelTestSupport {
         )
         let versionsViewModel = BibleVersionsViewModel(versionRepository: versionRepository)
         let authentication = BibleReaderAuthentication(
-            isSignedIn: { isSignedIn },
-            hasValidToken: { hasValidToken ?? isSignedIn },
+            isSignedIn: { readIsSignedIn?() ?? isSignedIn },
+            hasValidToken: {
+                if let validateToken {
+                    return await validateToken()
+                }
+                return hasValidToken ?? readIsSignedIn?() ?? isSignedIn
+            },
             signOut: signOut,
             hasPermission: hasPermission
         )

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
@@ -45,13 +45,16 @@ actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
 @MainActor
 final class MockBibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
     private(set) var queuedOperations: [PendingHighlightOperation] = []
+    private(set) var requestedReferences: [[BibleReference]] = []
+    var serverHighlights: [String: [BibleHighlight]] = [:]
 
     var hasPendingOperations: Bool {
         !queuedOperations.isEmpty
     }
 
     func highlights(for references: [BibleReference]) async throws -> [String: [BibleHighlight]] {
-        [:]
+        requestedReferences.append(references)
+        return serverHighlights
     }
 
     func queueOperation(_ operation: PendingHighlightOperation) {

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
@@ -46,8 +46,8 @@ actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
 final class MockBibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
     private(set) var queuedOperations: [PendingHighlightOperation] = []
 
-    var pendingOperationCount: Int {
-        queuedOperations.count
+    var hasPendingOperations: Bool {
+        !queuedOperations.isEmpty
     }
 
     func highlights(for references: [BibleReference]) async throws -> [String: [BibleHighlight]] {

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
@@ -57,6 +57,10 @@ final class MockBibleHighlightsRepository: BibleHighlightsRepositoryProtocol {
     func queueOperation(_ operation: PendingHighlightOperation) {
         queuedOperations.append(operation)
     }
+
+    func clearPendingOperations() {
+        queuedOperations.removeAll()
+    }
 }
 
 @MainActor


### PR DESCRIPTION
fix: when signing out, if there are pending highlights, confirm with the user, and, don't send access token when refreshing it

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses two issues: it guards sign-out with a confirmation dialog when there are pending (unsaved) highlights, and it fixes the token-refresh endpoint incorrectly sending the current access token as a Bearer header.

- **Pending-highlights sign-out guard**: `BibleHighlightsRepository` gains `hasPendingOperations` (which correctly covers in-flight operations via `processingQueue`) and `clearPendingOperations` with an `operationGeneration` counter that prevents cleared in-flight operations from re-queuing after they complete. `BibleReaderViewModel.signOut()` branches on `hasPendingOperations` to show the new confirmation dialog, and the new `confirmPendingHighlightsSignOut()` clears pending state before delegating to `confirmSignOut()`.
- **`omitAccessToken` fix**: `URLRequest.youVersion` and `YouVersionAPI.urlRequest` accept a new `omitAccessToken: Bool = false` flag; `refreshSignIn` now passes `true`, ensuring no Authorization header is sent on the refresh-token request.
- **`isSignedIn` refactor**: The property is now computed from `authentication.isSignedIn` rather than a cached stored `var`; `updateSignInState()` calls `hasValidToken()` for its side effects and discards the return value.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the core sign-out and token-refresh changes are well-guarded and well-tested.

The two primary changes — the pending-highlights confirmation dialog and the omitAccessToken fix — are straightforward, covered by targeted new tests, and introduce no regressions. The `isSignedIn` computed-property refactor works correctly in all current call paths, with a minor design concern noted about implicit reliance on adjacent state mutations for SwiftUI observability. No data-loss or auth regressions were found.

Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift — the `updateSignInState` / `isSignedIn` design change is worth a second look as the codebase evolves.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/APIs/URLRequest+YouVersion.swift | Adds `omitAccessToken: Bool = false` parameter; fixes the token-refresh endpoint incorrectly falling back to the stored access token when `accessToken: nil` was passed. |
| Sources/YouVersionPlatformCore/APIs/Users/Users.swift | Passes `omitAccessToken: true` to the refresh-token request, preventing the current (possibly expired) access token from being sent as a Bearer header during token refresh. |
| Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift | Introduces `hasPendingOperations` (includes `processingQueue` flag to cover in-flight ops) and `clearPendingOperations` with an `operationGeneration` counter to prevent cleared in-flight ops from re-queueing. Also refactors retry scheduling away from recursive `await processQueue()` to a detached `Task`-based `scheduleQueueProcessing`. |
| Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift | Adds `hasPendingOperations` via optional-cast protocol conformance; `reset()` now calls `clearPendingOperations()` on repositories that support it. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Adds pending-highlights sign-out confirmation path and converts `isSignedIn` from a stored property to a computed property; `updateSignInState()` now discards its return value, which is a design concern for SwiftUI observability. |
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Adds a new `.alert` for the pending-highlights sign-out confirmation, wired to the new `showSignOutWithPendingHighlightsConfirmation` binding. |
| Tests/YouVersionPlatformCoreTests/BibleHighlightsRepositoryTests.swift | Good new test coverage: `testClearPendingOperations`, `testClearPendingOperationsDoesNotRequeueProcessingOperation`, `testHasPendingOperationsWhileQueueIsProcessing`, and `testFailedOperationsAreRetriedWithDelayedProcessing`. The suspension-based mock correctly exercises the generation-counter race protection. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelSignInTests.swift | Replaces the old sign-out test with a pending-highlights path test and adds `signInReadsCurrentAuthenticationState`. The `showSignOutConfirmation` (no-pending-highlights) path is currently unexercised in this file (noted in prior review). |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift | Upgrades `MockBibleHighlightsRepository` to conform to the new pending-operations protocols; adds `MockBibleReaderAuthenticationState` to support dynamic auth-state testing. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User taps Sign Out] --> B{hasPendingOperations?}
    B -- processingQueue OR pendingServerOperations not empty --> C[showSignOutWithPendingHighlightsConfirmation = true]
    B -- false --> D[showSignOutConfirmation = true]
    C --> E[Alert: pending highlights dialog]
    D --> F[Alert: standard sign-out dialog]
    E -- confirm --> G[confirmPendingHighlightsSignOut]
    E -- cancel --> H[Dismissed]
    F -- confirm --> I[confirmSignOut]
    G --> J[highlightsViewModel.reset\nclearPendingOperations\noperationGeneration++]
    J --> I
    I --> K[authentication.signOut\nhighlightsViewModel.reset\nclearPendingHighlight]
    K --> L[User signed out]

    subgraph In-flight protection
        M[processQueue running\npendingServerOperations empty]
        M -- hasPendingOperations=true via processingQueue --> B
        N[clearPendingOperations called\noperationGeneration incremented]
        N -- in-flight op checks generation mismatch --> O[op NOT re-queued]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User taps Sign Out] --> B{hasPendingOperations?}
    B -- processingQueue OR pendingServerOperations not empty --> C[showSignOutWithPendingHighlightsConfirmation = true]
    B -- false --> D[showSignOutConfirmation = true]
    C --> E[Alert: pending highlights dialog]
    D --> F[Alert: standard sign-out dialog]
    E -- confirm --> G[confirmPendingHighlightsSignOut]
    E -- cancel --> H[Dismissed]
    F -- confirm --> I[confirmSignOut]
    G --> J[highlightsViewModel.reset\nclearPendingOperations\noperationGeneration++]
    J --> I
    I --> K[authentication.signOut\nhighlightsViewModel.reset\nclearPendingHighlight]
    K --> L[User signed out]

    subgraph In-flight protection
        M[processQueue running\npendingServerOperations empty]
        M -- hasPendingOperations=true via processingQueue --> B
        N[clearPendingOperations called\noperationGeneration incremented]
        N -- in-flight op checks generation mismatch --> O[op NOT re-queued]
    end
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift`, line 356-358 ([link](https://github.com/youversion/platform-sdk-swift/blob/f1168fb9a64cddb364bb0b8391873505ba20ff49/Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift#L356-L358)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`pendingOperationCount` silently reads zero while operations are in-flight**

   `processQueue()` copies operations out and immediately calls `pendingServerOperations.removeAll()` before the first `await`. Because `processQueue` is `@MainActor`, that `removeAll()` runs atomically before any suspension, but the subsequent `try await saveOperations(...)` suspends the main actor. If the user taps Sign Out during that suspension window, `pendingOperationCount` returns 0 and the confirmation dialog is never shown — highlights being actively sent to the network are silently discarded on sign-out. Tracking in-flight operations (e.g. an `inFlightCount` that is incremented before `removeAll()` and decremented in `defer`) would close this gap.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformCore/Bible/BibleHighlightsRepository.swift
   Line: 356-358

   Comment:
   **`pendingOperationCount` silently reads zero while operations are in-flight**

   `processQueue()` copies operations out and immediately calls `pendingServerOperations.removeAll()` before the first `await`. Because `processQueue` is `@MainActor`, that `removeAll()` runs atomically before any suspension, but the subsequent `try await saveOperations(...)` suspends the main actor. If the user taps Sign Out during that suspension window, `pendingOperationCount` returns 0 and the confirmation dialog is never shown — highlights being actively sent to the network are silently discarded on sign-out. Tracking in-flight operations (e.g. an `inFlightCount` that is incremented before `removeAll()` and decremented in `defer`) would close this gap.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformCore%2FBible%2FBibleHighlightsRepository.swift%0ALine%3A%20356-358%0A%0AComment%3A%0A**%60pendingOperationCount%60%20silently%20reads%20zero%20while%20operations%20are%20in-flight**%0A%0A%60processQueue%28%29%60%20copies%20operations%20out%20and%20immediately%20calls%20%60pendingServerOperations.removeAll%28%29%60%20before%20the%20first%20%60await%60.%20Because%20%60processQueue%60%20is%20%60%40MainActor%60%2C%20that%20%60removeAll%28%29%60%20runs%20atomically%20before%20any%20suspension%2C%20but%20the%20subsequent%20%60try%20await%20saveOperations%28...%29%60%20suspends%20the%20main%20actor.%20If%20the%20user%20taps%20Sign%20Out%20during%20that%20suspension%20window%2C%20%60pendingOperationCount%60%20returns%200%20and%20the%20confirmation%20dialog%20is%20never%20shown%20%E2%80%94%20highlights%20being%20actively%20sent%20to%20the%20network%20are%20silently%20discarded%20on%20sign-out.%20Tracking%20in-flight%20operations%20%28e.g.%20an%20%60inFlightCount%60%20that%20is%20incremented%20before%20%60removeAll%28%29%60%20and%20decremented%20in%20%60defer%60%29%20would%20close%20this%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformCore%2FBible%2FBibleHighlightsRepository.swift%0ALine%3A%20356-358%0A%0AComment%3A%0A**%60pendingOperationCount%60%20silently%20reads%20zero%20while%20operations%20are%20in-flight**%0A%0A%60processQueue%28%29%60%20copies%20operations%20out%20and%20immediately%20calls%20%60pendingServerOperations.removeAll%28%29%60%20before%20the%20first%20%60await%60.%20Because%20%60processQueue%60%20is%20%60%40MainActor%60%2C%20that%20%60removeAll%28%29%60%20runs%20atomically%20before%20any%20suspension%2C%20but%20the%20subsequent%20%60try%20await%20saveOperations%28...%29%60%20suspends%20the%20main%20actor.%20If%20the%20user%20taps%20Sign%20Out%20during%20that%20suspension%20window%2C%20%60pendingOperationCount%60%20returns%200%20and%20the%20confirmation%20dialog%20is%20never%20shown%20%E2%80%94%20highlights%20being%20actively%20sent%20to%20the%20network%20are%20silently%20discarded%20on%20sign-out.%20Tracking%20in-flight%20operations%20%28e.g.%20an%20%60inFlightCount%60%20that%20is%20incremented%20before%20%60removeAll%28%29%60%20and%20decremented%20in%20%60defer%60%29%20would%20close%20this%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22YPE-3651-pending-highlights-and-sign-in%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22YPE-3651-pending-highlights-and-sign-in%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformCore%2FBible%2FBibleHighlightsRepository.swift%0ALine%3A%20356-358%0A%0AComment%3A%0A**%60pendingOperationCount%60%20silently%20reads%20zero%20while%20operations%20are%20in-flight**%0A%0A%60processQueue%28%29%60%20copies%20operations%20out%20and%20immediately%20calls%20%60pendingServerOperations.removeAll%28%29%60%20before%20the%20first%20%60await%60.%20Because%20%60processQueue%60%20is%20%60%40MainActor%60%2C%20that%20%60removeAll%28%29%60%20runs%20atomically%20before%20any%20suspension%2C%20but%20the%20subsequent%20%60try%20await%20saveOperations%28...%29%60%20suspends%20the%20main%20actor.%20If%20the%20user%20taps%20Sign%20Out%20during%20that%20suspension%20window%2C%20%60pendingOperationCount%60%20returns%200%20and%20the%20confirmation%20dialog%20is%20never%20shown%20%E2%80%94%20highlights%20being%20actively%20sent%20to%20the%20network%20are%20silently%20discarded%20on%20sign-out.%20Tracking%20in-flight%20operations%20%28e.g.%20an%20%60inFlightCount%60%20that%20is%20incremented%20before%20%60removeAll%28%29%60%20and%20decremented%20in%20%60defer%60%29%20would%20close%20this%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

2. `Tests/YouVersionPlatformReaderTests/BibleReaderViewModelSignInTests.swift`, line 75-100 ([link](https://github.com/youversion/platform-sdk-swift/blob/f1168fb9a64cddb364bb0b8391873505ba20ff49/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelSignInTests.swift#L75-L100)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No-pending-highlights sign-out path is now untested**

   The updated test adds a highlight before calling `signOut()`, so it only exercises `showSignOutWithPendingHighlightsConfirmation`. The branch that sets `showSignOutConfirmation` (when `pendingOperationCount == 0`) lost its coverage. Adding a second test that calls `viewModel.signOut()` with no queued operations and asserts `viewModel.showSignOutConfirmation` would keep both paths verified.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Tests/YouVersionPlatformReaderTests/BibleReaderViewModelSignInTests.swift
   Line: 75-100

   Comment:
   **No-pending-highlights sign-out path is now untested**

   The updated test adds a highlight before calling `signOut()`, so it only exercises `showSignOutWithPendingHighlightsConfirmation`. The branch that sets `showSignOutConfirmation` (when `pendingOperationCount == 0`) lost its coverage. Adding a second test that calls `viewModel.signOut()` with no queued operations and asserts `viewModel.showSignOutConfirmation` would keep both paths verified.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Tests%2FYouVersionPlatformReaderTests%2FBibleReaderViewModelSignInTests.swift%0ALine%3A%2075-100%0A%0AComment%3A%0A**No-pending-highlights%20sign-out%20path%20is%20now%20untested**%0A%0AThe%20updated%20test%20adds%20a%20highlight%20before%20calling%20%60signOut%28%29%60%2C%20so%20it%20only%20exercises%20%60showSignOutWithPendingHighlightsConfirmation%60.%20The%20branch%20that%20sets%20%60showSignOutConfirmation%60%20%28when%20%60pendingOperationCount%20%3D%3D%200%60%29%20lost%20its%20coverage.%20Adding%20a%20second%20test%20that%20calls%20%60viewModel.signOut%28%29%60%20with%20no%20queued%20operations%20and%20asserts%20%60viewModel.showSignOutConfirmation%60%20would%20keep%20both%20paths%20verified.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Tests%2FYouVersionPlatformReaderTests%2FBibleReaderViewModelSignInTests.swift%0ALine%3A%2075-100%0A%0AComment%3A%0A**No-pending-highlights%20sign-out%20path%20is%20now%20untested**%0A%0AThe%20updated%20test%20adds%20a%20highlight%20before%20calling%20%60signOut%28%29%60%2C%20so%20it%20only%20exercises%20%60showSignOutWithPendingHighlightsConfirmation%60.%20The%20branch%20that%20sets%20%60showSignOutConfirmation%60%20%28when%20%60pendingOperationCount%20%3D%3D%200%60%29%20lost%20its%20coverage.%20Adding%20a%20second%20test%20that%20calls%20%60viewModel.signOut%28%29%60%20with%20no%20queued%20operations%20and%20asserts%20%60viewModel.showSignOutConfirmation%60%20would%20keep%20both%20paths%20verified.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22YPE-3651-pending-highlights-and-sign-in%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22YPE-3651-pending-highlights-and-sign-in%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Tests%2FYouVersionPlatformReaderTests%2FBibleReaderViewModelSignInTests.swift%0ALine%3A%2075-100%0A%0AComment%3A%0A**No-pending-highlights%20sign-out%20path%20is%20now%20untested**%0A%0AThe%20updated%20test%20adds%20a%20highlight%20before%20calling%20%60signOut%28%29%60%2C%20so%20it%20only%20exercises%20%60showSignOutWithPendingHighlightsConfirmation%60.%20The%20branch%20that%20sets%20%60showSignOutConfirmation%60%20%28when%20%60pendingOperationCount%20%3D%3D%200%60%29%20lost%20its%20coverage.%20Adding%20a%20second%20test%20that%20calls%20%60viewModel.signOut%28%29%60%20with%20no%20queued%20operations%20and%20asserts%20%60viewModel.showSignOutConfirmation%60%20would%20keep%20both%20paths%20verified.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["chore: restore compatibility"](https://github.com/youversion/platform-sdk-swift/commit/ce52727520b70583ff74d7cf6b8e4cb37a3fe89d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42187189)</sub>

<!-- /greptile_comment -->