### PR TITLE
feat: change opacity of highlights in light mode, to increase contrast

### DIFF
--- a/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
+++ b/Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift
@@ -153,7 +153,7 @@ extension BibleTextView {
                     }
                     if category == .scripture || category == .verseLabel {
                         t.backgroundColor = highlightColor
-                            .opacity(darkMode ? 0.3 : 1.0)
+                            .opacity(0.3)
                     }
                 }
                 isUnderlined = isSelected(reference) && category == .scripture


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the highlight-background rendering in `BibleTextView` by applying a uniform `0.3` opacity to all highlight colors in both light and dark mode, replacing the previous conditional that used full opacity (`1.0`) in light mode. The intent is to reduce the saturation of highlight colors so the overlaid scripture text remains easily readable on lighter backgrounds.

- **Opacity logic simplified**: `darkMode ? 0.3 : 1.0` → `0.3`, making highlight backgrounds consistent across appearance modes.
- **`darkMode` parameter preserved**: it still drives the verse-label foreground-color override on line 151 (`t.foregroundColor = .white`), so no dead code is left behind.

<h3>Confidence Score: 5/5</h3>

A clean, minimal change that unifies highlight opacity across appearance modes with no side effects on surrounding logic.

The change touches a single expression in one rendering path. The `darkMode` parameter continues to be used elsewhere in the same scope for foreground-color overrides, so nothing is orphaned. The opacity value (0.3) matches what dark mode already used, meaning the dark-mode visual is unchanged and only light-mode highlights become more translucent — exactly the stated intent.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformUI/Views/BibleTextView+Rendering.swift | Single-line change removes the dark/light mode conditional on highlight opacity, applying a uniform 0.3 opacity in both modes (previously 1.0 in light mode); the `darkMode` parameter is still used on line 151 for verse-label foreground color, so no dead code is introduced. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Render text run] --> B{Has highlight color?}
    B -- No --> C[No background set]
    B -- Yes --> D{category == .scripture\nor .verseLabel?}
    D -- No --> C
    D -- Yes --> E["Apply backgroundColor\n= highlightColor.opacity(0.3)\n(both light & dark mode)"]
    E --> F{darkMode &&\ncategory == .verseLabel?}
    F -- Yes --> G[Override foreground\ncolor → .white]
    F -- No --> H[Keep default foreground]
    G --> I[Compose into Text]
    H --> I
    C --> I
```

<sub>Reviews (1): Last reviewed commit: ["feat: change opacity of highlights in li..."](https://github.com/youversion/platform-sdk-swift/commit/577f37756eb0701d0527c0477cce0718366dc5c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46760571)</sub>

<!-- /greptile_comment -->