### PR TITLE
fix: split wall-of-text chapters into 10-verse chunks when necessary

### DIFF
--- a/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
@@ -17,6 +17,9 @@ public struct BibleTextView: View {
     @Binding var selectedVerses: Set<BibleReference>
     @Environment(\.colorScheme) private var colorScheme
     
+    private static let longBlockCharacterThreshold = 2000
+    private static let maximumVersesPerBlock = 10
+
     var ourHighlights: [BibleHighlight] {
         BibleHighlightsCache.shared.highlights(overlapping: reference)
     }
@@ -204,7 +207,7 @@ public struct BibleTextView: View {
         }
         do {
             if let providedBlocks {
-                self.blocks = providedBlocks
+                blocks = Self.blocksForDisplay(providedBlocks)
                 await updateVersionTextDirection()
                 loadingPhase = nil  // meaning, we've succeeded
             } else if let blocks = try await BibleVersionRendering.textBlocks(
@@ -218,7 +221,7 @@ public struct BibleTextView: View {
                 wocColor: textOptions.wordsOfChristColor,
                 fonts: BibleTextFonts(familyName: textOptions.fontFamily, baseSize: textOptions.fontSize)
             ) {
-                self.blocks = blocks
+                self.blocks = Self.blocksForDisplay(blocks)
                 await updateVersionTextDirection()
                 loadingPhase = nil  // meaning, we've succeeded
             } else {
@@ -232,6 +235,21 @@ public struct BibleTextView: View {
             YouVersionPlatformLogger.error("loadBlocks unexpected error: \(err)", category: "BibleText")
             loadingPhase = .failed
         }
+    }
+
+    /// When blocks is a single overly-large block, splits it into multiple smaller blocks.
+    /// This works around an memory allocation bug in iOS's textRenderer() implementation.
+    static func blocksForDisplay(
+        _ blocks: [BibleTextBlock],
+        longBlockCharacterThreshold: Int = Self.longBlockCharacterThreshold,
+        maximumVerseCount: Int = Self.maximumVersesPerBlock
+    ) -> [BibleTextBlock] {
+        guard blocks.count == 1,
+              let block = blocks.first,
+              block.text.asAttributedString.characters.count > longBlockCharacterThreshold else {
+            return blocks
+        }
+        return block.split(maximumVerseCount: maximumVerseCount)
     }
 
     @available(*, deprecated, renamed: "init(html:reference:textOptions:onVerseTap:)")

--- a/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView.swift
@@ -246,6 +246,7 @@ public struct BibleTextView: View {
     ) -> [BibleTextBlock] {
         guard blocks.count == 1,
               let block = blocks.first,
+              block.rows.isEmpty,
               block.text.asAttributedString.characters.count > longBlockCharacterThreshold else {
             return blocks
         }

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleAttributedString.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleAttributedString.swift
@@ -12,6 +12,10 @@ public final class BibleAttributedString: Equatable, Hashable {
         two = AttributedString(string)
     }
 
+    init(_ attributedString: AttributedString) {
+        two = attributedString
+    }
+
     static func +(lhs: BibleAttributedString, rhs: BibleAttributedString) -> BibleAttributedString { //swiftlint:disable:this function_name_whitespace
         let result = BibleAttributedString()
         result.two = lhs.two + rhs.two

--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleTextBlock.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleTextBlock.swift
@@ -67,4 +67,44 @@ public struct BibleTextBlock: Identifiable {
         let reference = firstScriptureRun?.1
         return reference?.verseStart
     }
+
+    /// Splits this block at Bible-reference run boundaries so each result contains no more than the requested verses.
+    /// Each result preserves the original layout metadata and receives only the footnotes referenced by its text.
+    func split(maximumVerseCount: Int) -> [BibleTextBlock] {
+        let attributedString = text.asAttributedString
+        var previousVerse: Int?
+        var verseCount = 0
+        let splitIndexes = attributedString.runs[\.bibleReference].compactMap { reference, range -> AttributedString.Index? in
+            guard let verse = reference?.verseStart, verse != previousVerse else {
+                return nil
+            }
+            previousVerse = verse
+            if verseCount == maximumVerseCount {
+                verseCount = 1
+                return range.lowerBound
+            }
+            verseCount += 1
+            return nil
+        }
+
+        guard !splitIndexes.isEmpty else {
+            return [self]
+        }
+
+        let boundaries = [attributedString.startIndex] + splitIndexes + [attributedString.endIndex]
+        return zip(boundaries, boundaries.dropFirst()).enumerated().map { index, bounds in
+            let slice = BibleAttributedString(AttributedString(attributedString[bounds.0..<bounds.1]))
+            let references = Set(slice.asAttributedString.runs[\.bibleReference].compactMap { reference, _ in reference })
+            return BibleTextBlock(
+                text: slice,
+                chapter: chapter,
+                firstLineHeadIndent: firstLineHeadIndent,
+                headIndent: headIndent,
+                marginTop: index == 0 ? marginTop : 0,
+                marginBottom: index == splitIndexes.count ? marginBottom : 0,
+                alignment: alignment,
+                footnotes: footnotes.filter { references.contains($0.reference) }
+            )
+        }
+    }
 }

--- a/Tests/YouVersionPlatformUITests/BibleVersionRenderingTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionRenderingTests.swift
@@ -312,6 +312,74 @@ import Testing
         #expect(layout.blockFirstVerse(forTargetVerse: 2) == 1)
     }
 
+    @Test func testLongBlockSplitsAtMaximumVerseCount() async throws {
+        let html = """
+        <div>
+            <div class="p">
+                \((1...45).map { verse in
+                    "<span class=\"yv-v\" v=\"\(verse)\"></span><span class=\"yv-vlbl\">\(verse)</span> Verse \(verse) text."
+                }.joined())
+            </div>
+        </div>
+        """
+        let reference = BibleReference(versionId: defaultVersionId, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 45)
+        let blocks = try await renderBlocks(html: html, reference: reference)
+        let block = try #require(blocks.first)
+        #expect(blocks.count == 1)
+        let footnote = BibleFootnote(
+            text: BibleAttributedString("Verse 21 footnote."),
+            reference: BibleReference(versionId: defaultVersionId, bookUSFM: "GEN", chapter: 1, verse: 21),
+            id: "1"
+        )
+        let configuredBlock = BibleTextBlock(
+            text: block.text,
+            chapter: block.chapter,
+            firstLineHeadIndent: 4,
+            headIndent: 8,
+            marginTop: 12,
+            marginBottom: 16,
+            alignment: .center,
+            footnotes: [footnote]
+        )
+
+        let splitBlocks = BibleTextView.blocksForDisplay(
+            [configuredBlock],
+            longBlockCharacterThreshold: 1,
+            maximumVerseCount: 20
+        )
+
+        #expect(splitBlocks.count == 3)
+        #expect(splitBlocks.compactMap(\.firstVerse) == [1, 21, 41])
+        #expect(splitBlocks.allSatisfy { $0.chapter == configuredBlock.chapter })
+        #expect(splitBlocks.allSatisfy { $0.firstLineHeadIndent == 4 && $0.headIndent == 8 })
+        #expect(splitBlocks.allSatisfy { $0.alignment == .center })
+        #expect(splitBlocks.map(\.marginTop) == [12, 0, 0])
+        #expect(splitBlocks.map(\.marginBottom) == [0, 0, 16])
+        #expect(splitBlocks.map(\.footnotes) == [[], [footnote], []])
+        #expect(splitBlocks[0].text.characters.contains("Verse 20 text."))
+        #expect(!splitBlocks[0].text.characters.contains("Verse 21 text."))
+        #expect(splitBlocks[1].text.characters.contains("Verse 40 text."))
+        #expect(!splitBlocks[1].text.characters.contains("Verse 41 text."))
+        #expect(splitBlocks[2].text.characters.contains("Verse 45 text."))
+    }
+
+    @Test func testShortAndAlreadyFormattedBlocksRemainUnchanged() async throws {
+        let html = """
+        <div>
+            <div class="p"><span class="yv-v" v="1"></span>First verse.</div>
+            <div class="p"><span class="yv-v" v="2"></span>Second verse.</div>
+        </div>
+        """
+        let reference = BibleReference(versionId: defaultVersionId, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 2)
+        let blocks = try await renderBlocks(html: html, reference: reference)
+
+        let alreadyFormattedBlocks = BibleTextView.blocksForDisplay(blocks, longBlockCharacterThreshold: 1)
+        let shortSingleBlock = BibleTextView.blocksForDisplay([try #require(blocks.first)], longBlockCharacterThreshold: 1_000)
+
+        #expect(alreadyFormattedBlocks.map(\.id) == blocks.map(\.id))
+        #expect(shortSingleBlock.map(\.id) == [blocks[0].id])
+    }
+
     @Test func testAcrosticChapterResolvesTargetVerseToOwningBlock() async throws {
         // Mirrors Psalm 119's shape: stanzas of verses separated by letter
         // headings, rendered as a full chapter. Verse 105 must resolve to its own

--- a/Tests/YouVersionPlatformUITests/BibleVersionRenderingTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionRenderingTests.swift
@@ -29,6 +29,28 @@ import Testing
         return try #require(blocks)
     }
 
+    private func singleBlock(verseCount: Int) async throws -> BibleTextBlock {
+        let html = """
+        <div>
+            <div class="p">
+                \((1...verseCount).map { verse in
+                    "<span class=\"yv-v\" v=\"\(verse)\"></span><span class=\"yv-vlbl\">\(verse)</span> Verse \(verse) text."
+                }.joined())
+            </div>
+        </div>
+        """
+        let reference = BibleReference(
+            versionId: defaultVersionId,
+            bookUSFM: "GEN",
+            chapter: 1,
+            verseStart: 1,
+            verseEnd: verseCount
+        )
+        let blocks = try await renderBlocks(html: html, reference: reference)
+        #expect(blocks.count == 1)
+        return try #require(blocks.first)
+    }
+
     private func hasHeaderContaining(_ blocks: [BibleTextBlock], text: String) -> Bool {
         blocks.contains { block in
             let runs = block.text.asAttributedString.runs[\.bibleTextCategory]
@@ -313,19 +335,7 @@ import Testing
     }
 
     @Test func testLongBlockSplitsAtMaximumVerseCount() async throws {
-        let html = """
-        <div>
-            <div class="p">
-                \((1...45).map { verse in
-                    "<span class=\"yv-v\" v=\"\(verse)\"></span><span class=\"yv-vlbl\">\(verse)</span> Verse \(verse) text."
-                }.joined())
-            </div>
-        </div>
-        """
-        let reference = BibleReference(versionId: defaultVersionId, bookUSFM: "GEN", chapter: 1, verseStart: 1, verseEnd: 45)
-        let blocks = try await renderBlocks(html: html, reference: reference)
-        let block = try #require(blocks.first)
-        #expect(blocks.count == 1)
+        let block = try await singleBlock(verseCount: 45)
         let footnote = BibleFootnote(
             text: BibleAttributedString("Verse 21 footnote."),
             reference: BibleReference(versionId: defaultVersionId, bookUSFM: "GEN", chapter: 1, verse: 21),
@@ -361,6 +371,29 @@ import Testing
         #expect(splitBlocks[1].text.characters.contains("Verse 40 text."))
         #expect(!splitBlocks[1].text.characters.contains("Verse 41 text."))
         #expect(splitBlocks[2].text.characters.contains("Verse 45 text."))
+    }
+
+    @Test func testLongBlockWithRowsRemainsUnchanged() async throws {
+        let block = try await singleBlock(verseCount: 45)
+        let tableBlock = BibleTextBlock(
+            text: block.text,
+            chapter: block.chapter,
+            firstLineHeadIndent: block.firstLineHeadIndent,
+            headIndent: block.headIndent,
+            marginTop: block.marginTop,
+            marginBottom: block.marginBottom,
+            alignment: block.alignment,
+            footnotes: block.footnotes,
+            rows: [[BibleAttributedString("Cell")]]
+        )
+
+        let displayBlocks = BibleTextView.blocksForDisplay(
+            [tableBlock],
+            longBlockCharacterThreshold: 1,
+            maximumVerseCount: 20
+        )
+
+        #expect(displayBlocks.map(\.id) == [tableBlock.id])
     }
 
     @Test func testShortAndAlreadyFormattedBlocksRemainUnchanged() async throws {


### PR DESCRIPTION
Some bible versions (e.g. GNV) have zero formatting and the entire chapter is one paragraph. That makes iOS fail to allocate a buffer when rendering the text object, particularly when the user has chosen a large font and/or lineSpacing. 

This PR notices when it's given a single huge block of text, and splits it in 10-verse chunks.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a safeguard that splits a single wall-of-text Bible chapter block into 10-verse chunks, working around an iOS memory allocation failure in `textRenderer()` for large `AttributedString` objects. The implementation is clean, well-tested, and appropriately scoped.

- `BibleTextView.blocksForDisplay()` acts as a gating function: it only splits when there is exactly one block, it is not a table (`rows.isEmpty`), and its character count exceeds a 2,000-character threshold. This prevents any impact on already-formatted chapters.
- `BibleTextBlock.split(maximumVerseCount:)` walks `AttributedString` runs, counts unique verses, and records split-boundaries in a single pass. The resulting blocks correctly preserve layout metadata (indentation, margins, alignment) and filter footnotes to only those whose `BibleReference` appears in each slice's runs.
- Three new `@Test` cases cover the main split scenario (45 verses, custom metadata, footnote redistribution), the table-block bypass, and the short/already-formatted bypass.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a data-transformation layer that only activates for single, unformatted, over-threshold blocks and returns everything else unchanged.

The gating function exits immediately for multi-block chapters, table blocks, and short blocks, so the split path is narrowly exercised. The verse-counting, boundary construction, margin assignment, and footnote filtering are all verified end-to-end by three new tests. No existing code paths are removed or altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformUI/Views/Rendering/BibleTextBlock.swift | Adds the internal `split(maximumVerseCount:)` method; verse-counting logic, margin assignment, and footnote filtering are all correct. |
| Sources/YouVersionPlatformUI/Views/BibleTextView.swift | Adds `blocksForDisplay()` gating function with constants; both `providedBlocks` and fetched-blocks paths are correctly updated to use it. |
| Sources/YouVersionPlatformUI/Views/Rendering/BibleAttributedString.swift | Adds an internal `init(_ attributedString: AttributedString)` initializer needed by `split`; correctly scoped as internal. |
| Tests/YouVersionPlatformUITests/BibleVersionRenderingTests.swift | Adds three new tests covering the split path, table-block bypass, and short/already-formatted bypass; uses `@testable import` to access internal APIs correctly. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant BTV as BibleTextView
    participant BFD as blocksForDisplay()
    participant BTB as BibleTextBlock
    participant AS as AttributedString runs

    BTV->>BFD: blocksForDisplay(blocks)
    BFD->>BFD: "guard blocks.count == 1 AND rows.isEmpty AND characters.count > 2000"
    alt short / multi-block / table
        BFD-->>BTV: return blocks unchanged
    else single long text block
        BFD->>BTB: block.split(maximumVerseCount: 10)
        BTB->>AS: iterate runs by bibleReference
        loop each unique verse run
            AS-->>BTB: (reference, range)
            BTB->>BTB: "if verseCount == max, record splitIndex and reset"
            BTB->>BTB: "else verseCount += 1"
        end
        BTB->>BTB: build boundaries array
        loop each slice
            BTB->>BTB: slice AttributedString, filter footnotes, assign margins
        end
        BTB-->>BFD: N BibleTextBlock chunks
        BFD-->>BTV: split blocks
    end
    BTV->>BTV: render blocks
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant BTV as BibleTextView
    participant BFD as blocksForDisplay()
    participant BTB as BibleTextBlock
    participant AS as AttributedString runs

    BTV->>BFD: blocksForDisplay(blocks)
    BFD->>BFD: "guard blocks.count == 1 AND rows.isEmpty AND characters.count > 2000"
    alt short / multi-block / table
        BFD-->>BTV: return blocks unchanged
    else single long text block
        BFD->>BTB: block.split(maximumVerseCount: 10)
        BTB->>AS: iterate runs by bibleReference
        loop each unique verse run
            AS-->>BTB: (reference, range)
            BTB->>BTB: "if verseCount == max, record splitIndex and reset"
            BTB->>BTB: "else verseCount += 1"
        end
        BTB->>BTB: build boundaries array
        loop each slice
            BTB->>BTB: slice AttributedString, filter footnotes, assign margins
        end
        BTB-->>BFD: N BibleTextBlock chunks
        BFD-->>BTV: split blocks
    end
    BTV->>BTV: render blocks
```

</a>

<sub>Reviews (3): Last reviewed commit: ["chore: merge main"](https://github.com/youversion/platform-sdk-swift/commit/fdeb3a8e8a020c50266e41419cd6038af97750b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45200090)</sub>

<!-- /greptile_comment -->