### PR TITLE
chore: update api-baseline files

### DIFF
--- a/.api-baseline/YouVersionPlatformCore.json
+++ b/.api-baseline/YouVersionPlatformCore.json
@@ -7798,6 +7798,101 @@
                 "static": true,
                 "throwing": true,
                 "funcSelfKind": "NonMutating"
+              },
+              {
+                "kind": "Function",
+                "name": "languages",
+                "printedName": "languages(country:preferredLanguage:fields:accessToken:session:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[YouVersionPlatformCore.LanguageOverview]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "LanguageOverview",
+                        "printedName": "YouVersionPlatformCore.LanguageOverview",
+                        "usr": "s:22YouVersionPlatformCore16LanguageOverviewV"
+                      }
+                    ],
+                    "usr": "s:Sa"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Array",
+                    "printedName": "[Swift.String]",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sa"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "hasDefaultArg": true,
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URLSession",
+                    "printedName": "Foundation.URLSession",
+                    "hasDefaultArg": true,
+                    "usr": "c:objc(cs)NSURLSession"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:22YouVersionPlatformCore0aB3APIO9LanguagesO9languages7country17preferredLanguage6fields11accessToken7sessionSayAA0J8OverviewVGSSSg_AOSaySSGAOSo12NSURLSessionCtYaKFZ",
+                "mangledName": "$s22YouVersionPlatformCore0aB3APIO9LanguagesO9languages7country17preferredLanguage6fields11accessToken7sessionSayAA0J8OverviewVGSSSg_AOSaySSGAOSo12NSURLSessionCtYaKFZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "throwing": true,
+                "funcSelfKind": "NonMutating"
               }
             ],
             "declKind": "Enum",
@@ -22311,6 +22406,10 @@
             "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV13hasPermissionySbAA010SignInWithabG0OFZ",
             "moduleName": "YouVersionPlatformCore",
             "static": true,
+            "deprecated": true,
+            "declAttributes": [
+              "Available"
+            ],
             "funcSelfKind": "NonMutating"
           },
           {

--- a/.api-baseline/YouVersionPlatformReader.json
+++ b/.api-baseline/YouVersionPlatformReader.json
@@ -6,6 +6,13 @@
     "children": [
       {
         "kind": "Import",
+        "name": "AppKit",
+        "printedName": "AppKit",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformReader"
+      },
+      {
+        "kind": "Import",
         "name": "CoreText",
         "printedName": "CoreText",
         "declKind": "Import",
@@ -76,9 +83,651 @@
       },
       {
         "kind": "TypeDecl",
+        "name": "BibleReaderNavigation",
+        "printedName": "BibleReaderNavigation",
+        "children": [
+          {
+            "kind": "TypeDecl",
+            "name": "Request",
+            "printedName": "Request",
+            "children": [
+              {
+                "kind": "Var",
+                "name": "reference",
+                "printedName": "reference",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC7RequestV9reference0abC4Core0E9ReferenceVvp",
+                "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationC7RequestV9reference0abC4Core0E9ReferenceVvp",
+                "moduleName": "YouVersionPlatformReader",
+                "declAttributes": [
+                  "HasStorage"
+                ],
+                "isLet": true,
+                "hasStorage": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleReference",
+                        "printedName": "YouVersionPlatformCore.BibleReference",
+                        "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC7RequestV9reference0abC4Core0E9ReferenceVvg",
+                    "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationC7RequestV9reference0abC4Core0E9ReferenceVvg",
+                    "moduleName": "YouVersionPlatformReader",
+                    "implicit": true,
+                    "declAttributes": [
+                      "Transparent"
+                    ],
+                    "accessorKind": "get"
+                  }
+                ]
+              },
+              {
+                "kind": "Var",
+                "name": "showsFullChapter",
+                "printedName": "showsFullChapter",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC7RequestV16showsFullChapterSbvp",
+                "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationC7RequestV16showsFullChapterSbvp",
+                "moduleName": "YouVersionPlatformReader",
+                "declAttributes": [
+                  "HasStorage"
+                ],
+                "isLet": true,
+                "hasStorage": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Bool",
+                        "printedName": "Swift.Bool",
+                        "usr": "s:Sb"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC7RequestV16showsFullChapterSbvg",
+                    "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationC7RequestV16showsFullChapterSbvg",
+                    "moduleName": "YouVersionPlatformReader",
+                    "implicit": true,
+                    "declAttributes": [
+                      "Transparent"
+                    ],
+                    "accessorKind": "get"
+                  }
+                ]
+              },
+              {
+                "kind": "Var",
+                "name": "scrollsToVerse",
+                "printedName": "scrollsToVerse",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC7RequestV14scrollsToVerseSbvp",
+                "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationC7RequestV14scrollsToVerseSbvp",
+                "moduleName": "YouVersionPlatformReader",
+                "declAttributes": [
+                  "HasStorage"
+                ],
+                "isLet": true,
+                "hasStorage": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Bool",
+                        "printedName": "Swift.Bool",
+                        "usr": "s:Sb"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC7RequestV14scrollsToVerseSbvg",
+                    "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationC7RequestV14scrollsToVerseSbvg",
+                    "moduleName": "YouVersionPlatformReader",
+                    "implicit": true,
+                    "declAttributes": [
+                      "Transparent"
+                    ],
+                    "accessorKind": "get"
+                  }
+                ]
+              },
+              {
+                "kind": "Var",
+                "name": "shouldFocus",
+                "printedName": "shouldFocus",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Var",
+                "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC7RequestV11shouldFocusSbvp",
+                "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationC7RequestV11shouldFocusSbvp",
+                "moduleName": "YouVersionPlatformReader",
+                "declAttributes": [
+                  "HasStorage"
+                ],
+                "isLet": true,
+                "hasStorage": true,
+                "accessors": [
+                  {
+                    "kind": "Accessor",
+                    "name": "Get",
+                    "printedName": "Get()",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Bool",
+                        "printedName": "Swift.Bool",
+                        "usr": "s:Sb"
+                      }
+                    ],
+                    "declKind": "Accessor",
+                    "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC7RequestV11shouldFocusSbvg",
+                    "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationC7RequestV11shouldFocusSbvg",
+                    "moduleName": "YouVersionPlatformReader",
+                    "implicit": true,
+                    "declAttributes": [
+                      "Transparent"
+                    ],
+                    "accessorKind": "get"
+                  }
+                ]
+              },
+              {
+                "kind": "Function",
+                "name": "__derived_struct_equals",
+                "printedName": "__derived_struct_equals(_:_:)",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Request",
+                    "printedName": "YouVersionPlatformReader.BibleReaderNavigation.Request",
+                    "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC7RequestV"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Request",
+                    "printedName": "YouVersionPlatformReader.BibleReaderNavigation.Request",
+                    "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC7RequestV"
+                  }
+                ],
+                "declKind": "Func",
+                "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC7RequestV23__derived_struct_equalsySbAE_AEtFZ",
+                "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationC7RequestV23__derived_struct_equalsySbAE_AEtFZ",
+                "moduleName": "YouVersionPlatformReader",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Implements"
+                ],
+                "funcSelfKind": "NonMutating"
+              }
+            ],
+            "declKind": "Struct",
+            "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC7RequestV",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationC7RequestV",
+            "moduleName": "YouVersionPlatformReader",
+            "conformances": [
+              {
+                "kind": "Conformance",
+                "name": "Copyable",
+                "printedName": "Copyable",
+                "usr": "s:s8CopyableP",
+                "mangledName": "$ss8CopyableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Equatable",
+                "printedName": "Equatable",
+                "usr": "s:SQ",
+                "mangledName": "$sSQ"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Escapable",
+                "printedName": "Escapable",
+                "usr": "s:s9EscapableP",
+                "mangledName": "$ss9EscapableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "Sendable",
+                "printedName": "Sendable",
+                "usr": "s:s8SendableP",
+                "mangledName": "$ss8SendableP"
+              },
+              {
+                "kind": "Conformance",
+                "name": "SendableMetatype",
+                "printedName": "SendableMetatype",
+                "usr": "s:s16SendableMetatypeP",
+                "mangledName": "$ss16SendableMetatypeP"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "pendingRequest",
+            "printedName": "pendingRequest",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformReader.BibleReaderNavigation.Request?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Request",
+                    "printedName": "YouVersionPlatformReader.BibleReaderNavigation.Request",
+                    "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC7RequestV"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC14pendingRequestAC0H0VSgvp",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationC14pendingRequestAC0H0VSgvp",
+            "moduleName": "YouVersionPlatformReader",
+            "declAttributes": [
+              "HasInitialValue",
+              "Final",
+              "SetterAccess",
+              "Custom"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "YouVersionPlatformReader.BibleReaderNavigation.Request?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Request",
+                        "printedName": "YouVersionPlatformReader.BibleReaderNavigation.Request",
+                        "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC7RequestV"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC14pendingRequestAC0H0VSgvg",
+                "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationC14pendingRequestAC0H0VSgvg",
+                "moduleName": "YouVersionPlatformReader",
+                "declAttributes": [
+                  "Final"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReaderNavigation",
+                "printedName": "YouVersionPlatformReader.BibleReaderNavigation",
+                "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:24YouVersionPlatformReader05BibleD10NavigationCACycfc",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationCACycfc",
+            "moduleName": "YouVersionPlatformReader",
+            "declAttributes": [
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "request",
+            "printedName": "request(_:showsFullChapter:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC7request_16showsFullChaptery0abC4Core0E9ReferenceV_SbtF",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationC7request_16showsFullChaptery0abC4Core0E9ReferenceV_SbtF",
+            "moduleName": "YouVersionPlatformReader",
+            "declAttributes": [
+              "Final",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "focusReference",
+            "printedName": "focusReference(_:scrollsToVerse:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC14focusReference_14scrollsToVersey0abC4Core0eH0V_SbtF",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationC14focusReference_14scrollsToVersey0abC4Core0eH0V_SbtF",
+            "moduleName": "YouVersionPlatformReader",
+            "intro_iOS": "18.0",
+            "declAttributes": [
+              "Final",
+              "Available",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC",
+        "mangledName": "$s24YouVersionPlatformReader05BibleD10NavigationC",
+        "moduleName": "YouVersionPlatformReader",
+        "declAttributes": [
+          "Final",
+          "Custom"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Observable",
+            "printedName": "Observable",
+            "usr": "s:11Observation10ObservableP",
+            "mangledName": "$s11Observation10ObservableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SendableMetatype",
+            "printedName": "SendableMetatype",
+            "usr": "s:s16SendableMetatypeP",
+            "mangledName": "$ss16SendableMetatypeP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
         "name": "BibleReaderView",
         "printedName": "BibleReaderView",
         "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(reference:verseSelectionStyle:onVerseTap:showsFullChapter:readerNavigation:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReaderView",
+                "printedName": "YouVersionPlatformReader.BibleReaderView",
+                "usr": "s:24YouVersionPlatformReader05BibleD4ViewV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReference",
+                "printedName": "YouVersionPlatformCore.BibleReference",
+                "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "VerseSelectionStyle",
+                "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                "hasDefaultArg": true,
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "((YouVersionPlatformCore.BibleReference) -> Swift.Void)?",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleReference) -> Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNameAlias",
+                        "name": "Void",
+                        "printedName": "Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Void",
+                            "printedName": "()"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleReference",
+                        "printedName": "YouVersionPlatformCore.BibleReference",
+                        "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "hasDefaultArg": true,
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformReader.BibleReaderNavigation?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReaderNavigation",
+                    "printedName": "YouVersionPlatformReader.BibleReaderNavigation",
+                    "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:24YouVersionPlatformReader05BibleD4ViewV9reference19verseSelectionStyle10onVerseTap16showsFullChapter16readerNavigationAC0abC4Core0E9ReferenceV_0abC2UI0liJ0VyAKcSgSbAA0edR0CSgtcfc",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD4ViewV9reference19verseSelectionStyle10onVerseTap16showsFullChapter16readerNavigationAC0abC4Core0E9ReferenceV_0abC2UI0liJ0VyAKcSgSbAA0edR0CSgtcfc",
+            "moduleName": "YouVersionPlatformReader",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "restoringLastPassage",
+            "printedName": "restoringLastPassage(verseSelectionStyle:onVerseTap:readerNavigation:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "BibleReaderView",
+                "printedName": "YouVersionPlatformReader.BibleReaderView",
+                "usr": "s:24YouVersionPlatformReader05BibleD4ViewV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "VerseSelectionStyle",
+                "printedName": "YouVersionPlatformUI.VerseSelectionStyle",
+                "hasDefaultArg": true,
+                "usr": "s:20YouVersionPlatformUI19VerseSelectionStyleV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "((YouVersionPlatformCore.BibleReference) -> Swift.Void)?",
+                "children": [
+                  {
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(YouVersionPlatformCore.BibleReference) -> Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNameAlias",
+                        "name": "Void",
+                        "printedName": "Swift.Void",
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Void",
+                            "printedName": "()"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "BibleReference",
+                        "printedName": "YouVersionPlatformCore.BibleReference",
+                        "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                      }
+                    ]
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformReader.BibleReaderNavigation?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReaderNavigation",
+                    "printedName": "YouVersionPlatformReader.BibleReaderNavigation",
+                    "usr": "s:24YouVersionPlatformReader05BibleD10NavigationC"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:24YouVersionPlatformReader05BibleD4ViewV20restoringLastPassage19verseSelectionStyle10onVerseTap16readerNavigationAC0abC2UI0nkL0V_y0abC4Core0E9ReferenceVcSgAA0edQ0CSgtFZ",
+            "mangledName": "$s24YouVersionPlatformReader05BibleD4ViewV20restoringLastPassage19verseSelectionStyle10onVerseTap16readerNavigationAC0abC2UI0nkL0V_y0abC4Core0E9ReferenceVcSgAA0edQ0CSgtFZ",
+            "moduleName": "YouVersionPlatformReader",
+            "static": true,
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
           {
             "kind": "Constructor",
             "name": "init",
@@ -158,8 +807,10 @@
             "usr": "s:24YouVersionPlatformReader05BibleD4ViewV9reference19verseSelectionStyle10onVerseTap16showsFullChapterAC0abC4Core0E9ReferenceVSg_0abC2UI0liJ0VyAJcSgSbtcfc",
             "mangledName": "$s24YouVersionPlatformReader05BibleD4ViewV9reference19verseSelectionStyle10onVerseTap16showsFullChapterAC0abC4Core0E9ReferenceVSg_0abC2UI0liJ0VyAJcSgSbtcfc",
             "moduleName": "YouVersionPlatformReader",
+            "deprecated": true,
             "declAttributes": [
               "Preconcurrency",
+              "Available",
               "Custom"
             ],
             "init_kind": "Designated"

--- a/.api-baseline/YouVersionPlatformUI.json
+++ b/.api-baseline/YouVersionPlatformUI.json
@@ -6,6 +6,13 @@
     "children": [
       {
         "kind": "Import",
+        "name": "AppKit",
+        "printedName": "AppKit",
+        "declKind": "Import",
+        "moduleName": "YouVersionPlatformUI"
+      },
+      {
+        "kind": "Import",
         "name": "AuthenticationServices",
         "printedName": "AuthenticationServices",
         "declKind": "Import",
@@ -2540,7 +2547,7 @@
           {
             "kind": "Constructor",
             "name": "init",
-            "printedName": "init(_:textOptions:selectedVerses:onVerseTap:placeholder:)",
+            "printedName": "init(_:textOptions:selectedVerses:onVerseTap:placeholder:focusedReference:)",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -2700,11 +2707,26 @@
                 ],
                 "hasDefaultArg": true,
                 "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "YouVersionPlatformCore.BibleReference?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "BibleReference",
+                    "printedName": "YouVersionPlatformCore.BibleReference",
+                    "usr": "s:22YouVersionPlatformCore14BibleReferenceV"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sq"
               }
             ],
             "declKind": "Constructor",
-            "usr": "s:20YouVersionPlatformUI13BibleTextViewV_11textOptions14selectedVerses10onVerseTap11placeholderAC0abC4Core0E9ReferenceV_AA0efI0VSg05SwiftD07BindingVyShyAJGGyAJ_SSSayAA0E8FootnoteVGSSSgtcSgAN03AnyG0VAA0eF12LoadingPhaseOcSgtcfc",
-            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV_11textOptions14selectedVerses10onVerseTap11placeholderAC0abC4Core0E9ReferenceV_AA0efI0VSg05SwiftD07BindingVyShyAJGGyAJ_SSSayAA0E8FootnoteVGSSSgtcSgAN03AnyG0VAA0eF12LoadingPhaseOcSgtcfc",
+            "usr": "s:20YouVersionPlatformUI13BibleTextViewV_11textOptions14selectedVerses10onVerseTap11placeholder16focusedReferenceAC0abC4Core0eQ0V_AA0efI0VSg05SwiftD07BindingVyShyAKGGyAK_SSSayAA0E8FootnoteVGSSSgtcSgAO03AnyG0VAA0eF12LoadingPhaseOcSgAKSgtcfc",
+            "mangledName": "$s20YouVersionPlatformUI13BibleTextViewV_11textOptions14selectedVerses10onVerseTap11placeholder16focusedReferenceAC0abC4Core0eQ0V_AA0efI0VSg05SwiftD07BindingVyShyAKGGyAK_SSSayAA0E8FootnoteVGSSSgtcSgAO03AnyG0VAA0eF12LoadingPhaseOcSgAKSgtcfc",
             "moduleName": "YouVersionPlatformUI",
             "declAttributes": [
               "Preconcurrency",
@@ -4821,6 +4843,7 @@
         "declAttributes": [
           "Final"
         ],
+        "hasMissingDesignatedInitializers": true,
         "conformances": [
           {
             "kind": "Conformance",


### PR DESCRIPTION
PUBLIC API additions since previous baseline:
15 added declaration(s).

Sources/YouVersionPlatformCore/APIs/Languages
  Languages.swift
    - static func YouVersionAPI.Languages.languages(country:preferredLanguage:fields:accessToken:session:)

Sources/YouVersionPlatformReader
  BibleReaderNavigation.swift
    - BibleReaderNavigation.init()
    - class BibleReaderNavigation
    - func BibleReaderNavigation.focusReference(_:scrollsToVerse:)
    - func BibleReaderNavigation.request(_:showsFullChapter:)
    - let BibleReaderNavigation.Request.reference
    - let BibleReaderNavigation.Request.scrollsToVerse
    - let BibleReaderNavigation.Request.shouldFocus
    - let BibleReaderNavigation.Request.showsFullChapter
    - struct BibleReaderNavigation.Request
    - var BibleReaderNavigation.pendingRequest
    Synthesized or associated declarations:
    - static func BibleReaderNavigation.Request.==

Sources/YouVersionPlatformReader
  BibleReaderView.swift
    - BibleReaderView.init(reference:verseSelectionStyle:onVerseTap:showsFullChapter:readerNavigation:)
    - static func BibleReaderView.restoringLastPassage(verseSelectionStyle:onVerseTap:readerNavigation:)

Sources/YouVersionPlatformUI/Views
  BibleTextView.swift
    - BibleTextView.init(_:textOptions:selectedVerses:onVerseTap:placeholder:focusedReference:)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes the generated API baselines. The main changes are:

- Adds the languages API and permission deprecation metadata.
- Adds Reader navigation APIs and updated reader initializers.
- Records the focused-reference parameter and macOS-visible imports.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed API baselines.
- The entries match the inspected declarations and macOS-targeted baseline workflow.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .api-baseline/YouVersionPlatformCore.json | Records the preferred-language API overload and permission deprecation metadata. |
| .api-baseline/YouVersionPlatformReader.json | Records Reader navigation, initializer, availability, deprecation, and macOS import changes. |
| .api-baseline/YouVersionPlatformUI.json | Records the focused-reference initializer parameter, initializer metadata, and macOS import. |

<sub>Reviews (1): Last reviewed commit: ["chore: update api-baseline files"](https://github.com/youversion/platform-sdk-swift/commit/3d02ab6359eb59a01e12a6153fec9efba8e60e84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46357408)</sub>

<!-- /greptile_comment -->