### PR TITLE
chore: silence deprecation warnings in the compatibility code

### DIFF
--- a/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
+++ b/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
@@ -36,6 +36,7 @@ public struct YouVersionPlatformConfiguration {
 
     public static let authStateDidChangeNotification = Notification.Name("YouVersionPlatformAuthStateDidChange")
 
+    @available(*, deprecated, message: "Use hasPermission(_:) instead.")
     static var permissionEnums: [SignInWithYouVersionPermission] {
         storedPermissions.compactMap { SignInWithYouVersionPermission(rawValue: $0) }
     }
@@ -142,6 +143,7 @@ public struct YouVersionPlatformConfiguration {
         UserDefaults.standard.set(rawValues, forKey: permissionsKey)
     }
     
+    @available(*, deprecated, message: "Use hasPermission(_:) with a raw String permission value instead.")
     public static func hasPermission(_ permission: SignInWithYouVersionPermission) -> Bool {
         permissionEnums.contains(permission)
     }

--- a/Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift
+++ b/Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift
@@ -40,6 +40,23 @@ public enum BibleTextFontOption {
     case font100emSmallCaps
 }
 
+private protocol LegacyBibleTextFontOptions {
+    static var textFont: BibleTextFontOption { get }
+    static var textFontBold: BibleTextFontOption { get }
+    static var textFontItalic: BibleTextFontOption { get }
+    static var smallCaps: BibleTextFontOption { get }
+    static var header: BibleTextFontOption { get }
+    static var headerItalic: BibleTextFontOption { get }
+    static var headerSmaller: BibleTextFontOption { get }
+    static var headerSmallerItalic: BibleTextFontOption { get }
+    static var header2: BibleTextFontOption { get }
+    static var header3: BibleTextFontOption { get }
+    static var header4: BibleTextFontOption { get }
+    static var font100emSmallCaps: BibleTextFontOption { get }
+}
+
+extension BibleTextFontOption: LegacyBibleTextFontOptions {}
+
 public struct BibleTextFonts {
     var fonts: [BibleTextFontOption: Font]
 
@@ -68,6 +85,8 @@ public struct BibleTextFonts {
             italicFamilyName = familyName
         }
 
+        let legacyOptions = BibleTextFontOption.self as LegacyBibleTextFontOptions.Type
+
         fonts = [
             .font076emItalic: Self.font(familyName: italicFamilyName, size: baseSize * 0.76).italic(),
             .font100em: Self.font(familyName: familyName, size: baseSize),
@@ -80,18 +99,18 @@ public struct BibleTextFonts {
             .verseNumFont: Self.font(familyName: "Helvetica Neue", size: baseSize * 0.65).smallCaps(),
             
             // below are deprecated:
-            .textFontItalic: Self.font(familyName: italicFamilyName, size: baseSize).italic(),
-            .textFontBold: Self.font(familyName: familyName, size: baseSize).bold(),
-            .smallCaps: Self.font(familyName: familyName, size: baseSize).lowercaseSmallCaps(),
-            .headerItalic: Self.font(familyName: italicFamilyName, size: baseSize * 1.1).italic(),
-            .headerSmaller: Self.font(familyName: familyName, size: baseSize * 0.9).weight(.medium),
-            .header2: Self.font(familyName: familyName, size: baseSize * 1.1).weight(.bold),
-            .header3: Self.font(familyName: familyName, size: baseSize * 1.1),
-            .header4: Self.font(familyName: familyName, size: baseSize * 1.1),
-            .header: Self.font(familyName: familyName, size: baseSize).bold(),
-            .headerSmallerItalic: Self.font(familyName: italicFamilyName, size: baseSize * 0.76).italic(),
-            .textFont: Self.font(familyName: familyName, size: baseSize),
-            .font100emSmallCaps: Self.font(familyName: familyName, size: baseSize).lowercaseSmallCaps()
+            legacyOptions.textFontItalic: Self.font(familyName: italicFamilyName, size: baseSize).italic(),
+            legacyOptions.textFontBold: Self.font(familyName: familyName, size: baseSize).bold(),
+            legacyOptions.smallCaps: Self.font(familyName: familyName, size: baseSize).lowercaseSmallCaps(),
+            legacyOptions.headerItalic: Self.font(familyName: italicFamilyName, size: baseSize * 1.1).italic(),
+            legacyOptions.headerSmaller: Self.font(familyName: familyName, size: baseSize * 0.9).weight(.medium),
+            legacyOptions.header2: Self.font(familyName: familyName, size: baseSize * 1.1).weight(.bold),
+            legacyOptions.header3: Self.font(familyName: familyName, size: baseSize * 1.1),
+            legacyOptions.header4: Self.font(familyName: familyName, size: baseSize * 1.1),
+            legacyOptions.header: Self.font(familyName: familyName, size: baseSize).bold(),
+            legacyOptions.headerSmallerItalic: Self.font(familyName: italicFamilyName, size: baseSize * 0.76).italic(),
+            legacyOptions.textFont: Self.font(familyName: familyName, size: baseSize),
+            legacyOptions.font100emSmallCaps: Self.font(familyName: familyName, size: baseSize).lowercaseSmallCaps()
         ]
     }
 

--- a/Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift
+++ b/Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift
@@ -40,6 +40,9 @@ public enum BibleTextFontOption {
     case font100emSmallCaps
 }
 
+// This protocol exists only to provide compability while also
+// avoiding us getting compilation warnings for our test cases etc.
+// When we remove the enum values such as .textFont, it should be removed.
 private protocol LegacyBibleTextFontOptions {
     static var textFont: BibleTextFontOption { get }
     static var textFontBold: BibleTextFontOption { get }
@@ -98,7 +101,7 @@ public struct BibleTextFonts {
             .footnote: Self.font(familyName: familyName, size: baseSize * 0.8),
             .verseNumFont: Self.font(familyName: "Helvetica Neue", size: baseSize * 0.65).smallCaps(),
             
-            // below are deprecated:
+            // below are deprecated, and will be removed when .textFont etc. are removed:
             legacyOptions.textFontItalic: Self.font(familyName: italicFamilyName, size: baseSize).italic(),
             legacyOptions.textFontBold: Self.font(familyName: familyName, size: baseSize).bold(),
             legacyOptions.smallCaps: Self.font(familyName: familyName, size: baseSize).lowercaseSmallCaps(),

--- a/Tests/YouVersionPlatformCoreTests/UsersModelsTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/UsersModelsTests.swift
@@ -4,6 +4,7 @@ import Testing
 
 @Suite struct UsersModelsTests {
 
+    @available(*, deprecated, message: "Exercises deprecated permission values for backwards compatibility.")
     @Test func permissionRawValuesAndDescription() throws {
         #expect(SignInWithYouVersionPermission.openid.rawValue == "openid")
         #expect(SignInWithYouVersionPermission.profile.rawValue == "profile")
@@ -12,6 +13,7 @@ import Testing
         #expect(SignInWithYouVersionPermission.allCases == [.openid, .profile, .email])
     }
 
+    @available(*, deprecated, message: "Exercises deprecated permission decoding for backwards compatibility.")
     @Test func decodingUnknownPermissionValueThrows() throws {
         let data = Data(#""future-permission""#.utf8)
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR suppresses compiler deprecation warnings in backward-compatibility code across three files using idiomatic Swift techniques, without changing any runtime behavior.

- **`YouVersionPlatformConfiguration.swift`**: Adds `@available(*, deprecated)` to `permissionEnums` and the enum-typed `hasPermission(_:)` overload, forming a consistent deprecation chain so internal callers no longer generate warnings.
- **`BibleTextFonts.swift`**: Introduces a `private protocol LegacyBibleTextFontOptions` whose requirements are satisfied by the 12 deprecated `BibleTextFontOption` cases. Accessing them through a metatype cast (`BibleTextFontOption.self as LegacyBibleTextFontOptions.Type`) is a well-established Swift technique that suppresses call-site warnings while keeping the dictionary entries functionally identical.
- **`UsersModelsTests.swift`**: Marks the two tests that exercise deprecated `SignInWithYouVersionPermission` APIs as `@available(*, deprecated)`, the idiomatic Swift pattern for silencing internal deprecation noise in backward-compatibility tests without disabling those tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely compile-time annotation changes with no runtime behavior differences.

All three changes are annotation-only: the deprecated @available markers and the protocol trick affect only what warnings the compiler emits. The deprecated enum cases and their font mappings in BibleTextFonts are identical to the previous code, just accessed through a different path. The test functions remain discoverable and runnable by the Swift Testing framework.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift | Marks `permissionEnums` and `hasPermission(_:SignInWithYouVersionPermission)` as `@available(*, deprecated)` with clear migration messages; the deprecation chain is consistent and both the internal and public APIs are correctly annotated. |
| Sources/YouVersionPlatformUI/Objects/BibleTextFonts.swift | Introduces a private `LegacyBibleTextFontOptions` protocol and a metatype cast to access all 12 deprecated `BibleTextFontOption` cases without triggering compiler deprecation warnings; the protocol lists every deprecated case and the dictionary mapping is identical to the pre-existing code. |
| Tests/YouVersionPlatformCoreTests/UsersModelsTests.swift | Two `@Test` functions that exercise deprecated `SignInWithYouVersionPermission` APIs are annotated `@available(*, deprecated)`, which is the idiomatic Swift way to suppress internal deprecation warnings while keeping the tests discoverable and runnable. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Public API
        A["hasPermission(_ permission: SignInWithYouVersionPermission)\n@available(*, deprecated)"]
    end

    subgraph Internal API
        B["permissionEnums: [SignInWithYouVersionPermission]\n@available(*, deprecated)"]
    end

    subgraph Tests
        T1["@Test permissionRawValuesAndDescription()\n@available(*, deprecated)"]
        T2["@Test decodingUnknownPermissionValueThrows()\n@available(*, deprecated)"]
    end

    subgraph BibleTextFonts Compatibility
        P["private protocol LegacyBibleTextFontOptions\n(12 deprecated case requirements)"]
        E["extension BibleTextFontOption: LegacyBibleTextFontOptions"]
        C["let legacyOptions = BibleTextFontOption.self\n    as LegacyBibleTextFontOptions.Type"]
        D["Dictionary entries via legacyOptions.textFont, .header, etc.\n(no deprecation warnings at call site)"]
    end

    A -->|calls| B
    T1 -->|exercises| A
    T2 -->|exercises deprecated SignInWithYouVersionPermission decoding| A
    P --> E
    E --> C
    C --> D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Public API
        A["hasPermission(_ permission: SignInWithYouVersionPermission)\n@available(*, deprecated)"]
    end

    subgraph Internal API
        B["permissionEnums: [SignInWithYouVersionPermission]\n@available(*, deprecated)"]
    end

    subgraph Tests
        T1["@Test permissionRawValuesAndDescription()\n@available(*, deprecated)"]
        T2["@Test decodingUnknownPermissionValueThrows()\n@available(*, deprecated)"]
    end

    subgraph BibleTextFonts Compatibility
        P["private protocol LegacyBibleTextFontOptions\n(12 deprecated case requirements)"]
        E["extension BibleTextFontOption: LegacyBibleTextFontOptions"]
        C["let legacyOptions = BibleTextFontOption.self\n    as LegacyBibleTextFontOptions.Type"]
        D["Dictionary entries via legacyOptions.textFont, .header, etc.\n(no deprecation warnings at call site)"]
    end

    A -->|calls| B
    T1 -->|exercises| A
    T2 -->|exercises deprecated SignInWithYouVersionPermission decoding| A
    P --> E
    E --> C
    C --> D
```

</a>

<sub>Reviews (3): Last reviewed commit: ["chore: merge main"](https://github.com/youversion/platform-sdk-swift/commit/bb101bb07c078356f12847d4848fe33ce753fd0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44621039)</sub>

<!-- /greptile_comment -->