### PR TITLE
refactor(reader): model scroll intent as a single ScrollAction BL-1901

### DIFF
--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -377,7 +377,8 @@ private struct ReaderContent: View {
                     Task { @MainActor in
                         // swiftlint:disable:next common_debug_statements
                         try? await Task.sleep(for: .seconds(0.5))
-                        viewModel.isChangingChapter = false
+                        // Scroll already consumed above; only end the chapter change.
+                        viewModel.finishChapterChange(clearingScroll: false)
                     }
                 case .toVerse:
                     verseScrollCoordinator.handleScrollTarget(proxy: scrollProxy)

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -364,24 +364,25 @@ private struct ReaderContent: View {
                 }
             }
             .coordinateSpace(.named("scrollView"))
-            .onChange(of: viewModel.scrollToTop) { _, shouldScroll in
-                if shouldScroll {
+            .onPreferenceChange(ChapterScrollAnchorsKey.self) { anchors in
+                verseScrollCoordinator.handleAnchors(anchors, proxy: scrollProxy)
+            }
+            .onChange(of: viewModel.scrollAction, initial: true) { _, action in
+                switch action {
+                case .top:
                     scrollProxy.scrollTo("topOfContent", anchor: .top)
-                    viewModel.scrollToTop = false
-                    // Wait for scroll animation before clearing the flag.
+                    // Mark the scroll consumed so a later navigation can re-arm it, but keep
+                    // chrome suppressed until the scroll animation settles before finishing.
+                    viewModel.clearScrollAction()
                     Task { @MainActor in
                         // swiftlint:disable:next common_debug_statements
                         try? await Task.sleep(for: .seconds(0.5))
                         viewModel.isChangingChapter = false
                     }
-                }
-            }
-            .onPreferenceChange(ChapterScrollAnchorsKey.self) { anchors in
-                verseScrollCoordinator.handleAnchors(anchors, proxy: scrollProxy)
-            }
-            .onChange(of: viewModel.scrollTargetReference, initial: true) { _, target in
-                if target != nil {
+                case .toVerse:
                     verseScrollCoordinator.handleScrollTarget(proxy: scrollProxy)
+                case .none:
+                    break
                 }
             }
         }

--- a/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
+++ b/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
@@ -92,8 +92,7 @@ final class VerseScrollCoordinator {
 
     private func clearScrollState() {
         fallbackTask?.cancel()
-        viewModel.clearScrollTarget()
-        viewModel.isChangingChapter = false
+        viewModel.finishChapterChange()
         isScrollPending = false
     }
 }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -30,7 +30,7 @@ extension BibleReaderViewModel {
         // back to minY = 0, since onGeometryChange won't fire again.
         lastScrollOffset = 0
         showChrome = true
-        scrollToTop = true
+        scrollAction = .top
     }
 
     func goToNextChapter() {
@@ -62,13 +62,13 @@ extension BibleReaderViewModel {
         // back to minY = 0, since onGeometryChange won't fire again.
         lastScrollOffset = 0
         showChrome = true
-        scrollToTop = true
+        scrollAction = .top
     }
 
     func goToReference(_ reference: BibleReference, showsFullChapter: Bool) async {
         await onHeaderSelectionChange(reference, showIntro: false)
         guard reference == self.reference else {
-            isChangingChapter = false
+            finishChapterChange()
             return
         }
         self.showsFullChapter = showsFullChapter
@@ -251,7 +251,7 @@ extension BibleReaderViewModel {
             // back to minY = 0, since onGeometryChange won't fire again.
             lastScrollOffset = 0
             showChrome = true
-            scrollToTop = true
+            scrollAction = .top
         } catch {
             YouVersionPlatformLogger.error("Error loading version/chapter: \(error)", category: "Reader")
         }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -253,10 +253,16 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         scrollAction = .none
     }
 
-    /// Ends an in-flight chapter change: clears any armed scroll and re-enables scroll-driven
-    /// chrome. This is the single place a navigation returns the reader to its resting state.
-    func finishChapterChange() {
-        scrollAction = .none
+    /// Ends an in-flight chapter change by re-enabling scroll-driven chrome, and — unless the
+    /// scroll was already consumed via ``clearScrollAction()`` — clearing any armed scroll. This
+    /// is the single place a navigation returns the reader to its resting state.
+    ///
+    /// Pass `clearingScroll: false` from a delayed settle where the scroll has already been
+    /// consumed, so a navigation that re-armed a scroll during the delay isn't clobbered.
+    func finishChapterChange(clearingScroll: Bool = true) {
+        if clearingScroll {
+            scrollAction = .none
+        }
         isChangingChapter = false
     }
 

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -7,6 +7,20 @@ import SwiftUI
 import YouVersionPlatformCore
 import YouVersionPlatformUI
 
+/// The single scroll intent a navigation produces. The reader observes this and
+/// performs exactly one of: nothing, scroll to the top, or scroll to a verse.
+///
+/// Modeling the two outcomes as one value (rather than a `scrollToTop` flag plus a
+/// `scrollTargetReference`) means a navigation can't arm both or neither, and there's
+/// no window where a `scrollToTop = true` write is immediately overwritten by a
+/// verse-scroll arm in the same run-loop tick — which SwiftUI would coalesce, dropping
+/// the intermediate value and the reset that depends on observing it.
+enum ScrollAction: Equatable {
+    case none
+    case top
+    case toVerse(BibleReference)
+}
+
 @MainActor
 @Observable
 final class BibleReaderViewModel: ReaderThemeProviding {
@@ -38,14 +52,21 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     // MARK: - UI state of the Reader itself
     var showChrome = true
     var lastScrollOffset: CGFloat = 0
-    var scrollToTop = false
     var isChangingChapter = false
+    var scrollAction: ScrollAction = .none
     var showsFullChapter: Bool {
         didSet {
             UserDefaults.standard.set(showsFullChapter, forKey: userDefaultsKeyForShowsFullChapter)
         }
     }
-    private(set) var scrollTargetReference: BibleReference?
+    /// The verse the reader should scroll to, if the current ``scrollAction`` is a verse scroll.
+    var scrollTargetReference: BibleReference? {
+        if case .toVerse(let reference) = scrollAction {
+            reference
+        } else {
+            nil
+        }
+    }
     var showingSignInSheet = false
     var showingFontSettings = false
     var showingFontList = false // swiftlint:disable:this collection_suffix_property
@@ -223,13 +244,20 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         guard showsFullChapter, let verseStart = reference.verseStart, verseStart > 1 else {
             return
         }
-        scrollTargetReference = reference
-        scrollToTop = false
+        scrollAction = .toVerse(reference)
     }
 
-    /// Clears the scroll target once the reader has brought it into view.
-    func clearScrollTarget() {
-        scrollTargetReference = nil
+    /// Marks the current ``scrollAction`` as consumed once the reader has begun acting on it,
+    /// without ending the chapter change (chrome stays suppressed until the scroll settles).
+    func clearScrollAction() {
+        scrollAction = .none
+    }
+
+    /// Ends an in-flight chapter change: clears any armed scroll and re-enables scroll-driven
+    /// chrome. This is the single place a navigation returns the reader to its resting state.
+    func finishChapterChange() {
+        scrollAction = .none
+        isChangingChapter = false
     }
 
     func loadUserSettingsFromStorage() {

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
@@ -209,7 +209,6 @@ let previousChapterCases: [PreviousChapterCase] = [
         // currentVersion is nil by default — the "no loaded version" state.
         vm.isChangingChapter = false
         vm.lastScrollOffset = 123
-        vm.scrollToTop = false
         vm.selectedVerses = [selectedReference]
         vm.showingVerseActionsDrawer = true
 
@@ -219,7 +218,7 @@ let previousChapterCases: [PreviousChapterCase] = [
         #expect(vm.showBookIntro == showIntro)
         #expect(vm.isChangingChapter == false)
         #expect(vm.lastScrollOffset == 123)
-        #expect(vm.scrollToTop == false)
+        #expect(vm.scrollAction == .none)
         #expect(vm.selectedVerses == [selectedReference])
         #expect(vm.showingVerseActionsDrawer == true)
     }
@@ -234,7 +233,6 @@ let previousChapterCases: [PreviousChapterCase] = [
         // currentVersion is nil by default — the "no loaded version" state.
         vm.isChangingChapter = false
         vm.lastScrollOffset = 123
-        vm.scrollToTop = false
         vm.selectedVerses = [selectedReference]
         vm.showingVerseActionsDrawer = true
 
@@ -244,7 +242,7 @@ let previousChapterCases: [PreviousChapterCase] = [
         #expect(vm.showBookIntro == showIntro)
         #expect(vm.isChangingChapter == false)
         #expect(vm.lastScrollOffset == 123)
-        #expect(vm.scrollToTop == false)
+        #expect(vm.scrollAction == .none)
         #expect(vm.selectedVerses == [selectedReference])
         #expect(vm.showingVerseActionsDrawer == true)
     }
@@ -468,7 +466,7 @@ let previousChapterCases: [PreviousChapterCase] = [
     private func assertNavigationSideEffects(on vm: BibleReaderViewModel) {
         #expect(vm.isChangingChapter == true)
         #expect(vm.lastScrollOffset == 0)
-        #expect(vm.scrollToTop == true)
+        #expect(vm.scrollAction == .top)
         #expect(vm.selectedVerses.isEmpty)
         #expect(vm.showingVerseActionsDrawer == false)
     }
@@ -491,7 +489,6 @@ let previousChapterCases: [PreviousChapterCase] = [
         vm.showBookIntro = showBookIntro
         vm.isChangingChapter = false
         vm.lastScrollOffset = 321
-        vm.scrollToTop = false
         vm.selectedVerses = [selectedReference]
         vm.showingVerseActionsDrawer = true
         return vm

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelNavigationStateTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelNavigationStateTests.swift
@@ -28,7 +28,7 @@ import Testing
         #expect(viewModel.showingVerseActionsDrawer == false)
         #expect(viewModel.showChrome)
         #expect(viewModel.lastScrollOffset == 0)
-        #expect(viewModel.scrollToTop)
+        #expect(viewModel.scrollAction == .top)
         #expect(await repository.requestedIds() == [111])
     }
 


### PR DESCRIPTION
## What changes

- **Single source of truth for scroll intent.** Folds `scrollToTop: Bool` + `scrollTargetReference: BibleReference?` into one `ScrollAction` enum (`.none` / `.top` / `.toVerse`). The two were mutually exclusive but independently mutable, so `setScrollTarget()` had to hand-maintain the invariant. As one value they can't get out of sync — and it closes the same-run-loop coalescing gap where `scrollToTop = true` (in `onHeaderSelectionChange`) was overwritten by `scrollToTop = false` (in `setScrollTarget`) before SwiftUI observed it. `scrollTargetReference` stays as a read-only derived accessor, so the coordinator and tests read unchanged.
- **Single exit point.** Adds `finishChapterChange()` (clears the armed scroll + resets `isChangingChapter`) as the one place a navigation returns to rest. The coordinator's `clearScrollState()` and `goToReference`'s error branch both route through it instead of poking `isChangingChapter`/`clearScrollTarget()` independently.
- **One `onChange` handler.** The view's two handlers collapse into a single exhaustive `switch` on `scrollAction`.

## Intentionally left alone

The `Task.sleep(0.5s)` scroll-to-top settle — it exists to ignore scroll-offset changes during the programmatic scroll animation (SwiftUI gives no scroll-completion callback), and fully event-driving it wants device testing. Flagged as a possible follow-up.

## No public API change

All changes are `internal`/`private` on `BibleReaderViewModel` (a `final` internal class); `ScrollAction` is internal. API-stability gate unaffected.

## Verification

- Reader unit suites green (`VerseScroll`, `Navigation`, `NavigationState`, `Interaction`); SwiftLint `--strict` clean.
- Driven end-to-end in the SampleApp on the simulator: full-chapter verse scroll (John 3:16), verse-range (Romans 8:28), whole chapter (Genesis 1), chapter nav, cold-launch restore (full chapter preserved), and chrome expand/collapse on scroll — including confirming `isChangingChapter` is released after the verse-scroll path, which is exactly the single-exit guarantee.

Totally your call whether to take it, adapt it, or toss it. Relates to BL-1901; follows up the review thread on #174.

> Note: branch is named `ae/scroll-action`; happy to rename to the `BL-1901-...` convention if you'd prefer before merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the reader's scroll intent into a single `ScrollAction` enum (`.none` / `.top` / `.toVerse`), replacing the two independently-mutable fields `scrollToTop: Bool` and `scrollTargetReference: BibleReference?`. The key win is eliminating a same-run-loop coalescing bug where a `.top` write could be overwritten by a `.toVerse` arm before SwiftUI observed it, and introducing `finishChapterChange()` as the single exit point that returns the reader to rest.

- **`ScrollAction` enum** eliminates the "can't arm both or neither" invariant that `setScrollTarget()` previously maintained by hand; `scrollTargetReference` is retained as a read-only computed accessor so existing callsites (coordinator, tests) are unaffected.
- **`finishChapterChange(clearingScroll:)`** unifies what were three independent mutation sites into one function; the `clearingScroll: false` overload correctly protects a re-armed scroll during the 0.5 s animation settle window.
- **Single `onChange(of: viewModel.scrollAction, initial: true)`** replaces two separate handlers and adds `initial: true` coverage for the cold-launch state, closing a minor gap in the previous implementation.

<h3>Confidence Score: 5/5</h3>

Clean refactor with no regressions; all scroll paths reviewed and the single-exit invariant holds throughout.

All scroll intent mutations now flow through `ScrollAction` and `finishChapterChange()`. The `clearingScroll: false` path correctly guards against clobbering a re-armed scroll during the async settle Task. The `initial: true` addition on the merged `onChange` is a net improvement. Unit suites cover the affected navigation paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Introduces `ScrollAction` enum and replaces two independent fields with a single source of truth; adds `clearScrollAction()` and `finishChapterChange(clearingScroll:)` as the unified resting-state exit point. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift | All `scrollToTop = true` sites replaced with `scrollAction = .top`; error-branch `isChangingChapter = false` in `goToReference` replaced with `finishChapterChange()`. Consistent and correct. |
| Sources/YouVersionPlatformReader/BibleReaderView.swift | Two `onChange` handlers collapsed into one exhaustive `switch` over `scrollAction` with `initial: true`; `finishChapterChange(clearingScroll: false)` correctly used in the 0.5 s settle Task. |
| Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift | `clearScrollState()` simplified to a single `finishChapterChange()` call, removing the independent two-field mutation. No logic changes. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift | `scrollToTop` assertions replaced with `scrollAction == .top` / `scrollAction == .none` expectations. Coverage unchanged. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelNavigationStateTests.swift | Updated to assert `scrollAction == .top` after `onHeaderSelectionChange`; aligns correctly with the new model. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Nav as Navigation
    participant VM as BibleReaderViewModel
    participant View as BibleReaderView
    participant VSC as VerseScrollCoordinator

    Note over Nav,VSC: Chapter navigation (scroll to top)
    Nav->>VM: "scrollAction = .top"
    VM-->>View: onChange fires (.top)
    View->>View: scrollProxy.scrollTo(topOfContent)
    View->>VM: clearScrollAction()
    View->>View: Task.sleep(0.5s)
    View->>VM: finishChapterChange(clearingScroll: false)

    Note over Nav,VSC: Verse navigation
    Nav->>VM: "onHeaderSelectionChange -> scrollAction = .top"
    Nav->>VM: "setScrollTarget() -> scrollAction = .toVerse(ref)"
    VM-->>View: onChange fires (.toVerse)
    View->>VSC: handleScrollTarget(proxy)
    VSC->>VM: finishChapterChange()

    Note over Nav,VSC: Guard branch (reference mismatch)
    Nav->>VM: goToReference - guard fails
    VM->>VM: finishChapterChange()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Nav as Navigation
    participant VM as BibleReaderViewModel
    participant View as BibleReaderView
    participant VSC as VerseScrollCoordinator

    Note over Nav,VSC: Chapter navigation (scroll to top)
    Nav->>VM: "scrollAction = .top"
    VM-->>View: onChange fires (.top)
    View->>View: scrollProxy.scrollTo(topOfContent)
    View->>VM: clearScrollAction()
    View->>View: Task.sleep(0.5s)
    View->>VM: finishChapterChange(clearingScroll: false)

    Note over Nav,VSC: Verse navigation
    Nav->>VM: "onHeaderSelectionChange -> scrollAction = .top"
    Nav->>VM: "setScrollTarget() -> scrollAction = .toVerse(ref)"
    VM-->>View: onChange fires (.toVerse)
    View->>VSC: handleScrollTarget(proxy)
    VSC->>VM: finishChapterChange()

    Note over Nav,VSC: Guard branch (reference mismatch)
    Nav->>VM: goToReference - guard fails
    VM->>VM: finishChapterChange()
```

</a>

<sub>Reviews (2): Last reviewed commit: ["refactor(reader): route scroll-to-top se..."](https://github.com/youversion/platform-sdk-swift/commit/0a393960d3a35379d2731a01c3bd0b3e2be6945c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43310437)</sub>

<!-- /greptile_comment -->