### PR TITLE
feat(reader): focus a verse in the Bible reader BL-1901

### DIFF
--- a/Examples/SampleApp/NavigateView.swift
+++ b/Examples/SampleApp/NavigateView.swift
@@ -47,7 +47,7 @@ struct NavigateView: View {
                 Section {
                     ForEach(examples, id: \.title) { example in
                         Button(example.title) {
-                            if example.shouldFocus {
+                            if example.shouldFocus, #available(iOS 18.0, *) {
                                 navigation.focusReference(example.reference)
                             } else {
                                 navigation.request(example.reference, showsFullChapter: example.showsFullChapter)

--- a/Examples/SampleApp/NavigateView.swift
+++ b/Examples/SampleApp/NavigateView.swift
@@ -8,7 +8,7 @@ struct NavigateView: View {
     let navigation: BibleReaderNavigation
     let onNavigate: () -> Void
 
-    private let examples: [(title: String, reference: BibleReference, showsFullChapter: Bool, focused: Bool)] = [
+    private let examples: [(title: String, reference: BibleReference, showsFullChapter: Bool, shouldFocus: Bool)] = [
         (
             "John 3:16 — full chapter, scrolled to the verse",
             BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16),
@@ -47,8 +47,8 @@ struct NavigateView: View {
                 Section {
                     ForEach(examples, id: \.title) { example in
                         Button(example.title) {
-                            if example.focused {
-                                navigation.focus(example.reference)
+                            if example.shouldFocus {
+                                navigation.focusReference(example.reference)
                             } else {
                                 navigation.request(example.reference, showsFullChapter: example.showsFullChapter)
                             }

--- a/Examples/SampleApp/NavigateView.swift
+++ b/Examples/SampleApp/NavigateView.swift
@@ -8,26 +8,36 @@ struct NavigateView: View {
     let navigation: BibleReaderNavigation
     let onNavigate: () -> Void
 
-    private let examples: [(title: String, reference: BibleReference, showsFullChapter: Bool)] = [
+    private let examples: [(title: String, reference: BibleReference, showsFullChapter: Bool, focused: Bool)] = [
         (
             "John 3:16 — full chapter, scrolled to the verse",
             BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16),
+            true,
+            false
+        ),
+        (
+            "John 3:16 — focused",
+            BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16),
+            true,
             true
         ),
         (
             "Psalm 119:105 — full chapter, scrolled to the verse",
             BibleReference(versionId: 3034, bookUSFM: "PSA", chapter: 119, verse: 105),
-            true
+            true,
+            false
         ),
         (
             "Romans 8:28 — just the verse range",
             BibleReference(versionId: 3034, bookUSFM: "ROM", chapter: 8, verse: 28),
+            false,
             false
         ),
         (
             "Genesis 1 — whole chapter",
             BibleReference(versionId: 3034, bookUSFM: "GEN", chapter: 1),
-            true
+            true,
+            false
         )
     ]
 
@@ -37,7 +47,11 @@ struct NavigateView: View {
                 Section {
                     ForEach(examples, id: \.title) { example in
                         Button(example.title) {
-                            navigation.request(example.reference, showsFullChapter: example.showsFullChapter)
+                            if example.focused {
+                                navigation.focus(example.reference)
+                            } else {
+                                navigation.request(example.reference, showsFullChapter: example.showsFullChapter)
+                            }
                             onNavigate()
                         }
                     }

--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ var body: some View {
 }
 ```
 
+To focus a verse — moving to its full chapter and dimming the other verses — call `focus(_:)`. The focus clears when the user scrolls, taps a verse, or navigates away.
+
+```swift
+readerNavigation.focus(reference)
+```
+
 To intercept verse taps instead of using the built-in sign-in flow:
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -191,10 +191,10 @@ var body: some View {
 }
 ```
 
-To focus a verse — moving to its full chapter and dimming the other verses — call `focus(_:)`. The focus clears when the user scrolls, taps a verse, or navigates away.
+To focus a verse — moving to its full chapter and dimming the other verses — call `focusReference(_:)`. The focus clears when the user scrolls, taps a verse, or navigates away.
 
 ```swift
-readerNavigation.focus(reference)
+readerNavigation.focusReference(reference)
 ```
 
 To intercept verse taps instead of using the built-in sign-in flow:

--- a/README.md
+++ b/README.md
@@ -191,10 +191,12 @@ var body: some View {
 }
 ```
 
-To focus a verse — moving to its full chapter and dimming the other verses — call `focusReference(_:)`. The focus clears when the user scrolls, taps a verse, or navigates away.
+To focus a verse — moving to its full chapter and dimming the other verses — call `focusReference(_:)`. The focus clears when the user scrolls, taps a verse, or navigates away. This is available on iOS 18 and later.
 
 ```swift
-readerNavigation.focusReference(reference)
+if #available(iOS 18.0, *) {
+    readerNavigation.focusReference(reference)
+}
 ```
 
 To intercept verse taps instead of using the built-in sign-in flow:

--- a/Sources/YouVersionPlatformReader/BibleReaderNavigation.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderNavigation.swift
@@ -4,11 +4,12 @@ import YouVersionPlatformCore
 @MainActor
 @Observable
 public final class BibleReaderNavigation {
-    /// A request for the reader: which reference to move to, and whether to
-    /// show its full chapter or only its verse range.
+    /// A request for the reader to act on.
     public struct Request: Equatable, Sendable {
         public let reference: BibleReference
         public let showsFullChapter: Bool
+        public let scrollsToVerse: Bool
+        public let focused: Bool
     }
 
     /// The request the reader should act on next.
@@ -20,7 +21,23 @@ public final class BibleReaderNavigation {
     /// any view that shares this object — the reader need not be on screen yet; it
     /// picks up the pending reference when it appears.
     public func request(_ reference: BibleReference, showsFullChapter: Bool = false) {
-        pendingRequest = Request(reference: reference, showsFullChapter: showsFullChapter)
+        pendingRequest = Request(
+            reference: reference,
+            showsFullChapter: showsFullChapter,
+            scrollsToVerse: true,
+            focused: false
+        )
+    }
+
+    /// Requests that the connected reader focus `reference`'s verse, dimming the rest of
+    /// the chapter around it.
+    public func focus(_ reference: BibleReference, scrollsToVerse: Bool = true) {
+        pendingRequest = Request(
+            reference: reference,
+            showsFullChapter: true,
+            scrollsToVerse: scrollsToVerse,
+            focused: true
+        )
     }
 
     /// Called by the reader once it has begun acting on the request.

--- a/Sources/YouVersionPlatformReader/BibleReaderNavigation.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderNavigation.swift
@@ -9,7 +9,7 @@ public final class BibleReaderNavigation {
         public let reference: BibleReference
         public let showsFullChapter: Bool
         public let scrollsToVerse: Bool
-        public let focused: Bool
+        public let shouldFocus: Bool
     }
 
     /// The request the reader should act on next.
@@ -25,18 +25,18 @@ public final class BibleReaderNavigation {
             reference: reference,
             showsFullChapter: showsFullChapter,
             scrollsToVerse: true,
-            focused: false
+            shouldFocus: false
         )
     }
 
     /// Requests that the connected reader focus `reference`'s verse, dimming the rest of
     /// the chapter around it.
-    public func focus(_ reference: BibleReference, scrollsToVerse: Bool = true) {
+    public func focusReference(_ reference: BibleReference, scrollsToVerse: Bool = true) {
         pendingRequest = Request(
             reference: reference,
             showsFullChapter: true,
             scrollsToVerse: scrollsToVerse,
-            focused: true
+            shouldFocus: true
         )
     }
 

--- a/Sources/YouVersionPlatformReader/BibleReaderNavigation.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderNavigation.swift
@@ -31,6 +31,7 @@ public final class BibleReaderNavigation {
 
     /// Requests that the connected reader focus `reference`'s verse, dimming the rest of
     /// the chapter around it.
+    @available(iOS 18.0, *)
     public func focusReference(_ reference: BibleReference, scrollsToVerse: Bool = true) {
         pendingRequest = Request(
             reference: reference,

--- a/Sources/YouVersionPlatformReader/BibleReaderView.swift
+++ b/Sources/YouVersionPlatformReader/BibleReaderView.swift
@@ -428,7 +428,8 @@ private struct ReaderContent: View {
                                 selectedVerses: $viewModel.selectedVerses,
                                 onVerseTap: { reference, actionType, footnotes, footnoteId in
                                     viewModel.handleVerseTap(reference: reference, actionType: actionType, footnotes: footnotes)
-                                }
+                                },
+                                focusedReference: viewModel.focusedReference
                             )
                         }
                         VStack(alignment: .center) {
@@ -453,6 +454,12 @@ private struct ReaderContent: View {
                     } action: { newOffset in
                         viewModel.handleScroll(offset: newOffset)
                     }
+                    // Tap anywhere in the reader to clear a focused reference.
+                    .simultaneousGesture(
+                        viewModel.focusedReference != nil
+                            ? TapGesture().onEnded { viewModel.clearFocus() }
+                            : nil
+                    )
                 } else {
                     progressView
                 }

--- a/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
+++ b/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
@@ -21,16 +21,20 @@ final class VerseScrollCoordinator {
     private var scrollTask: Task<Void, Never>?
     private var fallbackTask: Task<Void, Never>?
 
+    private var scrollTargetReference: BibleReference? {
+        viewModel.scrollTarget?.reference
+    }
+
     private var targetBlockID: Int? {
-        guard let target = viewModel.scrollTargetReference, let verse = target.verseStart,
-              let anchors, anchors.chapter == target.chapter else {
+        guard let reference = scrollTargetReference, let verse = reference.verseStart,
+              let anchors, anchors.chapter == reference.chapter else {
             return nil
         }
         return anchors.blockFirstVerse(forTargetVerse: verse)
     }
 
     private var isTargetChapterRendered: Bool {
-        viewModel.scrollTargetReference?.chapter == anchors?.chapter
+        scrollTargetReference?.chapter == anchors?.chapter
     }
 
     init(viewModel: BibleReaderViewModel) {
@@ -61,7 +65,7 @@ final class VerseScrollCoordinator {
     func handleAnchors(_ newAnchors: ChapterScrollAnchors?, proxy: ScrollViewProxy) {
         anchors = newAnchors
         if isScrollPending, let newAnchors,
-           newAnchors.chapter != viewModel.scrollTargetReference?.chapter {
+           newAnchors.chapter != scrollTargetReference?.chapter {
             scrollTask?.cancel()
             clearScrollState()
             return
@@ -86,6 +90,14 @@ final class VerseScrollCoordinator {
                 return
             }
             proxy.scrollTo(blockID, anchor: .top)
+            if let target = self?.viewModel.scrollTarget, target.focused {
+                // Focus `target.reference` a frame after the scroll.
+                await DisplayFrame().nextFrame()
+                if Task.isCancelled {
+                    return
+                }
+                self?.viewModel.focus(target.reference)
+            }
             self?.clearScrollState()
         }
     }

--- a/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
+++ b/Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift
@@ -90,13 +90,13 @@ final class VerseScrollCoordinator {
                 return
             }
             proxy.scrollTo(blockID, anchor: .top)
-            if let target = self?.viewModel.scrollTarget, target.focused {
+            if let target = self?.viewModel.scrollTarget, target.shouldFocus {
                 // Focus `target.reference` a frame after the scroll.
                 await DisplayFrame().nextFrame()
                 if Task.isCancelled {
                     return
                 }
-                self?.viewModel.focus(target.reference)
+                self?.viewModel.focusReference(target.reference)
             }
             self?.clearScrollState()
         }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -62,21 +62,21 @@ extension BibleReaderViewModel {
             return
         }
         readerNavigation.clearPendingRequest()
-        if request.focused, !request.scrollsToVerse {
+        if request.shouldFocus && !request.scrollsToVerse {
             removeVerseSelection()
-            focus(request.reference)
+            focusReference(request.reference)
         } else {
             Task {
-                await goToReference(request.reference, showsFullChapter: request.showsFullChapter, focused: request.focused)
+                await goToReference(request.reference, showsFullChapter: request.showsFullChapter, shouldFocus: request.shouldFocus)
             }
         }
     }
 
-    func goToReference(_ reference: BibleReference, showsFullChapter: Bool = false, focused: Bool = false) async {
+    func goToReference(_ reference: BibleReference, showsFullChapter: Bool = false, shouldFocus: Bool = false) async {
         await onHeaderSelectionChange(reference, showIntro: false)
         if reference == self.reference {
             self.showsFullChapter = showsFullChapter
-            setScrollTarget(focused: focused)
+            setScrollTarget(shouldFocus: shouldFocus)
         } else {
             finishChapterChange()
         }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -2,6 +2,9 @@ import SwiftUI
 import YouVersionPlatformCore
 import YouVersionPlatformUI
 
+/// How far the user must scroll to clear the focus.
+private let focusScrollThreshold: CGFloat = 2
+
 extension BibleReaderViewModel {
     func goToPreviousChapter() {
         guard let version else {
@@ -53,23 +56,27 @@ extension BibleReaderViewModel {
         resetScrollStateForNewChapter()
     }
 
-    /// Acts on any pending request from `readerNavigation`, moving the reader to the
-    /// requested passage.
+    /// Acts on any pending request from `readerNavigation`.
     func handleNavigationRequest(from readerNavigation: BibleReaderNavigation) {
         guard let request = readerNavigation.pendingRequest else {
             return
         }
         readerNavigation.clearPendingRequest()
-        Task {
-            await goToReference(request.reference, showsFullChapter: request.showsFullChapter)
+        if request.focused, !request.scrollsToVerse {
+            removeVerseSelection()
+            focus(request.reference)
+        } else {
+            Task {
+                await goToReference(request.reference, showsFullChapter: request.showsFullChapter, focused: request.focused)
+            }
         }
     }
 
-    func goToReference(_ reference: BibleReference, showsFullChapter: Bool = false) async {
+    func goToReference(_ reference: BibleReference, showsFullChapter: Bool = false, focused: Bool = false) async {
         await onHeaderSelectionChange(reference, showIntro: false)
         if reference == self.reference {
             self.showsFullChapter = showsFullChapter
-            setScrollTarget()
+            setScrollTarget(focused: focused)
         } else {
             finishChapterChange()
         }
@@ -83,8 +90,15 @@ extension BibleReaderViewModel {
     }
 
     func handleScroll(offset: CGFloat) {
+        let previousOffset = lastScrollOffset
+        lastScrollOffset = offset
         guard !isChangingChapter else {
             return
+        }
+
+        // A user scroll clears the focus.
+        if focusedReference != nil, abs(offset - previousOffset) > focusScrollThreshold {
+            clearFocus()
         }
 
         let threshold: CGFloat = 10
@@ -93,14 +107,13 @@ extension BibleReaderViewModel {
         // negative while scrolled down, positive when rubber-banding past top.
         if offset >= 0 {
             withAnimation(animation) { showChrome = true }
-        } else if abs(offset - lastScrollOffset) >= threshold {
-            if offset < lastScrollOffset - threshold {
+        } else if abs(offset - previousOffset) >= threshold {
+            if offset < previousOffset - threshold {
                 withAnimation(animation) { showChrome = false }
-            } else if offset > lastScrollOffset + threshold {
+            } else if offset > previousOffset + threshold {
                 withAnimation(animation) { showChrome = true }
             }
         }
-        lastScrollOffset = offset
     }
 
     func handleVerseTap(reference: BibleReference, actionType: String, footnotes: [BibleFootnote]) {
@@ -109,7 +122,10 @@ extension BibleReaderViewModel {
             footnotesToDisplay = footnotes
             return
         }
-        
+
+        // Tapping a verse clears the focus.
+        clearFocus()
+
         if let onVerseTap {
             onVerseTap(reference)
             return
@@ -236,6 +252,7 @@ extension BibleReaderViewModel {
     func onHeaderSelectionChange(_ reference: BibleReference, showIntro: Bool) async {
         isChangingChapter = true
         removeVerseSelection()
+        clearFocus()
         do {
             if version?.id != reference.versionId {
                 let newVersion = try await versionsViewModel.versionRepository.version(withId: reference.versionId)

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift
@@ -2,8 +2,8 @@ import SwiftUI
 import YouVersionPlatformCore
 import YouVersionPlatformUI
 
-/// How far the user must scroll to clear the focus.
-private let focusScrollThreshold: CGFloat = 2
+/// Used to distinguish between an intentional user scroll and an automatic reader scroll.
+private let userScrollThreshold: CGFloat = 2
 
 extension BibleReaderViewModel {
     func goToPreviousChapter() {
@@ -96,8 +96,8 @@ extension BibleReaderViewModel {
             return
         }
 
-        // A user scroll clears the focus.
-        if focusedReference != nil, abs(offset - previousOffset) > focusScrollThreshold {
+        // An intentional user scroll clears the focus.
+        if focusedReference != nil && abs(offset - previousOffset) > userScrollThreshold {
             clearFocus()
         }
 
@@ -123,7 +123,6 @@ extension BibleReaderViewModel {
             return
         }
 
-        // Tapping a verse clears the focus.
         clearFocus()
 
         if let onVerseTap {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -317,6 +317,10 @@ final class BibleReaderViewModel: ReaderThemeProviding {
 
     /// Focuses `reference`'s verse, dimming the rest of the chapter.
     func focusReference(_ reference: BibleReference) {
+        // The `.textRenderer(_:)` modifier is iOS 18+
+        guard #available(iOS 18.0, *) else {
+            return
+        }
         guard reference.verseStart != nil
               && reference.chapterReference == self.reference.chapterReference else {
             return

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -286,7 +286,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     /// Sets the current ``reference``'s verse as the target the reader should scroll to
     /// once its chapter lays out.
     func setScrollTarget(shouldFocus: Bool = false) {
-        guard showsFullChapter, let verseStart = reference.verseStart, verseStart > 1 else {
+        guard showsFullChapter && reference.verseStart != nil else {
             return
         }
         scrollAction = .reference(ScrollTarget(reference: reference, shouldFocus: shouldFocus))

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -315,7 +315,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         isChangingChapter = false
     }
 
-    /// Focuses `reference`'s verse, dimming the rest of the chapter.
+    /// Focuses `reference`'s verse (or verse range), dimming the rest of the chapter.
     func focusReference(_ reference: BibleReference) {
         guard reference.verseStart != nil
               && reference.chapterReference == self.reference.chapterReference else {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -7,12 +7,19 @@ import SwiftUI
 import YouVersionPlatformCore
 import YouVersionPlatformUI
 
+/// A verse the reader should scroll to, and whether it should be focused (dimming
+/// the rest of the chapter) once it lands.
+struct ScrollTarget: Equatable {
+    let reference: BibleReference
+    let focused: Bool
+}
+
 /// The single scroll intent a navigation produces. The reader observes this and
 /// performs exactly one of: nothing, scroll to the top, or scroll to a reference.
 enum ScrollAction: Equatable {
     case none
     case top
-    case reference(BibleReference)
+    case reference(ScrollTarget)
 }
 
 @MainActor
@@ -53,14 +60,15 @@ final class BibleReaderViewModel: ReaderThemeProviding {
             UserDefaults.standard.set(showsFullChapter, forKey: userDefaultsKeyForShowsFullChapter)
         }
     }
-    /// The reference the reader should scroll to, if the current ``scrollAction`` is a verse scroll.
-    var scrollTargetReference: BibleReference? {
-        if case .reference(let reference) = scrollAction {
-            reference
+    /// The target the reader should scroll to, if the current ``scrollAction`` is a reference.
+    var scrollTarget: ScrollTarget? {
+        if case .reference(let target) = scrollAction {
+            target
         } else {
             nil
         }
     }
+    private(set) var focusedReference: BibleReference?
     var showingSignInSheet = false
     var showingFontSettings = false
     var showingFontList = false // swiftlint:disable:this collection_suffix_property
@@ -277,11 +285,11 @@ final class BibleReaderViewModel: ReaderThemeProviding {
 
     /// Sets the current ``reference``'s verse as the target the reader should scroll to
     /// once its chapter lays out.
-    func setScrollTarget() {
+    func setScrollTarget(focused: Bool = false) {
         guard showsFullChapter, let verseStart = reference.verseStart, verseStart > 1 else {
             return
         }
-        scrollAction = .reference(reference)
+        scrollAction = .reference(ScrollTarget(reference: reference, focused: focused))
     }
 
     /// Marks the current ``scrollAction`` as consumed once the reader has begun acting on it,
@@ -295,6 +303,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         lastScrollOffset = 0
         showChrome = true
         scrollAction = .top
+        clearFocus()
     }
 
     /// Ends an in-flight chapter change by optionally clearing any armed scroll
@@ -304,6 +313,19 @@ final class BibleReaderViewModel: ReaderThemeProviding {
             scrollAction = .none
         }
         isChangingChapter = false
+    }
+
+    /// Focuses `reference`'s verse, dimming the rest of the chapter.
+    func focus(_ reference: BibleReference) {
+        guard reference.verseStart != nil,
+              reference.chapterReference == self.reference.chapterReference else {
+            return
+        }
+        focusedReference = reference
+    }
+
+    func clearFocus() {
+        focusedReference = nil
     }
 
     func loadUserSettingsFromStorage() {

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -11,7 +11,7 @@ import YouVersionPlatformUI
 /// the rest of the chapter) once it lands.
 struct ScrollTarget: Equatable {
     let reference: BibleReference
-    let focused: Bool
+    let shouldFocus: Bool
 }
 
 /// The single scroll intent a navigation produces. The reader observes this and
@@ -285,11 +285,11 @@ final class BibleReaderViewModel: ReaderThemeProviding {
 
     /// Sets the current ``reference``'s verse as the target the reader should scroll to
     /// once its chapter lays out.
-    func setScrollTarget(focused: Bool = false) {
+    func setScrollTarget(shouldFocus: Bool = false) {
         guard showsFullChapter, let verseStart = reference.verseStart, verseStart > 1 else {
             return
         }
-        scrollAction = .reference(ScrollTarget(reference: reference, focused: focused))
+        scrollAction = .reference(ScrollTarget(reference: reference, shouldFocus: shouldFocus))
     }
 
     /// Marks the current ``scrollAction`` as consumed once the reader has begun acting on it,
@@ -316,9 +316,9 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     }
 
     /// Focuses `reference`'s verse, dimming the rest of the chapter.
-    func focus(_ reference: BibleReference) {
-        guard reference.verseStart != nil,
-              reference.chapterReference == self.reference.chapterReference else {
+    func focusReference(_ reference: BibleReference) {
+        guard reference.verseStart != nil
+              && reference.chapterReference == self.reference.chapterReference else {
             return
         }
         focusedReference = reference

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -317,10 +317,6 @@ final class BibleReaderViewModel: ReaderThemeProviding {
 
     /// Focuses `reference`'s verse, dimming the rest of the chapter.
     func focusReference(_ reference: BibleReference) {
-        // The `.textRenderer(_:)` modifier is iOS 18+
-        guard #available(iOS 18.0, *) else {
-            return
-        }
         guard reference.verseStart != nil
               && reference.chapterReference == self.reference.chapterReference else {
             return

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
@@ -160,8 +160,8 @@ extension BibleTextView {
             }
             let isDimmed = isReferenceDimmed(reference, category: category)
             if isDimmed {
-                // Drop the link so SwiftUI's interactive text overlay
-                // doesn't repaint over the dimmed color.
+                // Drop the link so its `.tint` color doesn't
+                // repaint over the dimmed color the renderer draws.
                 t.link = nil
             }
             // swiftlint:disable:next shorthand_operator
@@ -227,20 +227,18 @@ extension BibleTextView {
         return parts.joined(separator: ", ")
     }
     
-    /// Whether a run should be dimmed because a different verse is focused. Only
-    /// scripture, verse-label, and heading runs dim; the focused verse and
+    /// Whether a run should be dimmed because a different reference is focused. Only
+    /// scripture, verse-label, and heading runs dim; the focused reference and
     /// footnote glyphs keep full color.
     private func isReferenceDimmed(_ reference: BibleReference?, category: BibleTextCategory?) -> Bool {
         guard let focusedReference,
               category == .scripture || category == .verseLabel || category == .header else {
             return false
         }
-        if let reference,
-           reference.chapter == focusedReference.chapter
-           && reference.verseStart == focusedReference.verseStart {
-            return false
+        guard let reference else {
+            return true
         }
-        return true
+        return !focusedReference.contains(with: reference)
     }
     
     private func fontRelativeLineSpacing(textOptions: BibleTextOptions) -> CGFloat {

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
@@ -57,13 +57,22 @@ extension BibleTextView {
     // SwiftUI draws background colors for our verse numbers. Without having
     // this active, the area painted in the background color sometimes shifts
     // upwards according to the baseline offset. And/or partially shifts.
-    struct BibleRenderer: TextRenderer {
+    struct BibleRenderer: TextRenderer, Animatable {
         let footnoteIcon: Image
         let verseSelectionStyle: VerseSelectionStyle
+        let dimmedTextColor: Color
+        var dimProgress: CGFloat // 0 = full color, 1 = fully dimmed.
 
-        init(verseSelectionStyle: VerseSelectionStyle = .solid) {
+        var animatableData: CGFloat {
+            get { dimProgress }
+            set { dimProgress = newValue }
+        }
+
+        init(verseSelectionStyle: VerseSelectionStyle = .solid, dimmedTextColor: Color = .primary, dimProgress: CGFloat = 0) {
             footnoteIcon = Image("footnoteIcon", bundle: .YouVersionUIBundle)
             self.verseSelectionStyle = verseSelectionStyle
+            self.dimmedTextColor = dimmedTextColor
+            self.dimProgress = dimProgress
         }
 
         func draw(layout: Text.Layout, in context: inout GraphicsContext) {
@@ -96,6 +105,20 @@ extension BibleTextView {
                             height: height
                         )
                         context.draw(footnoteImage, in: rect)
+                    } else if attrs?.dimmed == true, dimProgress > 0 {
+                        // Paint the muted color through a mask over the original glyph.
+                        if dimProgress < 1 {
+                            var original = context
+                            original.opacity = 1 - dimProgress
+                            original.draw(run)
+                        }
+                        context.drawLayer { layer in
+                            layer.opacity = dimProgress
+                            layer.clipToLayer { mask in
+                                mask.draw(run)
+                            }
+                            layer.fill(Path(lineRect), with: .color(dimmedTextColor))
+                        }
                     } else {
                         context.draw(run)
                     }
@@ -107,6 +130,7 @@ extension BibleTextView {
     struct RenderHowAttribute: TextAttribute {
         var underlined = false
         var footnoteImage = false
+        var dimmed = false
     }
 
     private func textView(for double: BibleAttributedString, firstLineHeadIndent: Int, blockId: UUID, textOptions: BibleTextOptions, darkMode: Bool) -> some View {
@@ -134,14 +158,21 @@ extension BibleTextView {
                 }
                 isUnderlined = isSelected(reference) && category == .scripture
             }
+            let dimmed = isDimmed(reference: reference, category: category)
+            if dimmed {
+                // Drop the link so SwiftUI's interactive text overlay
+                // doesn't repaint over the dimmed color.
+                t.link = nil
+            }
             // swiftlint:disable:next shorthand_operator
-            textCombo = textCombo + Text(t).customAttribute(RenderHowAttribute(underlined: isUnderlined, footnoteImage: category == .footnoteImage))
+            textCombo = textCombo + Text(t).customAttribute(RenderHowAttribute(underlined: isUnderlined, footnoteImage: category == .footnoteImage, dimmed: dimmed))
         }
-
+        
+        let resolvedTextColor = textOptions.textColor ?? .primary
         let retValue = textCombo
             // Verse runs carry link attributes (for OpenURLAction tap routing), so the
             // effective text color comes from .tint, not .foregroundStyle.
-            .tint(textOptions.textColor ?? .primary)
+            .tint(resolvedTextColor)
             .fixedSize(horizontal: false, vertical: true)
             .lineSpacing(fontRelativeLineSpacing(textOptions: textOptions))
             // Highlight state goes into `.accessibilityIdentifier`, NOT
@@ -153,7 +184,15 @@ extension BibleTextView {
             // XCUIElementTypeStaticText.
             .accessibilityIdentifier(highlightSummary(for: string))
         if #available(iOS 18.0, *) {
-            return retValue.textRenderer(BibleRenderer(verseSelectionStyle: textOptions.verseSelectionStyle))
+            let dimmedTextColor = resolvedTextColor.opacity(Self.dimmedTextOpacity)
+            return retValue.textRenderer(
+                BibleRenderer(
+                    verseSelectionStyle: textOptions.verseSelectionStyle,
+                    dimmedTextColor: dimmedTextColor,
+                    dimProgress: focusedReference == nil ? 0 : 1
+                )
+            )
+            .animation(Self.focusAnimation, value: focusedReference)
         } else {
             return retValue
         }
@@ -186,6 +225,22 @@ extension BibleTextView {
             parts.append("verse \(verse) highlighted \(accessibilityColorName(for: color))")
         }
         return parts.joined(separator: ", ")
+    }
+    
+    /// Whether a run should be dimmed because a different verse is focused. Only
+    /// scripture, verse-label, and heading runs dim; the focused verse and
+    /// footnote glyphs keep full color.
+    private func isDimmed(reference: BibleReference?, category: BibleTextCategory?) -> Bool {
+        guard let focusedReference,
+              category == .scripture || category == .verseLabel || category == .header else {
+            return false
+        }
+        if let reference,
+           reference.chapter == focusedReference.chapter,
+           reference.verseStart == focusedReference.verseStart {
+            return false
+        }
+        return true
     }
     
     private func fontRelativeLineSpacing(textOptions: BibleTextOptions) -> CGFloat {

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
@@ -105,7 +105,7 @@ extension BibleTextView {
                             height: height
                         )
                         context.draw(footnoteImage, in: rect)
-                    } else if attrs?.dimmed == true, dimProgress > 0 {
+                    } else if attrs?.isDimmed == true && dimProgress > 0 {
                         // Paint the muted color through a mask over the original glyph.
                         if dimProgress < 1 {
                             var original = context
@@ -130,7 +130,7 @@ extension BibleTextView {
     struct RenderHowAttribute: TextAttribute {
         var underlined = false
         var footnoteImage = false
-        var dimmed = false
+        var isDimmed = false
     }
 
     private func textView(for double: BibleAttributedString, firstLineHeadIndent: Int, blockId: UUID, textOptions: BibleTextOptions, darkMode: Bool) -> some View {
@@ -158,14 +158,14 @@ extension BibleTextView {
                 }
                 isUnderlined = isSelected(reference) && category == .scripture
             }
-            let dimmed = isDimmed(reference: reference, category: category)
-            if dimmed {
+            let isDimmed = isReferenceDimmed(reference, category: category)
+            if isDimmed {
                 // Drop the link so SwiftUI's interactive text overlay
                 // doesn't repaint over the dimmed color.
                 t.link = nil
             }
             // swiftlint:disable:next shorthand_operator
-            textCombo = textCombo + Text(t).customAttribute(RenderHowAttribute(underlined: isUnderlined, footnoteImage: category == .footnoteImage, dimmed: dimmed))
+            textCombo = textCombo + Text(t).customAttribute(RenderHowAttribute(underlined: isUnderlined, footnoteImage: category == .footnoteImage, isDimmed: isDimmed))
         }
         
         let resolvedTextColor = textOptions.textColor ?? .primary
@@ -230,14 +230,14 @@ extension BibleTextView {
     /// Whether a run should be dimmed because a different verse is focused. Only
     /// scripture, verse-label, and heading runs dim; the focused verse and
     /// footnote glyphs keep full color.
-    private func isDimmed(reference: BibleReference?, category: BibleTextCategory?) -> Bool {
+    private func isReferenceDimmed(_ reference: BibleReference?, category: BibleTextCategory?) -> Bool {
         guard let focusedReference,
               category == .scripture || category == .verseLabel || category == .header else {
             return false
         }
         if let reference,
-           reference.chapter == focusedReference.chapter,
-           reference.verseStart == focusedReference.verseStart {
+           reference.chapter == focusedReference.chapter
+           && reference.verseStart == focusedReference.verseStart {
             return false
         }
         return true

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
@@ -5,6 +5,10 @@ public struct BibleTextView: View {
 
     public typealias VerseTapAction = (BibleReference, String, [BibleFootnote], String?) -> Void
 
+    static let dimmedTextOpacity: CGFloat = 0.35
+    static let focusAnimation: Animation = .easeInOut(duration: 0.5)
+
+    let focusedReference: BibleReference?
     private let reference: BibleReference
     private let textOptions: BibleTextOptions
     private let onVerseTap: VerseTapAction?
@@ -33,6 +37,7 @@ public struct BibleTextView: View {
         self.textOptions = textOptions ?? BibleTextOptions()
         self.onVerseTap = onVerseTap
         self._selectedVerses = .constant([])
+        self.focusedReference = nil
         self.placeholder = nil
         self.blocks = []
         self.providedBlocks = nil
@@ -44,11 +49,13 @@ public struct BibleTextView: View {
         textOptions: BibleTextOptions? = nil,
         selectedVerses: Binding<Set<BibleReference>>,
         onVerseTap: VerseTapAction? = nil,
-        placeholder: ((BibleTextLoadingPhase) -> AnyView)? = nil
+        placeholder: ((BibleTextLoadingPhase) -> AnyView)? = nil,
+        focusedReference: BibleReference? = nil
     ) {
         self.reference = reference
         self.textOptions = textOptions ?? BibleTextOptions()
         self._selectedVerses = selectedVerses
+        self.focusedReference = focusedReference
         self.onVerseTap = onVerseTap
         self.placeholder = placeholder
         self.blocks = []
@@ -81,6 +88,7 @@ public struct BibleTextView: View {
         self.textOptions = textOptions ?? BibleTextOptions()
         self.onVerseTap = onVerseTap
         self._selectedVerses = .constant([])
+        self.focusedReference = nil
         self.placeholder = nil
         self.blocks = blocks
         self.providedBlocks = blocks

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelInteractionTests.swift
@@ -30,7 +30,7 @@ import Testing
     }
 
     @Test
-    func handleScrollDoesNothingWhileChangingChapter() {
+    func handleScrollTracksOffsetButLeavesChromeWhileChangingChapter() {
         let viewModel = Support.makeViewModel()
         viewModel.isChangingChapter = true
         viewModel.lastScrollOffset = -30
@@ -38,7 +38,7 @@ import Testing
 
         viewModel.handleScroll(offset: -100)
 
-        #expect(viewModel.lastScrollOffset == -30)
+        #expect(viewModel.lastScrollOffset == -100)
         #expect(viewModel.showChrome)
     }
 

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
@@ -310,6 +310,7 @@ import Testing
         #expect(navigation.pendingRequest == nil)
     }
 
+    @available(iOS 18.0, *)
     @Test
     func focusRequestScrollsToVerseAndShowsFullChapter() {
         let navigation = BibleReaderNavigation()
@@ -325,6 +326,7 @@ import Testing
         #expect(navigation.pendingRequest?.showsFullChapter == true)
     }
 
+    @available(iOS 18.0, *)
     @Test
     func focusInPlaceRequestFocusesWithoutScrolling() {
         let navigation = BibleReaderNavigation()

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
@@ -50,7 +50,7 @@ import Testing
 
         let viewModel = Support.makeViewModel(reference: reference, showsFullChapter: true)
 
-        #expect(viewModel.scrollAction == .reference(ScrollTarget(reference: reference, focused: false)))
+        #expect(viewModel.scrollAction == .reference(ScrollTarget(reference: reference, shouldFocus: false)))
     }
 
     @Test
@@ -72,7 +72,7 @@ import Testing
 
         #expect(viewModel.reference.bookUSFM == "JHN")
         #expect(viewModel.reference.chapter == 3)
-        #expect(viewModel.scrollAction == .reference(ScrollTarget(reference: target, focused: false)))
+        #expect(viewModel.scrollAction == .reference(ScrollTarget(reference: target, shouldFocus: false)))
         #expect(viewModel.isChangingChapter)
     }
 
@@ -135,9 +135,9 @@ import Testing
         let viewModel = makeFocusedViewModel()
 
         let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
-        await viewModel.goToReference(target, showsFullChapter: true, focused: true)
+        await viewModel.goToReference(target, showsFullChapter: true, shouldFocus: true)
 
-        #expect(viewModel.scrollAction == .reference(ScrollTarget(reference: target, focused: true)))
+        #expect(viewModel.scrollAction == .reference(ScrollTarget(reference: target, shouldFocus: true)))
         #expect(viewModel.focusedReference == nil)  // not focused until the scroll lands
     }
 
@@ -146,9 +146,9 @@ import Testing
     func setFocusedFocusesTheVerse() async {
         let viewModel = makeFocusedViewModel()
         let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
-        await viewModel.goToReference(target, showsFullChapter: true, focused: true)
+        await viewModel.goToReference(target, showsFullChapter: true, shouldFocus: true)
 
-        viewModel.focus(target)
+        viewModel.focusReference(target)
 
         #expect(viewModel.focusedReference == target)
     }
@@ -160,7 +160,7 @@ import Testing
         let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
         await viewModel.goToReference(target, showsFullChapter: true)
 
-        #expect(viewModel.scrollAction == .reference(ScrollTarget(reference: target, focused: false)))  // scroll only, no focus
+        #expect(viewModel.scrollAction == .reference(ScrollTarget(reference: target, shouldFocus: false)))  // scroll only, no focus
         #expect(viewModel.focusedReference == nil)
     }
 
@@ -171,7 +171,7 @@ import Testing
         let viewModel = makeFocusedViewModel()
 
         let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3)
-        await viewModel.goToReference(target, showsFullChapter: true, focused: true)
+        await viewModel.goToReference(target, showsFullChapter: true, shouldFocus: true)
 
         #expect(viewModel.scrollAction == .top)
         #expect(viewModel.focusedReference == nil)
@@ -184,7 +184,7 @@ import Testing
         let viewModel = makeFocusedViewModel()
         let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1, verse: 5)
 
-        viewModel.focus(target)
+        viewModel.focusReference(target)
 
         #expect(viewModel.focusedReference == target)
         #expect(viewModel.scrollAction == .none)  // nothing to scroll
@@ -195,7 +195,7 @@ import Testing
         let viewModel = makeFocusedViewModel()
         let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1)
 
-        viewModel.focus(target)
+        viewModel.focusReference(target)
 
         #expect(viewModel.focusedReference == nil)
     }
@@ -205,7 +205,7 @@ import Testing
         let viewModel = makeFocusedViewModel()
         let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
 
-        viewModel.focus(target)
+        viewModel.focusReference(target)
 
         #expect(viewModel.focusedReference == nil)
     }
@@ -215,7 +215,7 @@ import Testing
         let viewModel = makeFocusedViewModel()
         let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1, verse: 5)
         viewModel.lastScrollOffset = -400
-        viewModel.focus(target)
+        viewModel.focusReference(target)
 
         viewModel.handleScroll(offset: -600)
 
@@ -229,7 +229,7 @@ import Testing
         let viewModel = makeFocusedViewModel()
         let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1, verse: 5)
         viewModel.lastScrollOffset = -400   // the settled landing position
-        viewModel.focus(target)
+        viewModel.focusReference(target)
 
         viewModel.handleScroll(offset: -400.5)   // within the threshold
 
@@ -240,8 +240,8 @@ import Testing
     func verseTapClearsFocus() async {
         let viewModel = makeFocusedViewModel()
         let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
-        await viewModel.goToReference(target, showsFullChapter: true, focused: true)
-        viewModel.focus(target)
+        await viewModel.goToReference(target, showsFullChapter: true, shouldFocus: true)
+        viewModel.focusReference(target)
 
         viewModel.handleVerseTap(reference: target, actionType: "", footnotes: [])
 
@@ -252,8 +252,8 @@ import Testing
     func chapterNavigationClearsFocus() async {
         let viewModel = makeFocusedViewModel()
         let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
-        await viewModel.goToReference(target, showsFullChapter: true, focused: true)
-        viewModel.focus(target)
+        await viewModel.goToReference(target, showsFullChapter: true, shouldFocus: true)
+        viewModel.focusReference(target)
 
         viewModel.goToNextChapter()
 
@@ -298,10 +298,10 @@ import Testing
         let navigation = BibleReaderNavigation()
         let reference = BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16)
 
-        navigation.focus(reference)
+        navigation.focusReference(reference)
 
         #expect(navigation.pendingRequest?.reference == reference)
-        #expect(navigation.pendingRequest?.focused == true)
+        #expect(navigation.pendingRequest?.shouldFocus == true)
         #expect(navigation.pendingRequest?.scrollsToVerse == true)
         // Focus always shows the full chapter — there's nothing to dim around a
         // lone verse range.
@@ -313,10 +313,10 @@ import Testing
         let navigation = BibleReaderNavigation()
         let reference = BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16)
 
-        navigation.focus(reference, scrollsToVerse: false)
+        navigation.focusReference(reference, scrollsToVerse: false)
 
         #expect(navigation.pendingRequest?.reference == reference)
-        #expect(navigation.pendingRequest?.focused == true)
+        #expect(navigation.pendingRequest?.shouldFocus == true)
         #expect(navigation.pendingRequest?.scrollsToVerse == false)
     }
 
@@ -326,6 +326,6 @@ import Testing
 
         navigation.request(BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16))
 
-        #expect(navigation.pendingRequest?.focused == false)
+        #expect(navigation.pendingRequest?.shouldFocus == false)
     }
 }

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
@@ -15,14 +15,14 @@ import Testing
     func chapterOnlyReferenceArmsNoScroll() {
         let viewModel = makeViewModel(verse: nil)
 
-        #expect(viewModel.scrollTargetReference == nil)
+        #expect(viewModel.scrollAction == .none)
     }
 
     @Test
     func verseOneArmsNoScroll() {
         let viewModel = makeViewModel(verse: 1)
 
-        #expect(viewModel.scrollTargetReference == nil)
+        #expect(viewModel.scrollAction == .none)
     }
 
     @Test
@@ -32,14 +32,14 @@ import Testing
 
         let viewModel = Support.makeViewModel(reference: nil, showsFullChapter: true)
 
-        #expect(viewModel.scrollTargetReference == nil)
+        #expect(viewModel.scrollAction == .none)
     }
 
     @Test
     func verseRangeModeArmsNoScroll() {
         let viewModel = makeViewModel(verse: 14, showsFullChapter: false)
 
-        #expect(viewModel.scrollTargetReference == nil)
+        #expect(viewModel.scrollAction == .none)
     }
 
     // A reader constructed fresh at a verse (the path loop-ios uses for VOTD and
@@ -50,7 +50,7 @@ import Testing
 
         let viewModel = Support.makeViewModel(reference: reference, showsFullChapter: true)
 
-        #expect(viewModel.scrollTargetReference?.verseStart == 16)
+        #expect(viewModel.scrollAction == .reference(ScrollTarget(reference: reference, focused: false)))
     }
 
     @Test
@@ -59,7 +59,7 @@ import Testing
 
         let viewModel = Support.makeViewModel(reference: reference, showsFullChapter: false)
 
-        #expect(viewModel.scrollTargetReference == nil)
+        #expect(viewModel.scrollAction == .none)
     }
 
     @Test
@@ -72,7 +72,7 @@ import Testing
 
         #expect(viewModel.reference.bookUSFM == "JHN")
         #expect(viewModel.reference.chapter == 3)
-        #expect(viewModel.scrollTargetReference?.verseStart == 16)
+        #expect(viewModel.scrollAction == .reference(ScrollTarget(reference: target, focused: false)))
         #expect(viewModel.isChangingChapter)
     }
 
@@ -85,7 +85,7 @@ import Testing
         await viewModel.goToReference(target, showsFullChapter: false)
 
         #expect(viewModel.reference.chapter == 3)
-        #expect(viewModel.scrollTargetReference == nil)
+        #expect(viewModel.scrollAction == .top)
     }
 
     @Test
@@ -100,7 +100,7 @@ import Testing
         await viewModel.goToReference(target, showsFullChapter: true)
 
         #expect(viewModel.reference.chapter != 3)
-        #expect(viewModel.scrollTargetReference == nil)
+        #expect(viewModel.scrollAction == .none)
         #expect(viewModel.showsFullChapter == false)
         #expect(viewModel.isChangingChapter == false)
     }
@@ -116,7 +116,148 @@ import Testing
         )
 
         #expect(viewModel.reference.chapter == 3)
-        #expect(viewModel.scrollTargetReference == nil)
+        #expect(viewModel.scrollAction == .top)
+    }
+
+    // MARK: - Focus
+
+    private func makeFocusedViewModel() -> BibleReaderViewModel {
+        let viewModel = Support.makeViewModel()
+        viewModel.versionsViewModel.switchToVersion(Support.makeBibleVersion(id: Support.versionId))
+        return viewModel
+    }
+
+    // A focused navigation arms the scroll to focus its target once it lands.
+    // The dim itself isn't set until the coordinator scrolls the verse into view,
+    // so it fades in on landing rather than during the scroll.
+    @Test
+    func goToReferenceFocusedArmsFocusScrollTarget() async {
+        let viewModel = makeFocusedViewModel()
+
+        let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        await viewModel.goToReference(target, showsFullChapter: true, focused: true)
+
+        #expect(viewModel.scrollAction == .reference(ScrollTarget(reference: target, focused: true)))
+        #expect(viewModel.focusedReference == nil)  // not focused until the scroll lands
+    }
+
+    // The coordinator calls focus once it has scrolled the verse into view.
+    @Test
+    func setFocusedFocusesTheVerse() async {
+        let viewModel = makeFocusedViewModel()
+        let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        await viewModel.goToReference(target, showsFullChapter: true, focused: true)
+
+        viewModel.focus(target)
+
+        #expect(viewModel.focusedReference == target)
+    }
+
+    @Test
+    func goToReferenceWithoutFocusDoesNotArmFocus() async {
+        let viewModel = makeFocusedViewModel()
+
+        let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        await viewModel.goToReference(target, showsFullChapter: true)
+
+        #expect(viewModel.scrollAction == .reference(ScrollTarget(reference: target, focused: false)))  // scroll only, no focus
+        #expect(viewModel.focusedReference == nil)
+    }
+
+    // A chapter-only reference has no verse to scroll to, so nothing is armed and the
+    // coordinator never reaches its focus step.
+    @Test
+    func focusingChapterOnlyReferenceArmsNothing() async {
+        let viewModel = makeFocusedViewModel()
+
+        let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3)
+        await viewModel.goToReference(target, showsFullChapter: true, focused: true)
+
+        #expect(viewModel.scrollAction == .top)
+        #expect(viewModel.focusedReference == nil)
+    }
+
+    // Focusing in place dims the verse immediately, with no scroll armed — there's no
+    // scroll to observe, so it sets focusedReference directly.
+    @Test
+    func focusFocusesWithoutScrolling() {
+        let viewModel = makeFocusedViewModel()
+        let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1, verse: 5)
+
+        viewModel.focus(target)
+
+        #expect(viewModel.focusedReference == target)
+        #expect(viewModel.scrollAction == .none)  // nothing to scroll
+    }
+
+    @Test
+    func focusIgnoresChapterOnlyReference() {
+        let viewModel = makeFocusedViewModel()
+        let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1)
+
+        viewModel.focus(target)
+
+        #expect(viewModel.focusedReference == nil)
+    }
+
+    @Test
+    func focusIgnoresReferenceInAnotherChapter() {
+        let viewModel = makeFocusedViewModel()
+        let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+
+        viewModel.focus(target)
+
+        #expect(viewModel.focusedReference == nil)
+    }
+
+    @Test
+    func userScrollAwayClearsFocus() {
+        let viewModel = makeFocusedViewModel()
+        let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1, verse: 5)
+        viewModel.lastScrollOffset = -400
+        viewModel.focus(target)
+
+        viewModel.handleScroll(offset: -600)
+
+        #expect(viewModel.focusedReference == nil)
+    }
+
+    // The reveal scroll's settling stays within the threshold of its landing, so it
+    // doesn't dismiss the focus.
+    @Test
+    func smallScrollKeepsFocus() {
+        let viewModel = makeFocusedViewModel()
+        let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1, verse: 5)
+        viewModel.lastScrollOffset = -400   // the settled landing position
+        viewModel.focus(target)
+
+        viewModel.handleScroll(offset: -400.5)   // within the threshold
+
+        #expect(viewModel.focusedReference == target)
+    }
+
+    @Test
+    func verseTapClearsFocus() async {
+        let viewModel = makeFocusedViewModel()
+        let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        await viewModel.goToReference(target, showsFullChapter: true, focused: true)
+        viewModel.focus(target)
+
+        viewModel.handleVerseTap(reference: target, actionType: "", footnotes: [])
+
+        #expect(viewModel.focusedReference == nil)
+    }
+
+    @Test
+    func chapterNavigationClearsFocus() async {
+        let viewModel = makeFocusedViewModel()
+        let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        await viewModel.goToReference(target, showsFullChapter: true, focused: true)
+        viewModel.focus(target)
+
+        viewModel.goToNextChapter()
+
+        #expect(viewModel.focusedReference == nil)
     }
 }
 
@@ -150,5 +291,41 @@ import Testing
         navigation.clearPendingRequest()
 
         #expect(navigation.pendingRequest == nil)
+    }
+
+    @Test
+    func focusRequestScrollsToVerseAndShowsFullChapter() {
+        let navigation = BibleReaderNavigation()
+        let reference = BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16)
+
+        navigation.focus(reference)
+
+        #expect(navigation.pendingRequest?.reference == reference)
+        #expect(navigation.pendingRequest?.focused == true)
+        #expect(navigation.pendingRequest?.scrollsToVerse == true)
+        // Focus always shows the full chapter — there's nothing to dim around a
+        // lone verse range.
+        #expect(navigation.pendingRequest?.showsFullChapter == true)
+    }
+
+    @Test
+    func focusInPlaceRequestFocusesWithoutScrolling() {
+        let navigation = BibleReaderNavigation()
+        let reference = BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16)
+
+        navigation.focus(reference, scrollsToVerse: false)
+
+        #expect(navigation.pendingRequest?.reference == reference)
+        #expect(navigation.pendingRequest?.focused == true)
+        #expect(navigation.pendingRequest?.scrollsToVerse == false)
+    }
+
+    @Test
+    func requestIsNotFocused() {
+        let navigation = BibleReaderNavigation()
+
+        navigation.request(BibleReference(versionId: 3034, bookUSFM: "JHN", chapter: 3, verse: 16))
+
+        #expect(navigation.pendingRequest?.focused == false)
     }
 }

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift
@@ -18,11 +18,14 @@ import Testing
         #expect(viewModel.scrollAction == .none)
     }
 
+    // Verse 1 arms a scroll like any other verse: it's a no-op when the chapter is
+    // fresh (already at the top), but lands correctly if the reader was scrolled away.
     @Test
-    func verseOneArmsNoScroll() {
+    func verseOneArmsScroll() {
+        let reference = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1, verse: 1)
         let viewModel = makeViewModel(verse: 1)
 
-        #expect(viewModel.scrollAction == .none)
+        #expect(viewModel.scrollAction == .reference(ScrollTarget(reference: reference, shouldFocus: false)))
     }
 
     @Test
@@ -135,6 +138,20 @@ import Testing
         let viewModel = makeFocusedViewModel()
 
         let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 3, verse: 16)
+        await viewModel.goToReference(target, showsFullChapter: true, shouldFocus: true)
+
+        #expect(viewModel.scrollAction == .reference(ScrollTarget(reference: target, shouldFocus: true)))
+        #expect(viewModel.focusedReference == nil)  // not focused until the scroll lands
+    }
+
+    // Verse 1 arms a focus scroll like any other verse, so the focus lands via the
+    // coordinator once the verse is confirmed at the top — the reader may have been
+    // scrolled away before the request arrived.
+    @Test
+    func goToReferenceFocusedVerseOneArmsFocusScrollTarget() async {
+        let viewModel = makeFocusedViewModel()
+
+        let target = BibleReference(versionId: Support.versionId, bookUSFM: "JHN", chapter: 1, verse: 1)
         await viewModel.goToReference(target, showsFullChapter: true, shouldFocus: true)
 
         #expect(viewModel.scrollAction == .reference(ScrollTarget(reference: target, shouldFocus: true)))


### PR DESCRIPTION
## What

Adds programmatic verse focus to `BibleReaderView` — dimming the rest of the chapter so a verse stands out, matching the Flutter loop app's reader focus.

## API

On `BibleReaderNavigation`:

```swift
readerNavigation.focus(reference)                       // scroll to the verse, then dim
readerNavigation.focus(reference, scrollsToVerse: false) // dim in place (verse already on screen)
readerNavigation.request(reference, showsFullChapter: true) // plain navigation, no focus
```

## How it works

- Focus is set once the reveal scroll lands. The coordinator waits one display frame after scrolling so the scroll's *own* layout event isn't mistaken for a user scroll and made to dismiss the focus it just revealed.
- In-place focus skips the scroll entirely and sets `focusedReference` directly (there's no scroll to observe).
- The focus clears when the user scrolls away, taps a verse, or navigates elsewhere.
- Rendering drops the `.link` attribute on dimmed runs and recolors them via a glyph mask in `BibleRenderer` — SwiftUI's interactive text overlay otherwise ignores foreground color. The dim crossfades in/out via an animatable `dimProgress`.

## Testing

- `swift test` — all suites pass.
- Verified the reveal-scroll timing on the simulator (the frame-wait is what keeps focus from dismissing itself on its own landing scroll).

## Notes

- Targets `ss/drive-reader-from-outside-BL-1901` (builds on the shared `BibleReaderNavigation` command channel).

## Validation

https://github.com/user-attachments/assets/09b0f409-6e16-4eeb-9d03-dcd577a4129d

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds programmatic verse focus to `BibleReaderView` — dimming all non-focused verses in the chapter so a single verse stands out. The implementation is gated to iOS 18+ via `@available` on the public `focusReference(_:)` API, and the focus lifecycle (set on scroll landing, clear on user scroll, verse tap, or chapter change) is well-modelled with thorough tests.

- **Public API** (`BibleReaderNavigation.focusReference`) produces a `Request` with `shouldFocus: true`, which flows through `goToReference` → `setScrollTarget` → `VerseScrollCoordinator`, which applies the dim one frame after the reveal scroll lands to avoid dismissing its own scroll event.
- **Rendering** uses a new `Animatable` `BibleRenderer` with a `dimProgress` property, crossfading in/out via `.animation(_:value:)` tied to `focusedReference`; dimmed runs have their `.link` attribute stripped so SwiftUI's tint color doesn't repaint over the glyph mask.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The focus feature is well-isolated behind an iOS 18 API guard, the lifecycle (set on scroll landing, cleared on user scroll/verse tap/chapter change) is correctly wired, and the frame-wait timing prevents the coordinator's own reveal scroll from immediately dismissing the focus it just set.

All previously identified issues have been addressed in this revision: the lastScrollOffset baseline is now updated before the isChangingChapter guard so the focus-dismiss threshold is always anchored to the actual landing position; focusReference validates chapter matching internally so a captured-but-stale reference after a frame suspension is silently rejected; clearScrollState is only reached via the happy path (the Task.isCancelled returns exit before it); and the in-place focus path calls removeVerseSelection before setting focusedReference. The test suite covers scroll-armed focus, in-place focus, verse 1, cross-chapter guards, user-scroll dismiss, small-scroll retention, verse-tap clearing, and chapter-navigation clearing. No new correctness issues were found.

No files require special attention. BibleTextView.swift has a minor access-control inconsistency (previously flagged) but it is not a correctness concern.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Adds ScrollTarget struct, focusedReference state, focusReference/clearFocus methods, and updates setScrollTarget/resetScrollStateForNewChapter to integrate with the focus lifecycle. Logic is well-guarded. |
| Sources/YouVersionPlatformReader/VerseScrollCoordinator.swift | Post-scroll frame-wait focus path added. Cancellation is guarded at both await points; clearScrollState only runs on success paths. The chapter-validation inside focusReference acts as a correctness guard for the captured reference. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel+Navigation.swift | handleScroll now updates lastScrollOffset before the isChangingChapter guard, fixing the focus-dismiss baseline. handleVerseTap and onHeaderSelectionChange both call clearFocus; in-place focus path calls removeVerseSelection first. |
| Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift | BibleRenderer gains Animatable conformance via dimProgress, with correct crossfade blending. isReferenceDimmed correctly handles nil references and the header/verseLabel/scripture categories. Link stripping is protected by the iOS 18 focusReference guard at the entry point. |
| Sources/YouVersionPlatformUI/Views/BibleTextView.swift | focusedReference added as a non-private stored property; all other stored properties are private. Functionally correct but access level is inconsistent with the rest of the view. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelVerseScrollTests.swift | New focus test suite covers all key paths: scroll-armed focus, in-place focus, verse 1, chapter-only no-op, cross-chapter guard, user-scroll dismiss, small-scroll retention, verse-tap and chapter-navigation clearing. |
| Examples/SampleApp/NavigateView.swift | Adds 'John 3:16 — focused' example row using #available(iOS 18.0, *) guard; correctly falls back to plain navigation on older OS. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant Nav as BibleReaderNavigation
    participant VM as BibleReaderViewModel
    participant Coord as VerseScrollCoordinator
    participant View as BibleTextView

    Caller->>Nav: focusReference(ref) [iOS 18+]
    Nav->>Nav: "pendingRequest = Request(shouldFocus:true)"
    VM->>Nav: handleNavigationRequest()
    Nav-->>VM: pendingRequest (shouldFocus:true, scrollsToVerse:true)
    VM->>VM: goToReference(ref, shouldFocus:true)
    VM->>VM: onHeaderSelectionChange → clearFocus(), resetScrollState
    VM->>VM: setScrollTarget(shouldFocus:true)
    VM-->>Coord: "scrollAction = .reference(ScrollTarget(shouldFocus:true))"
    Coord->>Coord: handleScrollTarget / handleAnchors
    Coord->>Coord: scrollToTargetBlock
    note over Coord: await DisplayFrame (1st)
    Coord->>View: proxy.scrollTo(blockID)
    note over Coord: await DisplayFrame (2nd frame wait)
    Coord->>VM: focusReference(target.reference)
    VM->>VM: validate chapterReference matches, set focusedReference
    Coord->>VM: clearScrollState → finishChapterChange
    VM-->>View: focusedReference (via BibleTextView prop)
    View->>View: isReferenceDimmed() marks runs
    View->>View: BibleRenderer animates dimProgress 0→1
```

<sub>Reviews (11): Last reviewed commit: ["fix(reader): focus the whole verse range..."](https://github.com/youversion/platform-sdk-swift/commit/671b7b06ed72f5f56487107010bdb9e91b945c82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44511459)</sub>

<!-- /greptile_comment -->