### PR TITLE
chore: implement the protection

### DIFF
--- a/.claude/skills/audit-swift/SKILL.md
+++ b/.claude/skills/audit-swift/SKILL.md
@@ -82,7 +82,10 @@ Detailed naming guidance lives in the `naming` skill — load it for anything na
 
 ## Localization
 
-- Use existing localized strings if possible; prompt the user before adding new strings.
+- Never add or edit `Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings` in this repo.
+- Add or change English copy upstream in [platform-localization](https://github.com/youversion/platform-localization) (`sources/common/en.json`, typically under `swift.*` keys), then reference keys with `String.localized("dotted.key")` after sync.
+- Use existing localized keys when possible; do not introduce hardcoded user-facing UI string literals in `YouVersionPlatformUI` or `YouVersionPlatformReader`.
+- See `docs/localization-guardrails.md` for CI rules and local checks.
 
 ## Testing
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,6 +42,7 @@
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] All commit messages follow [conventional commits](https://www.conventionalcommits.org/) format
+- [ ] No hand-edits to `Localizable.xcstrings`; new copy uses `String.localized(...)` with keys added upstream in platform-localization ([localization guardrails](https://github.com/youversion/platform-sdk-swift/blob/main/docs/localization-guardrails.md))
 
 ## Conventional Commits
 

--- a/.github/scripts/check-locale-ownership.sh
+++ b/.github/scripts/check-locale-ownership.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_SHA="${BASE_SHA:?BASE_SHA is required}"
+HEAD_SHA="${HEAD_SHA:?HEAD_SHA is required}"
+PR_AUTHOR="${PR_AUTHOR:-}"
+HEAD_REF="${HEAD_REF:-}"
+ACTOR="${ACTOR:-}"
+
+# GitHub App identities surface as "<slug>[bot]" in pull_request.user.login and
+# as "app/<slug>" in some CLI/API contexts; accept both.
+LOCALIZATION_SYNC_BOT_APP="app/platform-localization-pr-bot"
+LOCALIZATION_SYNC_BOT_USER="platform-localization-pr-bot[bot]"
+LOCALE_PATH="Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings"
+FAILURE_MSG="Localizable.xcstrings is owned by platform-localization. Add strings upstream; do not edit ${LOCALE_PATH} in feature PRs. See docs/localization-guardrails.md"
+
+is_sync_bot_author() {
+  [[ "$PR_AUTHOR" == "$LOCALIZATION_SYNC_BOT_APP" \
+    || "$PR_AUTHOR" == "$LOCALIZATION_SYNC_BOT_USER" ]]
+}
+
+is_sync_branch() {
+  [[ "$HEAD_REF" =~ ^chore/localization-sync-swift- ]]
+}
+
+is_allowed_sync_pr() {
+  is_sync_bot_author && is_sync_branch
+}
+
+if is_allowed_sync_pr; then
+  echo "Locale ownership check skipped: allowed localization sync PR (actor=${ACTOR:-<unset>}, author=${PR_AUTHOR:-<unset>}, branch=${HEAD_REF:-<unset>})"
+  exit 0
+fi
+
+# Three-dot diff (merge-base) so catalog changes that landed on the base branch
+# after this PR branched are not misattributed to the PR.
+changed_files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" -- "$LOCALE_PATH" || true)"
+
+if [[ -z "$changed_files" ]]; then
+  echo "Locale ownership check passed: no catalog changes"
+  exit 0
+fi
+
+echo "::error title=Locale catalog is upstream-owned::${FAILURE_MSG}"
+echo ""
+echo "Changed catalog files:"
+echo "$changed_files"
+echo ""
+echo "$FAILURE_MSG"
+exit 1

--- a/.github/scripts/check-locale-ownership.sh
+++ b/.github/scripts/check-locale-ownership.sh
@@ -34,7 +34,7 @@ fi
 
 # Three-dot diff (merge-base) so catalog changes that landed on the base branch
 # after this PR branched are not misattributed to the PR.
-changed_files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" -- "$LOCALE_PATH" || true)"
+changed_files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" -- "$LOCALE_PATH")"
 
 if [[ -z "$changed_files" ]]; then
   echo "Locale ownership check passed: no catalog changes"

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -1,0 +1,50 @@
+name: Localization
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  locale-ownership:
+    name: Locale Ownership
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Block manual catalog edits
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          ACTOR: ${{ github.actor }}
+        run: bash .github/scripts/check-locale-ownership.sh
+
+  hardcoded-ui-strings:
+    name: Hardcoded UI Strings
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify no hardcoded UI strings
+        run: bash scripts/check-no-hardcoded-ui-strings.sh
+
+  key-existence:
+    name: Localization Key Existence
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify localization keys exist in catalog
+        run: bash scripts/check-localization-keys.sh

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -511,8 +511,20 @@ custom_rules:
     name: "SwiftUI Localization" # rule name. optional.
     regex: "\\W(Text|TextField|SecureField|Button|Label|Toggle|Picker|Menu|confirmationDialog|navigationTitle|navigationBarTitle|alert)\\((NSLocalizedString)" # matching pattern
     capture_group: 2
-    message: "SwiftUI can localize strings using only the key." # violation message. optional.
+    message: "Use String.localized(\"dotted.key\") instead of NSLocalizedString; see docs/localization-guardrails.md." # violation message. optional.
     severity: warning # violation severity. optional.
+
+  hardcoded_ui_string: # rule identifier
+    included: # quoted so YAML collapses \\ to \ like every other rule in this file
+      - "Sources/YouVersionPlatformUI/.*\\.swift"
+      - "Sources/YouVersionPlatformReader/.*\\.swift"
+    excluded: ".*Tests?\\.swift"
+    name: "Hardcoded UI String"
+    # "[^\"]{2} exempts single-character glyph literals (e.g. Text("A")), mirroring scripts/check-no-hardcoded-ui-strings.sh.
+    # For intentionally unlocalized text (e.g. in #Preview bodies), use Text(verbatim:).
+    regex: "(\\b(Text|Button|Label)\\(\\s*\"[^\"]{2}|\\.((navigationTitle|navigationBarTitle|accessibilityLabel|accessibilityHint))\\(\\s*\"[^\"]{2}|(\\bconfirmationDialog|\\balert)\\(\\s*\"[^\"]{2})"
+    message: "User-facing UI copy must use String.localized(...) rather than raw string literals. See docs/localization-guardrails.md."
+    severity: error
 
   ambiguous_dateformatter: # rule identifier
     included: ".*\\.swift" # regex that defines paths to include during linting. optional.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,10 +149,14 @@ Why: `main` HEAD reads `SDKVersion.current = "Dev"` so in-repo dev builds and PR
 
 ## Localization
 
-### SPM Resource Bundle Localization Workaround
-When adding new localizations to the SDK, the Sample App requires dummy localization files to ensure iOS recognizes the supported languages:
+User-facing strings are owned by [platform-localization](https://github.com/youversion/platform-localization) and synced into `Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings`. Do **not** edit the catalog in feature PRs — add or change English keys upstream (typically under `swift.*` in `sources/common/en.json`), then consume them via `String.localized("dotted.key")` after the sync PR lands.
 
-1. Add translations to `Sources/YouVersionPlatformReader/Resources/Localizable.xcstrings`
+See [docs/localization-guardrails.md](docs/localization-guardrails.md) for CI gates, bot exemption rules, and local verification commands.
+
+### SPM Resource Bundle Localization Workaround
+When platform-localization adds new locale support, the Sample App requires dummy localization files so iOS recognizes the supported languages. The sync PR only rewrites the string catalog — steps 2–5 below remain manual SDK-developer tasks and need a follow-up PR whenever a new locale lands:
+
+1. Wait for the localization sync PR to update `Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings` (do not edit the catalog locally).
 2. Create a corresponding `.lproj` directory in `Examples/SampleApp/` (e.g., `de.lproj/`, `fr.lproj/`)
 3. Add a dummy `Localizable.strings` file to each directory with content: `/* Dummy file to ensure [Language] localization is recognized */`
 4. Add the language code to `knownRegions` in `Examples/SampleApp.xcodeproj/project.pbxproj`

--- a/Sources/YouVersionPlatformUI/Views/YouVersionBigButtonStyle.swift
+++ b/Sources/YouVersionPlatformUI/Views/YouVersionBigButtonStyle.swift
@@ -29,7 +29,7 @@ public struct YouVersionBigButtonStyle: ButtonStyle {
 
 #Preview {
     Button(action: { }) {
-        Text("Test")
+        Text(verbatim: "Test")
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
     }

--- a/config/i18n/hardcoded-string-allowlist.txt
+++ b/config/i18n/hardcoded-string-allowlist.txt
@@ -1,0 +1,15 @@
+# Intentional hardcoded UI string exceptions for scripts/check-no-hardcoded-ui-strings.sh.
+# (The SwiftLint hardcoded_ui_string rule does not read this file; use Text(verbatim:)
+# or a swiftlint:disable comment for lines that must also pass SwiftLint.)
+#
+# Entry formats (path is a substring of the repo-relative path; pattern is a
+# substring of the code on the matched line):
+#   path
+#   path:pattern
+#   path:line:pattern
+#
+# Example:
+#   Sources/YouVersionPlatformUI/Views/SomeView.swift:Text("QR")
+#
+# Note: single-character glyphs (e.g. Text("A")) are always exempt and need no entry.
+# Prefer fixing call sites over growing this list.

--- a/docs/localization-guardrails.md
+++ b/docs/localization-guardrails.md
@@ -1,0 +1,117 @@
+# Localization Guardrails
+
+User-facing copy in the YouVersion Platform SDK (Swift) is owned by [platform-localization](https://github.com/youversion/platform-localization) and synced into this repository. SDK modules must not ship new hardcoded UI strings, and the string catalog must not be edited directly in feature PRs.
+
+## String architecture
+
+| Layer | File | Who edits |
+|-------|------|-----------|
+| Canonical catalog | `Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings` | platform-localization sync workflow only |
+| SDK access API | `String.localized(_:)` in `Sources/YouVersionPlatformUI/Utilities/LocalizationHelpers.swift` | SDK developers (API only) |
+
+**Modules with UI strings:** `YouVersionPlatformUI`, `YouVersionPlatformReader`
+
+**Out of scope:** `Tests/**`, `Examples/**` (demo app)
+
+## How to add or change user-facing copy
+
+1. Add or update keys in **platform-localization** under `sources/common/en.json` using the `swift.*` prefix (or shared unprefixed keys where appropriate).
+2. Wait for the localization distribute workflow to open a sync PR in this repo on branch `chore/localization-sync-swift-{YYYYMMDD}-{sha7}` authored by `app/platform-localization-pr-bot`.
+3. After the sync PR merges, reference the key in SDK code with `String.localized("dotted.key")`.
+
+Do **not** hand-edit `Localizable.xcstrings` in feature PRs.
+
+### Example
+
+```swift
+Text(String.localized("generic.cancel"))
+Button(String.localized("download.agreeButton")) { ... }
+    .accessibilityLabel(String.localized("signIn.button.accessibility"))
+```
+
+## Enforcement
+
+| Layer | Mechanism | Blocks merge? |
+|-------|-----------|---------------|
+| **CI** | `.github/workflows/localization.yml` — locale ownership | Yes |
+| **CI** | `scripts/check-no-hardcoded-ui-strings.sh` | Yes |
+| **CI** | `scripts/check-localization-keys.sh` | Yes |
+| **SwiftLint** | `hardcoded_ui_string` custom rule (error) | Yes |
+| **Greptile** | `greptile.json` advisory rules | No (advisory PR comments) |
+
+### Local checks
+
+```bash
+# Block manual catalog edits (simulate a feature PR)
+BASE_SHA=main HEAD_SHA=HEAD PR_AUTHOR=your-user HEAD_REF=feature/foo \
+  bash .github/scripts/check-locale-ownership.sh
+
+# Fail on hardcoded UI strings in UI + Reader modules
+bash scripts/check-no-hardcoded-ui-strings.sh
+
+# Fail when String.localized keys are missing an English value in the catalog
+bash scripts/check-localization-keys.sh
+
+swiftlint --strict
+swift test
+```
+
+## Hardcoded string policy
+
+The CI script and SwiftLint rule scan `Sources/YouVersionPlatformUI/**` and `Sources/YouVersionPlatformReader/**` for raw string literals passed to:
+
+- `Text(...)`, `Button(...)`, `Label(...)`
+- `.navigationTitle(...)`, `.navigationBarTitle(...)`
+- `.accessibilityLabel(...)`, `.accessibilityHint(...)`
+- `alert(...)`, `confirmationDialog(...)` title/message string literals
+
+**Fix violations** by wiring `String.localized("existing.key")` or adding keys upstream in platform-localization and consuming them after sync.
+
+### Exclusions (not flagged)
+
+| Category | Examples | CI script | SwiftLint rule |
+|----------|----------|-----------|----------------|
+| Tests & examples | `Tests/**`, `Examples/**` | ✅ | ✅ |
+| Single-character glyphs | Font-size `Text("A")` in font settings | ✅ | ✅ |
+| Localized values | `Text(String.localized("generic.ok"))` | ✅ | ✅ |
+| Verbatim text | `Text(verbatim: "Test")` | ✅ | ✅ |
+| `#Preview` blocks | SwiftUI preview scaffolding | ✅ | ❌ |
+| Comments | `// e.g. Text("example")` | ✅ | ❌ |
+| Allowlisted exceptions | `config/i18n/hardcoded-string-allowlist.txt` | ✅ | ❌ |
+
+The two gates are not identical: SwiftLint is a plain regex and does not read the
+allowlist or skip `#Preview` blocks and comments. For text that is intentionally
+unlocalized (preview scaffolding, glyphs longer than one character), prefer
+`Text(verbatim: "...")`, which passes both gates and states the intent; a
+`// swiftlint:disable:next hardcoded_ui_string` comment is the fallback for
+APIs without a verbatim form.
+
+Allowlist entries (CI script only) use `path`, `path:pattern`, or
+`path:line:pattern`, where `path` is a substring of the repo-relative file path
+and `pattern` is a substring of the code on the matched line.
+
+Prefer fixing call sites over adding allowlist entries.
+
+## Catalog ownership (locale sync PRs)
+
+`Localizable.xcstrings` may only be modified by localization sync PRs when **both** are true:
+
+- PR author is the platform-localization GitHub App — its login surfaces as `platform-localization-pr-bot[bot]` in the `pull_request` event (the `app/platform-localization-pr-bot` form used by some CLI/API contexts is also accepted)
+- Head branch matches `chore/localization-sync-swift-*`
+
+All other PRs that touch the catalog fail CI with a link to this document.
+
+Sync PRs still run the hardcoded-string and key-existence checks.
+
+## Greptile
+
+Advisory localization rules live in `greptile.json`. Greptile supplements but does not replace CI merge gates.
+
+Re-trigger review after config changes with `@greptileai review`.
+
+## References
+
+- String catalog: `Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings`
+- Hardcoded-string allowlist: `config/i18n/hardcoded-string-allowlist.txt`
+- CI workflow: `.github/workflows/localization.yml`
+- Upstream repo: [platform-localization](https://github.com/youversion/platform-localization)

--- a/greptile.json
+++ b/greptile.json
@@ -1,5 +1,20 @@
 {
   "customContext": {
+    "rules": [
+      {
+        "scope": [
+          "Sources/YouVersionPlatformUI/**/*.swift",
+          "Sources/YouVersionPlatformReader/**/*.swift"
+        ],
+        "rule": "No hardcoded user-facing UI strings: use String.localized(\"dotted.key\") for Text, Button, Label, navigationTitle, alert, confirmationDialog, accessibilityLabel, and accessibilityHint. CI scripts/check-no-hardcoded-ui-strings.sh and SwiftLint hardcoded_ui_string enforce this. See docs/localization-guardrails.md."
+      },
+      {
+        "scope": [
+          "Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings"
+        ],
+        "rule": "Localizable.xcstrings is upstream-owned by platform-localization. Do not edit in feature PRs. Add English keys as swift.* (or shared unprefixed keys) in platform-localization sources/common/en.json; translations arrive via Crowdin and sync PRs on chore/localization-sync-swift-* branches authored by app/platform-localization-pr-bot. See docs/localization-guardrails.md."
+      }
+    ],
     "files": [
       {
         "scope": ["**/*.swift"],
@@ -19,6 +34,15 @@
         "scope": ["**/*.swift"],
         "path": ".claude/skills/naming/SKILL.md",
         "description": "Naming Swift entities (types, protocols, functions, parameters, properties, cases) per Apple guidelines and project conventions."
+      },
+      {
+        "scope": [
+          "Sources/YouVersionPlatformUI/**",
+          "Sources/YouVersionPlatformReader/**",
+          "Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings"
+        ],
+        "path": "docs/localization-guardrails.md",
+        "description": "Localization guardrails: upstream-owned catalog, String.localized usage, CI enforcement."
       }
     ]
   }

--- a/scripts/check-localization-keys.sh
+++ b/scripts/check-localization-keys.sh
@@ -48,14 +48,57 @@ def catalog_keys_with_english(catalog: dict) -> set[str]:
     }
 
 
+# Keep in sync with strip_comments in scripts/check-no-hardcoded-ui-strings.sh
+def strip_comments(line: str, in_block_comment: bool) -> tuple[str, bool]:
+    """Return (code with strings kept, block-comment state)."""
+    kept: list[str] = []
+    in_string = False
+    i = 0
+    n = len(line)
+    while i < n:
+        ch = line[i]
+        if in_block_comment:
+            if line.startswith("*/", i):
+                in_block_comment = False
+                i += 2
+            else:
+                i += 1
+            continue
+        if in_string:
+            if ch == "\\" and i + 1 < n:
+                kept.append(line[i : i + 2])
+                i += 2
+                continue
+            kept.append(ch)
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if line.startswith("//", i):
+            break
+        if line.startswith("/*", i):
+            in_block_comment = True
+            i += 2
+            continue
+        kept.append(ch)
+        if ch == '"':
+            in_string = True
+        i += 1
+    return "".join(kept), in_block_comment
+
+
 def extract_keys_from_sources() -> set[str]:
     keys: set[str] = set()
     for scan_dir in scan_dirs:
         if not scan_dir.is_dir():
             continue
         for path in scan_dir.rglob("*.swift"):
-            text = path.read_text(encoding="utf-8")
-            keys.update(KEY_PATTERN.findall(text))
+            in_block_comment = False
+            code_lines: list[str] = []
+            for line in path.read_text(encoding="utf-8").splitlines():
+                code, in_block_comment = strip_comments(line, in_block_comment)
+                code_lines.append(code)
+            keys.update(KEY_PATTERN.findall("\n".join(code_lines)))
     return keys
 
 

--- a/scripts/check-localization-keys.sh
+++ b/scripts/check-localization-keys.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CATALOG="${ROOT}/Sources/YouVersionPlatformUI/Resources/Localizable.xcstrings"
+SCAN_DIRS=(
+  "${ROOT}/Sources/YouVersionPlatformUI"
+  "${ROOT}/Sources/YouVersionPlatformReader"
+)
+
+if [[ ! -f "$CATALOG" ]]; then
+  echo "String catalog not found: $CATALOG"
+  exit 1
+fi
+
+export ROOT CATALOG
+python3 - <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+root = Path(os.environ["ROOT"])
+catalog_path = Path(os.environ["CATALOG"])
+
+scan_dirs = [
+    root / "Sources/YouVersionPlatformUI",
+    root / "Sources/YouVersionPlatformReader",
+]
+
+KEY_PATTERN = re.compile(r'(?:String\.)?localized\(\s*"([^"]+)"\s*\)')
+
+
+def catalog_keys_with_english(catalog: dict) -> set[str]:
+    """Keys that carry an explicit English localization.
+
+    The catalog's sourceLanguage is en, but these are dotted keys, not natural-language
+    source strings — an entry without an en value renders the raw key at runtime.
+    """
+    strings = catalog.get("strings", {})
+    return {
+        key
+        for key, entry in strings.items()
+        if "en" in entry.get("localizations", {})
+    }
+
+
+def extract_keys_from_sources() -> set[str]:
+    keys: set[str] = set()
+    for scan_dir in scan_dirs:
+        if not scan_dir.is_dir():
+            continue
+        for path in scan_dir.rglob("*.swift"):
+            text = path.read_text(encoding="utf-8")
+            keys.update(KEY_PATTERN.findall(text))
+    return keys
+
+
+catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+catalog_keys = catalog_keys_with_english(catalog)
+source_keys = extract_keys_from_sources()
+
+missing = sorted(key for key in source_keys if key not in catalog_keys)
+
+if not missing:
+    print(f"Localization key existence check passed ({len(source_keys)} keys).")
+    sys.exit(0)
+
+print("::error title=Missing localization keys::String.localized keys must exist in Localizable.xcstrings (English). Add keys upstream in platform-localization.")
+print("")
+print("Keys referenced in SDK sources but missing from the catalog:")
+for key in missing:
+    print(f"  - {key}")
+print("")
+print("See docs/localization-guardrails.md")
+sys.exit(1)
+PY

--- a/scripts/check-no-hardcoded-ui-strings.sh
+++ b/scripts/check-no-hardcoded-ui-strings.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ALLOWLIST="${ROOT}/config/i18n/hardcoded-string-allowlist.txt"
+
+if [[ ! -f "$ALLOWLIST" ]]; then
+  echo "Allowlist file not found: $ALLOWLIST"
+  exit 1
+fi
+
+export ROOT ALLOWLIST
+python3 - <<'PY'
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+root = Path(os.environ["ROOT"])
+allowlist_path = Path(os.environ["ALLOWLIST"])
+
+scan_dirs = [
+    root / "Sources/YouVersionPlatformUI",
+    root / "Sources/YouVersionPlatformReader",
+]
+
+# Raw string literal arguments to common SwiftUI user-facing APIs.
+# Keep in sync with the hardcoded_ui_string custom rule in .swiftlint.yml.
+PATTERNS = [
+    re.compile(r'\bText\s*\(\s*"([^"]*)"'),
+    re.compile(r'\bButton\s*\(\s*"([^"]*)"'),
+    re.compile(r'\bLabel\s*\(\s*"([^"]*)"'),
+    re.compile(r'\.navigationTitle\s*\(\s*"([^"]*)"'),
+    re.compile(r'\.navigationBarTitle\s*\(\s*"([^"]*)"'),
+    re.compile(r'\.accessibilityLabel\s*\(\s*"([^"]*)"'),
+    re.compile(r'\.accessibilityHint\s*\(\s*"([^"]*)"'),
+    re.compile(r'\bconfirmationDialog\s*\(\s*"([^"]*)"'),
+    re.compile(r'\balert\s*\(\s*"([^"]*)"'),
+]
+
+
+def load_allowlist() -> list[tuple[str, int | None, str | None]]:
+    """Parse entries of the form path, path:pattern, or path:line:pattern."""
+    entries: list[tuple[str, int | None, str | None]] = []
+    for raw in allowlist_path.read_text(encoding="utf-8").splitlines():
+        entry = raw.strip()
+        if not entry or entry.startswith("#"):
+            continue
+        parts = entry.split(":", 2)
+        if len(parts) == 3 and parts[1].strip().isdigit():
+            entries.append((parts[0].strip(), int(parts[1]), parts[2].strip()))
+        elif len(parts) >= 2:
+            file_part, pattern = entry.split(":", 1)
+            entries.append((file_part.strip(), None, pattern.strip()))
+        else:
+            entries.append((entry, None, None))
+    return entries
+
+
+def is_allowlisted(rel_path: str, line_number: int, line: str, allowlist) -> bool:
+    for file_part, lineno, pattern in allowlist:
+        if file_part not in rel_path:
+            continue
+        if lineno is not None and lineno != line_number:
+            continue
+        if pattern is None or pattern in line:
+            return True
+    return False
+
+
+def strip_comments(line: str, in_block_comment: bool) -> tuple[str, str, bool]:
+    """Return (code with strings kept, code with string contents blanked, block-comment state).
+
+    Drops trailing // comments and /* */ bodies without being fooled by
+    delimiters inside string literals (e.g. Text("https://...")).
+    """
+    kept: list[str] = []
+    blanked: list[str] = []
+    in_string = False
+    i = 0
+    n = len(line)
+    while i < n:
+        ch = line[i]
+        if in_block_comment:
+            if line.startswith("*/", i):
+                in_block_comment = False
+                i += 2
+            else:
+                i += 1
+            continue
+        if in_string:
+            if ch == "\\" and i + 1 < n:
+                kept.append(line[i : i + 2])
+                i += 2
+                continue
+            kept.append(ch)
+            if ch == '"':
+                blanked.append(ch)
+                in_string = False
+            i += 1
+            continue
+        if line.startswith("//", i):
+            break
+        if line.startswith("/*", i):
+            in_block_comment = True
+            i += 2
+            continue
+        kept.append(ch)
+        blanked.append(ch)
+        if ch == '"':
+            in_string = True
+        i += 1
+    return "".join(kept), "".join(blanked), in_block_comment
+
+
+class PreviewTracker:
+    """Skips #Preview blocks, including the single-line `#Preview { ... }` form."""
+
+    def __init__(self) -> None:
+        self.depth = 0
+
+    def consume(self, code_line: str) -> bool:
+        """Feed one string-blanked code line; True means the line is preview scaffolding."""
+        if self.depth > 0:
+            self.depth = max(self.depth + code_line.count("{") - code_line.count("}"), 0)
+            return True
+        if re.search(r"#Preview\b", code_line):
+            self.depth = max(code_line.count("{") - code_line.count("}"), 0)
+            return True
+        return False
+
+
+def should_skip_literal(literal: str) -> bool:
+    # Single-character glyphs (and empty placeholders) are not localizable copy.
+    return len(literal) <= 1
+
+
+def scan_file(path: Path, allowlist) -> list[tuple[int, str, str]]:
+    rel_path = path.relative_to(root).as_posix()
+    violations: list[tuple[int, str, str]] = []
+    preview = PreviewTracker()
+    in_block_comment = False
+
+    for index, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        code, blanked, in_block_comment = strip_comments(line, in_block_comment)
+        if preview.consume(blanked):
+            continue
+
+        for pattern in PATTERNS:
+            match = pattern.search(code)
+            if not match:
+                continue
+            literal = match.group(1)
+            if should_skip_literal(literal):
+                continue
+            if is_allowlisted(rel_path, index, code, allowlist):
+                continue
+            violations.append((index, literal, line.strip()))
+            break
+
+    return violations
+
+
+allowlist = load_allowlist()
+all_violations: list[tuple[str, int, str, str]] = []
+
+for scan_dir in scan_dirs:
+    if not scan_dir.is_dir():
+        continue
+    for path in sorted(scan_dir.rglob("*.swift")):
+        for line_number, literal, line in scan_file(path, allowlist):
+            rel_path = path.relative_to(root).as_posix()
+            all_violations.append((rel_path, line_number, literal, line))
+
+if not all_violations:
+    print("Hardcoded UI string check passed.")
+    sys.exit(0)
+
+print("::error title=Hardcoded UI strings detected::User-facing copy must use String.localized(...). See docs/localization-guardrails.md")
+print("")
+print("Hardcoded UI string violations:")
+for rel_path, line_number, literal, line in all_violations:
+    print(f"  {rel_path}:{line_number}: \"{literal}\" — {line}")
+print("")
+print("Fix by using String.localized(\"dotted.key\") with keys added upstream in platform-localization.")
+sys.exit(1)
+PY


### PR DESCRIPTION
## Description

This PR puts in place protection and checks for localization files. The goal is to guide users to make localization changes in the localization repo.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [ ] `fix:` Bug fix (non-breaking change which fixes an issue)
- [X] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [X] `ci:` CI configuration changes
- [X] `chore:` Other changes (maintenance, etc.)

## Breaking Changes

<!-- If this PR contains breaking changes, mark this box and describe them below -->

- [ ] This PR contains **BREAKING CHANGES**

<!-- If checked, explain the breaking changes and provide migration instructions -->

**Breaking Change Details:**
<!-- Remove this section if not applicable -->

**Migration Guide:**
<!-- Provide step-by-step instructions for users to migrate their code -->

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] All commit messages follow [conventional commits](https://www.conventionalcommits.org/) format

## Conventional Commits

<!-- Your commit messages should follow this format -->

✅ **All commits in this PR follow conventional commit format:**

```
<type>(<scope>): <subject>

[optional body]

[optional footer]
```

**Example commit messages:**
- `feat(api): add Bible verse lookup method`
- `fix(auth): resolve token refresh race condition`
- `docs: update installation instructions`

For breaking changes:
- `feat(api)!: redesign Bible content API`

See [CONTRIBUTING.md](../CONTRIBUTING.md#conventional-commits) for detailed guidelines.

## Related Issues

<!-- Link any related issues using keywords like "Closes", "Fixes", or "Resolves" -->

Closes #
Relates to #

## Additional Context

<!-- Add any other context about the PR here, such as: -->
<!-- - Screenshots (for UI changes) -->
<!-- - Performance benchmarks (for performance improvements) -->
<!-- - Links to external resources or discussions -->

## Reviewer Notes

<!-- Any specific areas you'd like reviewers to focus on? -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR establishes a full localization guardrail system — blocking hand-edits to the upstream-owned `Localizable.xcstrings` catalog and preventing hardcoded UI strings from landing in the `YouVersionPlatformUI` and `YouVersionPlatformReader` modules.

- **CI workflow** (`.github/workflows/localization.yml`) adds three merge-blocking jobs: catalog ownership (only the `platform-localization-pr-bot` sync bot may modify `Localizable.xcstrings`), hardcoded-string detection, and localization-key existence, each backed by a dedicated shell/Python script.
- **SwiftLint custom rule** `hardcoded_ui_string` provides IDE-time enforcement alongside CI; the `YouVersionBigButtonStyle` preview is updated to `Text(verbatim:)` to satisfy the new rule.
- **Documentation and agent context** (`docs/localization-guardrails.md`, `AGENTS.md`, `greptile.json`, SKILL.md, PR template) are all updated to point developers to the correct upstream-first workflow.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive CI/tooling with no runtime impact on SDK consumers.

The three new CI scripts are well-constructed: comment stripping prevents false positives from commented-out code, the PreviewTracker correctly uses a string-blanked view for brace counting, and the catalog ownership check uses a proper merge-base diff with both bot-identity conditions required together. The previously raised concerns (strip_comments omission in the key-existence script and the || true masking in the ownership check) are both cleanly resolved in this version.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/localization.yml | New CI workflow with three merge-blocking jobs; correct permissions (contents: read only), fetch-depth: 0 scoped to the job that needs git history, and concurrency cancellation configured properly. |
| .github/scripts/check-locale-ownership.sh | New script guarding catalog ownership; uses set -euo pipefail throughout, three-dot merge-base diff to avoid misattributing base-branch changes, and dual-form bot-identity check. Both prior review concerns (|| true and strip_comments) are cleanly resolved in this version. |
| scripts/check-no-hardcoded-ui-strings.sh | New script scanning UI/Reader sources for raw string literals; includes a careful strip_comments pass, a brace-depth PreviewTracker using the string-blanked view, allowlist support, and single-character glyph exemption — all consistent with the SwiftLint rule and docs. |
| scripts/check-localization-keys.sh | New script verifying that every String.localized key referenced in production sources has an explicit English entry in the catalog; strip_comments logic kept in sync with the sister script, and catalog_keys_with_english correctly requires an explicit en localization. |
| docs/localization-guardrails.md | New reference document covering the full localization architecture, enforcement table, local check commands, allowlist format, and catalog ownership rules — clear and well-structured. |
| .swiftlint.yml | Adds hardcoded_ui_string custom rule (error severity) covering Text/Button/Label/navigationTitle/accessibilityLabel/accessibilityHint/alert/confirmationDialog; single-char exemption via [^"]{2} mirrors the CI script's len<=1 skip. |
| Sources/YouVersionPlatformUI/Views/YouVersionBigButtonStyle.swift | Preview updated from Text("Test") to Text(verbatim: "Test"), satisfying both the new SwiftLint rule and CI script. |
| greptile.json | Adds two advisory rules (no hardcoded UI strings, catalog ownership) and registers docs/localization-guardrails.md as context for UI/Reader/xcstrings file changes. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer PR
    participant GH as GitHub Actions
    participant Own as locale-ownership job
    participant HCS as hardcoded-ui-strings job
    participant KE as key-existence job

    Dev->>GH: open / push to PR
    GH->>Own: trigger (fetch-depth: 0)
    GH->>HCS: trigger (default checkout)
    GH->>KE: trigger (default checkout)

    Own->>Own: "is PR_AUTHOR == sync bot AND HEAD_REF matches chore/localization-sync-swift-*?"
    alt Sync bot PR
        Own-->>GH: skip (allowed)
    else Feature PR
        Own->>Own: git diff BASE...HEAD -- Localizable.xcstrings
        alt xcstrings unchanged
            Own-->>GH: pass
        else xcstrings modified
            Own-->>GH: fail — catalog is upstream-owned
        end
    end

    HCS->>HCS: "scan Sources/YouVersionPlatformUI + Reader, strip comments, skip #Preview blocks"
    alt No raw string literals in UI APIs
        HCS-->>GH: pass
    else Hardcoded UI string found
        HCS-->>GH: fail — use String.localized(...)
    end

    KE->>KE: extract String.localized keys, check each has English entry in xcstrings
    alt All keys present in catalog
        KE-->>GH: pass
    else Key missing from catalog
        KE-->>GH: fail — add key upstream in platform-localization
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer PR
    participant GH as GitHub Actions
    participant Own as locale-ownership job
    participant HCS as hardcoded-ui-strings job
    participant KE as key-existence job

    Dev->>GH: open / push to PR
    GH->>Own: trigger (fetch-depth: 0)
    GH->>HCS: trigger (default checkout)
    GH->>KE: trigger (default checkout)

    Own->>Own: "is PR_AUTHOR == sync bot AND HEAD_REF matches chore/localization-sync-swift-*?"
    alt Sync bot PR
        Own-->>GH: skip (allowed)
    else Feature PR
        Own->>Own: git diff BASE...HEAD -- Localizable.xcstrings
        alt xcstrings unchanged
            Own-->>GH: pass
        else xcstrings modified
            Own-->>GH: fail — catalog is upstream-owned
        end
    end

    HCS->>HCS: "scan Sources/YouVersionPlatformUI + Reader, strip comments, skip #Preview blocks"
    alt No raw string literals in UI APIs
        HCS-->>GH: pass
    else Hardcoded UI string found
        HCS-->>GH: fail — use String.localized(...)
    end

    KE->>KE: extract String.localized keys, check each has English entry in xcstrings
    alt All keys present in catalog
        KE-->>GH: pass
    else Key missing from catalog
        KE-->>GH: fail — add key upstream in platform-localization
    end
```

</a>

<sub>Reviews (4): Last reviewed commit: ["fix: git diff"](https://github.com/youversion/platform-sdk-swift/commit/cba0431248957be130276e347ce2a430df56a1e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44511872)</sub>

<!-- /greptile_comment -->