### PR TITLE
fix: toggle sign-in/out menu

### DIFF
--- a/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderMenuView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderHeaderMenuView.swift
@@ -3,12 +3,13 @@ import YouVersionPlatformCore
 
 struct BibleReaderHeaderMenuView: View {
     @Environment(BibleReaderViewModel.self) private var viewModel
+    @State private var observedIsSignedIn: Bool?
 
     var body: some View {
         Menu {
             Button(String.localized("menu.fontSettings"), action: openFontSettings)
             if YouVersionPlatformConfiguration.isSignInEnabled {
-                if viewModel.isSignedIn {
+                if isSignedIn {
                     Button(String.localized("menu.signOut"), role: .destructive, action: signOut)
                 } else {
                     Button(String.localized("menu.signIn"), action: signIn)
@@ -21,12 +22,29 @@ struct BibleReaderHeaderMenuView: View {
                 .padding()
         }
         .task {
-            await viewModel.updateSignInState()
+            await updateSignInState()
         }
+        .onReceive(
+            NotificationCenter.default.publisher(for: YouVersionPlatformConfiguration.authStateDidChangeNotification)
+        ) { _ in
+            Task {
+                await updateSignInState()
+            }
+        }
+    }
+
+    private var isSignedIn: Bool {
+        observedIsSignedIn ?? viewModel.isSignedIn
     }
 
     private func openFontSettings() {
         viewModel.openFontSettings()
+    }
+
+    @MainActor
+    private func updateSignInState() async {
+        await viewModel.updateSignInState()
+        observedIsSignedIn = viewModel.isSignedIn
     }
 
     private func signOut() {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Sign In / Sign Out menu item not toggling correctly after an auth state change. The root cause is that `BibleReaderViewModel.isSignedIn` is a computed property reading from a `private let` authentication dependency, which the `@Observable` macro cannot track — so SwiftUI never knew to re-render the menu.

- Introduces a local `@State private var observedIsSignedIn: Bool?` that is written after every call to `viewModel.updateSignInState()`, giving SwiftUI a trackable source of truth for the menu toggle.
- Adds an `.onReceive` subscription to `authStateDidChangeNotification` (posted by `saveAuthData`/`clearAuthTokens` on every real sign-in/sign-out transition) to trigger a refresh on auth changes outside the initial `.task`.
- The `observedIsSignedIn ?? viewModel.isSignedIn` fallback cleanly handles the brief window before the first async refresh completes.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change correctly wires up a notification-driven state refresh to fix the sign-in menu toggle.

The fix correctly addresses the observation-tracking gap for a computed property backed by a private dependency. The notification posting path through saveAuthData/clearAuthTokens covers both sign-in and sign-out transitions, and the ?? fallback handles the initial load window cleanly. The one thing worth revisiting is the unstructured Task inside .onReceive, which outlives the view lifecycle — though the practical impact is negligible given how short-lived the task is.

No files require special attention; BibleReaderHeaderMenuView.swift is the only changed file and the logic is straightforward.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/Components/BibleReaderHeaderMenuView.swift | Adds local @State caching of auth state plus a NotificationCenter observer so the menu correctly toggles Sign In / Sign Out after auth changes that aren't observable through the @Observable ViewModel. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant BibleReaderHeaderMenuView
    participant BibleReaderViewModel
    participant Authentication
    participant NotificationCenter

    Note over BibleReaderHeaderMenuView: View appears
    BibleReaderHeaderMenuView->>BibleReaderViewModel: .task → updateSignInState()
    BibleReaderViewModel->>Authentication: hasValidToken()
    Authentication-->>BibleReaderViewModel: Bool
    BibleReaderViewModel-->>BibleReaderHeaderMenuView: viewModel.isSignedIn
    BibleReaderHeaderMenuView->>BibleReaderHeaderMenuView: "observedIsSignedIn = viewModel.isSignedIn"

    Note over User,NotificationCenter: Sign In / Sign Out occurs
    Authentication->>Authentication: saveAuthData / clearAuthTokens
    Authentication->>NotificationCenter: post(authStateDidChangeNotification)
    NotificationCenter-->>BibleReaderHeaderMenuView: .onReceive fires
    BibleReaderHeaderMenuView->>BibleReaderHeaderMenuView: "Task { await updateSignInState() }"
    BibleReaderHeaderMenuView->>BibleReaderViewModel: updateSignInState()
    BibleReaderViewModel->>Authentication: hasValidToken()
    Authentication-->>BibleReaderViewModel: Bool
    BibleReaderViewModel-->>BibleReaderHeaderMenuView: viewModel.isSignedIn
    BibleReaderHeaderMenuView->>BibleReaderHeaderMenuView: "observedIsSignedIn = viewModel.isSignedIn"
    BibleReaderHeaderMenuView-->>User: Re-renders menu (Sign In ↔ Sign Out)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant BibleReaderHeaderMenuView
    participant BibleReaderViewModel
    participant Authentication
    participant NotificationCenter

    Note over BibleReaderHeaderMenuView: View appears
    BibleReaderHeaderMenuView->>BibleReaderViewModel: .task → updateSignInState()
    BibleReaderViewModel->>Authentication: hasValidToken()
    Authentication-->>BibleReaderViewModel: Bool
    BibleReaderViewModel-->>BibleReaderHeaderMenuView: viewModel.isSignedIn
    BibleReaderHeaderMenuView->>BibleReaderHeaderMenuView: "observedIsSignedIn = viewModel.isSignedIn"

    Note over User,NotificationCenter: Sign In / Sign Out occurs
    Authentication->>Authentication: saveAuthData / clearAuthTokens
    Authentication->>NotificationCenter: post(authStateDidChangeNotification)
    NotificationCenter-->>BibleReaderHeaderMenuView: .onReceive fires
    BibleReaderHeaderMenuView->>BibleReaderHeaderMenuView: "Task { await updateSignInState() }"
    BibleReaderHeaderMenuView->>BibleReaderViewModel: updateSignInState()
    BibleReaderViewModel->>Authentication: hasValidToken()
    Authentication-->>BibleReaderViewModel: Bool
    BibleReaderViewModel-->>BibleReaderHeaderMenuView: viewModel.isSignedIn
    BibleReaderHeaderMenuView->>BibleReaderHeaderMenuView: "observedIsSignedIn = viewModel.isSignedIn"
    BibleReaderHeaderMenuView-->>User: Re-renders menu (Sign In ↔ Sign Out)
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformReader%2FComponents%2FBibleReaderHeaderMenuView.swift%3A6-34%0AThe%20%60Task%20%7B%20await%20updateSignInState%28%29%20%7D%60%20inside%20%60.onReceive%60%20is%20an%20unstructured%20task%20%E2%80%94%20it%20isn't%20tied%20to%20the%20view's%20lifetime%20and%20won't%20be%20cancelled%20if%20the%20view%20disappears%20while%20%60viewModel.updateSignInState%28%29%60%20is%20awaiting%20a%20network%20response.%20In%20practice%20the%20write%20to%20%60observedIsSignedIn%60%20is%20a%20no-op%20once%20SwiftUI%20has%20released%20the%20state%20storage%2C%20but%20a%20more%20lifecycle-aware%20approach%20is%20to%20use%20%60.task%28id%3A%29%60%20driven%20by%20a%20simple%20counter%20state%20variable%20so%20SwiftUI%20automatically%20cancels%20and%20restarts%20the%20work%20on%20each%20auth%20change.%0A%0A%60%60%60suggestion%0A%20%20%20%20%40State%20private%20var%20observedIsSignedIn%3A%20Bool%3F%0A%20%20%20%20%40State%20private%20var%20authStateVersion%3A%20Int%20%3D%200%0A%0A%20%20%20%20var%20body%3A%20some%20View%20%7B%0A%20%20%20%20%20%20%20%20Menu%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20Button%28String.localized%28%22menu.fontSettings%22%29%2C%20action%3A%20openFontSettings%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20YouVersionPlatformConfiguration.isSignInEnabled%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20isSignedIn%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Button%28String.localized%28%22menu.signOut%22%29%2C%20role%3A%20.destructive%2C%20action%3A%20signOut%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Button%28String.localized%28%22menu.signIn%22%29%2C%20action%3A%20signIn%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%20label%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20Image%28systemName%3A%20%22ellipsis.circle%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.imageScale%28.large%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.foregroundStyle%28viewModel.readerTextPrimaryColor%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.padding%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20.task%28id%3A%20authStateVersion%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20await%20updateSignInState%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20.onReceive%28%0A%20%20%20%20%20%20%20%20%20%20%20%20NotificationCenter.default.publisher%28for%3A%20YouVersionPlatformConfiguration.authStateDidChangeNotification%29%0A%20%20%20%20%20%20%20%20%29%20%7B%20_%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20authStateVersion%20%2B%3D%201%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=184&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformReader%2FComponents%2FBibleReaderHeaderMenuView.swift%3A6-34%0AThe%20%60Task%20%7B%20await%20updateSignInState%28%29%20%7D%60%20inside%20%60.onReceive%60%20is%20an%20unstructured%20task%20%E2%80%94%20it%20isn't%20tied%20to%20the%20view's%20lifetime%20and%20won't%20be%20cancelled%20if%20the%20view%20disappears%20while%20%60viewModel.updateSignInState%28%29%60%20is%20awaiting%20a%20network%20response.%20In%20practice%20the%20write%20to%20%60observedIsSignedIn%60%20is%20a%20no-op%20once%20SwiftUI%20has%20released%20the%20state%20storage%2C%20but%20a%20more%20lifecycle-aware%20approach%20is%20to%20use%20%60.task%28id%3A%29%60%20driven%20by%20a%20simple%20counter%20state%20variable%20so%20SwiftUI%20automatically%20cancels%20and%20restarts%20the%20work%20on%20each%20auth%20change.%0A%0A%60%60%60suggestion%0A%20%20%20%20%40State%20private%20var%20observedIsSignedIn%3A%20Bool%3F%0A%20%20%20%20%40State%20private%20var%20authStateVersion%3A%20Int%20%3D%200%0A%0A%20%20%20%20var%20body%3A%20some%20View%20%7B%0A%20%20%20%20%20%20%20%20Menu%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20Button%28String.localized%28%22menu.fontSettings%22%29%2C%20action%3A%20openFontSettings%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20YouVersionPlatformConfiguration.isSignInEnabled%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20isSignedIn%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Button%28String.localized%28%22menu.signOut%22%29%2C%20role%3A%20.destructive%2C%20action%3A%20signOut%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Button%28String.localized%28%22menu.signIn%22%29%2C%20action%3A%20signIn%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%20label%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20Image%28systemName%3A%20%22ellipsis.circle%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.imageScale%28.large%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.foregroundStyle%28viewModel.readerTextPrimaryColor%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.padding%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20.task%28id%3A%20authStateVersion%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20await%20updateSignInState%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20.onReceive%28%0A%20%20%20%20%20%20%20%20%20%20%20%20NotificationCenter.default.publisher%28for%3A%20YouVersionPlatformConfiguration.authStateDidChangeNotification%29%0A%20%20%20%20%20%20%20%20%29%20%7B%20_%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20authStateVersion%20%2B%3D%201%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=184&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22fix_updating_menu%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_updating_menu%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASources%2FYouVersionPlatformReader%2FComponents%2FBibleReaderHeaderMenuView.swift%3A6-34%0AThe%20%60Task%20%7B%20await%20updateSignInState%28%29%20%7D%60%20inside%20%60.onReceive%60%20is%20an%20unstructured%20task%20%E2%80%94%20it%20isn't%20tied%20to%20the%20view's%20lifetime%20and%20won't%20be%20cancelled%20if%20the%20view%20disappears%20while%20%60viewModel.updateSignInState%28%29%60%20is%20awaiting%20a%20network%20response.%20In%20practice%20the%20write%20to%20%60observedIsSignedIn%60%20is%20a%20no-op%20once%20SwiftUI%20has%20released%20the%20state%20storage%2C%20but%20a%20more%20lifecycle-aware%20approach%20is%20to%20use%20%60.task%28id%3A%29%60%20driven%20by%20a%20simple%20counter%20state%20variable%20so%20SwiftUI%20automatically%20cancels%20and%20restarts%20the%20work%20on%20each%20auth%20change.%0A%0A%60%60%60suggestion%0A%20%20%20%20%40State%20private%20var%20observedIsSignedIn%3A%20Bool%3F%0A%20%20%20%20%40State%20private%20var%20authStateVersion%3A%20Int%20%3D%200%0A%0A%20%20%20%20var%20body%3A%20some%20View%20%7B%0A%20%20%20%20%20%20%20%20Menu%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20Button%28String.localized%28%22menu.fontSettings%22%29%2C%20action%3A%20openFontSettings%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20YouVersionPlatformConfiguration.isSignInEnabled%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20isSignedIn%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Button%28String.localized%28%22menu.signOut%22%29%2C%20role%3A%20.destructive%2C%20action%3A%20signOut%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Button%28String.localized%28%22menu.signIn%22%29%2C%20action%3A%20signIn%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%20label%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20Image%28systemName%3A%20%22ellipsis.circle%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.imageScale%28.large%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.foregroundStyle%28viewModel.readerTextPrimaryColor%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.padding%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20.task%28id%3A%20authStateVersion%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20await%20updateSignInState%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20.onReceive%28%0A%20%20%20%20%20%20%20%20%20%20%20%20NotificationCenter.default.publisher%28for%3A%20YouVersionPlatformConfiguration.authStateDidChangeNotification%29%0A%20%20%20%20%20%20%20%20%29%20%7B%20_%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20authStateVersion%20%2B%3D%201%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=184&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/YouVersionPlatformReader/Components/BibleReaderHeaderMenuView.swift:6-34
The `Task { await updateSignInState() }` inside `.onReceive` is an unstructured task — it isn't tied to the view's lifetime and won't be cancelled if the view disappears while `viewModel.updateSignInState()` is awaiting a network response. In practice the write to `observedIsSignedIn` is a no-op once SwiftUI has released the state storage, but a more lifecycle-aware approach is to use `.task(id:)` driven by a simple counter state variable so SwiftUI automatically cancels and restarts the work on each auth change.

```suggestion
    @State private var observedIsSignedIn: Bool?
    @State private var authStateVersion: Int = 0

    var body: some View {
        Menu {
            Button(String.localized("menu.fontSettings"), action: openFontSettings)
            if YouVersionPlatformConfiguration.isSignInEnabled {
                if isSignedIn {
                    Button(String.localized("menu.signOut"), role: .destructive, action: signOut)
                } else {
                    Button(String.localized("menu.signIn"), action: signIn)
                }
            }
        } label: {
            Image(systemName: "ellipsis.circle")
                .imageScale(.large)
                .foregroundStyle(viewModel.readerTextPrimaryColor)
                .padding()
        }
        .task(id: authStateVersion) {
            await updateSignInState()
        }
        .onReceive(
            NotificationCenter.default.publisher(for: YouVersionPlatformConfiguration.authStateDidChangeNotification)
        ) { _ in
            authStateVersion += 1
        }
    }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: update sign-in/out menu"](https://github.com/youversion/platform-sdk-swift/commit/3aa71222be282a3f5a571373706024ca06078972) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42821229)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->