### PR TITLE
fix: language names prefer the iOS name, but also send Accept-Language

### DIFF
--- a/Sources/YouVersionPlatformCore/APIs/Languages/Languages.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Languages/Languages.swift
@@ -60,9 +60,34 @@ public extension YouVersionAPI {
         /// - Parameters:
         ///   - country: An optional country code for filtering languages. If provided, only languages
         ///     used in that country will be returned.
+        ///   - fields: The fields to include in each language overview.
+        ///   - accessToken: An optional access token. Defaults to the configured access token.
         ///   - session: The URLSession used to perform the request. Defaults to `URLSession.shared`.
         /// - Returns: An array of LanguageOverview objects.
         public static func languages(country: String? = nil, fields: [String] = [], accessToken providedToken: String? = nil, session: URLSession = .shared) async throws -> [LanguageOverview] {
+            try await languages(
+                country: country,
+                preferredLanguage: nil,
+                fields: fields,
+                accessToken: providedToken,
+                session: session
+            )
+        }
+
+        /// Retrieves a list of languages supported in the Platform.
+        ///
+        /// This function fetches language overviews from the YouVersion Platform API.
+        /// A valid `YouVersionPlatformConfiguration.appKey` must be set for the request to succeed.
+        ///
+        /// - Parameters:
+        ///   - country: An optional country code for filtering languages. If provided, only languages
+        ///     used in that country will be returned.
+        ///   - preferredLanguage: An optional language code for localizing the response.
+        ///   - fields: The fields to include in each language overview.
+        ///   - accessToken: An optional access token. Defaults to the configured access token.
+        ///   - session: The URLSession used to perform the request. Defaults to `URLSession.shared`.
+        /// - Returns: An array of LanguageOverview objects.
+        public static func languages(country: String? = nil, preferredLanguage: String? = nil, fields: [String] = [], accessToken providedToken: String? = nil, session: URLSession = .shared) async throws -> [LanguageOverview] {
             let accessToken = providedToken ?? YouVersionPlatformConfiguration.accessToken
 
             var allResults: [LanguageOverview] = []
@@ -79,7 +104,10 @@ public extension YouVersionAPI {
                     throw URLError(.badURL)
                 }
 
-                let request = YouVersionAPI.urlRequest(with: url, accessToken: accessToken, session: session)
+                var request = YouVersionAPI.urlRequest(with: url, accessToken: accessToken, session: session)
+                if let preferredLanguage {
+                    request.setValue(preferredLanguage, forHTTPHeaderField: "Accept-Language")
+                }
                 let (data, response) = try await session.data(for: request)
 
                 guard let httpResponse = response as? HTTPURLResponse else {

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -279,8 +279,13 @@ public final class BibleVersionsViewModel {
     
     private func loadSuggestedLanguages() async {
         let region = Locale.current.region?.identifier ?? "US"
+        let preferredLanguage = Locale.current.language.languageCode?.identifier
         do {
-            suggestedLanguages = try await YouVersionAPI.Languages.languages(country: region, fields: ["language", "display_names"])
+            suggestedLanguages = try await YouVersionAPI.Languages.languages(
+                country: region,
+                preferredLanguage: preferredLanguage,
+                fields: ["language", "display_names"]
+            )
         } catch {
             YouVersionPlatformLogger.error("Error fetching languages: \(error.localizedDescription)", category: "Reader")
         }
@@ -302,7 +307,7 @@ public final class BibleVersionsViewModel {
     }
 
     func languageName(_ lang: String) -> String {
-        languageNames[lang] ?? Locale.current.localizedString(forLanguageCode: lang) ?? lang
+        Locale.current.localizedString(forLanguageCode: lang) ?? languageNames[lang] ?? lang
     }
 
     /// Returns deduplicated language tags from the list, preserving order.

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -279,7 +279,11 @@ public final class BibleVersionsViewModel {
     
     private func loadSuggestedLanguages() async {
         let region = Locale.current.region?.identifier ?? "US"
-        let preferredLanguage = Locale.current.language.languageCode?.identifier
+        let maximalIdentifier = Locale.current.language.maximalIdentifier
+        let minimalIdentifier = Locale.current.language.minimalIdentifier
+        let preferredLanguage = maximalIdentifier == minimalIdentifier
+            ? maximalIdentifier
+            : "\(maximalIdentifier), \(minimalIdentifier);q=0.9"
         do {
             suggestedLanguages = try await YouVersionAPI.Languages.languages(
                 country: region,

--- a/Tests/YouVersionPlatformCoreTests/LanguagesAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/LanguagesAPITests.swift
@@ -121,13 +121,13 @@ import Testing
         }
 
         _ = try await YouVersionAPI.Languages.languages(
-            preferredLanguage: "es",
+            preferredLanguage: "zh-Hant-TW, zh-TW;q=0.9",
             accessToken: "swift-test-suite",
             session: session
         )
 
         let request = try #require(capturedRequest)
-        #expect(request.value(forHTTPHeaderField: "Accept-Language") == "es")
+        #expect(request.value(forHTTPHeaderField: "Accept-Language") == "zh-Hant-TW, zh-TW;q=0.9")
     }
 
     @MainActor

--- a/Tests/YouVersionPlatformCoreTests/LanguagesAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/LanguagesAPITests.swift
@@ -107,6 +107,30 @@ import Testing
     }
 
     @MainActor
+    @Test func languagesWithPreferredLanguageSetsAcceptLanguageHeader() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+
+        let responseData = try JSONEncoder().encode(LanguagesResponse(data: [], nextPageToken: nil, totalSize: nil))
+        var capturedRequest: URLRequest?
+
+        HTTPMocking.setHandler(token: token) { request in
+            capturedRequest = request
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (responseData, response)
+        }
+
+        _ = try await YouVersionAPI.Languages.languages(
+            preferredLanguage: "es",
+            accessToken: "swift-test-suite",
+            session: session
+        )
+
+        let request = try #require(capturedRequest)
+        #expect(request.value(forHTTPHeaderField: "Accept-Language") == "es")
+    }
+
+    @MainActor
     @Test func languagesUnauthorizedThrowsNotPermitted() async throws {
         let (session, token) = HTTPMocking.makeSession()
         defer { HTTPMocking.clear(token: token) }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves localized language names in the Bible version picker. The main changes are:

- Adds optional `Accept-Language` support to the languages API.
- Sends script-aware locale preferences when loading suggested languages.
- Prefers the iOS language name with API names as a fallback.
- Tests exact propagation of the new request header.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The updated request preserves script information in the language preference.
- The header is applied throughout paginated language requests.
- No blocking issue remains in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/APIs/Languages/Languages.swift | Adds a compatible languages API overload and applies the preferred language header to each paginated request. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift | Builds a script-aware language preference and updates the language-name fallback order. |
| Tests/YouVersionPlatformCoreTests/LanguagesAPITests.swift | Verifies that the preferred language is sent unchanged in the request header. |

<sub>Reviews (2): Last reviewed commit: ["chore: upgrade from language identifier ..."](https://github.com/youversion/platform-sdk-swift/commit/7ed1b2b0e1919872d715f1f6608e61f662c14d72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45767256)</sub>

<!-- /greptile_comment -->