### PR TITLE
fix: harden isSameHexColor

### DIFF
--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -2,6 +2,13 @@ import SwiftUI
 import YouVersionPlatformCore
 import YouVersionPlatformUI
 
+func hexColorValueForComparison(_ color: String) -> String {
+    guard color.starts(with: "#") else {
+        return color
+    }
+    return String(color.dropFirst())
+}
+
 extension BibleReaderViewModel {
     func goToPreviousChapter() {
         guard let version else {
@@ -135,8 +142,8 @@ extension BibleReaderViewModel {
     }
 
     private func isSameHexColor(_ a: String, _ b: String) -> Bool {
-        let cleanA = a.starts(with: "#") ? String(a.split(separator: "#").last!) : a
-        let cleanB = b.starts(with: "#") ? String(b.split(separator: "#").last!) : b
+        let cleanA = hexColorValueForComparison(a)
+        let cleanB = hexColorValueForComparison(b)
         return cleanA.localizedCaseInsensitiveCompare(cleanB) == .orderedSame
     }
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -2,13 +2,6 @@ import SwiftUI
 import YouVersionPlatformCore
 import YouVersionPlatformUI
 
-func hexColorValueForComparison(_ color: String) -> String {
-    guard color.starts(with: "#") else {
-        return color
-    }
-    return String(color.dropFirst())
-}
-
 extension BibleReaderViewModel {
     func goToPreviousChapter() {
         guard let version else {
@@ -141,7 +134,14 @@ extension BibleReaderViewModel {
         !selectedVerses.isEmpty && selectedVersesWithColor(color).count == selectedVerses.count
     }
 
-    private func isSameHexColor(_ a: String, _ b: String) -> Bool {
+    func hexColorValueForComparison(_ color: String) -> String {
+        guard color.starts(with: "#") else {
+            return color
+        }
+        return String(color.dropFirst())
+    }
+
+    func isSameHexColor(_ a: String, _ b: String) -> Bool {
         let cleanA = hexColorValueForComparison(a)
         let cleanB = hexColorValueForComparison(b)
         return cleanA.localizedCaseInsensitiveCompare(cleanB) == .orderedSame

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
@@ -144,6 +144,13 @@ import Testing
 #endif
     }
 
+    @Test
+    func hexColorValueForComparisonRemovesLeadingHash() {
+        #expect(hexColorValueForComparison("#") == "")
+        #expect(hexColorValueForComparison("#DDAAFF") == "DDAAFF")
+        #expect(hexColorValueForComparison("DDAAFF") == "DDAAFF")
+    }
+
 #if !canImport(UIKit)
     @Test
     func highlightColorActionsNoOpWhenColorCannotBeConverted() {

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
@@ -146,9 +146,21 @@ import Testing
 
     @Test
     func hexColorValueForComparisonRemovesLeadingHash() {
-        #expect(hexColorValueForComparison("#") == "")
-        #expect(hexColorValueForComparison("#DDAAFF") == "DDAAFF")
-        #expect(hexColorValueForComparison("DDAAFF") == "DDAAFF")
+        let viewModel = Support.makeViewModel()
+
+        #expect(viewModel.hexColorValueForComparison("#") == "")
+        #expect(viewModel.hexColorValueForComparison("#DDAAFF") == "DDAAFF")
+        #expect(viewModel.hexColorValueForComparison("DDAAFF") == "DDAAFF")
+    }
+
+    @Test
+    func isSameHexColorComparesColorsWithoutLeadingHashes() {
+        let viewModel = Support.makeViewModel()
+
+        #expect(viewModel.isSameHexColor("#DDAAFF", "DDAAFF"))
+        #expect(viewModel.isSameHexColor("ddaaff", "#DDAAFF"))
+        #expect(viewModel.isSameHexColor("#", "DDAAFF") == false)
+        #expect(viewModel.isSameHexColor("#DDAAFF", "#AABBCC") == false)
     }
 
 #if !canImport(UIKit)


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens `isSameHexColor` by extracting the `#`-stripping logic into a dedicated `hexColorValueForComparison` helper and replacing the original `split(separator: \"#\").last!` force-unwrap — which crashes when the input is `\"#\"` — with the safe `dropFirst()` approach. Both helpers are promoted from `private` to `internal` so unit tests can reach them via `@testable import`.

- **Bug fix**: `\"#\".split(separator: \"#\")` returns an empty array; force-unwrapping `.last!` on it was a latent crash. The new `dropFirst()` path returns an empty string instead.
- **New tests**: Two focused test functions exercise the helper directly and `isSameHexColor` across mixed-prefix and mixed-case inputs.
- **Access level trade-off**: `isSameHexColor` moves from `private` to `internal`; the access-level discussion is already captured in prior review threads.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change eliminates a real crash path and the new tests directly cover the fixed edge case.

The original `split(separator: "#").last!` would crash on the input `"#"` (empty array, force-unwrap). The replacement uses `dropFirst()`, which is unconditionally safe, and the new test suite explicitly asserts the `"#"` edge case. No existing behaviour is regressed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift | Extracts hex-stripping logic into `hexColorValueForComparison` using safe `dropFirst()`, replacing a crashable `split(separator:).last!` force-unwrap; both helpers promoted to `internal` to support direct unit testing. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift | Adds targeted unit tests for `hexColorValueForComparison` (including the `"#"` crash edge case) and `isSameHexColor` (mixed-prefix and mixed-case comparisons). |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["hexColorValueForComparison(color)"] --> B{starts with '#'?}
    B -- No --> C[return color as-is]
    B -- Yes --> D["return color.dropFirst()"]
    E["isSameHexColor(a, b)"] --> F["cleanA = hexColorValueForComparison(a)"]
    F --> G["cleanB = hexColorValueForComparison(b)"]
    G --> H["localizedCaseInsensitiveCompare(cleanA, cleanB)"]
    H --> I{== .orderedSame?}
    I -- Yes --> J[return true]
    I -- No --> K[return false]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["hexColorValueForComparison(color)"] --> B{starts with '#'?}
    B -- No --> C[return color as-is]
    B -- Yes --> D["return color.dropFirst()"]
    E["isSameHexColor(a, b)"] --> F["cleanA = hexColorValueForComparison(a)"]
    F --> G["cleanB = hexColorValueForComparison(b)"]
    G --> H["localizedCaseInsensitiveCompare(cleanA, cleanB)"]
    H --> I{== .orderedSame?}
    I -- Yes --> J[return true]
    I -- No --> K[return false]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test: improve tests for colors"](https://github.com/youversion/platform-sdk-swift/commit/16abf44a556d98a8b442b4f966f69f9c4e9c3e62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43029117)</sub>

<!-- /greptile_comment -->