### PR TITLE
feat: switch to Untitled serif from Baskerville in a few places

### DIFF
--- a/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
@@ -8,6 +8,14 @@ public enum ReaderFonts {
     // MARK: - Font Installation
 
     private nonisolated(unsafe) static var fontsNeedInstallation = true
+    private static let fontResourceNames = [
+        "UntitledSerifApp-Medium",
+        "UntitledSerifApp-MediumItalic",
+        "UntitledSerifApp-Regular",
+        "UntitledSerifApp-RegularItalic",
+        "UntitledSerifApp-Bold",
+        "UntitledSerifApp-BoldItalic"
+    ]
 
     public static func installFontsIfNeeded() {
         guard fontsNeedInstallation else {
@@ -15,16 +23,12 @@ public enum ReaderFonts {
         }
         fontsNeedInstallation = false
 
-        let fontNames = [
-            "UntitledSerifApp-Medium",
-            "UntitledSerifApp-MediumItalic",
-            "UntitledSerifApp-Regular",
-            "UntitledSerifApp-RegularItalic",
-            "UntitledSerifApp-Bold",
-            "UntitledSerifApp-BoldItalic"
-        ]
+        installFonts()
+    }
+
+    static func installFonts() {
         let bundle = Bundle.YouVersionReaderBundle
-        for name in fontNames {
+        for name in fontResourceNames {
             if let cfURL = bundle.url(forResource: name, withExtension: "ttf") as CFURL? {
                 CTFontManagerRegisterFontsForURL(cfURL, CTFontManagerScope.process, nil)
             } else {

--- a/Sources/YouVersionPlatformUI/Utilities/YouVersionFonts.swift
+++ b/Sources/YouVersionPlatformUI/Utilities/YouVersionFonts.swift
@@ -34,7 +34,7 @@ public enum YouVersionFonts {
     @available(*, deprecated, renamed: "captionsSmall")
     public static var fontCaptionsS: Font { captionsSmall }
 
-    /// The preferred font for Bible version abbreviations.
+    /// The preferred font for Bible version text and abbreviations.
     public static func preferredBibleTextFont(size: CGFloat) -> Font {
         Font.custom("Untitled Serif", size: size, relativeTo: .body)
     }

--- a/Sources/YouVersionPlatformUI/Utilities/YouVersionFonts.swift
+++ b/Sources/YouVersionPlatformUI/Utilities/YouVersionFonts.swift
@@ -1,3 +1,5 @@
+import CoreText
+import Foundation
 import SwiftUI
 
 public enum YouVersionFonts {
@@ -9,6 +11,9 @@ public enum YouVersionFonts {
     public static let labelSmall = Font.system(size: 11, weight: .medium)
     public static let captionsLarge = Font.system(size: 13)
     public static let captionsSmall = Font.system(size: 11)
+
+    private static let untitledSerifFamilyName = "Untitled Serif"
+    private static let fallbackBibleTextFontFamilyName = "Baskerville"
 
     @available(*, deprecated, renamed: "systemMedium")
     public static var fontSystemM: Font { systemMedium }
@@ -34,8 +39,17 @@ public enum YouVersionFonts {
     @available(*, deprecated, renamed: "captionsSmall")
     public static var fontCaptionsS: Font { captionsSmall }
 
-    /// The preferred font for Bible version text and abbreviations.
+    /// Returns Untitled Serif when available, otherwise Baskerville.
     public static func preferredBibleTextFont(size: CGFloat) -> Font {
-        Font.custom("Untitled Serif", size: size, relativeTo: .body)
+        let familyName = isFontFamilyAvailable(untitledSerifFamilyName)
+            ? untitledSerifFamilyName
+            : fallbackBibleTextFontFamilyName
+
+        return Font.custom(familyName, size: size, relativeTo: .body)
+    }
+
+    static func isFontFamilyAvailable(_ familyName: String) -> Bool {
+        let font = CTFontCreateWithName(familyName as CFString, 12, nil)
+        return CTFontCopyFamilyName(font) as String == familyName
     }
 }

--- a/Sources/YouVersionPlatformUI/Utilities/YouVersionFonts.swift
+++ b/Sources/YouVersionPlatformUI/Utilities/YouVersionFonts.swift
@@ -34,8 +34,8 @@ public enum YouVersionFonts {
     @available(*, deprecated, renamed: "captionsSmall")
     public static var fontCaptionsS: Font { captionsSmall }
 
-    /// For YouVersion uses of the Untitled font, use Baskerville as a fallback.
+    /// The preferred font for Bible version abbreviations.
     public static func preferredBibleTextFont(size: CGFloat) -> Font {
-        Font.custom("Baskerville", size: size)
+        Font.custom("Untitled Serif", size: size, relativeTo: .body)
     }
 }

--- a/Tests/YouVersionPlatformReaderTests/ReaderFontsTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/ReaderFontsTests.swift
@@ -1,8 +1,32 @@
+import CoreText
+import Foundation
 import SwiftUI
 import Testing
 @testable import YouVersionPlatformReader
+@testable import YouVersionPlatformUI
 
+@MainActor
+@Suite(.serialized)
 struct ReaderFontsTests {
+    @Test
+    func preferredBibleTextFontChangesAfterReaderFontsAreInstalled() throws {
+        let fontURLs = try #require(
+            Bundle.YouVersionReaderBundle.urls(forResourcesWithExtension: "ttf", subdirectory: nil)
+        )
+
+        for fontURL in fontURLs {
+            CTFontManagerUnregisterFontsForURL(fontURL as CFURL, .process, nil)
+        }
+
+        let fallbackFontDescription = debugDescription(of: YouVersionFonts.preferredBibleTextFont(size: 20))
+        #expect(fallbackFontDescription.contains("Baskerville"))
+
+        ReaderFonts.installFonts()
+
+        let readerFontDescription = debugDescription(of: YouVersionFonts.preferredBibleTextFont(size: 20))
+        #expect(readerFontDescription.contains("Untitled Serif"))
+    }
+
     @Test
     func isPermittedFontAcceptsSuggestedAndOtherFamilies() {
         #expect(ReaderFonts.isPermittedFont("Untitled Serif"))

--- a/Tests/YouVersionPlatformUITests/YouVersionFontsTests.swift
+++ b/Tests/YouVersionPlatformUITests/YouVersionFontsTests.swift
@@ -1,0 +1,14 @@
+import Testing
+@testable import YouVersionPlatformUI
+
+struct YouVersionFontsTests {
+    @Test
+    func reportsAvailableFontFamily() {
+        #expect(YouVersionFonts.isFontFamilyAvailable("Helvetica"))
+    }
+
+    @Test
+    func reportsUnavailableFontFamily() {
+        #expect(!YouVersionFonts.isFontFamilyAvailable("Definitely Not A Font Family"))
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates shared Bible-text font selection and its tests.
- Selects Untitled Serif when CoreText reports that family as available, otherwise selecting Baskerville.
- Refactors Reader font registration into a reusable internal helper.
- Adds coverage for font availability and behavior before and after Reader font registration.

<h3>Confidence Score: 4/5</h3>

The PR does not appear safe to merge until standalone YouVersionPlatformUI consumers can access and register Untitled Serif as requested in the existing thread.

The new availability check avoids an implicit system substitution, but standalone BibleVersionPickingButton usage still has no path to the Reader-owned font resources and therefore deterministically renders Baskerville instead of Untitled Serif.

**Files Needing Attention:** Sources/YouVersionPlatformUI/Utilities/YouVersionFonts.swift; Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift | Extracts the bundled Untitled Serif resource list and registration loop for direct test coverage. |
| Sources/YouVersionPlatformUI/Utilities/YouVersionFonts.swift | Adds CoreText-based family availability detection and an explicit Baskerville fallback. |
| Tests/YouVersionPlatformReaderTests/ReaderFontsTests.swift | Verifies preferred font selection before and after registering Reader-owned font resources. |
| Tests/YouVersionPlatformUITests/YouVersionFontsTests.swift | Covers positive and negative font-family availability checks. |

<sub>Reviews (2): Last reviewed commit: ["fix: have fallbackFontDescription return..."](https://github.com/youversion/platform-sdk-swift/commit/629d36d9c2b7ccf012e8a55a7681c22354fdbc19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48850980)</sub>

<!-- /greptile_comment -->