### PR TITLE
chore: update api-baseline files after 5.3.0 release

### DIFF
--- a/.api-baseline/YouVersionPlatformCore.json
+++ b/.api-baseline/YouVersionPlatformCore.json
@@ -2766,6 +2766,78 @@
         "children": [
           {
             "kind": "Function",
+            "name": "dataExchangeTokenURL",
+            "printedName": "dataExchangeTokenURL(appKey:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO20dataExchangeTokenURL6appKey10Foundation0I0VSgSS_tFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO20dataExchangeTokenURL6appKey10Foundation0I0VSgSS_tFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "dataExchangeURL",
+            "printedName": "dataExchangeURL(token:appKey:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.URL?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore10URLBuilderO15dataExchangeURL5token6appKey10Foundation0H0VSgSS_SStFZ",
+            "mangledName": "$s22YouVersionPlatformCore10URLBuilderO15dataExchangeURL5token6appKey10Foundation0H0VSgSS_SStFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
             "name": "organizationsURL",
             "printedName": "organizationsURL(id:)",
             "children": [
@@ -4008,6 +4080,52 @@
               {
                 "kind": "TypeNominal",
                 "name": "Set",
+                "printedName": "Swift.Set<Swift.String>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sh"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "URL",
+                "printedName": "Foundation.URL",
+                "usr": "s:10Foundation3URLV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB31PKCEAuthorizationRequestBuilderO4make6appKey11permissions11redirectURLAA0efgabhI0VSS_ShySSG10Foundation0P0VtKFZ",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB31PKCEAuthorizationRequestBuilderO4make6appKey11permissions11redirectURLAA0efgabhI0VSS_ShySSG10Foundation0P0VtKFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "make",
+            "printedName": "make(appKey:permissions:redirectURL:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionPKCEAuthorizationRequest",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionPKCEAuthorizationRequest",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB24PKCEAuthorizationRequestV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
                 "printedName": "Swift.Set<YouVersionPlatformCore.SignInWithYouVersionPermission>",
                 "children": [
                   {
@@ -4031,6 +4149,10 @@
             "mangledName": "$s22YouVersionPlatformCore010SignInWithaB31PKCEAuthorizationRequestBuilderO4make6appKey11permissions11redirectURLAA0efgabhI0VSS_ShyAA0efgaB10PermissionOG10Foundation0P0VtKFZ",
             "moduleName": "YouVersionPlatformCore",
             "static": true,
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
             "throwing": true,
             "funcSelfKind": "NonMutating"
           },
@@ -4213,6 +4335,140 @@
           },
           {
             "kind": "Var",
+            "name": "allCases",
+            "printedName": "allCases",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPermission",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8allCasesSayACGvpZ",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8allCasesSayACGvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SignInWithYouVersionPermission",
+                        "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                        "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8allCasesSayACGvgZ",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8allCasesSayACGvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(rawValue:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPermission",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueACSgSS_tcfc",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueACSgSS_tcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "rawValue",
+            "printedName": "rawValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueSSvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueSSvp",
+            "moduleName": "YouVersionPlatformCore",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueSSvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueSSvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
             "name": "description",
             "printedName": "description",
             "children": [
@@ -4251,38 +4507,51 @@
           {
             "kind": "Constructor",
             "name": "init",
-            "printedName": "init(rawValue:)",
+            "printedName": "init(from:)",
             "children": [
               {
                 "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SignInWithYouVersionPermission",
-                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
-                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
-                  }
-                ],
-                "usr": "s:Sq"
+                "name": "SignInWithYouVersionPermission",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
               },
               {
                 "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
               }
             ],
             "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueACSgSS_tcfc",
-            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueACSgSS_tcfc",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO4fromACs7Decoder_p_tKcfc",
             "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "declAttributes": [
-              "Inlinable"
-            ],
+            "throwing": true,
             "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "encode",
+            "printedName": "encode(to:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Encoder",
+                "printedName": "any Swift.Encoder",
+                "usr": "s:s7EncoderP"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO6encode2toys7Encoder_p_tKF",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO6encode2toys7Encoder_p_tKF",
+            "moduleName": "YouVersionPlatformCore",
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
           },
           {
             "kind": "TypeAlias",
@@ -4308,7 +4577,11 @@
             "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8AllCasesa",
             "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8AllCasesa",
             "moduleName": "YouVersionPlatformCore",
-            "implicit": true
+            "deprecated": true,
+            "implicit": true,
+            "declAttributes": [
+              "Available"
+            ]
           },
           {
             "kind": "TypeAlias",
@@ -4326,108 +4599,10 @@
             "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8RawValuea",
             "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8RawValuea",
             "moduleName": "YouVersionPlatformCore",
-            "implicit": true
-          },
-          {
-            "kind": "Var",
-            "name": "allCases",
-            "printedName": "allCases",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Array",
-                "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SignInWithYouVersionPermission",
-                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
-                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
-                  }
-                ],
-                "usr": "s:Sa"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8allCasesSayACGvpZ",
-            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8allCasesSayACGvpZ",
-            "moduleName": "YouVersionPlatformCore",
-            "static": true,
+            "deprecated": true,
             "implicit": true,
             "declAttributes": [
-              "Nonisolated"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Array",
-                    "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SignInWithYouVersionPermission",
-                        "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
-                        "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
-                      }
-                    ],
-                    "usr": "s:Sa"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8allCasesSayACGvgZ",
-                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8allCasesSayACGvgZ",
-                "moduleName": "YouVersionPlatformCore",
-                "static": true,
-                "implicit": true,
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "rawValue",
-            "printedName": "rawValue",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueSSvp",
-            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueSSvp",
-            "moduleName": "YouVersionPlatformCore",
-            "implicit": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueSSvg",
-                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO8rawValueSSvg",
-                "moduleName": "YouVersionPlatformCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Inlinable"
-                ],
-                "accessorKind": "get"
-              }
+              "Available"
             ]
           }
         ],
@@ -4435,7 +4610,10 @@
         "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO",
         "mangledName": "$s22YouVersionPlatformCore010SignInWithaB10PermissionO",
         "moduleName": "YouVersionPlatformCore",
-        "enumRawTypeName": "String",
+        "deprecated": true,
+        "declAttributes": [
+          "Available"
+        ],
         "isEnumExhaustive": true,
         "conformances": [
           {
@@ -4810,27 +4988,27 @@
           },
           {
             "kind": "Var",
-            "name": "permissions",
-            "printedName": "permissions",
+            "name": "permissionValues",
+            "printedName": "permissionValues",
             "children": [
               {
                 "kind": "TypeNominal",
                 "name": "Array",
-                "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
+                "printedName": "[Swift.String]",
                 "children": [
                   {
                     "kind": "TypeNominal",
-                    "name": "SignInWithYouVersionPermission",
-                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
-                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
                   }
                 ],
                 "usr": "s:Sa"
               }
             ],
             "declKind": "Var",
-            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV11permissionsSayAA0efgaB10PermissionOGvp",
-            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV11permissionsSayAA0efgaB10PermissionOGvp",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV16permissionValuesSaySSGvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV16permissionValuesSaySSGvp",
             "moduleName": "YouVersionPlatformCore",
             "declAttributes": [
               "HasStorage"
@@ -4846,21 +5024,21 @@
                   {
                     "kind": "TypeNominal",
                     "name": "Array",
-                    "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
+                    "printedName": "[Swift.String]",
                     "children": [
                       {
                         "kind": "TypeNominal",
-                        "name": "SignInWithYouVersionPermission",
-                        "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
-                        "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
                       }
                     ],
                     "usr": "s:Sa"
                   }
                 ],
                 "declKind": "Accessor",
-                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV11permissionsSayAA0efgaB10PermissionOGvg",
-                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV11permissionsSayAA0efgaB10PermissionOGvg",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV16permissionValuesSaySSGvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV16permissionValuesSaySSGvg",
                 "moduleName": "YouVersionPlatformCore",
                 "implicit": true,
                 "declAttributes": [
@@ -5119,6 +5297,210 @@
             ]
           },
           {
+            "kind": "Var",
+            "name": "permissions",
+            "printedName": "permissions",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPermission",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV11permissionsSayAA0efgaB10PermissionOGvp",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV11permissionsSayAA0efgaB10PermissionOGvp",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SignInWithYouVersionPermission",
+                        "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                        "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV11permissionsSayAA0efgaB10PermissionOGvg",
+                "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV11permissionsSayAA0efgaB10PermissionOGvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(accessToken:expiresIn:refreshToken:idToken:permissionValues:yvpUserId:name:profilePicture:email:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionResult",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.String]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV11accessToken07expiresF007refreshJ002idJ016permissionValues9yvpUserId4name14profilePicture5emailACSSSg_A3MSaySSGA4Mtcfc",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV11accessToken07expiresF007refreshJ002idJ016permissionValues9yvpUserId4name14profilePicture5emailACSSSg_A3MSaySSGA4Mtcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
             "kind": "Constructor",
             "name": "init",
             "printedName": "init(accessToken:expiresIn:refreshToken:idToken:permissions:yvpUserId:name:profilePicture:email:)",
@@ -5263,12 +5645,16 @@
             "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV11accessToken07expiresF007refreshJ002idJ011permissions9yvpUserId4name14profilePicture5emailACSSSg_A3MSayAA0efgaB10PermissionOGA4Mtcfc",
             "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV11accessToken07expiresF007refreshJ002idJ011permissions9yvpUserId4name14profilePicture5emailACSSSg_A3MSayAA0efgaB10PermissionOGA4Mtcfc",
             "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
             "init_kind": "Designated"
           },
           {
             "kind": "Constructor",
             "name": "init",
-            "printedName": "init(accessToken:refreshToken:idToken:expiryDate:)",
+            "printedName": "init(accessToken:refreshToken:idToken:expiryDate:permissionValues:)",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -5331,12 +5717,120 @@
                   }
                 ],
                 "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.String]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sa"
               }
             ],
             "declKind": "Constructor",
-            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV11accessToken07refreshJ002idJ010expiryDateACSSSg_A2H10Foundation0N0VSgtcfc",
-            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV11accessToken07refreshJ002idJ010expiryDateACSSSg_A2H10Foundation0N0VSgtcfc",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV11accessToken07refreshJ002idJ010expiryDate16permissionValuesACSSSg_A2I10Foundation0N0VSgSaySSGtcfc",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV11accessToken07refreshJ002idJ010expiryDate16permissionValuesACSSSg_A2I10Foundation0N0VSgSaySSGtcfc",
             "moduleName": "YouVersionPlatformCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(accessToken:refreshToken:idToken:expiryDate:permissions:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionResult",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.Date?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Date",
+                    "printedName": "Foundation.Date",
+                    "usr": "s:10Foundation4DateV"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[YouVersionPlatformCore.SignInWithYouVersionPermission]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SignInWithYouVersionPermission",
+                    "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                    "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV11accessToken07refreshJ002idJ010expiryDate11permissionsACSSSg_A2I10Foundation0N0VSgSayAA0efgaB10PermissionOGtcfc",
+            "mangledName": "$s22YouVersionPlatformCore010SignInWithaB6ResultV11accessToken07refreshJ002idJ010expiryDate11permissionsACSSSg_A2I10Foundation0N0VSgSayAA0efgaB10PermissionOGtcfc",
+            "moduleName": "YouVersionPlatformCore",
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
             "init_kind": "Designated"
           }
         ],
@@ -7089,6 +7583,117 @@
             "declKind": "Enum",
             "usr": "s:22YouVersionPlatformCore0aB3APIO10HighlightsO",
             "mangledName": "$s22YouVersionPlatformCore0aB3APIO10HighlightsO",
+            "moduleName": "YouVersionPlatformCore",
+            "isFromExtension": true,
+            "isEnumExhaustive": true,
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "hasPermission",
+            "printedName": "hasPermission(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0aB3APIO13hasPermissionySbSSFZ",
+            "mangledName": "$s22YouVersionPlatformCore0aB3APIO13hasPermissionySbSSFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "TypeDecl",
+            "name": "DataExchange",
+            "printedName": "DataExchange",
+            "children": [
+              {
+                "kind": "Function",
+                "name": "updateToken",
+                "printedName": "updateToken(permissions:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Set",
+                    "printedName": "Swift.Set<Swift.String>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sh"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO12DataExchangeO11updateToken11permissions06accessI07sessionSSShySSG_SSSgSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO12DataExchangeO11updateToken11permissions06accessI07sessionSSShySSG_SSSgSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
+              }
+            ],
+            "declKind": "Enum",
+            "usr": "s:22YouVersionPlatformCore0aB3APIO12DataExchangeO",
+            "mangledName": "$s22YouVersionPlatformCore0aB3APIO12DataExchangeO",
             "moduleName": "YouVersionPlatformCore",
             "isFromExtension": true,
             "isEnumExhaustive": true,
@@ -11803,6 +12408,143 @@
       },
       {
         "kind": "TypeDecl",
+        "name": "BibleHighlightsPendingOperationsReporting",
+        "printedName": "BibleHighlightsPendingOperationsReporting",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "hasPendingOperations",
+            "printedName": "hasPendingOperations",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore41BibleHighlightsPendingOperationsReportingP03hasgH0Sbvp",
+            "mangledName": "$s22YouVersionPlatformCore41BibleHighlightsPendingOperationsReportingP03hasgH0Sbvp",
+            "moduleName": "YouVersionPlatformCore",
+            "protocolReq": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore41BibleHighlightsPendingOperationsReportingP03hasgH0Sbvg",
+                "mangledName": "$s22YouVersionPlatformCore41BibleHighlightsPendingOperationsReportingP03hasgH0Sbvg",
+                "moduleName": "YouVersionPlatformCore",
+                "genericSig": "<Self where Self : YouVersionPlatformCore.BibleHighlightsPendingOperationsReporting>",
+                "protocolReq": true,
+                "reqNewWitnessTableEntry": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:22YouVersionPlatformCore41BibleHighlightsPendingOperationsReportingP",
+        "mangledName": "$s22YouVersionPlatformCore41BibleHighlightsPendingOperationsReportingP",
+        "moduleName": "YouVersionPlatformCore",
+        "genericSig": "<Self : YouVersionPlatformCore.BibleHighlightsRepositoryProtocol>",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleHighlightsRepositoryProtocol",
+            "printedName": "BibleHighlightsRepositoryProtocol",
+            "usr": "s:22YouVersionPlatformCore33BibleHighlightsRepositoryProtocolP",
+            "mangledName": "$s22YouVersionPlatformCore33BibleHighlightsRepositoryProtocolP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "BibleHighlightsPendingOperationsClearing",
+        "printedName": "BibleHighlightsPendingOperationsClearing",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "clearPendingOperations",
+            "printedName": "clearPendingOperations()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore40BibleHighlightsPendingOperationsClearingP05cleargH0yyF",
+            "mangledName": "$s22YouVersionPlatformCore40BibleHighlightsPendingOperationsClearingP05cleargH0yyF",
+            "moduleName": "YouVersionPlatformCore",
+            "genericSig": "<Self where Self : YouVersionPlatformCore.BibleHighlightsPendingOperationsClearing>",
+            "protocolReq": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:22YouVersionPlatformCore40BibleHighlightsPendingOperationsClearingP",
+        "mangledName": "$s22YouVersionPlatformCore40BibleHighlightsPendingOperationsClearingP",
+        "moduleName": "YouVersionPlatformCore",
+        "genericSig": "<Self : YouVersionPlatformCore.BibleHighlightsRepositoryProtocol>",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleHighlightsRepositoryProtocol",
+            "printedName": "BibleHighlightsRepositoryProtocol",
+            "usr": "s:22YouVersionPlatformCore33BibleHighlightsRepositoryProtocolP",
+            "mangledName": "$s22YouVersionPlatformCore33BibleHighlightsRepositoryProtocolP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
         "name": "OperationResult",
         "printedName": "OperationResult",
         "children": [
@@ -12344,6 +13086,46 @@
           },
           {
             "kind": "Var",
+            "name": "hasPendingOperations",
+            "printedName": "hasPendingOperations",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC20hasPendingOperationsSbvp",
+            "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC20hasPendingOperationsSbvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC20hasPendingOperationsSbvg",
+                "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC20hasPendingOperationsSbvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
             "name": "pendingOperationCount",
             "printedName": "pendingOperationCount",
             "children": [
@@ -12381,6 +13163,26 @@
                 "accessorKind": "get"
               }
             ]
+          },
+          {
+            "kind": "Function",
+            "name": "clearPendingOperations",
+            "printedName": "clearPendingOperations()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore25BibleHighlightsRepositoryC22clearPendingOperationsyyF",
+            "mangledName": "$s22YouVersionPlatformCore25BibleHighlightsRepositoryC22clearPendingOperationsyyF",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
           },
           {
             "kind": "Var",
@@ -12430,6 +13232,7 @@
         "declAttributes": [
           "Custom"
         ],
+        "hasMissingDesignatedInitializers": true,
         "conformances": [
           {
             "kind": "Conformance",
@@ -12458,6 +13261,20 @@
             "printedName": "SendableMetatype",
             "usr": "s:s16SendableMetatypeP",
             "mangledName": "$ss16SendableMetatypeP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleHighlightsPendingOperationsClearing",
+            "printedName": "BibleHighlightsPendingOperationsClearing",
+            "usr": "s:22YouVersionPlatformCore40BibleHighlightsPendingOperationsClearingP",
+            "mangledName": "$s22YouVersionPlatformCore40BibleHighlightsPendingOperationsClearingP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "BibleHighlightsPendingOperationsReporting",
+            "printedName": "BibleHighlightsPendingOperationsReporting",
+            "usr": "s:22YouVersionPlatformCore41BibleHighlightsPendingOperationsReportingP",
+            "mangledName": "$s22YouVersionPlatformCore41BibleHighlightsPendingOperationsReportingP"
           },
           {
             "kind": "Conformance",
@@ -12579,6 +13396,46 @@
               "Custom"
             ],
             "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "hasPendingOperations",
+            "printedName": "hasPendingOperations",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC20hasPendingOperationsSbvp",
+            "mangledName": "$s22YouVersionPlatformCore24BibleHighlightsViewModelC20hasPendingOperationsSbvp",
+            "moduleName": "YouVersionPlatformCore",
+            "declAttributes": [
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore24BibleHighlightsViewModelC20hasPendingOperationsSbvg",
+                "mangledName": "$s22YouVersionPlatformCore24BibleHighlightsViewModelC20hasPendingOperationsSbvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
           },
           {
             "kind": "Function",
@@ -13935,6 +14792,43 @@
                 "declKind": "Accessor",
                 "usr": "s:22YouVersionPlatformCore14BibleReferenceV7isRangeSbvg",
                 "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV7isRangeSbvg",
+                "moduleName": "YouVersionPlatformCore",
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "chapterReference",
+            "printedName": "chapterReference",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore14BibleReferenceV07chapterF0ACvp",
+            "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV07chapterF0ACvp",
+            "moduleName": "YouVersionPlatformCore",
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV07chapterF0ACvg",
+                "mangledName": "$s22YouVersionPlatformCore14BibleReferenceV07chapterF0ACvg",
                 "moduleName": "YouVersionPlatformCore",
                 "accessorKind": "get"
               }
@@ -20926,6 +21820,69 @@
             ]
           },
           {
+            "kind": "Var",
+            "name": "authStateDidChangeNotification",
+            "printedName": "authStateDidChangeNotification",
+            "children": [
+              {
+                "kind": "TypeNameAlias",
+                "name": "Name",
+                "printedName": "Foundation.Notification.Name",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Name",
+                    "printedName": "Foundation.NSNotification.Name",
+                    "usr": "c:@T@NSNotificationName"
+                  }
+                ]
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV30authStateDidChangeNotificationSo18NSNotificationNameavpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV30authStateDidChangeNotificationSo18NSNotificationNameavpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Name",
+                    "printedName": "Foundation.Notification.Name",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Name",
+                        "printedName": "Foundation.NSNotification.Name",
+                        "usr": "c:@T@NSNotificationName"
+                      }
+                    ]
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV30authStateDidChangeNotificationSo18NSNotificationNameavgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV30authStateDidChangeNotificationSo18NSNotificationNameavgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
             "kind": "Function",
             "name": "configure",
             "printedName": "configure(appKey:apiHost:appName:isSignInEnabled:signInPromptMessage:permittedLanguageTags:permittedVersionIds:)",
@@ -21103,7 +22060,7 @@
           {
             "kind": "Function",
             "name": "saveAuthData",
-            "printedName": "saveAuthData(accessToken:refreshToken:idToken:expiryDate:)",
+            "printedName": "saveAuthData(accessToken:refreshToken:idToken:expiryDate:permissions:)",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -21165,11 +22122,34 @@
                   }
                 ],
                 "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "[Swift.String]?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
               }
             ],
             "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV12saveAuthData11accessToken07refreshJ002idJ010expiryDateySSSg_A2I10Foundation0N0VSgtFZ",
-            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV12saveAuthData11accessToken07refreshJ002idJ010expiryDateySSSg_A2I10Foundation0N0VSgtFZ",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV12saveAuthData11accessToken07refreshJ002idJ010expiryDate11permissionsySSSg_A2J10Foundation0N0VSgSaySSGSgtFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV12saveAuthData11accessToken07refreshJ002idJ010expiryDate11permissionsySSSg_A2J10Foundation0N0VSgSaySSGSgtFZ",
             "moduleName": "YouVersionPlatformCore",
             "static": true,
             "declAttributes": [
@@ -21307,6 +22287,56 @@
                 "accessorKind": "get"
               }
             ]
+          },
+          {
+            "kind": "Function",
+            "name": "hasPermission",
+            "printedName": "hasPermission(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionPermission",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionPermission",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB10PermissionO"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV13hasPermissionySbAA010SignInWithabG0OFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV13hasPermissionySbAA010SignInWithabG0OFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hasPermission",
+            "printedName": "hasPermission(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV13hasPermissionySbSSFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV13hasPermissionySbSSFZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "funcSelfKind": "NonMutating"
           }
         ],
         "declKind": "Struct",
@@ -21364,7 +22394,7 @@
           {
             "kind": "Function",
             "name": "youVersion",
-            "printedName": "youVersion(_:accessToken:cachePolicy:)",
+            "printedName": "youVersion(_:accessToken:cachePolicy:omitAccessToken:)",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -21406,11 +22436,18 @@
                   }
                 ],
                 "hasDefaultArg": true
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
               }
             ],
             "declKind": "Func",
-            "usr": "s:10Foundation10URLRequestV22YouVersionPlatformCoreE03youD0_11accessToken11cachePolicyAcA3URLV_SSSgSo017NSURLRequestCacheK0VtFZ",
-            "mangledName": "$s10Foundation10URLRequestV22YouVersionPlatformCoreE03youD0_11accessToken11cachePolicyAcA3URLV_SSSgSo017NSURLRequestCacheK0VtFZ",
+            "usr": "s:10Foundation10URLRequestV22YouVersionPlatformCoreE03youD0_11accessToken11cachePolicy010omitAccessI0AcA3URLV_SSSgSo017NSURLRequestCacheK0VSbtFZ",
+            "mangledName": "$s10Foundation10URLRequestV22YouVersionPlatformCoreE03youD0_11accessToken11cachePolicy010omitAccessI0AcA3URLV_SSSgSo017NSURLRequestCacheK0VSbtFZ",
             "moduleName": "YouVersionPlatformCore",
             "static": true,
             "isFromExtension": true,

--- a/.api-baseline/YouVersionPlatformReader.json
+++ b/.api-baseline/YouVersionPlatformReader.json
@@ -20,6 +20,13 @@
       },
       {
         "kind": "Import",
+        "name": "Observation",
+        "printedName": "Observation",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformReader"
+      },
+      {
+        "kind": "Import",
         "name": "SwiftUI",
         "printedName": "SwiftUI",
         "declKind": "Import",
@@ -75,7 +82,7 @@
           {
             "kind": "Constructor",
             "name": "init",
-            "printedName": "init(reference:verseSelectionStyle:onVerseTap:)",
+            "printedName": "init(reference:verseSelectionStyle:onVerseTap:showsFullChapter:)",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -138,11 +145,18 @@
                 ],
                 "hasDefaultArg": true,
                 "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
               }
             ],
             "declKind": "Constructor",
-            "usr": "s:24YouVersionPlatformReader05BibleD4ViewV9reference19verseSelectionStyle10onVerseTapAC0abC4Core0E9ReferenceVSg_0abC2UI0liJ0VyAIcSgtcfc",
-            "mangledName": "$s24YouVersionPlatformReader05BibleD4ViewV9reference19verseSelectionStyle10onVerseTapAC0abC4Core0E9ReferenceVSg_0abC2UI0liJ0VyAIcSgtcfc",
+            "usr": "s:24YouVersionPlatformReader05BibleD4ViewV9reference19verseSelectionStyle10onVerseTap16showsFullChapterAC0abC4Core0E9ReferenceVSg_0abC2UI0liJ0VyAJcSgSbtcfc",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD4ViewV9reference19verseSelectionStyle10onVerseTap16showsFullChapterAC0abC4Core0E9ReferenceVSg_0abC2UI0liJ0VyAJcSgSbtcfc",
             "moduleName": "YouVersionPlatformReader",
             "declAttributes": [
               "Preconcurrency",

--- a/.api-baseline/YouVersionPlatformUI.json
+++ b/.api-baseline/YouVersionPlatformUI.json
@@ -62,6 +62,101 @@
       },
       {
         "kind": "TypeDecl",
+        "name": "DataExchangeSession",
+        "printedName": "DataExchangeSession",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(contextProvider:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "DataExchangeSession",
+                "printedName": "YouVersionPlatformUI.DataExchangeSession",
+                "usr": "s:20YouVersionPlatformUI19DataExchangeSessionV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "ASWebAuthenticationPresentationContextProviding",
+                "printedName": "any AuthenticationServices.ASWebAuthenticationPresentationContextProviding",
+                "usr": "c:objc(pl)ASWebAuthenticationPresentationContextProviding"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI19DataExchangeSessionV15contextProviderACSo47ASWebAuthenticationPresentationContextProviding_p_tcfc",
+            "mangledName": "$s20YouVersionPlatformUI19DataExchangeSessionV15contextProviderACSo47ASWebAuthenticationPresentationContextProviding_p_tcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "requestDataExchange",
+            "printedName": "requestDataExchange(permissions:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.String]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.String>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI19DataExchangeSessionV07requesteF011permissionsSaySSGShySSG_tYaKF",
+            "mangledName": "$s20YouVersionPlatformUI19DataExchangeSessionV07requesteF011permissionsSaySSGShySSG_tYaKF",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "Custom"
+            ],
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI19DataExchangeSessionV",
+        "mangledName": "$s20YouVersionPlatformUI19DataExchangeSessionV",
+        "moduleName": "YouVersionPlatformUI",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
         "name": "BibleTextFontOption",
         "printedName": "BibleTextFontOption",
         "children": [
@@ -174,43 +269,6 @@
             "declKind": "EnumElement",
             "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO15font100emItalicyA2CmF",
             "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO15font100emItalicyA2CmF",
-            "moduleName": "YouVersionPlatformUI"
-          },
-          {
-            "kind": "Var",
-            "name": "font100emSmallCaps",
-            "printedName": "font100emSmallCaps",
-            "children": [
-              {
-                "kind": "TypeFunc",
-                "name": "Function",
-                "printedName": "(YouVersionPlatformUI.BibleTextFontOption.Type) -> YouVersionPlatformUI.BibleTextFontOption",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "BibleTextFontOption",
-                    "printedName": "YouVersionPlatformUI.BibleTextFontOption",
-                    "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "YouVersionPlatformUI.BibleTextFontOption.Type",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "BibleTextFontOption",
-                        "printedName": "YouVersionPlatformUI.BibleTextFontOption",
-                        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "declKind": "EnumElement",
-            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO18font100emSmallCapsyA2CmF",
-            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO18font100emSmallCapsyA2CmF",
             "moduleName": "YouVersionPlatformUI"
           },
           {
@@ -880,6 +938,47 @@
             "declKind": "EnumElement",
             "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO7header4yA2CmF",
             "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO7header4yA2CmF",
+            "moduleName": "YouVersionPlatformUI",
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "font100emSmallCaps",
+            "printedName": "font100emSmallCaps",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(YouVersionPlatformUI.BibleTextFontOption.Type) -> YouVersionPlatformUI.BibleTextFontOption",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleTextFontOption",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                    "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "YouVersionPlatformUI.BibleTextFontOption.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleTextFontOption",
+                        "printedName": "YouVersionPlatformUI.BibleTextFontOption",
+                        "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "s:20YouVersionPlatformUI19BibleTextFontOptionO18font100emSmallCapsyA2CmF",
+            "mangledName": "$s20YouVersionPlatformUI19BibleTextFontOptionO18font100emSmallCapsyA2CmF",
             "moduleName": "YouVersionPlatformUI",
             "deprecated": true,
             "declAttributes": [
@@ -4575,7 +4674,7 @@
           {
             "kind": "Function",
             "name": "setFont",
-            "printedName": "setFont(_:from:)",
+            "printedName": "setFont(_:from:inSmallcaps:)",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -4594,11 +4693,18 @@
                 "name": "BibleTextFonts",
                 "printedName": "YouVersionPlatformUI.BibleTextFonts",
                 "usr": "s:20YouVersionPlatformUI14BibleTextFontsV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
               }
             ],
             "declKind": "Func",
-            "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC7setFont_4fromAcA0e4TextI6OptionO_AA0eK5FontsVtF",
-            "mangledName": "$s20YouVersionPlatformUI21BibleAttributedStringC7setFont_4fromAcA0e4TextI6OptionO_AA0eK5FontsVtF",
+            "usr": "s:20YouVersionPlatformUI21BibleAttributedStringC7setFont_4from11inSmallcapsAcA0e4TextI6OptionO_AA0eM5FontsVSbtF",
+            "mangledName": "$s20YouVersionPlatformUI21BibleAttributedStringC7setFont_4from11inSmallcapsAcA0e4TextI6OptionO_AA0eM5FontsVSbtF",
             "moduleName": "YouVersionPlatformUI",
             "declAttributes": [
               "Final",
@@ -5605,6 +5711,68 @@
                 "declKind": "Accessor",
                 "usr": "s:20YouVersionPlatformUI14BibleTextBlockV9footnotesSayAA0E8FootnoteVGvg",
                 "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV9footnotesSayAA0E8FootnoteVGvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "firstVerse",
+            "printedName": "firstVerse",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Int?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI14BibleTextBlockV10firstVerseSiSgvp",
+            "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV10firstVerseSiSgvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.Int?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI14BibleTextBlockV10firstVerseSiSgvg",
+                "mangledName": "$s20YouVersionPlatformUI14BibleTextBlockV10firstVerseSiSgvg",
                 "moduleName": "YouVersionPlatformUI",
                 "implicit": true,
                 "declAttributes": [
@@ -7387,6 +7555,453 @@
             "printedName": "Hashable",
             "usr": "s:SH",
             "mangledName": "$sSH"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "ChapterScrollAnchors",
+        "printedName": "ChapterScrollAnchors",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "chapter",
+            "printedName": "chapter",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV7chapterSivp",
+            "mangledName": "$s20YouVersionPlatformUI20ChapterScrollAnchorsV7chapterSivp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV7chapterSivg",
+                "mangledName": "$s20YouVersionPlatformUI20ChapterScrollAnchorsV7chapterSivg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "blockFirstVerses",
+            "printedName": "blockFirstVerses",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV16blockFirstVersesSaySiGvp",
+            "mangledName": "$s20YouVersionPlatformUI20ChapterScrollAnchorsV16blockFirstVersesSaySiGvp",
+            "moduleName": "YouVersionPlatformUI",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.Int]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV16blockFirstVersesSaySiGvg",
+                "mangledName": "$s20YouVersionPlatformUI20ChapterScrollAnchorsV16blockFirstVersesSaySiGvg",
+                "moduleName": "YouVersionPlatformUI",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(chapter:blockFirstVerses:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "ChapterScrollAnchors",
+                "printedName": "YouVersionPlatformUI.ChapterScrollAnchors",
+                "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.Int]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV7chapter16blockFirstVersesACSi_SaySiGtcfc",
+            "mangledName": "$s20YouVersionPlatformUI20ChapterScrollAnchorsV7chapter16blockFirstVersesACSi_SaySiGtcfc",
+            "moduleName": "YouVersionPlatformUI",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "blockFirstVerse",
+            "printedName": "blockFirstVerse(forTargetVerse:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.Int?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV15blockFirstVerse09forTargetJ0SiSgSi_tF",
+            "mangledName": "$s20YouVersionPlatformUI20ChapterScrollAnchorsV15blockFirstVerse09forTargetJ0SiSgSi_tF",
+            "moduleName": "YouVersionPlatformUI",
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "__derived_struct_equals",
+            "printedName": "__derived_struct_equals(_:_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "ChapterScrollAnchors",
+                "printedName": "YouVersionPlatformUI.ChapterScrollAnchors",
+                "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "ChapterScrollAnchors",
+                "printedName": "YouVersionPlatformUI.ChapterScrollAnchors",
+                "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV23__derived_struct_equalsySbAC_ACtFZ",
+            "mangledName": "$s20YouVersionPlatformUI20ChapterScrollAnchorsV23__derived_struct_equalsySbAC_ACtFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "implicit": true,
+            "declAttributes": [
+              "Implements"
+            ],
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV",
+        "mangledName": "$s20YouVersionPlatformUI20ChapterScrollAnchorsV",
+        "moduleName": "YouVersionPlatformUI",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "ChapterScrollAnchorsKey",
+        "printedName": "ChapterScrollAnchorsKey",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "defaultValue",
+            "printedName": "defaultValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.ChapterScrollAnchors?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ChapterScrollAnchors",
+                    "printedName": "YouVersionPlatformUI.ChapterScrollAnchors",
+                    "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:20YouVersionPlatformUI23ChapterScrollAnchorsKeyV12defaultValueAA0efG0VSgvpZ",
+            "mangledName": "$s20YouVersionPlatformUI23ChapterScrollAnchorsKeyV12defaultValueAA0efG0VSgvpZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "YouVersionPlatformUI.ChapterScrollAnchors?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "ChapterScrollAnchors",
+                        "printedName": "YouVersionPlatformUI.ChapterScrollAnchors",
+                        "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:20YouVersionPlatformUI23ChapterScrollAnchorsKeyV12defaultValueAA0efG0VSgvgZ",
+                "mangledName": "$s20YouVersionPlatformUI23ChapterScrollAnchorsKeyV12defaultValueAA0efG0VSgvgZ",
+                "moduleName": "YouVersionPlatformUI",
+                "static": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Function",
+            "name": "reduce",
+            "printedName": "reduce(value:nextValue:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.ChapterScrollAnchors?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ChapterScrollAnchors",
+                    "printedName": "YouVersionPlatformUI.ChapterScrollAnchors",
+                    "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV"
+                  }
+                ],
+                "paramValueOwnership": "InOut",
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "() -> YouVersionPlatformUI.ChapterScrollAnchors?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "YouVersionPlatformUI.ChapterScrollAnchors?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "ChapterScrollAnchors",
+                        "printedName": "YouVersionPlatformUI.ChapterScrollAnchors",
+                        "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "typeAttributes": [
+                  "noescape"
+                ]
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:20YouVersionPlatformUI23ChapterScrollAnchorsKeyV6reduce5value9nextValueyAA0efG0VSgz_AIyXEtFZ",
+            "mangledName": "$s20YouVersionPlatformUI23ChapterScrollAnchorsKeyV6reduce5value9nextValueyAA0efG0VSgz_AIyXEtFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "Value",
+            "printedName": "Value",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformUI.ChapterScrollAnchors?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ChapterScrollAnchors",
+                    "printedName": "YouVersionPlatformUI.ChapterScrollAnchors",
+                    "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:20YouVersionPlatformUI23ChapterScrollAnchorsKeyV5Valuea",
+            "mangledName": "$s20YouVersionPlatformUI23ChapterScrollAnchorsKeyV5Valuea",
+            "moduleName": "YouVersionPlatformUI",
+            "implicit": true
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:20YouVersionPlatformUI23ChapterScrollAnchorsKeyV",
+        "mangledName": "$s20YouVersionPlatformUI23ChapterScrollAnchorsKeyV",
+        "moduleName": "YouVersionPlatformUI",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "PreferenceKey",
+            "printedName": "PreferenceKey",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "Value",
+                "printedName": "Value",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "YouVersionPlatformUI.ChapterScrollAnchors?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "ChapterScrollAnchors",
+                        "printedName": "YouVersionPlatformUI.ChapterScrollAnchors",
+                        "usr": "s:20YouVersionPlatformUI20ChapterScrollAnchorsV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ]
+              }
+            ],
+            "usr": "s:7SwiftUI13PreferenceKeyP",
+            "mangledName": "$s7SwiftUI13PreferenceKeyP"
           }
         ]
       },
@@ -12664,6 +13279,50 @@
               },
               {
                 "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[Swift.String]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sa"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "ASWebAuthenticationPresentationContextProviding",
+                "printedName": "any AuthenticationServices.ASWebAuthenticationPresentationContextProviding",
+                "usr": "c:objc(pl)ASWebAuthenticationPresentationContextProviding"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:22YouVersionPlatformCore0aB3APIO5UsersO0abC2UIE6signIn11permissions15contextProviderAA04Signi4WithaB6ResultVSaySSG_So47ASWebAuthenticationPresentationContextProviding_ptYaKFZ",
+            "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO0abC2UIE6signIn11permissions15contextProviderAA04Signi4WithaB6ResultVSaySSG_So47ASWebAuthenticationPresentationContextProviding_ptYaKFZ",
+            "moduleName": "YouVersionPlatformUI",
+            "static": true,
+            "declAttributes": [
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "signIn",
+            "printedName": "signIn(permissions:contextProvider:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SignInWithYouVersionResult",
+                "printedName": "YouVersionPlatformCore.SignInWithYouVersionResult",
+                "usr": "s:22YouVersionPlatformCore010SignInWithaB6ResultV"
+              },
+              {
+                "kind": "TypeNominal",
                 "name": "Set",
                 "printedName": "Swift.Set<YouVersionPlatformCore.SignInWithYouVersionPermission>",
                 "children": [
@@ -12688,7 +13347,9 @@
             "mangledName": "$s22YouVersionPlatformCore0aB3APIO5UsersO0abC2UIE6signIn11permissions15contextProviderAA04Signi4WithaB6ResultVShyAA0minaB10PermissionOG_So47ASWebAuthenticationPresentationContextProviding_ptYaKFZ",
             "moduleName": "YouVersionPlatformUI",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
+              "Available",
               "Custom"
             ],
             "isFromExtension": true,
@@ -14173,6 +14834,152 @@
             "printedName": "Escapable",
             "usr": "s:s9EscapableP",
             "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "ColorScheme",
+        "printedName": "ColorScheme",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "readerTheme",
+            "printedName": "readerTheme",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "ReaderTheme",
+                "printedName": "YouVersionPlatformUI.ReaderTheme",
+                "usr": "s:20YouVersionPlatformUI11ReaderThemeV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:7SwiftUI11ColorSchemeO018YouVersionPlatformB0E11readerThemeAD06ReaderI0Vvp",
+            "mangledName": "$s7SwiftUI11ColorSchemeO018YouVersionPlatformB0E11readerThemeAD06ReaderI0Vvp",
+            "moduleName": "YouVersionPlatformUI",
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ReaderTheme",
+                    "printedName": "YouVersionPlatformUI.ReaderTheme",
+                    "usr": "s:20YouVersionPlatformUI11ReaderThemeV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:7SwiftUI11ColorSchemeO018YouVersionPlatformB0E11readerThemeAD06ReaderI0Vvg",
+                "mangledName": "$s7SwiftUI11ColorSchemeO018YouVersionPlatformB0E11readerThemeAD06ReaderI0Vvg",
+                "moduleName": "YouVersionPlatformUI",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "s:7SwiftUI11ColorSchemeO",
+        "mangledName": "$s7SwiftUI11ColorSchemeO",
+        "moduleName": "SwiftUICore",
+        "intro_Macosx": "10.15",
+        "intro_iOS": "13.0",
+        "intro_tvOS": "13.0",
+        "intro_watchOS": "6.0",
+        "declAttributes": [
+          "OriginallyDefinedIn",
+          "OriginallyDefinedIn",
+          "OriginallyDefinedIn",
+          "OriginallyDefinedIn",
+          "Available",
+          "Available",
+          "Available",
+          "Available"
+        ],
+        "isExternal": true,
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "CaseIterable",
+            "printedName": "CaseIterable",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "AllCases",
+                "printedName": "AllCases",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "AllCases",
+                    "printedName": "SwiftUI.ColorScheme.AllCases",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Array",
+                        "printedName": "[SwiftUI.ColorScheme]",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "ColorScheme",
+                            "printedName": "SwiftUI.ColorScheme",
+                            "usr": "s:7SwiftUI11ColorSchemeO"
+                          }
+                        ],
+                        "usr": "s:Sa"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:s12CaseIterableP",
+            "mangledName": "$ss12CaseIterableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
           },
           {
             "kind": "Conformance",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes the API baseline snapshots after the 5.3.0 release. The main changes are:

- New Core data-exchange and string-based sign-in permission APIs.
- Deprecated enum-based sign-in permission and small-caps font APIs.
- New pending-highlight operation reporting and clearing API surface.
- Reader full-chapter scrolling and UI anchor baseline entries.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after small follow-ups around permission validation and reader anchor state.

- The baseline entries mostly match the public API surface that was inspected.
- The remaining issues are conditional compatibility and state-handling concerns, not clear release blockers.
- No build-breaking baseline mismatch was found in the changed snapshots.

.api-baseline/YouVersionPlatformCore.json and .api-baseline/YouVersionPlatformUI.json

<details open><summary><h3>Security Review</h3></summary>

The new string-based permission surface should validate or constrain permission values before sending them through sign-in and data-exchange flows.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .api-baseline/YouVersionPlatformCore.json | Updates Core baseline entries for data exchange, sign-in permissions, pending highlight operations, and related deprecations. |
| .api-baseline/YouVersionPlatformReader.json | Updates Reader baseline entries for Observation usage and the new full-chapter reader initializer option. |
| .api-baseline/YouVersionPlatformUI.json | Updates UI baseline entries for data exchange sessions, reader scroll anchors, font handling, and theme helpers. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0A.api-baseline%2FYouVersionPlatformCore.json%3A4088-4098%0A**Raw%20Permission%20Strings%20Reach%20Auth**%0A%0AThe%20new%20%60Set%3CString%3E%60%20permission%20surface%20lets%20callers%20pass%20values%20outside%20the%20old%20enum%20cases%2C%20and%20those%20strings%20flow%20into%20OAuth%20%60requested_permissions%60%20or%20data-exchange%20token%20requests%20without%20SDK-side%20validation.%20A%20typo%20like%20%60Profile%60%20or%20a%20comma-bearing%20value%20can%20be%20sent%20as%20a%20different%20permission%20field%20than%20intended%2C%20which%20can%20make%20sign-in%20fail%20or%20request%20unexpected%20permissions.%0A%0A%23%23%23%20Issue%202%20of%204%0A.api-baseline%2FYouVersionPlatformCore.json%3A5299-5355%0A**Deprecated%20Permissions%20Drop%20Values**%0A%0AThe%20new%20stored%20result%20value%20is%20%60%5BString%5D%60%2C%20but%20the%20deprecated%20%60permissions%60%20API%20still%20exposes%20%60%5BSignInWithYouVersionPermission%5D%60.%20When%20the%20server%20returns%20a%20newer%20permission%20string%2C%20old%20callers%20reading%20%60result.permissions%60%20lose%20that%20granted%20value%20through%20the%20enum%20conversion%20and%20can%20make%20decisions%20from%20an%20incomplete%20permission%20list.%0A%0A%23%23%23%20Issue%203%20of%204%0A.api-baseline%2FYouVersionPlatformCore.json%3A13167-13186%0A**Pending%20Queue%20Clears%20Globally**%0A%0AThe%20new%20public%20clearing%20API%20maps%20to%20a%20repository-level%20%60clearPendingOperations%28%29%60%20that%20removes%20the%20whole%20pending%20highlight%20queue.%20When%20sign-out%20reset%20is%20called%20while%20the%20shared%20repository%20still%20contains%20unsynced%20operations%20from%20another%20reader%2Fsession%20scope%2C%20those%20operations%20can%20be%20discarded%20instead%20of%20only%20clearing%20the%20intended%20account%20state.%0A%0A%23%23%23%20Issue%204%20of%204%0A.api-baseline%2FYouVersionPlatformUI.json%3A7860-7895%0A**Nil%20Anchors%20Preserve%20Stale%20State**%0A%0AThe%20new%20preference%20key%20keeps%20the%20previous%20%60ChapterScrollAnchors%60%20when%20a%20child%20emits%20%60nil%60.%20During%20a%20chapter%20change%2C%20an%20empty%20intermediate%20render%20can%20leave%20the%20old%20chapter%20anchors%20active%20long%20enough%20for%20the%20scroll%20coordinator%20to%20target%20a%20block%20ID%20from%20the%20previous%20chapter%2C%20making%20the%20requested%20verse%20scroll%20a%20no-op.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0A.api-baseline%2FYouVersionPlatformCore.json%3A4088-4098%0A**Raw%20Permission%20Strings%20Reach%20Auth**%0A%0AThe%20new%20%60Set%3CString%3E%60%20permission%20surface%20lets%20callers%20pass%20values%20outside%20the%20old%20enum%20cases%2C%20and%20those%20strings%20flow%20into%20OAuth%20%60requested_permissions%60%20or%20data-exchange%20token%20requests%20without%20SDK-side%20validation.%20A%20typo%20like%20%60Profile%60%20or%20a%20comma-bearing%20value%20can%20be%20sent%20as%20a%20different%20permission%20field%20than%20intended%2C%20which%20can%20make%20sign-in%20fail%20or%20request%20unexpected%20permissions.%0A%0A%23%23%23%20Issue%202%20of%204%0A.api-baseline%2FYouVersionPlatformCore.json%3A5299-5355%0A**Deprecated%20Permissions%20Drop%20Values**%0A%0AThe%20new%20stored%20result%20value%20is%20%60%5BString%5D%60%2C%20but%20the%20deprecated%20%60permissions%60%20API%20still%20exposes%20%60%5BSignInWithYouVersionPermission%5D%60.%20When%20the%20server%20returns%20a%20newer%20permission%20string%2C%20old%20callers%20reading%20%60result.permissions%60%20lose%20that%20granted%20value%20through%20the%20enum%20conversion%20and%20can%20make%20decisions%20from%20an%20incomplete%20permission%20list.%0A%0A%23%23%23%20Issue%203%20of%204%0A.api-baseline%2FYouVersionPlatformCore.json%3A13167-13186%0A**Pending%20Queue%20Clears%20Globally**%0A%0AThe%20new%20public%20clearing%20API%20maps%20to%20a%20repository-level%20%60clearPendingOperations%28%29%60%20that%20removes%20the%20whole%20pending%20highlight%20queue.%20When%20sign-out%20reset%20is%20called%20while%20the%20shared%20repository%20still%20contains%20unsynced%20operations%20from%20another%20reader%2Fsession%20scope%2C%20those%20operations%20can%20be%20discarded%20instead%20of%20only%20clearing%20the%20intended%20account%20state.%0A%0A%23%23%23%20Issue%204%20of%204%0A.api-baseline%2FYouVersionPlatformUI.json%3A7860-7895%0A**Nil%20Anchors%20Preserve%20Stale%20State**%0A%0AThe%20new%20preference%20key%20keeps%20the%20previous%20%60ChapterScrollAnchors%60%20when%20a%20child%20emits%20%60nil%60.%20During%20a%20chapter%20change%2C%20an%20empty%20intermediate%20render%20can%20leave%20the%20old%20chapter%20anchors%20active%20long%20enough%20for%20the%20scroll%20coordinator%20to%20target%20a%20block%20ID%20from%20the%20previous%20chapter%2C%20making%20the%20requested%20verse%20scroll%20a%20no-op.%0A%0A&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22update-basline%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22update-basline%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0A.api-baseline%2FYouVersionPlatformCore.json%3A4088-4098%0A**Raw%20Permission%20Strings%20Reach%20Auth**%0A%0AThe%20new%20%60Set%3CString%3E%60%20permission%20surface%20lets%20callers%20pass%20values%20outside%20the%20old%20enum%20cases%2C%20and%20those%20strings%20flow%20into%20OAuth%20%60requested_permissions%60%20or%20data-exchange%20token%20requests%20without%20SDK-side%20validation.%20A%20typo%20like%20%60Profile%60%20or%20a%20comma-bearing%20value%20can%20be%20sent%20as%20a%20different%20permission%20field%20than%20intended%2C%20which%20can%20make%20sign-in%20fail%20or%20request%20unexpected%20permissions.%0A%0A%23%23%23%20Issue%202%20of%204%0A.api-baseline%2FYouVersionPlatformCore.json%3A5299-5355%0A**Deprecated%20Permissions%20Drop%20Values**%0A%0AThe%20new%20stored%20result%20value%20is%20%60%5BString%5D%60%2C%20but%20the%20deprecated%20%60permissions%60%20API%20still%20exposes%20%60%5BSignInWithYouVersionPermission%5D%60.%20When%20the%20server%20returns%20a%20newer%20permission%20string%2C%20old%20callers%20reading%20%60result.permissions%60%20lose%20that%20granted%20value%20through%20the%20enum%20conversion%20and%20can%20make%20decisions%20from%20an%20incomplete%20permission%20list.%0A%0A%23%23%23%20Issue%203%20of%204%0A.api-baseline%2FYouVersionPlatformCore.json%3A13167-13186%0A**Pending%20Queue%20Clears%20Globally**%0A%0AThe%20new%20public%20clearing%20API%20maps%20to%20a%20repository-level%20%60clearPendingOperations%28%29%60%20that%20removes%20the%20whole%20pending%20highlight%20queue.%20When%20sign-out%20reset%20is%20called%20while%20the%20shared%20repository%20still%20contains%20unsynced%20operations%20from%20another%20reader%2Fsession%20scope%2C%20those%20operations%20can%20be%20discarded%20instead%20of%20only%20clearing%20the%20intended%20account%20state.%0A%0A%23%23%23%20Issue%204%20of%204%0A.api-baseline%2FYouVersionPlatformUI.json%3A7860-7895%0A**Nil%20Anchors%20Preserve%20Stale%20State**%0A%0AThe%20new%20preference%20key%20keeps%20the%20previous%20%60ChapterScrollAnchors%60%20when%20a%20child%20emits%20%60nil%60.%20During%20a%20chapter%20change%2C%20an%20empty%20intermediate%20render%20can%20leave%20the%20old%20chapter%20anchors%20active%20long%20enough%20for%20the%20scroll%20coordinator%20to%20target%20a%20block%20ID%20from%20the%20previous%20chapter%2C%20making%20the%20requested%20verse%20scroll%20a%20no-op.%0A%0A&repo=youversion%2Fplatform-sdk-swift&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
.api-baseline/YouVersionPlatformCore.json:4088-4098
**Raw Permission Strings Reach Auth**

The new `Set<String>` permission surface lets callers pass values outside the old enum cases, and those strings flow into OAuth `requested_permissions` or data-exchange token requests without SDK-side validation. A typo like `Profile` or a comma-bearing value can be sent as a different permission field than intended, which can make sign-in fail or request unexpected permissions.

### Issue 2 of 4
.api-baseline/YouVersionPlatformCore.json:5299-5355
**Deprecated Permissions Drop Values**

The new stored result value is `[String]`, but the deprecated `permissions` API still exposes `[SignInWithYouVersionPermission]`. When the server returns a newer permission string, old callers reading `result.permissions` lose that granted value through the enum conversion and can make decisions from an incomplete permission list.

### Issue 3 of 4
.api-baseline/YouVersionPlatformCore.json:13167-13186
**Pending Queue Clears Globally**

The new public clearing API maps to a repository-level `clearPendingOperations()` that removes the whole pending highlight queue. When sign-out reset is called while the shared repository still contains unsynced operations from another reader/session scope, those operations can be discarded instead of only clearing the intended account state.

### Issue 4 of 4
.api-baseline/YouVersionPlatformUI.json:7860-7895
**Nil Anchors Preserve Stale State**

The new preference key keeps the previous `ChapterScrollAnchors` when a child emits `nil`. During a chapter change, an empty intermediate render can leave the old chapter anchors active long enough for the scroll coordinator to target a block ID from the previous chapter, making the requested verse scroll a no-op.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update api-baseline files after 5..."](https://github.com/youversion/platform-sdk-swift/commit/0efc8321a6be2f0d9bff0a116bd18187f72a72d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43854938)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->