### PR TITLE
a11y: label highlight color picker buttons and rendered highlights

### DIFF
--- a/Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift
@@ -44,7 +44,7 @@ struct BibleReaderDrawer: View {
     }
 
     private func accessibilityColorName(for color: Color) -> String {
-        return UIColor(color).accessibilityName
+        UIColor(color).accessibilityName
     }
 
     private var highlightColorButtons: some View {

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift
@@ -43,6 +43,10 @@ struct BibleReaderDrawer: View {
         ]
     }
 
+    private func accessibilityColorName(for color: Color) -> String {
+        return UIColor(color).accessibilityName
+    }
+
     private var highlightColorButtons: some View {
         let colorsToRemove = highlightColors.filter(viewModel.isColorPresentOnAnySelectedVerses)
         let colorsToAdd = highlightColors.filter { !viewModel.isColorPresentOnAllSelectedVerses($0) }
@@ -54,11 +58,13 @@ struct BibleReaderDrawer: View {
                             Image("highlight_checkmark", bundle: .YouVersionUIBundle)
                         )
                 }
+                .accessibilityLabel("Remove \(accessibilityColorName(for: color)) highlight")
             }
             ForEach(colorsToAdd, id: \.self) { color in
                 Button(action: { viewModel.addVerseColor(color) }) {
                     coloredCircle(with: color)
                 }
+                .accessibilityLabel("\(accessibilityColorName(for: color)) highlight")
             }
         }
         .padding(.horizontal)

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 import YouVersionPlatformUI
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 struct BibleReaderDrawer: View {
     @Environment(BibleReaderViewModel.self) private var viewModel
@@ -43,8 +48,22 @@ struct BibleReaderDrawer: View {
         ]
     }
 
+    /// Cross-platform color-name lookup. UIColor is UIKit-only, so guard
+    /// per platform: iOS/tvOS/watchOS get UIColor, macOS gets NSColor.
+    /// The output funnels into `.accessibilityIdentifier` — a
+    /// UI-automation-only attribute that VoiceOver never speaks. Real
+    /// assistive-tech users hear no highlight announcement on these
+    /// buttons (matching the Bible iOS app's model — highlights are
+    /// visual affordances, not narrated inline). Automation queries
+    /// the identifier via Appium's `@name` fallback.
     private func accessibilityColorName(for color: Color) -> String {
-        UIColor(color).accessibilityName
+        #if canImport(UIKit)
+        return UIColor(color).accessibilityName
+        #elseif canImport(AppKit)
+        return NSColor(color).accessibilityName
+        #else
+        return ""
+        #endif
     }
 
     private var highlightColorButtons: some View {
@@ -58,13 +77,13 @@ struct BibleReaderDrawer: View {
                             Image("highlight_checkmark", bundle: .YouVersionUIBundle)
                         )
                 }
-                .accessibilityLabel("Remove \(accessibilityColorName(for: color)) highlight")
+                .accessibilityIdentifier("Remove \(accessibilityColorName(for: color)) highlight")
             }
             ForEach(colorsToAdd, id: \.self) { color in
                 Button(action: { viewModel.addVerseColor(color) }) {
                     coloredCircle(with: color)
                 }
-                .accessibilityLabel("\(accessibilityColorName(for: color)) highlight")
+                .accessibilityIdentifier("\(accessibilityColorName(for: color)) highlight")
             }
         }
         .padding(.horizontal)

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
@@ -128,11 +128,26 @@ extension BibleTextView {
             .tint(textOptions.textColor ?? .primary)
             .fixedSize(horizontal: false, vertical: true)
             .lineSpacing(fontRelativeLineSpacing(textOptions: textOptions))
+            .accessibilityValue(highlightSummary(for: string))
         if #available(iOS 18.0, *) {
             return retValue.textRenderer(BibleRenderer(verseSelectionStyle: textOptions.verseSelectionStyle))
         } else {
             return retValue
         }
+    }
+
+    private func highlightSummary(for string: AttributedString) -> String {
+        var parts: [String] = []
+        var seen = Set<Int>()
+        for run in string.runs[\.bibleTextCategory, \.bibleReference] {
+            guard run.0 == .scripture, let ref = run.1, let verse = ref.verseStart else { continue }
+            if seen.contains(verse) { continue }
+            let color = highlightFor(reference: ref)
+            if color == .clear { continue }
+            seen.insert(verse)
+            parts.append("verse \(verse) highlighted \(UIColor(color).accessibilityName)")
+        }
+        return parts.joined(separator: ", ")
     }
     
     private func fontRelativeLineSpacing(textOptions: BibleTextOptions) -> CGFloat {

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
@@ -261,7 +261,9 @@ extension BibleTextView {
         // may cover a range (e.g. v1–v5), so match by inclusion in
         // [verseStart, verseEnd] — not verseStart equality, which would
         // announce only the first verse of every range and drop the rest.
-        guard let refVerse = reference.verseStart else { return nil }
+        guard let refVerse = reference.verseStart else {
+            return nil
+        }
         for highlight in ourHighlights {
             guard highlight.reference.chapter == reference.chapter,
                   let start = highlight.reference.verseStart else { continue }

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 import YouVersionPlatformCore
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 extension BibleTextView {
     @ViewBuilder
@@ -128,12 +133,35 @@ extension BibleTextView {
             .tint(textOptions.textColor ?? .primary)
             .fixedSize(horizontal: false, vertical: true)
             .lineSpacing(fontRelativeLineSpacing(textOptions: textOptions))
-            .accessibilityValue(highlightSummary(for: string))
+            // Highlight state goes into `.accessibilityIdentifier`, NOT
+            // `.accessibilityValue`. Rationale: VoiceOver reads value but
+            // never identifier — real assistive-tech users hear scripture
+            // only (matches the Bible iOS app's model where highlights are
+            // visual affordances, not narrated inline). UI automation
+            // queries the identifier via Appium's `@name` fallback on
+            // XCUIElementTypeStaticText.
+            .accessibilityIdentifier(highlightSummary(for: string))
         if #available(iOS 18.0, *) {
             return retValue.textRenderer(BibleRenderer(verseSelectionStyle: textOptions.verseSelectionStyle))
         } else {
             return retValue
         }
+    }
+
+    /// Cross-platform color-name lookup. See BibleReaderDrawer for the
+    /// same guard rationale — UIColor is UIKit-only, so macOS builds
+    /// use NSColor. The output funnels into `.accessibilityIdentifier`
+    /// (never spoken by VoiceOver), so the localized string Apple
+    /// returns here is acceptable — it's data for automation, not
+    /// narration.
+    private func accessibilityColorName(for color: Color) -> String {
+        #if canImport(UIKit)
+        return UIColor(color).accessibilityName
+        #elseif canImport(AppKit)
+        return NSColor(color).accessibilityName
+        #else
+        return ""
+        #endif
     }
 
     private func highlightSummary(for string: AttributedString) -> String {
@@ -145,7 +173,7 @@ extension BibleTextView {
             let color = highlightFor(reference: ref)
             if color == .clear { continue }
             seen.insert(verse)
-            parts.append("verse \(verse) highlighted \(UIColor(color).accessibilityName)")
+            parts.append("verse \(verse) highlighted \(accessibilityColorName(for: color))")
         }
         return parts.joined(separator: ", ")
     }
@@ -217,8 +245,16 @@ extension BibleTextView {
     }
 
     private func highlightFor(reference: BibleReference) -> Color {
+        // Rendered runs carry a single-verse reference. A STORED highlight
+        // may cover a range (e.g. v1–v5), so match by inclusion in
+        // [verseStart, verseEnd] — not verseStart equality, which would
+        // announce only the first verse of every range and drop the rest.
+        guard let refVerse = reference.verseStart else { return .clear }
         for highlight in ourHighlights {
-            if highlight.reference.chapter == reference.chapter && highlight.reference.verseStart == reference.verseStart {
+            guard highlight.reference.chapter == reference.chapter,
+                  let start = highlight.reference.verseStart else { continue }
+            let end = highlight.reference.verseEnd ?? start
+            if refVerse >= start && refVerse <= end {
                 return Color(hex: highlight.color)
             }
         }


### PR DESCRIPTION
## Summary

Adds UI-automation accessibility metadata to two spots in the Bible reader (`BibleReaderDrawer.swift`, `BibleTextView+Rendering.swift`), plus a range-highlight lookup fix. Purely additive to the accessibility surface — nothing pre-existing was refactored.

**Highlight state ships in `.accessibilityIdentifier`, not `.accessibilityLabel` / `.accessibilityValue`.** Rationale: VoiceOver reads `label` / `value` (spoken to real users) but never reads `identifier` (silent, automation-only). Putting highlight-color announcements in the spoken attributes would make VoiceOver users hear a comma-joined summary of every highlight in a block before the scripture — bad UX for assistive-tech users. The Bible iOS app's own model (`NativeReaderHost.swift`) treats highlights as visual affordances only, never narrated. We match that: real users hear scripture; UI automation queries the identifier via Appium's `@name` fallback on iOS.

**Color picker buttons** (`BibleReaderDrawer.swift`)

- Add-color: `.accessibilityIdentifier("<Color> highlight")`
- Remove-color (checkmark overlay state): `.accessibilityIdentifier("Remove <Color> highlight")`
- No `.accessibilityLabel` set — VoiceOver falls back to defaults (a follow-up ticket, YPE-4021, tracks adding localized user-facing labels once davidfedor confirms the wording).

**Rendered verse text** (`BibleTextView+Rendering.swift`)

- Per-block `Text` carries `.accessibilityIdentifier(highlightSummary(for: string))` — a comma-joined `"verse N highlighted <color>"` per highlighted verse in the block.
- Verse's natural `.accessibilityLabel` (the scripture text from the SwiftUI `Text`) is unchanged — that's what VoiceOver reads.

**Range highlight lookup fix** (`highlightFor(reference:)`)

- Previously matched only when `highlight.verseStart == reference.verseStart` — a stored highlight covering v1–v5 announced only v1.
- Now matches when the rendered run's verse falls in `[verseStart, verseEnd]` inclusive.

**Color-name source**

- `UIColor(color).accessibilityName` (macOS: `NSColor(color).accessibilityName`), guarded via `#if canImport(UIKit) / #elseif canImport(AppKit)`. Fixes macOS build regression.
- Returns localized names on the user's device locale. Safe here because the string lands in `.accessibilityIdentifier` (silent, automation-only); target automation devices are English-only today. Non-English automation would need an internal hex→English mapping (deferred).

**Automation contract change**

The corpus (`platform_swift_sdk_automation`) queries these identifiers via `@name`. Previous locators used `@label` / `@value`; the new locators use `@name` because iOS Appium returns `accessibilityIdentifier` under `@name` (falling back to `accessibilityLabel` if identifier is unset). Corpus PR #22 updates the affected PageStore entries. Live-proven against BrowserStack real device: 42/43 flows pass, all 12 highlights flows green.

## Test plan

- [x] Build succeeds locally (Release archive for iOS device).
- [x] macOS build compiles (no `UIColor` reference outside the `#if canImport(UIKit)` guard).
- [x] Physical iPhone install (development-signed, team `AM88PVBRSG`) verified via `xcrun devicectl device install app`.
- [x] **VoiceOver — verses:** swipe through a highlighted chapter with VoiceOver on. Confirmed VoiceOver reads **scripture only**; **no** "highlighted <color>" announcement per verse. Highlights are silent to VoiceOver as intended.
- [x] **VoiceOver — buttons:** swipe to the color picker with VoiceOver on. Confirmed no "cyan highlight" / "yellow highlight" narration is spoken; VoiceOver falls back to iOS defaults (`"button"` on add-color, `"highlight_checkmark button"` on remove-color from the image asset name). **This is intentional for this PR**; localized user-facing labels are tracked in YPE-4021 as a davidfedor follow-up.
- [x] **Appium tree — verses:** confirmed `XCUIElementTypeStaticText` now surfaces the highlight summary under `@name` (from `.accessibilityIdentifier`); `@value` no longer carries the summary; `@label` still carries the scripture text.
- [x] **Appium tree — buttons:** confirmed `XCUIElementTypeButton @name` = `"<Color> highlight"` / `"Remove <Color> highlight"`.
- [x] **Range highlight:** applied a multi-verse highlight (verses 1–5) and confirmed all five verses report their color in the identifier — not just verse 1.
- [x] **End-to-end BS regression:** full corpus run against `bs://947d661e698ae9baefa844cd68d9a822a5adccab` → 42/43 flows passed, 113/117 TCs (only 4 pre-existing `untested_format` from unrelated PageStore gaps; 1 flake `version_detail_sample` = BS session-init, not corpus).

## Related follow-ups (tracked, not blocking this PR)

- **YPE-4021** — localized `.accessibilityLabel` on highlight color picker + remove-color buttons (addresses davidfedor's UX concern for real VoiceOver users; requires his input on wording + new `String.localized` keys).
- **YPE-4019** — canonical `sign_in` SharedStep with internal Path A/B branching (Codex design critique on corpus PR #22).
- **YPE-4020** — codify session lessons in hinqa standards + playbook docs (keyboard-dismiss pattern, `.accessibilityLabel` vs `.accessibilityIdentifier`, "passed=True ≠ intended effect").

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds accessibility metadata for Bible reader highlights. The main changes are:

- Color picker buttons now expose highlight action identifiers.
- Rendered scripture blocks now expose highlight summaries through accessibility identifiers.
- Highlight lookup now matches verses inside stored highlight ranges.
- Color names now use guarded UIKit/AppKit paths for Apple platforms.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/Components/BibleReaderDrawer.swift | Adds guarded UIKit/AppKit color-name lookup and highlight button accessibility identifiers. |
| Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift | Adds rendered highlight identifiers and updates highlight matching to include verse ranges. |

<sub>Reviews (4): Last reviewed commit: ["style: split return nil to new line (Swi..."](https://github.com/youversion/platform-sdk-swift/commit/9eabc33d8f212b25e783f8be0e3f60bcf6c386b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44188684)</sub>

**Context used:**

- Rule used - No hardcoded user-facing UI strings: use String.lo... ([source](greptile.json))

<!-- /greptile_comment -->