### PR TITLE
fix(reader): show My Versions list once user has any saved version BL-1902

### DIFF
--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsStack.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsStack.swift
@@ -28,7 +28,7 @@ public struct BibleVersionsStack: View {
 
     @ViewBuilder
     private var rootView: some View {
-        if viewModel.myVersions.count > 1 {
+        if !viewModel.myVersions.isEmpty {
             BibleVersionsMyVersionsView()
         } else {
             ZStack {


### PR DESCRIPTION
https://github.com/user-attachments/assets/be5dca71-9dba-43e4-9d7c-d0a8dd10396b



## Summary
- On a fresh install, the Versions tab (Bible reader, Stories, Play Memory Game) showed the entire list of all available Bible versions instead of just the user's saved versions.
- Root cause: `BibleVersionsStack.rootView` only showed the scoped `BibleVersionsMyVersionsView()` when `viewModel.myVersions.count > 1`. On a fresh install exactly one version (the fallback default) is saved, so it fell through to the full `BibleVersionsListView()` instead.
- Fix: switch the check to `!viewModel.myVersions.isEmpty`, so a single saved version is enough to show the scoped "My Versions" list.

Fixes BL-1902.

## Test plan
- [x] `swift build`
- [x] `swift test --filter BibleVersionsViewModelTests`
- [x] SwiftLint clean on the changed file

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Bible version picker to show saved versions sooner.

- Changes the root picker branch to use any saved version.
- Shows the My Versions view when only the fallback/default version is saved.
- Keeps the full version list reachable through More Versions.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsStack.swift | Updates the root view condition so a single saved version opens the My Versions list. |

<sub>Reviews (2): Last reviewed commit: ["fix(reader): show My Versions list once ..."](https://github.com/youversion/platform-sdk-swift/commit/113e382d3501950c469219af68d706a9a34881c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43122759)</sub>

<!-- /greptile_comment -->