### PR TITLE
fix: avoid data race while refreshing tokens

### DIFF
--- a/Sources/YouVersionPlatformCore/APIs/Bible/Highlights.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/Highlights.swift
@@ -59,7 +59,7 @@ public extension YouVersionAPI {
             accessToken providedToken: String? = nil,
             session: URLSession = .shared
         ) async throws -> [HighlightResponse] {
-            guard let accessToken = providedToken ?? YouVersionPlatformConfiguration.accessToken else {
+            guard let accessToken = await YouVersionAPI.accessToken(providedToken: providedToken, session: session) else {
                 throw YouVersionAPIError.missingAuthentication
             }
 
@@ -154,7 +154,7 @@ public extension YouVersionAPI {
             accessToken providedToken: String?,
             session: URLSession
         ) async throws -> Bool {
-            guard let accessToken = providedToken ?? YouVersionPlatformConfiguration.accessToken else {
+            guard let accessToken = await YouVersionAPI.accessToken(providedToken: providedToken, session: session) else {
                 throw YouVersionAPIError.missingAuthentication
             }
             guard let url = URLBuilder.highlightsURL else {
@@ -208,7 +208,7 @@ public extension YouVersionAPI {
             accessToken providedToken: String? = nil,
             session: URLSession = .shared
         ) async throws -> Bool {
-            guard let accessToken = providedToken ?? YouVersionPlatformConfiguration.accessToken else {
+            guard let accessToken = await YouVersionAPI.accessToken(providedToken: providedToken, session: session) else {
                 throw YouVersionAPIError.missingAuthentication
             }
             guard let url = URLBuilder.highlightsDeleteURL(bibleId: bibleId, passageId: passageId) else {

--- a/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
@@ -5,6 +5,8 @@ import FoundationNetworking
 
 public enum YouVersionAPI {
 
+    private static let accessTokenProvider = AccessTokenProvider()
+
     /// This doesn't refresh the token when required, and therefore doesn't have to be async.
     public static var isSignedIn: Bool {
         YouVersionPlatformConfiguration.accessToken != nil
@@ -12,29 +14,14 @@ public enum YouVersionAPI {
 
     /// This can cause a token refresh if an access token is present but is old.
     public static func hasValidToken(session: URLSession = .shared) async -> Bool {
-        guard let data = YouVersionPlatformConfiguration.authData,
-              let expiry = data.expiryDate
-        else {
-            return false
+        await accessTokenProvider.accessToken(session: session) != nil
+    }
+
+    static func accessToken(providedToken: String?, session: URLSession) async -> String? {
+        if let providedToken {
+            return providedToken
         }
-        guard expiry.timeIntervalSinceNow < 30 else {
-            return true
-        }
-        guard let refreshToken = data.refreshToken,
-              let result = try? await Users.refreshSignIn(withToken: refreshToken, idToken: data.idToken, session: session) else {
-            YouVersionPlatformLogger.error("token refresh failed", category: "Auth")
-            return false
-        }
-        await MainActor.run {
-            YouVersionPlatformConfiguration.saveAuthData(
-                accessToken: result.accessToken,
-                refreshToken: result.refreshToken,
-                idToken: result.idToken,
-                expiryDate: result.expiryDate,
-                permissions: result.permissionValues
-            )
-        }
-        return true
+        return await accessTokenProvider.accessToken(session: session)
     }
 
     static func data(at url: URL, accessToken: String?, session: URLSession) async throws -> Data {
@@ -90,6 +77,64 @@ public enum YouVersionAPI {
         }
 
         return request
+    }
+}
+
+private actor AccessTokenProvider {
+    private var refreshTask: Task<String?, Never>?
+
+    func accessToken(session: URLSession) async -> String? {
+        guard let authData = YouVersionPlatformConfiguration.authData,
+              let accessToken = authData.accessToken,
+              let expiryDate = authData.expiryDate else {
+            return nil
+        }
+        guard expiryDate.timeIntervalSinceNow < 30 else {
+            return accessToken
+        }
+        if let refreshTask {
+            return await refreshTask.value
+        }
+        guard let refreshToken = authData.refreshToken else {
+            return nil
+        }
+
+        let task = Task {
+            await Self.refreshAccessToken(
+                refreshToken: refreshToken,
+                idToken: authData.idToken,
+                session: session
+            )
+        }
+        refreshTask = task
+        let refreshedAccessToken = await task.value
+        refreshTask = nil
+        return refreshedAccessToken
+    }
+
+    private static func refreshAccessToken(
+        refreshToken: String,
+        idToken: String?,
+        session: URLSession
+    ) async -> String? {
+        guard let result = try? await YouVersionAPI.Users.refreshSignIn(
+            withToken: refreshToken,
+            idToken: idToken,
+            session: session
+        ) else {
+            YouVersionPlatformLogger.error("token refresh failed", category: "Auth")
+            return nil
+        }
+        await MainActor.run {
+            YouVersionPlatformConfiguration.saveAuthData(
+                accessToken: result.accessToken,
+                refreshToken: result.refreshToken,
+                idToken: result.idToken,
+                expiryDate: result.expiryDate,
+                permissions: result.permissionValues
+            )
+        }
+        return result.accessToken
     }
 }
 

--- a/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
@@ -85,9 +85,11 @@ private actor AccessTokenProvider {
 
     func accessToken(session: URLSession) async -> String? {
         guard let authData = YouVersionPlatformConfiguration.authData,
-              let accessToken = authData.accessToken,
-              let expiryDate = authData.expiryDate else {
+              let accessToken = authData.accessToken else {
             return nil
+        }
+        guard let expiryDate = authData.expiryDate else {
+            return accessToken
         }
         guard expiryDate.timeIntervalSinceNow < 30 else {
             return accessToken

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
@@ -30,8 +30,11 @@ public class BibleHighlightsViewModel: ObservableObject {
             object: nil,
             queue: nil
         ) { [weak self] _ in
+            let isSignedIn = YouVersionAPI.isSignedIn
             Task { @MainActor in
-                self?.reset()
+                if !isSignedIn {
+                    self?.reset()
+                }
             }
         }
     }

--- a/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleHighlightsViewModel.swift
@@ -30,11 +30,8 @@ public class BibleHighlightsViewModel: ObservableObject {
             object: nil,
             queue: nil
         ) { [weak self] _ in
-            let isSignedIn = YouVersionAPI.isSignedIn
             Task { @MainActor in
-                if !isSignedIn {
-                    self?.reset()
-                }
+                self?.reset()
             }
         }
     }

--- a/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
+++ b/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
@@ -118,15 +118,13 @@ public struct YouVersionPlatformConfiguration {
     }
 
     public static var authData: SignInWithYouVersionResult? {
-        guard
-            let accessToken = UserDefaults.standard.string(forKey: accessTokenKey),
-            let refreshToken = UserDefaults.standard.string(forKey: refreshTokenKey),
-            let expiryDate = UserDefaults.standard.object(forKey: expiryDateKey) as? Date
-        else {
+        guard let accessToken = UserDefaults.standard.string(forKey: accessTokenKey) else {
             return nil
         }
 
+        let refreshToken = UserDefaults.standard.string(forKey: refreshTokenKey)
         let idToken = UserDefaults.standard.string(forKey: idTokenKey)
+        let expiryDate = UserDefaults.standard.object(forKey: expiryDateKey) as? Date
 
         return SignInWithYouVersionResult(
             accessToken: accessToken,

--- a/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
+++ b/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
@@ -96,7 +96,7 @@ public struct YouVersionPlatformConfiguration {
         expiryDate: Date?,
         permissions: [String]? = nil
     ) {
-        let previousAccessToken = Self.accessToken
+        let wasSignedIn = Self.accessToken != nil
         UserDefaults.standard.set(accessToken, forKey: accessTokenKey)
         UserDefaults.standard.set(refreshToken, forKey: refreshTokenKey)
         UserDefaults.standard.set(idToken, forKey: idTokenKey)
@@ -104,7 +104,7 @@ public struct YouVersionPlatformConfiguration {
         if let permissions {
             savePermissions(permissions)
         }
-        postAuthStateDidChangeNotificationIfNeeded(previousAccessToken: previousAccessToken)
+        postAuthStateDidChangeNotificationIfNeeded(wasSignedIn: wasSignedIn)
     }
 
     @MainActor
@@ -150,8 +150,8 @@ public struct YouVersionPlatformConfiguration {
         storedPermissions.contains(permission)
     }
 
-    private static func postAuthStateDidChangeNotificationIfNeeded(previousAccessToken: String?) {
-        guard previousAccessToken != accessToken else {
+    private static func postAuthStateDidChangeNotificationIfNeeded(wasSignedIn: Bool) {
+        guard wasSignedIn != (accessToken != nil) else {
             return
         }
         NotificationCenter.default.post(name: authStateDidChangeNotification, object: nil)

--- a/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
+++ b/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
@@ -96,7 +96,7 @@ public struct YouVersionPlatformConfiguration {
         expiryDate: Date?,
         permissions: [String]? = nil
     ) {
-        let wasSignedIn = Self.accessToken != nil
+        let previousAccessToken = Self.accessToken
         UserDefaults.standard.set(accessToken, forKey: accessTokenKey)
         UserDefaults.standard.set(refreshToken, forKey: refreshTokenKey)
         UserDefaults.standard.set(idToken, forKey: idTokenKey)
@@ -104,7 +104,7 @@ public struct YouVersionPlatformConfiguration {
         if let permissions {
             savePermissions(permissions)
         }
-        postAuthStateDidChangeNotificationIfNeeded(wasSignedIn: wasSignedIn)
+        postAuthStateDidChangeNotificationIfNeeded(previousAccessToken: previousAccessToken)
     }
 
     @MainActor
@@ -152,8 +152,8 @@ public struct YouVersionPlatformConfiguration {
         storedPermissions.contains(permission)
     }
 
-    private static func postAuthStateDidChangeNotificationIfNeeded(wasSignedIn: Bool) {
-        guard wasSignedIn != (accessToken != nil) else {
+    private static func postAuthStateDidChangeNotificationIfNeeded(previousAccessToken: String?) {
+        guard previousAccessToken != accessToken else {
             return
         }
         NotificationCenter.default.post(name: authStateDidChangeNotification, object: nil)

--- a/Tests/YouVersionPlatformCoreTests/YouVersionAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/YouVersionAPITests.swift
@@ -86,6 +86,63 @@ extension ConfigurationStateTests {
             await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
         }
 
+        @Test func authenticatedRequestWaitsForSharedTokenRefresh() async throws {
+            let originalAppKey = YouVersionPlatformConfiguration.appKey
+            let responsePayload: [String: String] = [
+                "access_token": "new-access-token",
+                "expires_in": "7200",
+                "refresh_token": "new-refresh-token",
+                "scope": "highlights"
+            ]
+            let responseData = try JSONEncoder().encode(responsePayload)
+
+            await YouVersionPlatformConfiguration.configure(appKey: "test-app")
+            await YouVersionPlatformConfiguration.saveAuthData(
+                accessToken: "expired-access-token",
+                refreshToken: "old-refresh-token",
+                idToken: "id-token",
+                expiryDate: Date(timeIntervalSinceNow: -60),
+                permissions: ["highlights"]
+            )
+
+            let (session, token) = HTTPMocking.makeSession()
+            defer { HTTPMocking.clear(token: token) }
+            var refreshRequestCount = 0
+            var highlightsAuthorizationHeader: String?
+
+            HTTPMocking.setHandler(token: token) { request in
+                switch request.url?.path {
+                case "/auth/token":
+                    refreshRequestCount += 1
+                    Thread.sleep(forTimeInterval: 0.1)
+                    let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                    return (responseData, response)
+                case "/v1/highlights":
+                    highlightsAuthorizationHeader = request.value(forHTTPHeaderField: "Authorization")
+                    let response = HTTPURLResponse(url: request.url!, statusCode: 204, httpVersion: nil, headerFields: nil)!
+                    return (Data(), response)
+                default:
+                    throw URLError(.badURL)
+                }
+            }
+
+            async let tokenIsValid = YouVersionAPI.hasValidToken(session: session)
+            async let highlights = YouVersionAPI.Highlights.highlights(
+                bibleId: 1,
+                passageId: "GEN.1",
+                session: session
+            )
+            let (isValid, loadedHighlights) = try await (tokenIsValid, highlights)
+
+            #expect(isValid)
+            #expect(loadedHighlights.isEmpty)
+            #expect(refreshRequestCount == 1)
+            #expect(highlightsAuthorizationHeader == "Bearer new-access-token")
+
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+            await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+        }
+
         @Test func hasValidTokenReturnsFalseWhenRefreshFails() async {
             let originalAppKey = YouVersionPlatformConfiguration.appKey
             await YouVersionPlatformConfiguration.configure(appKey: "test-app")

--- a/Tests/YouVersionPlatformCoreTests/YouVersionAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/YouVersionAPITests.swift
@@ -139,6 +139,15 @@ extension ConfigurationStateTests {
             #expect(refreshRequestCount == 1)
             #expect(highlightsAuthorizationHeader == "Bearer new-access-token")
 
+            _ = try await YouVersionAPI.Highlights.highlights(
+                bibleId: 1,
+                passageId: "GEN.2",
+                session: session
+            )
+
+            #expect(refreshRequestCount == 1)
+            #expect(highlightsAuthorizationHeader == "Bearer new-access-token")
+
             await YouVersionPlatformConfiguration.clearAuthTokens()
             await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
         }

--- a/Tests/YouVersionPlatformCoreTests/YouVersionAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/YouVersionAPITests.swift
@@ -39,6 +39,66 @@ extension ConfigurationStateTests {
             await YouVersionPlatformConfiguration.clearAuthTokens()
         }
 
+        @Test func authenticatedRequestUsesAccessTokenWithoutRefreshTokenWhenUnexpired() async throws {
+            await YouVersionPlatformConfiguration.saveAuthData(
+                accessToken: "access-token",
+                refreshToken: nil,
+                idToken: nil,
+                expiryDate: Date(timeIntervalSinceNow: 3600)
+            )
+
+            let (session, token) = HTTPMocking.makeSession()
+            defer { HTTPMocking.clear(token: token) }
+            var authorizationHeader: String?
+
+            HTTPMocking.setHandler(token: token) { request in
+                #expect(request.url?.path == "/v1/highlights")
+                authorizationHeader = request.value(forHTTPHeaderField: "Authorization")
+                let response = HTTPURLResponse(url: request.url!, statusCode: 204, httpVersion: nil, headerFields: nil)!
+                return (Data(), response)
+            }
+
+            _ = try await YouVersionAPI.Highlights.highlights(
+                bibleId: 1,
+                passageId: "GEN.1",
+                session: session
+            )
+
+            #expect(authorizationHeader == "Bearer access-token")
+
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+        }
+
+        @Test func authenticatedRequestUsesAccessTokenWhenExpiryIsUnknown() async throws {
+            await YouVersionPlatformConfiguration.saveAuthData(
+                accessToken: "access-token",
+                refreshToken: nil,
+                idToken: nil,
+                expiryDate: nil
+            )
+
+            let (session, token) = HTTPMocking.makeSession()
+            defer { HTTPMocking.clear(token: token) }
+            var authorizationHeader: String?
+
+            HTTPMocking.setHandler(token: token) { request in
+                #expect(request.url?.path == "/v1/highlights")
+                authorizationHeader = request.value(forHTTPHeaderField: "Authorization")
+                let response = HTTPURLResponse(url: request.url!, statusCode: 204, httpVersion: nil, headerFields: nil)!
+                return (Data(), response)
+            }
+
+            _ = try await YouVersionAPI.Highlights.highlights(
+                bibleId: 1,
+                passageId: "GEN.1",
+                session: session
+            )
+
+            #expect(authorizationHeader == "Bearer access-token")
+
+            await YouVersionPlatformConfiguration.clearAuthTokens()
+        }
+
         @Test func hasValidTokenRefreshesExpiringTokenAndStoresResponse() async throws {
             let originalAppKey = YouVersionPlatformConfiguration.appKey
             let responsePayload: [String: String] = [

--- a/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
@@ -5,6 +5,24 @@ import FoundationNetworking
 import Testing
 @testable import YouVersionPlatformCore
 
+@MainActor
+private final class AuthStateHighlightsRepository: BibleHighlightsPendingOperationsReporting, BibleHighlightsPendingOperationsClearing {
+    private(set) var hasPendingOperations = true
+    private(set) var clearPendingOperationsCallCount = 0
+
+    func highlights(for references: [BibleReference]) async throws -> [String: [BibleHighlight]] {
+        [:]
+    }
+
+    func queueOperation(_ operation: PendingHighlightOperation) {
+    }
+
+    func clearPendingOperations() {
+        hasPendingOperations = false
+        clearPendingOperationsCallCount += 1
+    }
+}
+
 extension ConfigurationStateTests {
     @Suite(.serialized) struct YouVersionPlatformConfigurationTests {
         
@@ -177,7 +195,7 @@ extension ConfigurationStateTests {
             #expect(YouVersionPlatformConfiguration.accessToken == nil)
         }
 
-        @Test @MainActor func authStateDidChangeNotificationPostsWhenSignInStateChanges() async {
+        @Test @MainActor func authStateDidChangeNotificationPostsWhenAccessTokenChanges() async {
             @MainActor final class NotificationCounter {
                 private(set) var count = 0
 
@@ -216,7 +234,43 @@ extension ConfigurationStateTests {
             )
             YouVersionPlatformConfiguration.clearAuthTokens()
 
-            #expect(counter.count == 2)
+            #expect(counter.count == 3)
+        }
+
+        @Test @MainActor func tokenRefreshDoesNotClearPendingHighlightOperations() async {
+            YouVersionPlatformConfiguration.clearAuthTokens()
+            YouVersionPlatformConfiguration.saveAuthData(
+                accessToken: "access-1",
+                refreshToken: "refresh-1",
+                idToken: nil,
+                expiryDate: Date(timeIntervalSinceNow: 60)
+            )
+            let repository = AuthStateHighlightsRepository()
+            let viewModel = BibleHighlightsViewModel(
+                cache: BibleHighlightsCache(),
+                repository: repository
+            )
+
+            YouVersionPlatformConfiguration.saveAuthData(
+                accessToken: "access-2",
+                refreshToken: "refresh-2",
+                idToken: nil,
+                expiryDate: Date(timeIntervalSinceNow: 3600)
+            )
+            for _ in 0..<10 {
+                await Task.yield()
+            }
+
+            #expect(viewModel.hasPendingOperations)
+            #expect(repository.clearPendingOperationsCallCount == 0)
+
+            YouVersionPlatformConfiguration.clearAuthTokens()
+            for _ in 0..<10 where repository.clearPendingOperationsCallCount == 0 {
+                await Task.yield()
+            }
+
+            #expect(!viewModel.hasPendingOperations)
+            #expect(repository.clearPendingOperationsCallCount == 1)
         }
 
         // MARK: - Permissions

--- a/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
@@ -5,24 +5,6 @@ import FoundationNetworking
 import Testing
 @testable import YouVersionPlatformCore
 
-@MainActor
-private final class AuthStateHighlightsRepository: BibleHighlightsPendingOperationsReporting, BibleHighlightsPendingOperationsClearing {
-    private(set) var hasPendingOperations = true
-    private(set) var clearPendingOperationsCallCount = 0
-
-    func highlights(for references: [BibleReference]) async throws -> [String: [BibleHighlight]] {
-        [:]
-    }
-
-    func queueOperation(_ operation: PendingHighlightOperation) {
-    }
-
-    func clearPendingOperations() {
-        hasPendingOperations = false
-        clearPendingOperationsCallCount += 1
-    }
-}
-
 extension ConfigurationStateTests {
     @Suite(.serialized) struct YouVersionPlatformConfigurationTests {
         
@@ -201,7 +183,7 @@ extension ConfigurationStateTests {
             #expect(YouVersionPlatformConfiguration.accessToken == nil)
         }
 
-        @Test @MainActor func authStateDidChangeNotificationPostsWhenAccessTokenChanges() async {
+        @Test @MainActor func authStateDidChangeNotificationPostsWhenSignInStateChanges() async {
             @MainActor final class NotificationCounter {
                 private(set) var count = 0
 
@@ -240,43 +222,7 @@ extension ConfigurationStateTests {
             )
             YouVersionPlatformConfiguration.clearAuthTokens()
 
-            #expect(counter.count == 3)
-        }
-
-        @Test @MainActor func tokenRefreshDoesNotClearPendingHighlightOperations() async {
-            YouVersionPlatformConfiguration.clearAuthTokens()
-            YouVersionPlatformConfiguration.saveAuthData(
-                accessToken: "access-1",
-                refreshToken: "refresh-1",
-                idToken: nil,
-                expiryDate: Date(timeIntervalSinceNow: 60)
-            )
-            let repository = AuthStateHighlightsRepository()
-            let viewModel = BibleHighlightsViewModel(
-                cache: BibleHighlightsCache(),
-                repository: repository
-            )
-
-            YouVersionPlatformConfiguration.saveAuthData(
-                accessToken: "access-2",
-                refreshToken: "refresh-2",
-                idToken: nil,
-                expiryDate: Date(timeIntervalSinceNow: 3600)
-            )
-            for _ in 0..<10 {
-                await Task.yield()
-            }
-
-            #expect(viewModel.hasPendingOperations)
-            #expect(repository.clearPendingOperationsCallCount == 0)
-
-            YouVersionPlatformConfiguration.clearAuthTokens()
-            for _ in 0..<10 where repository.clearPendingOperationsCallCount == 0 {
-                await Task.yield()
-            }
-
-            #expect(!viewModel.hasPendingOperations)
-            #expect(repository.clearPendingOperationsCallCount == 1)
+            #expect(counter.count == 2)
         }
 
         // MARK: - Permissions

--- a/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
@@ -174,16 +174,22 @@ extension ConfigurationStateTests {
             await YouVersionPlatformConfiguration.clearAuthTokens()
         }
         
-        @Test func authDataReturnsNilWhenRefreshTokenMissing() async {
+        @Test func authDataReturnsPartialResultWhenRefreshTokenMissing() async {
             let expiry = Date(timeIntervalSinceNow: 3600)
             await YouVersionPlatformConfiguration.saveAuthData(accessToken: "access-1", refreshToken: nil, idToken: nil, expiryDate: expiry)
-            #expect(YouVersionPlatformConfiguration.authData == nil)
+            let data = YouVersionPlatformConfiguration.authData
+            #expect(data?.accessToken == "access-1")
+            #expect(data?.refreshToken == nil)
+            #expect(data?.expiryDate == expiry)
             await YouVersionPlatformConfiguration.clearAuthTokens()
         }
-        
-        @Test func authDataReturnsNilWhenExpiryDateMissing() async {
+
+        @Test func authDataReturnsPartialResultWhenExpiryDateMissing() async {
             await YouVersionPlatformConfiguration.saveAuthData(accessToken: "access-1", refreshToken: "refresh-1", idToken: nil, expiryDate: nil)
-            #expect(YouVersionPlatformConfiguration.authData == nil)
+            let data = YouVersionPlatformConfiguration.authData
+            #expect(data?.accessToken == "access-1")
+            #expect(data?.refreshToken == "refresh-1")
+            #expect(data?.expiryDate == nil)
             await YouVersionPlatformConfiguration.clearAuthTokens()
         }
         


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a data race that could trigger duplicate token-refresh network calls when multiple concurrent API requests encounter an expiring token. It also relaxes `authData` to return a partial result when `refreshToken` or `expiryDate` is absent (previously it returned `nil`, incorrectly blocking callers who had a valid access token stored without those fields).

- Introduces the `AccessTokenProvider` Swift actor, which serializes token-refresh decisions and coalesces concurrent refresh requests onto a single `Task`, ensuring only one network call is made and all waiters receive the same result.
- `authData` now only guards on `accessToken` being present; `refreshToken` and `expiryDate` are surfaced as optional fields so callers with partial auth state are handled correctly.
- All Highlights endpoints route token acquisition through `YouVersionAPI.accessToken(providedToken:session:)` instead of reading `YouVersionPlatformConfiguration.accessToken` directly, bringing them into the deduplication path.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the actor correctly serializes refresh decisions, the `authData` relaxation is tested end-to-end, and no regressions were found in the changed paths.

The `AccessTokenProvider` actor model is correctly implemented: refresh deduplication works because the actor is suspended at `await task.value` while concurrent callers join the same task, and `saveAuthData` via `await MainActor.run` completes before the task returns. The `authData` change is intentional and covered by new tests. No incorrect logic, missing guards, or broken contracts were found across the five changed files.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift | Introduces the `AccessTokenProvider` actor to deduplicate concurrent token refreshes; `hasValidToken` and `accessToken` helper are simplified and correctly delegate to the actor. Logic is sound. |
| Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift | Relaxes `authData` to only require `accessToken`, allowing partial results when `refreshToken` or `expiryDate` is absent. Change is intentional, tested, and doesn't affect `postAuthStateDidChangeNotificationIfNeeded` behaviour. |
| Sources/YouVersionPlatformCore/APIs/Bible/Highlights.swift | All three Highlights call sites replaced direct `accessToken` reads with `await YouVersionAPI.accessToken(providedToken:session:)`, routing through the new actor-backed provider. |
| Tests/YouVersionPlatformCoreTests/YouVersionAPITests.swift | Adds three new test cases: unexpired token without refresh token, unknown expiry, and the key concurrent-refresh deduplication test. Coverage is thorough and uses mock sessions cleanly. |
| Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift | Updates two tests whose expectations matched the old strict-nil behaviour of `authData`; new assertions correctly validate the partial-result semantics. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CallerA
    participant CallerB
    participant Provider
    participant Config
    participant RefreshAPI

    CallerA->>Provider: "accessToken(session:)"
    Provider->>Config: "authData"
    Config-->>Provider: "token expiring soon"
    Provider->>Provider: "refreshTask == nil, create Task"
    CallerB->>Provider: "accessToken(session:)"
    Provider->>Provider: "refreshTask != nil, join existing task"
    Provider->>RefreshAPI: "refreshSignIn(withToken:)"
    RefreshAPI-->>Provider: "new tokens"
    Provider->>Config: "saveAuthData (MainActor.run)"
    Config-->>Provider: "saved"
    Provider-->>CallerA: "newAccessToken"
    Provider-->>CallerB: "newAccessToken (shared result)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CallerA
    participant CallerB
    participant Provider
    participant Config
    participant RefreshAPI

    CallerA->>Provider: "accessToken(session:)"
    Provider->>Config: "authData"
    Config-->>Provider: "token expiring soon"
    Provider->>Provider: "refreshTask == nil, create Task"
    CallerB->>Provider: "accessToken(session:)"
    Provider->>Provider: "refreshTask != nil, join existing task"
    Provider->>RefreshAPI: "refreshSignIn(withToken:)"
    RefreshAPI-->>Provider: "new tokens"
    Provider->>Config: "saveAuthData (MainActor.run)"
    Config-->>Provider: "saved"
    Provider-->>CallerA: "newAccessToken"
    Provider-->>CallerB: "newAccessToken (shared result)"
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift`, line 155-160 ([link](https://github.com/youversion/platform-sdk-swift/blob/dc9a8123db8c686a7c4da21cc738353d37554043/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift#L155-L160)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Public notification now fires on every token value change**

   `authStateDidChangeNotification` is a `public` API, and this change broadens its semantics: it now fires whenever the stored access token *value* changes, which includes silent background token refreshes, not only when the user signs in or out. `BibleHighlightsViewModel` is guarded against this (it checks `isSignedIn` before calling `reset()`), but any SDK consumer observing this notification directly will now receive extra firings they didn't before. A consumer that clears caches or triggers a full data reload on every notification would do so unnecessarily on every refresh. A comment on the declaration of `authStateDidChangeNotification` explaining the updated semantics, or a release-note entry, would help adopters adapt safely.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
   Line: 155-160

   Comment:
   **Public notification now fires on every token value change**

   `authStateDidChangeNotification` is a `public` API, and this change broadens its semantics: it now fires whenever the stored access token *value* changes, which includes silent background token refreshes, not only when the user signs in or out. `BibleHighlightsViewModel` is guarded against this (it checks `isSignedIn` before calling `reset()`), but any SDK consumer observing this notification directly will now receive extra firings they didn't before. A consumer that clears caches or triggers a full data reload on every notification would do so unnecessarily on every refresh. A comment on the declaration of `authStateDidChangeNotification` explaining the updated semantics, or a release-note entry, would help adopters adapt safely.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformCore%2FYouVersionPlatformConfiguration.swift%0ALine%3A%20155-160%0A%0AComment%3A%0A**Public%20notification%20now%20fires%20on%20every%20token%20value%20change**%0A%0A%60authStateDidChangeNotification%60%20is%20a%20%60public%60%20API%2C%20and%20this%20change%20broadens%20its%20semantics%3A%20it%20now%20fires%20whenever%20the%20stored%20access%20token%20*value*%20changes%2C%20which%20includes%20silent%20background%20token%20refreshes%2C%20not%20only%20when%20the%20user%20signs%20in%20or%20out.%20%60BibleHighlightsViewModel%60%20is%20guarded%20against%20this%20%28it%20checks%20%60isSignedIn%60%20before%20calling%20%60reset%28%29%60%29%2C%20but%20any%20SDK%20consumer%20observing%20this%20notification%20directly%20will%20now%20receive%20extra%20firings%20they%20didn't%20before.%20A%20consumer%20that%20clears%20caches%20or%20triggers%20a%20full%20data%20reload%20on%20every%20notification%20would%20do%20so%20unnecessarily%20on%20every%20refresh.%20A%20comment%20on%20the%20declaration%20of%20%60authStateDidChangeNotification%60%20explaining%20the%20updated%20semantics%2C%20or%20a%20release-note%20entry%2C%20would%20help%20adopters%20adapt%20safely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=210&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformCore%2FYouVersionPlatformConfiguration.swift%0ALine%3A%20155-160%0A%0AComment%3A%0A**Public%20notification%20now%20fires%20on%20every%20token%20value%20change**%0A%0A%60authStateDidChangeNotification%60%20is%20a%20%60public%60%20API%2C%20and%20this%20change%20broadens%20its%20semantics%3A%20it%20now%20fires%20whenever%20the%20stored%20access%20token%20*value*%20changes%2C%20which%20includes%20silent%20background%20token%20refreshes%2C%20not%20only%20when%20the%20user%20signs%20in%20or%20out.%20%60BibleHighlightsViewModel%60%20is%20guarded%20against%20this%20%28it%20checks%20%60isSignedIn%60%20before%20calling%20%60reset%28%29%60%29%2C%20but%20any%20SDK%20consumer%20observing%20this%20notification%20directly%20will%20now%20receive%20extra%20firings%20they%20didn't%20before.%20A%20consumer%20that%20clears%20caches%20or%20triggers%20a%20full%20data%20reload%20on%20every%20notification%20would%20do%20so%20unnecessarily%20on%20every%20refresh.%20A%20comment%20on%20the%20declaration%20of%20%60authStateDidChangeNotification%60%20explaining%20the%20updated%20semantics%2C%20or%20a%20release-note%20entry%2C%20would%20help%20adopters%20adapt%20safely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=210&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22YPE-4108-refresh-token-highlights-race%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22YPE-4108-refresh-token-highlights-race%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FYouVersionPlatformCore%2FYouVersionPlatformConfiguration.swift%0ALine%3A%20155-160%0A%0AComment%3A%0A**Public%20notification%20now%20fires%20on%20every%20token%20value%20change**%0A%0A%60authStateDidChangeNotification%60%20is%20a%20%60public%60%20API%2C%20and%20this%20change%20broadens%20its%20semantics%3A%20it%20now%20fires%20whenever%20the%20stored%20access%20token%20*value*%20changes%2C%20which%20includes%20silent%20background%20token%20refreshes%2C%20not%20only%20when%20the%20user%20signs%20in%20or%20out.%20%60BibleHighlightsViewModel%60%20is%20guarded%20against%20this%20%28it%20checks%20%60isSignedIn%60%20before%20calling%20%60reset%28%29%60%29%2C%20but%20any%20SDK%20consumer%20observing%20this%20notification%20directly%20will%20now%20receive%20extra%20firings%20they%20didn't%20before.%20A%20consumer%20that%20clears%20caches%20or%20triggers%20a%20full%20data%20reload%20on%20every%20notification%20would%20do%20so%20unnecessarily%20on%20every%20refresh.%20A%20comment%20on%20the%20declaration%20of%20%60authStateDidChangeNotification%60%20explaining%20the%20updated%20semantics%2C%20or%20a%20release-note%20entry%2C%20would%20help%20adopters%20adapt%20safely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-swift&pr=210&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["chore: merge main"](https://github.com/youversion/platform-sdk-swift/commit/244ac0619be7ae5fe84c4a2b1c585108c1d6c0f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45719660)</sub>

<!-- /greptile_comment -->