### PR TITLE
feat: add "scripts/check-api-stability.sh additions"

### DIFF
--- a/scripts/check-api-stability.sh
+++ b/scripts/check-api-stability.sh
@@ -6,6 +6,7 @@
 # Usage:
 #   scripts/check-api-stability.sh update   # overwrite baselines in .api-baseline/
 #   scripts/check-api-stability.sh check    # diff current API against baselines; non-zero exit on breakage
+#   scripts/check-api-stability.sh additions # list new public API grouped by source folder
 #
 # If no mode is given, defaults to `check`.
 
@@ -13,8 +14,8 @@ set -euo pipefail
 
 MODE="${1:-check}"
 
-if [[ "$MODE" != "update" && "$MODE" != "check" ]]; then
-  echo "usage: $0 [update|check]" >&2
+if [[ "$MODE" != "update" && "$MODE" != "check" && "$MODE" != "additions" ]]; then
+  echo "usage: $0 [update|check|additions]" >&2
   exit 2
 fi
 
@@ -60,9 +61,34 @@ if [[ "$MODE" == "update" ]]; then
   exit 0
 fi
 
-# check mode
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
+
+if [[ "$MODE" == "additions" ]]; then
+  for module in "${MODULES[@]}"; do
+    baseline="$BASELINE_DIR/$module.json"
+    current="$WORK_DIR/$module.json"
+
+    if [[ ! -f "$baseline" ]]; then
+      echo "Missing baseline for $module at $baseline" >&2
+      echo "Run: scripts/check-api-stability.sh update" >&2
+      exit 1
+    fi
+
+    echo "Dumping $module..."
+    dump_module "$module" "$current"
+  done
+
+  echo
+  python3 "$REPO_ROOT/scripts/report-api-additions.py" \
+    "$BASELINE_DIR" \
+    "$WORK_DIR" \
+    "$REPO_ROOT/Sources" \
+    "${MODULES[@]}"
+  exit 0
+fi
+
+# check mode
 
 FAILED_MODULES=()
 TOTAL_BREAKAGES=0

--- a/scripts/report-api-additions.py
+++ b/scripts/report-api-additions.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Report public API additions between swift-api-digester dumps.
+
+The stability check intentionally treats additive public API as allowed, but
+release reviewers still need to see what new surface area is being exposed.
+This script compares baseline and current digester JSON by USR, then groups
+new declarations by the Swift source file that appears to implement them.
+
+Usage:
+  report-api-additions.py <baseline-dir> <current-dir> <sources-dir> <module>...
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import sys
+
+
+DECLARATION_KINDS = frozenset(
+    {
+        "AssociatedType",
+        "Constructor",
+        "Function",
+        "Subscript",
+        "TypeAlias",
+        "TypeDecl",
+        "Var",
+    }
+)
+
+
+TYPE_DECL_KINDS = {
+    "Class": "class",
+    "Enum": "enum",
+    "Protocol": "protocol",
+    "Struct": "struct",
+}
+
+
+@dataclass(frozen=True)
+class Scope:
+    name: str
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class SourceMatch:
+    path: Path
+    index: int
+    owner: str | None
+    score: int
+
+
+@dataclass(frozen=True)
+class Addition:
+    module: str
+    kind: str
+    decl_kind: str | None
+    name: str
+    printed_name: str
+    usr: str
+    context: tuple[str, ...]
+    implicit: bool
+    static: bool
+    is_let: bool
+
+
+def load_dump(path: Path) -> dict:
+    with path.open() as file:
+        return json.load(file)
+
+
+def collect_declarations(
+    node: dict | list,
+    module: str,
+    context: tuple[str, ...] = (),
+) -> list[Addition]:
+    declarations: list[Addition] = []
+
+    if isinstance(node, list):
+        for child in node:
+            declarations.extend(collect_declarations(child, module, context))
+        return declarations
+
+    if not isinstance(node, dict):
+        return declarations
+
+    kind = node.get("kind")
+    node_module = node.get("moduleName", module)
+    if kind in DECLARATION_KINDS and node.get("usr") and node_module == module:
+        declarations.append(
+            Addition(
+                module=module,
+                kind=kind,
+                decl_kind=node.get("declKind"),
+                name=node.get("name") or "",
+                printed_name=node.get("printedName") or node.get("name") or "",
+                usr=node["usr"],
+                context=context,
+                implicit=bool(node.get("implicit")),
+                static=bool(node.get("static")),
+                is_let=bool(node.get("isLet")),
+            )
+        )
+
+    if kind == "TypeDecl":
+        type_name = node.get("printedName") or node.get("name") or ""
+        child_context = context + (type_name,)
+    else:
+        child_context = context
+
+    for child in node.get("children", []) or []:
+        declarations.extend(collect_declarations(child, module, child_context))
+
+    return declarations
+
+
+def public_declarations(path: Path, module: str) -> dict[str, Addition]:
+    dump = load_dump(path)
+    root = dump["ABIRoot"]
+    return {declaration.usr: declaration for declaration in collect_declarations(root, module)}
+
+
+def matching_brace_index(text: str, open_brace: int) -> int:
+    depth = 0
+    for index in range(open_brace, len(text)):
+        char = text[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+    return len(text)
+
+
+def source_scopes(text: str) -> list[Scope]:
+    pattern = re.compile(
+        r"\b(?:public\s+)?(?:final\s+)?"
+        r"(?:extension|struct|class|enum|protocol|actor)\s+"
+        r"([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?)"
+        r"[^{}]*\{"
+    )
+    scopes: list[Scope] = []
+    for match in pattern.finditer(text):
+        open_brace = text.find("{", match.start())
+        scopes.append(
+            Scope(
+                name=match.group(1),
+                start=open_brace,
+                end=matching_brace_index(text, open_brace),
+            )
+        )
+    return scopes
+
+
+def owner_at(scopes: list[Scope], index: int) -> str | None:
+    containing = [scope for scope in scopes if scope.start < index < scope.end]
+    if not containing:
+        return None
+    containing.sort(key=lambda scope: scope.start)
+    names: list[str] = []
+    for scope in containing:
+        if "." in scope.name:
+            names = scope.name.split(".")
+        else:
+            names.append(scope.name)
+    return ".".join(names)
+
+
+def regex_for_addition(addition: Addition) -> re.Pattern[str]:
+    escaped_name = re.escape(addition.name)
+    if addition.kind == "TypeDecl":
+        return re.compile(
+            rf"\b(?:public\s+)?(?:final\s+)?"
+            rf"(?:struct|class|enum|protocol|actor)\s+{escaped_name}\b"
+        )
+    if addition.kind == "Constructor":
+        return re.compile(r"\binit\s*\(")
+    if addition.decl_kind == "EnumElement":
+        return re.compile(rf"\bcase\s+{escaped_name}\b")
+    if addition.kind == "Function":
+        return re.compile(rf"\bfunc\s+{escaped_name}\s*\(")
+    if addition.kind == "Subscript":
+        return re.compile(r"\bsubscript\s*\(")
+    if addition.kind == "TypeAlias":
+        return re.compile(rf"\btypealias\s+{escaped_name}\b")
+    if addition.kind == "AssociatedType":
+        return re.compile(rf"\bassociatedtype\s+{escaped_name}\b")
+    return re.compile(rf"\b(?:var|let)\s+{escaped_name}\b")
+
+
+def context_score(addition: Addition, owner: str | None) -> int:
+    if not owner:
+        return 0
+    if not addition.context:
+        return 10
+    owner_parts = owner.split(".")
+    context_parts = list(addition.context)
+    if owner_parts[-len(context_parts):] == context_parts:
+        return 40
+    if context_parts[-1] in owner_parts:
+        return 20
+    return 0
+
+
+def find_source_match(addition: Addition, source_files: list[Path]) -> SourceMatch | None:
+    pattern = regex_for_addition(addition)
+    best: SourceMatch | None = None
+
+    for path in source_files:
+        text = path.read_text()
+        context_is_present = any(part in text for part in addition.context)
+        if (
+            addition.name
+            and addition.name not in text
+            and addition.kind != "Constructor"
+            and not context_is_present
+        ):
+            continue
+
+        scopes = source_scopes(text)
+        for match in pattern.finditer(text):
+            owner = owner_at(scopes, match.start())
+            matched_context_score = context_score(addition, owner)
+            if addition.context and matched_context_score == 0:
+                continue
+            score = 50 + matched_context_score
+            if addition.context and any(part in text for part in addition.context):
+                score += 10
+            if addition.kind == "Constructor" and addition.context and addition.context[-1] not in text:
+                continue
+            candidate = SourceMatch(path=path, index=match.start(), owner=owner, score=score)
+            if best is None or candidate.score > best.score:
+                best = candidate
+
+        if addition.context and addition.context[-1] in text:
+            owner = addition.context[-1]
+            index = text.find(owner)
+            owner_pattern = re.compile(
+                rf"\b(?:public\s+)?(?:final\s+)?"
+                rf"(?:struct|class|enum|protocol|actor)\s+{re.escape(owner)}\b"
+            )
+            owner_match = owner_pattern.search(text)
+            score = 45 if owner_match else 20
+            index = owner_match.start() if owner_match else index
+            candidate = SourceMatch(path=path, index=index, owner=owner, score=score)
+            if best is None or candidate.score > best.score:
+                best = candidate
+
+    return best
+
+
+def declaration_owner(addition: Addition, source_match: SourceMatch | None) -> str | None:
+    if addition.context:
+        owner = ".".join(addition.context)
+        if source_match and source_match.owner and source_match.owner.endswith(f".{owner}"):
+            return source_match.owner
+        return owner
+    if source_match and source_match.owner and addition.kind != "TypeDecl":
+        return source_match.owner
+    return None
+
+
+def qualified_name(addition: Addition, source_match: SourceMatch | None) -> str:
+    owner = declaration_owner(addition, source_match)
+    if addition.kind == "Constructor":
+        return f"{owner}.init{addition.printed_name.removeprefix('init')}" if owner else addition.printed_name
+    if addition.name == "__derived_struct_equals" and owner:
+        return f"{owner}.=="
+    if owner:
+        return f"{owner}.{addition.printed_name}"
+    return addition.printed_name
+
+
+def display_label(addition: Addition, source_match: SourceMatch | None) -> str:
+    name = qualified_name(addition, source_match)
+    prefix = "static " if addition.static else ""
+
+    if addition.kind == "TypeDecl":
+        decl_kind = TYPE_DECL_KINDS.get(addition.decl_kind or "", (addition.decl_kind or "type").lower())
+        if addition.context:
+            name = ".".join(addition.context + (addition.printed_name,))
+        return f"{decl_kind} {name}"
+    if addition.kind == "Constructor":
+        return name
+    if addition.decl_kind == "EnumElement":
+        return f"case {name}"
+    if addition.kind == "Function":
+        return f"{prefix}func {name}"
+    if addition.kind == "Subscript":
+        return f"{prefix}subscript {name}"
+    if addition.kind == "TypeAlias":
+        return f"typealias {name}"
+    if addition.kind == "AssociatedType":
+        return f"associatedtype {name}"
+
+    storage = "let" if addition.is_let else "var"
+    return f"{prefix}{storage} {name}"
+
+
+def source_files_for_module(sources_dir: Path, module: str) -> list[Path]:
+    module_dir = sources_dir / module
+    if not module_dir.exists():
+        return []
+    return sorted(module_dir.rglob("*.swift"))
+
+
+def print_report(
+    additions_by_path: dict[Path | None, list[tuple[Addition, SourceMatch | None]]],
+    sources_dir: Path,
+) -> None:
+    total = sum(len(items) for items in additions_by_path.values())
+    print("==============================================================")
+    print(" PUBLIC API additions since baseline")
+    print("==============================================================")
+
+    if total == 0:
+        print("No public API additions detected.")
+        return
+
+    print(f"{total} added declaration(s).")
+    print()
+
+    def sort_key(path: Path | None) -> str:
+        return "zzzz_unmapped" if path is None else path.as_posix()
+
+    for path in sorted(additions_by_path, key=sort_key):
+        items = additions_by_path[path]
+        if path is None:
+            print("Unmapped")
+        else:
+            try:
+                display_path = path.relative_to(sources_dir.parent)
+            except ValueError:
+                display_path = path
+            print(display_path.parent.as_posix())
+            print(f"  {display_path.name}")
+
+        explicit = [(addition, match) for addition, match in items if not addition.implicit]
+        implicit = [(addition, match) for addition, match in items if addition.implicit]
+
+        for addition, match in sorted(explicit, key=lambda item: display_label(*item)):
+            print(f"    - {display_label(addition, match)}")
+
+        if implicit:
+            print("    Synthesized or associated declarations:")
+            for addition, match in sorted(implicit, key=lambda item: display_label(*item)):
+                print(f"    - {display_label(addition, match)}")
+
+        print()
+
+
+def main() -> int:
+    if len(sys.argv) < 5:
+        print(
+            "usage: report-api-additions.py <baseline-dir> <current-dir> <sources-dir> <module>...",
+            file=sys.stderr,
+        )
+        return 2
+
+    baseline_dir = Path(sys.argv[1])
+    current_dir = Path(sys.argv[2])
+    sources_dir = Path(sys.argv[3])
+    modules = sys.argv[4:]
+
+    additions_by_path: dict[Path | None, list[tuple[Addition, SourceMatch | None]]] = {}
+
+    for module in modules:
+        baseline = public_declarations(baseline_dir / f"{module}.json", module)
+        current = public_declarations(current_dir / f"{module}.json", module)
+        source_files = source_files_for_module(sources_dir, module)
+
+        added_usrs = sorted(current.keys() - baseline.keys())
+        for usr in added_usrs:
+            addition = current[usr]
+            source_match = find_source_match(addition, source_files)
+            path = source_match.path if source_match else None
+            additions_by_path.setdefault(path, []).append((addition, source_match))
+
+    print_report(additions_by_path, sources_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/report-api-additions.py
+++ b/scripts/report-api-additions.py
@@ -39,6 +39,9 @@ TYPE_DECL_KINDS = {
     "Struct": "struct",
 }
 
+SWIFT_ATTRIBUTE_PATTERN = r"@[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?\s+"
+SWIFT_DECLARATION_PREFIX_PATTERN = rf"(?:(?:public|open|final)\s+|{SWIFT_ATTRIBUTE_PATTERN})*"
+
 
 @dataclass(frozen=True)
 class Scope:
@@ -140,7 +143,7 @@ def matching_brace_index(text: str, open_brace: int) -> int:
 
 def source_scopes(text: str) -> list[Scope]:
     pattern = re.compile(
-        r"\b(?:public\s+)?(?:final\s+)?"
+        rf"\b{SWIFT_DECLARATION_PREFIX_PATTERN}"
         r"(?:extension|struct|class|enum|protocol|actor)\s+"
         r"([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?)"
         r"[^{}]*\{"
@@ -176,7 +179,7 @@ def regex_for_addition(addition: Addition) -> re.Pattern[str]:
     escaped_name = re.escape(addition.name)
     if addition.kind == "TypeDecl":
         return re.compile(
-            rf"\b(?:public\s+)?(?:final\s+)?"
+            rf"\b{SWIFT_DECLARATION_PREFIX_PATTERN}"
             rf"(?:struct|class|enum|protocol|actor)\s+{escaped_name}\b"
         )
     if addition.kind == "Constructor":
@@ -240,14 +243,15 @@ def find_source_match(addition: Addition, source_files: list[Path]) -> SourceMat
 
         if addition.context and addition.context[-1] in text:
             owner = addition.context[-1]
-            index = text.find(owner)
             owner_pattern = re.compile(
-                rf"\b(?:public\s+)?(?:final\s+)?"
-                rf"(?:struct|class|enum|protocol|actor)\s+{re.escape(owner)}\b"
+                rf"\b{SWIFT_DECLARATION_PREFIX_PATTERN}"
+                rf"(?:extension|struct|class|enum|protocol|actor)\s+{re.escape(owner)}\b"
             )
             owner_match = owner_pattern.search(text)
-            score = 45 if owner_match else 20
-            index = owner_match.start() if owner_match else index
+            if owner_match is None:
+                continue
+            score = 45
+            index = owner_match.start()
             candidate = SourceMatch(path=path, index=index, owner=owner, score=score)
             if best is None or candidate.score > best.score:
                 best = candidate


### PR DESCRIPTION
feat: add "scripts/check-api-stability.sh additions" to list new public APIs, grouped by source folder

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a public API additions report to the existing stability tooling. The main changes are:

- Adds an `additions` mode to `scripts/check-api-stability.sh`.
- Dumps current API JSON and compares it with stored baselines.
- Adds `scripts/report-api-additions.py` to group new public declarations by source location.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/check-api-stability.sh | Adds the new `additions` command path and invokes the reporting script after dumping module APIs. |
| scripts/report-api-additions.py | Adds API dump comparison, Swift source matching, declaration labeling, and grouped report output. |

<sub>Reviews (2): Last reviewed commit: ["chore: address PR feedback"](https://github.com/youversion/platform-sdk-swift/commit/e85a506684ec18075dd022292b056018a154ea28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42905058)</sub>

<!-- /greptile_comment -->