### PR TITLE
feat: add excludedVersionIds

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,17 @@ YouVersionPlatformConfiguration.configure(
 
 IDs are the YouVersion Bible version IDs (e.g. `111` for NIV, `1588` for AMP). Combines with `permittedLanguageTags` — a version must satisfy both filters to be shown.
 
+To make every otherwise available version selectable except for specific versions, pass `excludedVersionIds`:
+
+```swift
+YouVersionPlatformConfiguration.configure(
+    appKey: "YOUR_APP_KEY_HERE",
+    excludedVersionIds: [4212]
+)
+```
+
+Excluded IDs are omitted from SDK-managed version selection, restored selections, and automatic fallbacks. Exclusion takes precedence when an ID appears in both `permittedVersionIds` and `excludedVersionIds`.
+
 
 ### Implementing Sign In
 

--- a/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
+++ b/Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift
@@ -25,6 +25,11 @@ public struct YouVersionPlatformConfiguration {
     /// filters to be available.
     nonisolated(unsafe) public private(set) static var permittedVersionIds: Set<Int>?
 
+    /// Bible version IDs that should not be made available in the version picker UI,
+    /// restored selections, or automatic fallbacks. When empty, no versions are excluded.
+    /// Exclusion takes precedence over ``permittedVersionIds``.
+    nonisolated(unsafe) public private(set) static var excludedVersionIds: Set<Int> = []
+
     private static let installIdKey = "YouVersionPlatformInstallID"
     nonisolated(unsafe) public private(set) static var installId: String?
 
@@ -54,7 +59,8 @@ public struct YouVersionPlatformConfiguration {
         isSignInEnabled: Bool = true,
         signInPromptMessage: String? = nil,
         permittedLanguageTags: Set<String>? = nil,
-        permittedVersionIds: Set<Int>? = nil
+        permittedVersionIds: Set<Int>? = nil,
+        excludedVersionIds: Set<Int> = []
     ) {
         let defaults = UserDefaults.standard
 
@@ -70,6 +76,7 @@ public struct YouVersionPlatformConfiguration {
         Self.signInPromptMessage = signInPromptMessage
         Self.permittedLanguageTags = permittedLanguageTags
         Self.permittedVersionIds = permittedVersionIds
+        Self.excludedVersionIds = excludedVersionIds
 
         // Create and save an Install ID if it's not present
         if let existing = defaults.string(forKey: installIdKey) {

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -145,10 +145,13 @@ public final class BibleVersionsViewModel {
         myVersions.insert(version)
     }
     
-    /// Returns true when a version satisfies the configured `permittedLanguageTags`
-    /// and `permittedVersionIds` filters. A `nil` filter means "no restriction" on
-    /// that dimension.
-    private func isPermitted(versionId: Int, languageTag: String?) -> Bool {
+    /// Returns true when a version satisfies the configured `permittedLanguageTags`,
+    /// `permittedVersionIds`, and `excludedVersionIds` filters. A `nil` permitted
+    /// filter means "no restriction" on that dimension.
+    func isPermitted(versionId: Int, languageTag: String?) -> Bool {
+        guard !YouVersionPlatformConfiguration.excludedVersionIds.contains(versionId) else {
+            return false
+        }
         if let permittedTags = YouVersionPlatformConfiguration.permittedLanguageTags {
             guard let languageTag, permittedTags.contains(languageTag) else {
                 return false
@@ -176,7 +179,8 @@ public final class BibleVersionsViewModel {
     private func fallbackVersion(savedIds: Set<Int>) async -> Int? {
         let downloadedVersionIds = BibleVersionRepository.defaultDownloadedVersionIds
         if let downloadedVersionId = downloadedVersionIds.first(where: {
-            YouVersionPlatformConfiguration.permittedVersionIds?.contains($0) ?? true
+            !YouVersionPlatformConfiguration.excludedVersionIds.contains($0)
+                && (YouVersionPlatformConfiguration.permittedVersionIds?.contains($0) ?? true)
         }) {
             return downloadedVersionId
         }

--- a/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/YouVersionPlatformConfigurationTests.swift
@@ -84,7 +84,7 @@ extension ConfigurationStateTests {
             await YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
             #expect(YouVersionPlatformConfiguration.installId == firstId)
         }
-        
+
         // MARK: - configureSignIn
         
         @Test func configureSignInSetsAppName() async {

--- a/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
@@ -59,7 +59,7 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
 }
 
 @MainActor
-@Suite struct BibleVersionsViewModelTests {
+@Suite(.serialized) struct BibleVersionsViewModelTests {
     @Test
     func initUsesSharedRepositoryByDefault() {
         let viewModel = BibleVersionsViewModel()
@@ -108,6 +108,23 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
         #expect(viewModel.showGenericAlert)
         #expect(viewModel.textForGenericAlertTitle == .localized("generic.error"))
         #expect(viewModel.textForGenericAlertBody == .localized("reader.versionAccessErrorBody"))
+    }
+
+    @Test
+    func excludedVersionIsNotPermitted() {
+        let originalAppKey = YouVersionPlatformConfiguration.appKey
+        YouVersionPlatformConfiguration.configure(
+            appKey: originalAppKey,
+            permittedVersionIds: [4212, 4213],
+            excludedVersionIds: [4212]
+        )
+        defer {
+            YouVersionPlatformConfiguration.configure(appKey: originalAppKey)
+        }
+        let viewModel = BibleVersionsViewModel()
+
+        #expect(!viewModel.isPermitted(versionId: 4212, languageTag: "en"))
+        #expect(viewModel.isPermitted(versionId: 4213, languageTag: "en"))
     }
 
     @Test


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds configurable Bible-version exclusions.
- Introduces excludedVersionIds in YouVersionPlatformConfiguration.
- Applies exclusions to picker filtering and automatic fallback selection.
- Documents exclusion behavior and adds focused configuration/UI tests.

<h3>Confidence Score: 4/5</h3>

The PR should be fixed before merging because reader navigation can still select and retain an explicitly excluded version.

Filtering correctly removes excluded IDs from picker and fallback candidates, but the shared switching methods do not enforce the restriction when reader navigation supplies a version directly.

**Files Needing Attention:** Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift and the shared version-switch/navigation paths

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/YouVersionPlatformConfiguration.swift | Adds the default-empty excludedVersionIds configuration property and configure parameter. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift | Filters excluded versions from lists and fallbacks, but direct version-switch paths can bypass the new restriction. |
| Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift | Adds a serialized exclusion-precedence test, though it does not exercise direct reader navigation or switching. |
| README.md | Documents configuration, precedence, and intended selection behavior for excluded IDs. |

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%3A152-154%0A**Direct%20switches%20bypass%20exclusions**%0A%0AWhen%20reader%20navigation%20or%20header%20selection%20supplies%20an%20excluded%20version%20ID%2C%20the%20shared%20%60switchToVersion%60%20methods%20set%20it%20without%20invoking%20%60isPermitted%60%2C%20causing%20the%20reader%20to%20select%20the%20excluded%20version%20and%20add%20it%20to%20My%20Versions.%20Please%20enforce%20this%20restriction%20at%20the%20shared%20switching%20boundary%20so%20all%20selection%20paths%20receive%20the%20new%20protection.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youversion%2Fplatform-sdk-swift&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%3A152-154%0A**Direct%20switches%20bypass%20exclusions**%0A%0AWhen%20reader%20navigation%20or%20header%20selection%20supplies%20an%20excluded%20version%20ID%2C%20the%20shared%20%60switchToVersion%60%20methods%20set%20it%20without%20invoking%20%60isPermitted%60%2C%20causing%20the%20reader%20to%20select%20the%20excluded%20version%20and%20add%20it%20to%20My%20Versions.%20Please%20enforce%20this%20restriction%20at%20the%20shared%20switching%20boundary%20so%20all%20selection%20paths%20receive%20the%20new%20protection.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22YPE-4424-exclude-bible-version-ids%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22YPE-4424-exclude-bible-version-ids%22.%0A%0A%23%23%23%20Issue%201%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%3A152-154%0A**Direct%20switches%20bypass%20exclusions**%0A%0AWhen%20reader%20navigation%20or%20header%20selection%20supplies%20an%20excluded%20version%20ID%2C%20the%20shared%20%60switchToVersion%60%20methods%20set%20it%20without%20invoking%20%60isPermitted%60%2C%20causing%20the%20reader%20to%20select%20the%20excluded%20version%20and%20add%20it%20to%20My%20Versions.%20Please%20enforce%20this%20restriction%20at%20the%20shared%20switching%20boundary%20so%20all%20selection%20paths%20receive%20the%20new%20protection.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youversion%2Fplatform-sdk-swift&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift:152-154
**Direct switches bypass exclusions**

When reader navigation or header selection supplies an excluded version ID, the shared `switchToVersion` methods set it without invoking `isPermitted`, causing the reader to select the excluded version and add it to My Versions. Please enforce this restriction at the shared switching boundary so all selection paths receive the new protection.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add excludedVersionIds"](https://github.com/youversion/platform-sdk-swift/commit/9be029d8a620d821692e1bd02fd283e7f5549d7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49145255)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->