### PR TITLE
chore: update api-baseline given the excludedVersionIds addition

### DIFF
--- a/.api-baseline/YouVersionPlatformCore.json
+++ b/.api-baseline/YouVersionPlatformCore.json
@@ -22137,6 +22137,72 @@
           },
           {
             "kind": "Var",
+            "name": "excludedVersionIds",
+            "printedName": "excludedVersionIds",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "usr": "s:Sh"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV08excludedB3IdsShySiGvpZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV08excludedB3IdsShySiGvpZ",
+            "moduleName": "YouVersionPlatformCore",
+            "static": true,
+            "declAttributes": [
+              "HasInitialValue",
+              "Nonisolated",
+              "SetterAccess",
+              "HasStorage"
+            ],
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Set",
+                    "printedName": "Swift.Set<Swift.Int>",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ],
+                    "usr": "s:Sh"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV08excludedB3IdsShySiGvgZ",
+                "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV08excludedB3IdsShySiGvgZ",
+                "moduleName": "YouVersionPlatformCore",
+                "static": true,
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
             "name": "installId",
             "printedName": "installId",
             "children": [
@@ -22267,7 +22333,7 @@
           {
             "kind": "Function",
             "name": "configure",
-            "printedName": "configure(appKey:apiHost:appName:isSignInEnabled:signInPromptMessage:permittedLanguageTags:permittedVersionIds:)",
+            "printedName": "configure(appKey:apiHost:appName:isSignInEnabled:signInPromptMessage:permittedLanguageTags:permittedVersionIds:excludedVersionIds:)",
             "children": [
               {
                 "kind": "TypeNominal",
@@ -22385,11 +22451,26 @@
                 ],
                 "hasDefaultArg": true,
                 "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Set",
+                "printedName": "Swift.Set<Swift.Int>",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "hasDefaultArg": true,
+                "usr": "s:Sh"
               }
             ],
             "declKind": "Func",
-            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV9configure6appKey7apiHost0G4Name15isSignInEnabled04signN13PromptMessage21permittedLanguageTags0sB3IdsySSSg_A2LSbALShySSGSgShySiGSgtFZ",
-            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV9configure6appKey7apiHost0G4Name15isSignInEnabled04signN13PromptMessage21permittedLanguageTags0sB3IdsySSSg_A2LSbALShySSGSgShySiGSgtFZ",
+            "usr": "s:22YouVersionPlatformCore0abC13ConfigurationV9configure6appKey7apiHost0G4Name15isSignInEnabled04signN13PromptMessage21permittedLanguageTags0sB3Ids08excludedbV0ySSSg_A2MSbAMShySSGSgShySiGSgAPtFZ",
+            "mangledName": "$s22YouVersionPlatformCore0abC13ConfigurationV9configure6appKey7apiHost0G4Name15isSignInEnabled04signN13PromptMessage21permittedLanguageTags0sB3Ids08excludedbV0ySSSg_A2MSbAMShySSGSgShySiGSgAPtFZ",
             "moduleName": "YouVersionPlatformCore",
             "static": true,
             "declAttributes": [


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the committed YouVersionPlatformCore API baseline to reflect the new `excludedVersionIds` configuration API.
- Adds the public static `excludedVersionIds` property.
- Adds the defaulted `excludedVersionIds` parameter to `configure`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the baseline update matches the current public API declaration.

The changed baseline records the new static property and configuration parameter with the expected types, ordering, default-argument metadata, and generated symbol information.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .api-baseline/YouVersionPlatformCore.json | The baseline metadata consistently reflects the added `Set<Int>` property and defaulted configuration parameter; no actionable issues were identified. |

<sub>Reviews (1): Last reviewed commit: ["chore: update api-baseline given the exc..."](https://github.com/youversion/platform-sdk-swift/commit/d150bd01758dfd3c7e9240855725b96cf5005420) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49714515)</sub>

<!-- /greptile_comment -->