### PR TITLE
test: expand BibleHighlightsRepository coverage

### DIFF
--- a/Examples/SampleApp/SampleApp.swift
+++ b/Examples/SampleApp/SampleApp.swift
@@ -9,7 +9,7 @@ struct SampleApp: App {
     init() {
         // Get your app key from https://platform.youversion.com/
         YouVersionPlatformConfiguration.configure(
-            appKey: <#Your App Key#>,
+            appKey: "0l11yjhHCGe1vmAGoceT7yFhXdDu4O7UZTxToqOAfiqjsIA9", // prod SampleApp
             appName: "Sample App",
             signInPromptMessage: "Sign in to see your YouVersion highlights in this Sample App."
         )

--- a/Examples/SampleApp/SampleApp.swift
+++ b/Examples/SampleApp/SampleApp.swift
@@ -9,7 +9,7 @@ struct SampleApp: App {
     init() {
         // Get your app key from https://platform.youversion.com/
         YouVersionPlatformConfiguration.configure(
-            appKey: "0l11yjhHCGe1vmAGoceT7yFhXdDu4O7UZTxToqOAfiqjsIA9", // prod SampleApp
+            appKey: <#Your App Key#>,
             appName: "Sample App",
             signInPromptMessage: "Sign in to see your YouVersion highlights in this Sample App."
         )

--- a/Tests/YouVersionPlatformCoreTests/BibleHighlightsRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleHighlightsRepositoryTests.swift
@@ -10,6 +10,9 @@ class MockBibleHighlightsAPI: BibleHighlightsAPIProtocol {
     var getHighlightsCallCount = 0
     var updateHighlightCallCount = 0
     var deleteHighlightCallCount = 0
+    var createHighlightCalls: [(bibleId: Int, passageId: String, color: String)] = []
+    var updateHighlightCalls: [(bibleId: Int, passageId: String, color: String)] = []
+    var deleteHighlightCalls: [(bibleId: Int, passageId: String)] = []
     
     var shouldThrowError = false
     var shouldSuspendCreateHighlight = false
@@ -24,6 +27,9 @@ class MockBibleHighlightsAPI: BibleHighlightsAPIProtocol {
         getHighlightsCallCount = 0
         updateHighlightCallCount = 0
         deleteHighlightCallCount = 0
+        createHighlightCalls = []
+        updateHighlightCalls = []
+        deleteHighlightCalls = []
         shouldThrowError = false
         shouldSuspendCreateHighlight = false
         mockCreateHighlightResult = true
@@ -56,6 +62,7 @@ class MockBibleHighlightsAPI: BibleHighlightsAPIProtocol {
     
     func createHighlight(bibleId: Int, passageId: String, color: String) async throws -> Bool {
         createHighlightCallCount += 1
+        createHighlightCalls.append((bibleId, passageId, color))
 
         if shouldSuspendCreateHighlight {
             await withCheckedContinuation { continuation in
@@ -72,6 +79,7 @@ class MockBibleHighlightsAPI: BibleHighlightsAPIProtocol {
     
     func updateHighlight(bibleId: Int, passageId: String, color: String) async throws -> Bool {
         updateHighlightCallCount += 1
+        updateHighlightCalls.append((bibleId, passageId, color))
         
         if shouldThrowError {
             throw NSError(domain: "TestError", code: 1, userInfo: nil)
@@ -82,12 +90,20 @@ class MockBibleHighlightsAPI: BibleHighlightsAPIProtocol {
     
     func deleteHighlight(bibleId: Int, passageId: String) async throws -> Bool {
         deleteHighlightCallCount += 1
+        deleteHighlightCalls.append((bibleId, passageId))
         
         if shouldThrowError {
             throw NSError(domain: "TestError", code: 1, userInfo: nil)
         }
         
         return mockDeleteHighlightResult
+    }
+}
+
+@MainActor
+final class ThrowingBibleHighlightsRepository: BibleHighlightsRepository {
+    override func saveOperations(_ operations: [PendingHighlightOperation]) async throws -> [UUID: Bool] {
+        throw NSError(domain: "TestError", code: 1)
     }
 }
 
@@ -186,6 +202,25 @@ struct BibleHighlightsRepositoryTests {
         #expect(result.count == 1)
         #expect(result["1_GEN_1"]?.isEmpty == true)
     }
+
+    @Test
+    func testHighlightsIgnoresInvalidPassageIDs() async throws {
+        let mockAPI = setUp()
+        let repository = BibleHighlightsRepository(api: mockAPI)
+        mockAPI.mockGetHighlightsResult = [
+            HighlightResponse(bibleId: 1, passageId: "GEN.1", color: "FF0000"),
+            HighlightResponse(bibleId: 1, passageId: "GEN.chapter.1", color: "00FF00"),
+            HighlightResponse(bibleId: 1, passageId: "GEN.1.verse", color: "0000FF"),
+            HighlightResponse(bibleId: 1, passageId: "GEN.1.2", color: "FFFF00")
+        ]
+
+        let references = [BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1)]
+        let result = try await repository.highlights(for: references)
+
+        #expect(result["1_GEN_1"]?.count == 1)
+        #expect(result["1_GEN_1"]?.first?.reference.verseStart == 2)
+        #expect(result["1_GEN_1"]?.first?.color == "#FFFF00")
+    }
     
     // MARK: - Test Operation Processing
     
@@ -200,7 +235,25 @@ struct BibleHighlightsRepositoryTests {
         let result = try await repository.saveOperations([operation])
         
         #expect(mockAPI.createHighlightCallCount == 1)
+        #expect(mockAPI.createHighlightCalls.first?.bibleId == 1)
+        #expect(mockAPI.createHighlightCalls.first?.passageId == "GEN.1.1")
+        #expect(mockAPI.createHighlightCalls.first?.color == "FF0000")
         #expect(result.count == 1)
+        #expect(result[operation.id] == true)
+    }
+
+    @Test
+    func testSaveOperationsAddDefaultsToFirstVerse() async throws {
+        let mockAPI = setUp()
+        let repository = BibleHighlightsRepository(api: mockAPI)
+        let reference = BibleReference(versionId: 42, bookUSFM: "JHN", chapter: 3)
+        let operation = PendingHighlightOperation(references: [reference], color: "00FF00", operationType: .add)
+
+        let result = try await repository.saveOperations([operation])
+
+        #expect(mockAPI.createHighlightCalls.first?.bibleId == 42)
+        #expect(mockAPI.createHighlightCalls.first?.passageId == "JHN.3.1")
+        #expect(mockAPI.createHighlightCalls.first?.color == "00FF00")
         #expect(result[operation.id] == true)
     }
     
@@ -215,8 +268,24 @@ struct BibleHighlightsRepositoryTests {
         let result = try await repository.saveOperations([operation])
         
         #expect(mockAPI.deleteHighlightCallCount == 1)
+        #expect(mockAPI.deleteHighlightCalls.first?.bibleId == 1)
+        #expect(mockAPI.deleteHighlightCalls.first?.passageId == "GEN.1.1")
         #expect(result.count == 1)
         #expect(result[operation.id] == true)
+    }
+
+    @Test
+    func testSaveOperationsRemoveHandlesFailure() async throws {
+        let mockAPI = setUp()
+        mockAPI.mockDeleteHighlightResult = false
+        let repository = BibleHighlightsRepository(api: mockAPI)
+        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let operation = PendingHighlightOperation(references: [reference], color: nil, operationType: .remove)
+
+        let result = try await repository.saveOperations([operation])
+
+        #expect(mockAPI.deleteHighlightCallCount == 1)
+        #expect(result[operation.id] == false)
     }
     
     @Test
@@ -230,8 +299,25 @@ struct BibleHighlightsRepositoryTests {
         let result = try await repository.saveOperations([operation])
         
         #expect(mockAPI.updateHighlightCallCount == 1)
+        #expect(mockAPI.updateHighlightCalls.first?.bibleId == 1)
+        #expect(mockAPI.updateHighlightCalls.first?.passageId == "GEN.1.1")
+        #expect(mockAPI.updateHighlightCalls.first?.color == "00FF00")
         #expect(result.count == 1)
         #expect(result[operation.id] == true)
+    }
+
+    @Test
+    func testSaveOperationsUpdateHandlesThrownError() async throws {
+        let mockAPI = setUp()
+        mockAPI.shouldThrowError = true
+        let repository = BibleHighlightsRepository(api: mockAPI)
+        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let operation = PendingHighlightOperation(references: [reference], color: "#00FF00", operationType: .update)
+
+        let result = try await repository.saveOperations([operation])
+
+        #expect(mockAPI.updateHighlightCallCount == 1)
+        #expect(result[operation.id] == false)
     }
     
     @Test
@@ -338,6 +424,35 @@ struct BibleHighlightsRepositoryTests {
         repository.queueOperation(operation1)
         
         #expect(repository.hasPendingOperations)
+    }
+
+    @Test
+    func testPendingOperationCountExcludesProcessingOperation() async {
+        let mockAPI = setUp()
+        mockAPI.shouldSuspendCreateHighlight = true
+        let repository = BibleHighlightsRepository(api: mockAPI)
+        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let processingOperation = PendingHighlightOperation(
+            references: [reference],
+            color: "#FF0000",
+            operationType: .add
+        )
+        let pendingOperation = PendingHighlightOperation(
+            references: [reference],
+            color: "#00FF00",
+            operationType: .update
+        )
+
+        repository.queueOperation(processingOperation)
+        await mockAPI.waitForCreateHighlightToStart()
+        repository.queueOperation(pendingOperation)
+
+        #expect(repository.pendingOperationCount == 1)
+
+        mockAPI.resumeCreateHighlight()
+        while repository.hasPendingOperations {
+            await Task.yield()
+        }
     }
 
     @Test
@@ -479,6 +594,27 @@ struct BibleHighlightsRepositoryTests {
     }
 
     @Test
+    func testProcessQueueHandlesUnexpectedSaveOperationsError() async {
+        let mockAPI = setUp()
+        let repository = ThrowingBibleHighlightsRepository(api: mockAPI, retryDelayNanoseconds: 60_000_000_000)
+        let reference = BibleReference(versionId: 1, bookUSFM: "GEN", chapter: 1, verse: 1)
+        let operation = PendingHighlightOperation(references: [reference], color: "#FF0000", operationType: .add)
+
+        repository.queueOperation(operation)
+        while repository.getOperationResult(for: operation.id) == nil {
+            await Task.yield()
+        }
+
+        let result = repository.getOperationResult(for: operation.id)
+        #expect(result?.success == false)
+        #expect(result?.error != nil)
+        #expect(result?.retryCount == 1)
+        #expect(repository.pendingOperationCount == 1)
+
+        repository.clearPendingOperations()
+    }
+
+    @Test
     func testFailedOperationsAreRetriedWithDelayedProcessing() async {
         let mockAPI = setUp()
         mockAPI.mockCreateHighlightResult = false
@@ -568,4 +704,4 @@ struct BibleHighlightsRepositoryTests {
         #expect(mockAPI.createHighlightCallCount >= 2)
         #expect(!repository.hasPendingOperations)
     }
-} 
+}


### PR DESCRIPTION
## Summary
- Add repository tests for highlight parsing, default verse selection, and failure handling.
- Capture mock API call arguments to verify the correct bible IDs, passage IDs, and colors are sent.
- Cover pending-operation counting while one operation is actively processing.
- Update the sample app to use the production app key placeholder replacement.

## Testing
- Not run (not requested)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands coverage for `BibleHighlightsRepository`. The main changes are:

- Mock API call arguments are captured for create, update, and delete calls.
- Tests cover highlight parsing, default verse selection, and failed save operations.
- Pending-operation counting is checked while another operation is processing.
- Queue error handling is tested through a throwing repository helper.

<h3>Confidence Score: 2/5</h3>

This should be fixed before merging.
- The throwing repository helper still overrides non-open production API from a separate test module.
- A clean Swift test build can fail before the new queue error test runs.

**Files Needing Attention:** Tests/YouVersionPlatformCoreTests/BibleHighlightsRepositoryTests.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Tests/YouVersionPlatformCoreTests/BibleHighlightsRepositoryTests.swift | Adds broader repository coverage, but the throwing helper can still block the test target from compiling. |

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0ATests%2FYouVersionPlatformCoreTests%2FBibleHighlightsRepositoryTests.swift%3A104-105%0A**Override%20Still%20Fails**%0A%0AThis%20helper%20is%20still%20defined%20in%20the%20%60YouVersionPlatformCoreTests%60%20target%2C%20but%20%60BibleHighlightsRepository%60%20and%20%60saveOperations%60%20are%20only%20%60public%60%20in%20%60YouVersionPlatformCore%60.%20Swift%20only%20allows%20cross-module%20subclassing%20and%20overrides%20for%20%60open%60%20APIs%2C%20and%20%60%40testable%20import%60%20does%20not%20change%20that%20rule.%20A%20clean%20test%20build%20can%20reject%20this%20before%20%60testProcessQueueHandlesUnexpectedSaveOperationsError%60%20runs.%20A%20protocol%20seam%2C%20injected%20throwing%20closure%2C%20or%20same-module%20test%20helper%20would%20avoid%20the%20cross-module%20override.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youversion%2Fplatform-sdk-swift&pr=197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0ATests%2FYouVersionPlatformCoreTests%2FBibleHighlightsRepositoryTests.swift%3A104-105%0A**Override%20Still%20Fails**%0A%0AThis%20helper%20is%20still%20defined%20in%20the%20%60YouVersionPlatformCoreTests%60%20target%2C%20but%20%60BibleHighlightsRepository%60%20and%20%60saveOperations%60%20are%20only%20%60public%60%20in%20%60YouVersionPlatformCore%60.%20Swift%20only%20allows%20cross-module%20subclassing%20and%20overrides%20for%20%60open%60%20APIs%2C%20and%20%60%40testable%20import%60%20does%20not%20change%20that%20rule.%20A%20clean%20test%20build%20can%20reject%20this%20before%20%60testProcessQueueHandlesUnexpectedSaveOperationsError%60%20runs.%20A%20protocol%20seam%2C%20injected%20throwing%20closure%2C%20or%20same-module%20test%20helper%20would%20avoid%20the%20cross-module%20override.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22tests-biblehighlightsrepository%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22tests-biblehighlightsrepository%22.%0A%0A%23%23%23%20Issue%201%0ATests%2FYouVersionPlatformCoreTests%2FBibleHighlightsRepositoryTests.swift%3A104-105%0A**Override%20Still%20Fails**%0A%0AThis%20helper%20is%20still%20defined%20in%20the%20%60YouVersionPlatformCoreTests%60%20target%2C%20but%20%60BibleHighlightsRepository%60%20and%20%60saveOperations%60%20are%20only%20%60public%60%20in%20%60YouVersionPlatformCore%60.%20Swift%20only%20allows%20cross-module%20subclassing%20and%20overrides%20for%20%60open%60%20APIs%2C%20and%20%60%40testable%20import%60%20does%20not%20change%20that%20rule.%20A%20clean%20test%20build%20can%20reject%20this%20before%20%60testProcessQueueHandlesUnexpectedSaveOperationsError%60%20runs.%20A%20protocol%20seam%2C%20injected%20throwing%20closure%2C%20or%20same-module%20test%20helper%20would%20avoid%20the%20cross-module%20override.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youversion%2Fplatform-sdk-swift&pr=197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
Tests/YouVersionPlatformCoreTests/BibleHighlightsRepositoryTests.swift:104-105
**Override Still Fails**

This helper is still defined in the `YouVersionPlatformCoreTests` target, but `BibleHighlightsRepository` and `saveOperations` are only `public` in `YouVersionPlatformCore`. Swift only allows cross-module subclassing and overrides for `open` APIs, and `@testable import` does not change that rule. A clean test build can reject this before `testProcessQueueHandlesUnexpectedSaveOperationsError` runs. A protocol seam, injected throwing closure, or same-module test helper would avoid the cross-module override.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["chore: merge main"](https://github.com/youversion/platform-sdk-swift/commit/8177501528f51f15c9675fbf2d36c8d16335c1d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43946088)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->