### PR TITLE
fix: make tvos build again

### DIFF
--- a/Examples/SampleApp/ContextProvider.swift
+++ b/Examples/SampleApp/ContextProvider.swift
@@ -1,5 +1,6 @@
 import AuthenticationServices
 
+#if !os(tvOS)
 class ContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
@@ -9,3 +10,4 @@ class ContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding
         return window
     }
 }
+#endif

--- a/Examples/SampleApp/ProfileView.swift
+++ b/Examples/SampleApp/ProfileView.swift
@@ -2,7 +2,9 @@ import SwiftUI
 import YouVersionPlatform
 
 struct ProfileView: View {
+#if !os(tvOS)
     @State private var contextProvider = ContextProvider()
+#endif
     @State private var isSignedIn = false
     @State private var dataExchangeStatusText: String?
     @State private var hasHighlightsPermission = false
@@ -46,10 +48,14 @@ struct ProfileView: View {
     func doSignIn() {
         Task {
             do {
+#if os(tvOS)
+                _ = try await YouVersionAPI.Users.signIn(permissions: [.profile, .email])
+#else
                 _ = try await YouVersionAPI.Users.signIn(
                     permissions: [.profile, .email],
                     contextProvider: contextProvider
                 )
+#endif
                 // The user is signed in! Their accessToken will automatically be saved
                 // to UserDefaults on this device, so they don't have to log in again next time.
                 // Now you may use accessors like YouVersionAPI.Users.currentUserName.
@@ -71,7 +77,11 @@ struct ProfileView: View {
         dataExchangeStatusText = nil
         Task {
             do {
+#if os(tvOS)
+                let session = DataExchangeSession()
+#else
                 let session = DataExchangeSession(contextProvider: contextProvider)
+#endif
                 let result = try await session.requestDataExchange(permissions: [.highlights])
                 if !result.isGranted {
                     dataExchangeStatusText = "Highlights permission status: \(result.status)"

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -178,7 +178,11 @@ private struct ReaderContent: View {
         .onChange(of: viewModel.startSignInFlow) { _, newValue in
             // TODO: move this to the viewModel
             if newValue {
+#if os(tvOS)
+                viewModel.startSignIn()
+#else
                 viewModel.startSignIn(contextProvider: contextProvider)
+#endif
             }
         }
         .onChange(of: viewModel.startDataExchangeFlow) { _, newValue in

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -378,6 +378,23 @@ final class BibleReaderViewModel: ReaderThemeProviding {
             }
         }
     }
+#else
+    func startSignIn() {
+        Task {
+            do {
+                startSignInFlow = false
+                let result = try await YouVersionAPI.Users.signIn(permissions: [.profile, .highlights])
+                await updateSignInState()
+                if let permissions = result.permissions, permissions.contains(.highlights) {
+                    continuePendingHighlightAfterSignIn()
+                } else {
+                    clearPendingHighlight()
+                }
+            } catch {
+                YouVersionPlatformLogger.error("\(error)", category: "Reader")
+            }
+        }
+    }
 #endif
 
     func signIn() {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the tvOS build by adding `#if os(tvOS)` / `#if !os(tvOS)` conditional compilation guards around `ASWebAuthenticationPresentationContextProviding`-dependent code, which is unavailable on tvOS.

- `ContextProvider` (both in the sample app and as a nested class in `BibleReaderView`) is fully guarded behind `#if !os(tvOS)`, and every call site that references `contextProvider` is given a matching tvOS-safe code path.
- A new `startSignIn()` overload (no contextProvider argument) is added to `BibleReaderViewModel` for tvOS, exactly paralleling the existing non-tvOS `startSignIn(contextProvider:)` — same permissions, same post-sign-in highlight continuation logic.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive conditional compilation guards with no impact on the existing iOS/macOS paths.

Every changed code path on non-tvOS platforms is left untouched; the new tvOS branches are simple call-site redirects to already-tested API surfaces (parameterless signIn and DataExchangeSession). The tvOS startSignIn() in the ViewModel faithfully mirrors the non-tvOS implementation with no behavioral differences beyond dropping the contextProvider.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Examples/SampleApp/ContextProvider.swift | Wraps the entire ContextProvider class in #if !os(tvOS) since ASWebAuthenticationPresentationContextProviding is unavailable on tvOS. Minimal, correct change. |
| Examples/SampleApp/ProfileView.swift | Guards the contextProvider @State property and adds tvOS-specific sign-in / DataExchangeSession code paths that omit the contextProvider argument. Logic mirrors the existing non-tvOS paths correctly. |
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Adds a #if os(tvOS) branch in the startSignInFlow onChange observer to call the new no-arg startSignIn(). Consistent with the already-present tvOS branch for startDataExchangeFlow. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Adds the tvOS startSignIn() method as the #else branch of the existing #if !os(tvOS) block; logic is an exact parallel of the non-tvOS implementation, using the same permissions and post-sign-in highlight continuation. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant View as BibleReaderView / ProfileView
    participant VM as BibleReaderViewModel
    participant API as YouVersionAPI

    Note over View,API: non-tvOS path
    View->>VM: startSignIn(contextProvider:)
    VM->>API: Users.signIn(permissions:, contextProvider:)
    API-->>VM: SignInResult
    VM->>VM: updateSignInState()
    VM->>VM: continuePendingHighlightAfterSignIn() / clearPendingHighlight()

    Note over View,API: tvOS path (new)
    View->>VM: startSignIn()
    VM->>API: Users.signIn(permissions:)
    API-->>VM: SignInResult
    VM->>VM: updateSignInState()
    VM->>VM: continuePendingHighlightAfterSignIn() / clearPendingHighlight()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant View as BibleReaderView / ProfileView
    participant VM as BibleReaderViewModel
    participant API as YouVersionAPI

    Note over View,API: non-tvOS path
    View->>VM: startSignIn(contextProvider:)
    VM->>API: Users.signIn(permissions:, contextProvider:)
    API-->>VM: SignInResult
    VM->>VM: updateSignInState()
    VM->>VM: continuePendingHighlightAfterSignIn() / clearPendingHighlight()

    Note over View,API: tvOS path (new)
    View->>VM: startSignIn()
    VM->>API: Users.signIn(permissions:)
    API-->>VM: SignInResult
    VM->>VM: updateSignInState()
    VM->>VM: continuePendingHighlightAfterSignIn() / clearPendingHighlight()
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix: make tvos build again"](https://github.com/youversion/platform-sdk-swift/commit/bd4feb48482d297dc7dda0d277ff9b3d79a0468d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42814802)</sub>

<!-- /greptile_comment -->