### PR TITLE
feat: obey cache-control headers for Bible content and metadata

### DIFF
--- a/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
@@ -52,10 +52,16 @@ extension YouVersionAPI.Bible {
                 books: index.books,
                 textDirection: index.textDirection,
             ),
-            expirationDate: [metadataResponse.expirationDate, indexResponse.expirationDate]
-                .compactMap { $0 }
-                .min()
+            expirationDate: combinedExpirationDate(
+                metadataResponse.expirationDate,
+                indexResponse.expirationDate
+            ),
+            isCacheable: metadataResponse.isCacheable && indexResponse.isCacheable
         )
+    }
+
+    private static func combinedExpirationDate(_ first: Date?, _ second: Date?) -> Date? {
+        [first, second].compactMap { $0 }.min()
     }
 
     @available(*, deprecated, renamed: "version(withId:accessToken:session:)")
@@ -93,7 +99,8 @@ extension YouVersionAPI.Bible {
         let response = try await YouVersionAPI.responseData(at: url, accessToken: accessToken, session: session)
         return CachedBibleContent(
             value: try JSONDecoder().decode(BibleVersion.self, from: response.value),
-            expirationDate: response.expirationDate
+            expirationDate: response.expirationDate,
+            isCacheable: response.isCacheable
         )
     }
 
@@ -117,7 +124,8 @@ extension YouVersionAPI.Bible {
         let response = try await YouVersionAPI.responseData(at: url, accessToken: accessToken, session: session)
         return CachedBibleContent(
             value: try JSONDecoder().decode(BibleVersionIndex.self, from: response.value),
-            expirationDate: response.expirationDate
+            expirationDate: response.expirationDate,
+            isCacheable: response.isCacheable
         )
     }
 
@@ -164,7 +172,8 @@ extension YouVersionAPI.Bible {
 
         return CachedBibleContent(
             value: content,
-            expirationDate: httpResponse.cacheExpirationDate()
+            expirationDate: httpResponse.cacheExpirationDate(),
+            isCacheable: httpResponse.allowsCaching
         )
     }
     

--- a/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
@@ -17,7 +17,7 @@ extension YouVersionAPI.Bible {
         withId versionId: Int,
         accessToken providedToken: String? = nil,
         session: URLSession = .shared
-    ) async throws -> CachedBibleContent<BibleVersion> {
+    ) async throws -> BibleContentResponse<BibleVersion> {
         let accessToken = providedToken ?? YouVersionPlatformConfiguration.accessToken
 
         async let metadataTask = metadataResponseForVersion(
@@ -35,7 +35,7 @@ extension YouVersionAPI.Bible {
         let metadata = metadataResponse.value
         let index = indexResponse.value
 
-        return CachedBibleContent(
+        return BibleContentResponse(
             value: BibleVersion(
                 id: metadata.id,
                 abbreviation: metadata.abbreviation,
@@ -52,16 +52,9 @@ extension YouVersionAPI.Bible {
                 books: index.books,
                 textDirection: index.textDirection,
             ),
-            expirationDate: combinedExpirationDate(
-                metadataResponse.expirationDate,
-                indexResponse.expirationDate
-            ),
+            expirationDate: min(metadataResponse.expirationDate, indexResponse.expirationDate),
             isCacheable: metadataResponse.isCacheable && indexResponse.isCacheable
         )
-    }
-
-    private static func combinedExpirationDate(_ first: Date?, _ second: Date?) -> Date? {
-        [first, second].compactMap { $0 }.min()
     }
 
     @available(*, deprecated, renamed: "version(withId:accessToken:session:)")
@@ -92,12 +85,12 @@ extension YouVersionAPI.Bible {
         withId versionId: Int,
         accessToken: String?,
         session: URLSession
-    ) async throws -> CachedBibleContent<BibleVersion> {
+    ) async throws -> BibleContentResponse<BibleVersion> {
         guard let url = URLBuilder.versionURL(versionId: versionId) else {
             throw URLError(.badURL)
         }
         let response = try await YouVersionAPI.responseData(at: url, accessToken: accessToken, session: session)
-        return CachedBibleContent(
+        return BibleContentResponse(
             value: try JSONDecoder().decode(BibleVersion.self, from: response.value),
             expirationDate: response.expirationDate,
             isCacheable: response.isCacheable
@@ -113,7 +106,7 @@ extension YouVersionAPI.Bible {
         withId versionId: Int,
         accessToken: String?,
         session: URLSession
-    ) async throws -> CachedBibleContent<BibleVersionIndex> {
+    ) async throws -> BibleContentResponse<BibleVersionIndex> {
         struct BibleVersionChaptersResponse: Codable {
             let data: [BibleChapter]
         }
@@ -122,7 +115,7 @@ extension YouVersionAPI.Bible {
             throw URLError(.badURL)
         }
         let response = try await YouVersionAPI.responseData(at: url, accessToken: accessToken, session: session)
-        return CachedBibleContent(
+        return BibleContentResponse(
             value: try JSONDecoder().decode(BibleVersionIndex.self, from: response.value),
             expirationDate: response.expirationDate,
             isCacheable: response.isCacheable
@@ -140,7 +133,7 @@ extension YouVersionAPI.Bible {
         reference: BibleReference,
         accessToken providedToken: String? = nil,
         session: URLSession = .shared
-    ) async throws -> CachedBibleContent<String> {
+    ) async throws -> BibleContentResponse<String> {
         let accessToken = providedToken ?? YouVersionPlatformConfiguration.accessToken
         guard let url = URLBuilder.passageURL(reference: reference, format: "html") else {
             throw URLError(.badURL)
@@ -170,7 +163,7 @@ extension YouVersionAPI.Bible {
             throw YouVersionAPIError.invalidDownload
         }
 
-        return CachedBibleContent(
+        return BibleContentResponse(
             value: content,
             expirationDate: httpResponse.cacheExpirationDate(),
             isCacheable: httpResponse.allowsCaching

--- a/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift
@@ -7,34 +7,59 @@ public extension YouVersionAPI {
     enum Bible {}
 }
 
-public extension YouVersionAPI.Bible {
+extension YouVersionAPI.Bible {
 
-    static func version(withId versionId: Int, accessToken providedToken: String? = nil, session: URLSession = .shared) async throws -> BibleVersion {
+    public static func version(withId versionId: Int, accessToken providedToken: String? = nil, session: URLSession = .shared) async throws -> BibleVersion {
+        try await versionResponse(withId: versionId, accessToken: providedToken, session: session).value
+    }
+
+    static func versionResponse(
+        withId versionId: Int,
+        accessToken providedToken: String? = nil,
+        session: URLSession = .shared
+    ) async throws -> CachedBibleContent<BibleVersion> {
         let accessToken = providedToken ?? YouVersionPlatformConfiguration.accessToken
 
-        async let metadata = metadataForVersion(withId: versionId, accessToken: accessToken, session: session)
-        async let index = indexForVersion(withId: versionId, accessToken: accessToken, session: session)
+        async let metadataTask = metadataResponseForVersion(
+            withId: versionId,
+            accessToken: accessToken,
+            session: session
+        )
+        async let indexTask = indexResponseForVersion(
+            withId: versionId,
+            accessToken: accessToken,
+            session: session
+        )
 
-        return try await BibleVersion(
-            id: metadata.id,
-            abbreviation: metadata.abbreviation,
-            promotionalContent: metadata.promotionalContent,
-            copyright: metadata.copyright,
-            languageTag: metadata.languageTag,
-            localizedAbbreviation: metadata.localizedAbbreviation,
-            localizedTitle: metadata.localizedTitle,
-            readerFooter: metadata.readerFooter,
-            readerFooterUrl: metadata.readerFooterUrl,
-            title: metadata.title,
-            organizationId: metadata.organizationId,
-            bookCodes: metadata.bookCodes,
-            books: index.books,
-            textDirection: index.textDirection,
+        let (metadataResponse, indexResponse) = try await (metadataTask, indexTask)
+        let metadata = metadataResponse.value
+        let index = indexResponse.value
+
+        return CachedBibleContent(
+            value: BibleVersion(
+                id: metadata.id,
+                abbreviation: metadata.abbreviation,
+                promotionalContent: metadata.promotionalContent,
+                copyright: metadata.copyright,
+                languageTag: metadata.languageTag,
+                localizedAbbreviation: metadata.localizedAbbreviation,
+                localizedTitle: metadata.localizedTitle,
+                readerFooter: metadata.readerFooter,
+                readerFooterUrl: metadata.readerFooterUrl,
+                title: metadata.title,
+                organizationId: metadata.organizationId,
+                bookCodes: metadata.bookCodes,
+                books: index.books,
+                textDirection: index.textDirection,
+            ),
+            expirationDate: [metadataResponse.expirationDate, indexResponse.expirationDate]
+                .compactMap { $0 }
+                .min()
         )
     }
 
     @available(*, deprecated, renamed: "version(withId:accessToken:session:)")
-    static func version(versionId: Int, accessToken providedToken: String? = nil, session: URLSession = .shared) async throws -> BibleVersion {
+    public static func version(versionId: Int, accessToken providedToken: String? = nil, session: URLSession = .shared) async throws -> BibleVersion {
         try await version(withId: versionId, accessToken: providedToken, session: session)
     }
 
@@ -53,20 +78,35 @@ public extension YouVersionAPI.Bible {
     ///   - `YouVersionAPIError.notPermitted` if the app key is invalid or lacks permission.
     ///   - `YouVersionAPIError.cannotDownload` if the server returns an error response.
     ///   - `YouVersionAPIError.invalidResponse` if the server response is not valid.
-    static func metadataForVersion(withId versionId: Int, accessToken: String?, session: URLSession = .shared) async throws -> BibleVersion {
+    public static func metadataForVersion(withId versionId: Int, accessToken: String?, session: URLSession = .shared) async throws -> BibleVersion {
+        try await metadataResponseForVersion(withId: versionId, accessToken: accessToken, session: session).value
+    }
+
+    private static func metadataResponseForVersion(
+        withId versionId: Int,
+        accessToken: String?,
+        session: URLSession
+    ) async throws -> CachedBibleContent<BibleVersion> {
         guard let url = URLBuilder.versionURL(versionId: versionId) else {
             throw URLError(.badURL)
         }
-        let data = try await YouVersionAPI.data(at: url, accessToken: accessToken, session: session)
-        return try JSONDecoder().decode(BibleVersion.self, from: data)
+        let response = try await YouVersionAPI.responseData(at: url, accessToken: accessToken, session: session)
+        return CachedBibleContent(
+            value: try JSONDecoder().decode(BibleVersion.self, from: response.value),
+            expirationDate: response.expirationDate
+        )
     }
 
     @available(*, deprecated, renamed: "metadataForVersion(withId:accessToken:session:)")
-    static func basicVersion(versionId: Int, accessToken: String?, session: URLSession = .shared) async throws -> BibleVersion {
+    public static func basicVersion(versionId: Int, accessToken: String?, session: URLSession = .shared) async throws -> BibleVersion {
         try await metadataForVersion(withId: versionId, accessToken: accessToken, session: session)
     }
 
-    private static func indexForVersion(withId versionId: Int, accessToken: String?, session: URLSession = .shared) async throws -> BibleVersionIndex {
+    private static func indexResponseForVersion(
+        withId versionId: Int,
+        accessToken: String?,
+        session: URLSession
+    ) async throws -> CachedBibleContent<BibleVersionIndex> {
         struct BibleVersionChaptersResponse: Codable {
             let data: [BibleChapter]
         }
@@ -74,14 +114,25 @@ public extension YouVersionAPI.Bible {
         guard let url = URLBuilder.versionIndexURL(versionId: versionId) else {
             throw URLError(.badURL)
         }
-        let data = try await YouVersionAPI.data(at: url, accessToken: accessToken, session: session)
-        return try JSONDecoder().decode(BibleVersionIndex.self, from: data)
+        let response = try await YouVersionAPI.responseData(at: url, accessToken: accessToken, session: session)
+        return CachedBibleContent(
+            value: try JSONDecoder().decode(BibleVersionIndex.self, from: response.value),
+            expirationDate: response.expirationDate
+        )
     }
 
     // MARK: - Chapter Content
 
     /// Fetches the content of a single Bible chapter from the server.
-    static func chapter(reference: BibleReference, accessToken providedToken: String? = nil, session: URLSession = .shared) async throws -> String {
+    public static func chapter(reference: BibleReference, accessToken providedToken: String? = nil, session: URLSession = .shared) async throws -> String {
+        try await chapterResponse(reference: reference, accessToken: providedToken, session: session).value
+    }
+
+    static func chapterResponse(
+        reference: BibleReference,
+        accessToken providedToken: String? = nil,
+        session: URLSession = .shared
+    ) async throws -> CachedBibleContent<String> {
         let accessToken = providedToken ?? YouVersionPlatformConfiguration.accessToken
         guard let url = URLBuilder.passageURL(reference: reference, format: "html") else {
             throw URLError(.badURL)
@@ -111,11 +162,14 @@ public extension YouVersionAPI.Bible {
             throw YouVersionAPIError.invalidDownload
         }
 
-        return content
+        return CachedBibleContent(
+            value: content,
+            expirationDate: httpResponse.cacheExpirationDate()
+        )
     }
     
     /// Fetches the html content of the "intro" (introductory material) for a book from the server.
-    static func introMaterial(versionId: Int, passageId: String, accessToken providedToken: String? = nil, session: URLSession = .shared) async throws -> String {
+    public static func introMaterial(versionId: Int, passageId: String, accessToken providedToken: String? = nil, session: URLSession = .shared) async throws -> String {
         guard let url = URLBuilder.passageIntroURL(versionId: versionId, passageId: passageId) else {
             throw URLError(.badURL)
         }

--- a/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
@@ -25,6 +25,14 @@ public enum YouVersionAPI {
     }
 
     static func data(at url: URL, accessToken: String?, session: URLSession) async throws -> Data {
+        try await responseData(at: url, accessToken: accessToken, session: session).value
+    }
+
+    static func responseData(
+        at url: URL,
+        accessToken: String?,
+        session: URLSession
+    ) async throws -> CachedBibleContent<Data> {
         let request = urlRequest(with: url, accessToken: accessToken, session: session)
         let (data, response) = try await session.data(for: request)
 
@@ -42,7 +50,10 @@ public enum YouVersionAPI {
             YouVersionPlatformLogger.error("from server: \(httpResponse.statusCode)", category: "API")
             throw YouVersionAPIError.cannotDownload
         }
-        return data
+        return CachedBibleContent(
+            value: data,
+            expirationDate: httpResponse.cacheExpirationDate()
+        )
     }
 
     static func urlRequest(

--- a/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
@@ -52,7 +52,8 @@ public enum YouVersionAPI {
         }
         return CachedBibleContent(
             value: data,
-            expirationDate: httpResponse.cacheExpirationDate()
+            expirationDate: httpResponse.cacheExpirationDate(),
+            isCacheable: httpResponse.allowsCaching
         )
     }
 

--- a/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
+++ b/Sources/YouVersionPlatformCore/APIs/YouVersionAPI.swift
@@ -32,7 +32,7 @@ public enum YouVersionAPI {
         at url: URL,
         accessToken: String?,
         session: URLSession
-    ) async throws -> CachedBibleContent<Data> {
+    ) async throws -> BibleContentResponse<Data> {
         let request = urlRequest(with: url, accessToken: accessToken, session: session)
         let (data, response) = try await session.data(for: request)
 
@@ -50,7 +50,7 @@ public enum YouVersionAPI {
             YouVersionPlatformLogger.error("from server: \(httpResponse.statusCode)", category: "API")
             throw YouVersionAPIError.cannotDownload
         }
-        return CachedBibleContent(
+        return BibleContentResponse(
             value: data,
             expirationDate: httpResponse.cacheExpirationDate(),
             isCacheable: httpResponse.allowsCaching

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -42,65 +42,76 @@ actor ChapterMemoryCache {
 
 /// Manages a medium-duration cache of Bible chapter data; it's not in-memory therefore will survive the app being terminated.
 actor BibleChapterDiskCache {
+    private let coordinator: BibleContentCacheCoordinator
     private let storage: BibleContentStorage
 
-    init(directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()) {
+    init(
+        directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider(),
+        coordinator: BibleContentCacheCoordinator = .shared
+    ) {
+        self.coordinator = coordinator
         storage = BibleContentStorage(storageKind: .cache, directoryProvider: directoryProvider)
     }
 
-    func chapterContent(withReference reference: BibleReference, currentDate: Date = Date()) -> String? {
-        cachedChapterContent(withReference: reference, currentDate: currentDate)?.value
+    func chapterContent(withReference reference: BibleReference, currentDate: Date = Date()) async -> String? {
+        await cachedChapterContent(withReference: reference, currentDate: currentDate)?.value
     }
 
     func cachedChapterContent(
         withReference reference: BibleReference,
         currentDate: Date
-    ) -> CachedBibleContent<String>? {
+    ) async -> CachedBibleContent<String>? {
         let resource = BibleContentStorageResource.chapter(
             versionId: reference.versionId,
             chapterPassageId: reference.chapterPassageId
         )
-        guard !storage.isExpired(resource, currentDate: currentDate) else {
-            storage.removeCachedResource(resource)
-            return nil
+        return await coordinator.perform {
+            guard !storage.isExpired(resource, currentDate: currentDate) else {
+                storage.removeCacheEntry(resource)
+                return nil
+            }
+            guard let content = storage.string(for: resource) else {
+                return nil
+            }
+            return CachedBibleContent(
+                value: content,
+                expirationDate: storage.expirationDate(for: resource)
+            )
         }
-        guard let content = storage.string(for: resource) else {
-            return nil
-        }
-        return CachedBibleContent(
-            value: content,
-            expirationDate: storage.expirationDate(for: resource)
-        )
     }
 
-    func addChapterContent(_ content: String, reference: BibleReference, expirationDate: Date) {
+    func addChapterContent(_ content: String, reference: BibleReference, expirationDate: Date) async {
         let resource = BibleContentStorageResource.chapter(
             versionId: reference.versionId,
             chapterPassageId: reference.chapterPassageId
         )
-        do {
-            try storage.writeExpirationDate(expirationDate, for: resource)
-            try storage.writeString(
-                content,
-                to: resource
-            )
-        } catch {
-            storage.removeCachedResource(resource)
-            YouVersionPlatformLogger.notice(
-                "BibleChapterDiskCache failed to write data: \(error.localizedDescription)",
-                category: "ChapterCache"
-            )
+        await coordinator.perform {
+            do {
+                try storage.writeExpirationDate(expirationDate, for: resource)
+                try storage.writeString(
+                    content,
+                    to: resource
+                )
+            } catch {
+                storage.removeCacheEntry(resource)
+                YouVersionPlatformLogger.notice(
+                    "BibleChapterDiskCache failed to write data: \(error.localizedDescription)",
+                    category: "ChapterCache"
+                )
+            }
         }
     }
 
-    func removeVersion(withId id: Int) {
-        do {
-            try storage.remove(.chaptersDirectory(versionId: id))
-        } catch {
-            YouVersionPlatformLogger.notice(
-                "BibleChapterDiskCache got error while removing: \(error.localizedDescription)",
-                category: "ChapterCache"
-            )
+    func removeVersion(withId id: Int) async {
+        await coordinator.perform {
+            do {
+                try storage.remove(.chaptersDirectory(versionId: id))
+            } catch {
+                YouVersionPlatformLogger.notice(
+                    "BibleChapterDiskCache got error while removing: \(error.localizedDescription)",
+                    category: "ChapterCache"
+                )
+            }
         }
     }
 }
@@ -203,15 +214,16 @@ public actor BibleChapterRepository: ObservableObject {
         }
 
         let response = try await provider.chapterContent(for: reference)
+        let expirationDate = response.expirationDate
+            ?? currentDate.addingTimeInterval(BibleContentCachePolicy.defaultDuration)
+
+        await memoryCache.addChapterContent(
+            response.value,
+            reference: reference,
+            expirationDate: expirationDate
+        )
 
         if response.isCacheable {
-            let expirationDate = response.expirationDate
-                ?? currentDate.addingTimeInterval(BibleContentCachePolicy.defaultDuration)
-            await memoryCache.addChapterContent(
-                response.value,
-                reference: reference,
-                expirationDate: expirationDate
-            )
             await diskCache.addChapterContent(
                 response.value,
                 reference: reference,

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -4,16 +4,27 @@ import SwiftUI
 #endif
 
 actor ChapterMemoryCache {
-    private var cache: [String: String] = [:]
+    private var cache: [String: CachedBibleContent<String>] = [:]
 
     init() {}
 
-    func chapterContent(withReference reference: BibleReference) -> String? {
-        cache[Self.cacheKey(reference: reference)]
+    func chapterContent(withReference reference: BibleReference, currentDate: Date) -> String? {
+        let key = Self.cacheKey(reference: reference)
+        guard let cached = cache[key] else {
+            return nil
+        }
+        if let expirationDate = cached.expirationDate, expirationDate <= currentDate {
+            cache[key] = nil
+            return nil
+        }
+        return cached.value
     }
 
-    func addChapterContent(_ content: String, reference: BibleReference) {
-        cache[Self.cacheKey(reference: reference)] = content
+    func addChapterContent(_ content: String, reference: BibleReference, expirationDate: Date? = nil) {
+        cache[Self.cacheKey(reference: reference)] = CachedBibleContent(
+            value: content,
+            expirationDate: expirationDate
+        )
     }
 
     func removeVersion(withId id: Int) {
@@ -37,19 +48,44 @@ actor BibleChapterDiskCache {
         storage = BibleContentStorage(storageKind: .cache, directoryProvider: directoryProvider)
     }
 
-    func chapterContent(withReference reference: BibleReference) -> String? {
-        storage.string(
-            for: .chapter(versionId: reference.versionId, chapterPassageId: reference.chapterPassageId)
+    func chapterContent(withReference reference: BibleReference, currentDate: Date = Date()) -> String? {
+        cachedChapterContent(withReference: reference, currentDate: currentDate)?.value
+    }
+
+    func cachedChapterContent(
+        withReference reference: BibleReference,
+        currentDate: Date
+    ) -> CachedBibleContent<String>? {
+        let resource = BibleContentStorageResource.chapter(
+            versionId: reference.versionId,
+            chapterPassageId: reference.chapterPassageId
+        )
+        guard !storage.isExpired(resource, currentDate: currentDate) else {
+            storage.removeCachedResource(resource)
+            return nil
+        }
+        guard let content = storage.string(for: resource) else {
+            return nil
+        }
+        return CachedBibleContent(
+            value: content,
+            expirationDate: storage.expirationDate(for: resource)
         )
     }
 
-    func addChapterContent(_ content: String, reference: BibleReference) {
+    func addChapterContent(_ content: String, reference: BibleReference, expirationDate: Date? = nil) {
+        let resource = BibleContentStorageResource.chapter(
+            versionId: reference.versionId,
+            chapterPassageId: reference.chapterPassageId
+        )
         do {
             try storage.writeString(
                 content,
-                to: .chapter(versionId: reference.versionId, chapterPassageId: reference.chapterPassageId)
+                to: resource
             )
+            try storage.writeExpirationDate(expirationDate, for: resource)
         } catch {
+            storage.removeCachedResource(resource)
             YouVersionPlatformLogger.notice(
                 "BibleChapterDiskCache failed to write data: \(error.localizedDescription)",
                 category: "ChapterCache"
@@ -100,14 +136,14 @@ actor BibleChapterDownloadCache {
 }
 
 protocol BibleChapterContentProviding: Sendable {
-    func chapterContent(for reference: BibleReference) async throws -> String
+    func chapterContent(for reference: BibleReference) async throws -> CachedBibleContent<String>
 }
 
 final class BibleChapterContentAPI: BibleChapterContentProviding {
     init() {}
 
-    func chapterContent(for reference: BibleReference) async throws -> String {
-        try await YouVersionAPI.Bible.chapter(reference: reference)
+    func chapterContent(for reference: BibleReference) async throws -> CachedBibleContent<String> {
+        try await YouVersionAPI.Bible.chapterResponse(reference: reference)
     }
 }
 
@@ -138,13 +174,27 @@ public actor BibleChapterRepository: ObservableObject {
     }
 
     public func chapter(withReference reference: BibleReference) async throws -> String {
-        if let cachedContent = await memoryCache.chapterContent(withReference: reference) {
+        try await chapter(withReference: reference, currentDate: Date())
+    }
+
+    func chapter(withReference reference: BibleReference, currentDate: Date) async throws -> String {
+        if let cachedContent = await memoryCache.chapterContent(
+            withReference: reference,
+            currentDate: currentDate
+        ) {
             return cachedContent
         }
 
-        if let cachedContent = await diskCache.chapterContent(withReference: reference) {
-            await memoryCache.addChapterContent(cachedContent, reference: reference)
-            return cachedContent
+        if let cached = await diskCache.cachedChapterContent(
+            withReference: reference,
+            currentDate: currentDate
+        ) {
+            await memoryCache.addChapterContent(
+                cached.value,
+                reference: reference,
+                expirationDate: cached.expirationDate
+            )
+            return cached.value
         }
 
         if let cachedContent = await downloadCache.chapterContent(withReference: reference) {
@@ -152,12 +202,20 @@ public actor BibleChapterRepository: ObservableObject {
             return cachedContent
         }
 
-        let content = try await provider.chapterContent(for: reference)
+        let response = try await provider.chapterContent(for: reference)
 
-        await memoryCache.addChapterContent(content, reference: reference)
-        await diskCache.addChapterContent(content, reference: reference)
+        await memoryCache.addChapterContent(
+            response.value,
+            reference: reference,
+            expirationDate: response.expirationDate
+        )
+        await diskCache.addChapterContent(
+            response.value,
+            reference: reference,
+            expirationDate: response.expirationDate
+        )
 
-        return content
+        return response.value
     }
 
     func chaptersArePresent(versionId: Int) -> Bool {

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -73,7 +73,7 @@ actor BibleChapterDiskCache {
         )
     }
 
-    func addChapterContent(_ content: String, reference: BibleReference, expirationDate: Date? = nil) {
+    func addChapterContent(_ content: String, reference: BibleReference, expirationDate: Date) {
         let resource = BibleContentStorageResource.chapter(
             versionId: reference.versionId,
             chapterPassageId: reference.chapterPassageId
@@ -204,16 +204,20 @@ public actor BibleChapterRepository: ObservableObject {
 
         let response = try await provider.chapterContent(for: reference)
 
-        await memoryCache.addChapterContent(
-            response.value,
-            reference: reference,
-            expirationDate: response.expirationDate
-        )
-        await diskCache.addChapterContent(
-            response.value,
-            reference: reference,
-            expirationDate: response.expirationDate
-        )
+        if response.isCacheable {
+            let expirationDate = response.expirationDate
+                ?? currentDate.addingTimeInterval(BibleContentCachePolicy.defaultDuration)
+            await memoryCache.addChapterContent(
+                response.value,
+                reference: reference,
+                expirationDate: expirationDate
+            )
+            await diskCache.addChapterContent(
+                response.value,
+                reference: reference,
+                expirationDate: expirationDate
+            )
+        }
 
         return response.value
     }

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -147,13 +147,13 @@ actor BibleChapterDownloadCache {
 }
 
 protocol BibleChapterContentProviding: Sendable {
-    func chapterContent(for reference: BibleReference) async throws -> CachedBibleContent<String>
+    func chapterContent(for reference: BibleReference) async throws -> BibleContentResponse<String>
 }
 
 final class BibleChapterContentAPI: BibleChapterContentProviding {
     init() {}
 
-    func chapterContent(for reference: BibleReference) async throws -> CachedBibleContent<String> {
+    func chapterContent(for reference: BibleReference) async throws -> BibleContentResponse<String> {
         try await YouVersionAPI.Bible.chapterResponse(reference: reference)
     }
 }
@@ -214,20 +214,18 @@ public actor BibleChapterRepository: ObservableObject {
         }
 
         let response = try await provider.chapterContent(for: reference)
-        let expirationDate = response.expirationDate
-            ?? currentDate.addingTimeInterval(BibleContentCachePolicy.defaultDuration)
 
         await memoryCache.addChapterContent(
             response.value,
             reference: reference,
-            expirationDate: expirationDate
+            expirationDate: response.expirationDate
         )
 
         if response.isCacheable {
             await diskCache.addChapterContent(
                 response.value,
                 reference: reference,
-                expirationDate: expirationDate
+                expirationDate: response.expirationDate
             )
         }
 

--- a/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift
@@ -79,11 +79,11 @@ actor BibleChapterDiskCache {
             chapterPassageId: reference.chapterPassageId
         )
         do {
+            try storage.writeExpirationDate(expirationDate, for: resource)
             try storage.writeString(
                 content,
                 to: resource
             )
-            try storage.writeExpirationDate(expirationDate, for: resource)
         } catch {
             storage.removeCachedResource(resource)
             YouVersionPlatformLogger.notice(

--- a/Sources/YouVersionPlatformCore/Bible/BibleContentStorage.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleContentStorage.swift
@@ -35,6 +35,21 @@ private struct BibleContentCacheExpiration: Codable {
     let expirationDate: Date
 }
 
+private enum BibleContentStoragePath {
+    static let versionDirectoryPrefix = "bible_"
+    static let versionMetadataFileName = "BibleVersionMetadata_v1"
+    static let chaptersDirectoryName = "Chapters"
+    static let expirationFileExtension = "expiration"
+}
+
+actor BibleContentCacheCoordinator {
+    static let shared = BibleContentCacheCoordinator()
+
+    func perform<Value: Sendable>(_ operation: @Sendable () throws -> Value) rethrows -> Value {
+        try operation()
+    }
+}
+
 struct BibleContentStorage: Sendable {
     private let storageKind: BibleContentStorageKind
     private let directoryProvider: BibleContentDirectoryProviding
@@ -56,7 +71,7 @@ struct BibleContentStorage: Sendable {
         )) ?? []
 
         var ids: [Int] = []
-        let prefix = "bible_"
+        let prefix = BibleContentStoragePath.versionDirectoryPrefix
 
         for url in urls {
             if let values = try? url.resourceValues(forKeys: [.isDirectoryKey]),
@@ -78,22 +93,28 @@ struct BibleContentStorage: Sendable {
         switch resource {
         case let .versionDirectory(versionId):
             directoryProvider.rootURL(for: storageKind)
-                .appending(path: "bible_\(versionId)", directoryHint: .isDirectory)
+                .appending(
+                    path: BibleContentStoragePath.versionDirectoryPrefix + String(versionId),
+                    directoryHint: .isDirectory
+                )
         case let .versionMetadata(versionId):
             url(for: .versionDirectory(versionId: versionId))
-                .appending(path: "BibleVersionMetadata_v1", directoryHint: .notDirectory)
+                .appending(
+                    path: BibleContentStoragePath.versionMetadataFileName,
+                    directoryHint: .notDirectory
+                )
         case let .versionMetadataExpiration(versionId):
             url(for: .versionMetadata(versionId: versionId))
-                .appendingPathExtension("expiration")
+                .appendingPathExtension(BibleContentStoragePath.expirationFileExtension)
         case let .chaptersDirectory(versionId):
             url(for: .versionDirectory(versionId: versionId))
-                .appending(path: "Chapters", directoryHint: .isDirectory)
+                .appending(path: BibleContentStoragePath.chaptersDirectoryName, directoryHint: .isDirectory)
         case let .chapter(versionId, chapterPassageId):
             url(for: .chaptersDirectory(versionId: versionId))
                 .appending(path: chapterPassageId, directoryHint: .notDirectory)
         case let .chapterExpiration(versionId, chapterPassageId):
             url(for: .chapter(versionId: versionId, chapterPassageId: chapterPassageId))
-                .appendingPathExtension("expiration")
+                .appendingPathExtension(BibleContentStoragePath.expirationFileExtension)
         }
     }
 
@@ -168,9 +189,8 @@ struct BibleContentStorage: Sendable {
         )
     }
 
-    func removeCachedResource(_ resource: BibleContentStorageResource) {
-        try? remove(resource)
-        try? remove(expirationResource(for: resource))
+    func removeCacheEntry(_ contentResource: BibleContentStorageResource) {
+        removeCacheEntry(at: url(for: contentResource))
     }
 
     func removeExpiredCachedResources(currentDate: Date) {
@@ -184,33 +204,34 @@ struct BibleContentStorage: Sendable {
         }
 
         let urls = enumerator.compactMap { $0 as? URL }
-        let expirationURLs = urls.filter { $0.pathExtension == "expiration" }
+        let expirationURLs = urls.filter {
+            $0.pathExtension == BibleContentStoragePath.expirationFileExtension
+        }
         for expirationURL in expirationURLs {
             guard let cacheExpiration = data(at: expirationURL).flatMap({
                 try? JSONDecoder().decode(BibleContentCacheExpiration.self, from: $0)
             }) else {
-                try? FileManager.default.removeItem(at: expirationURL.deletingPathExtension())
-                try? FileManager.default.removeItem(at: expirationURL)
+                removeCacheEntry(at: expirationURL.deletingPathExtension())
                 continue
             }
             guard cacheExpiration.expirationDate <= currentDate else {
                 continue
             }
-            try? FileManager.default.removeItem(at: expirationURL.deletingPathExtension())
-            try? FileManager.default.removeItem(at: expirationURL)
+            removeCacheEntry(at: expirationURL.deletingPathExtension())
         }
 
         let contentURLs = urls.filter { url in
             guard (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true else {
                 return false
             }
-            return url.lastPathComponent == "BibleVersionMetadata_v1"
-                || (url.pathComponents.contains("Chapters") && url.pathExtension != "expiration")
+            return url.lastPathComponent == BibleContentStoragePath.versionMetadataFileName
+                || (url.pathComponents.contains(BibleContentStoragePath.chaptersDirectoryName)
+                    && url.pathExtension != BibleContentStoragePath.expirationFileExtension)
         }
         for contentURL in contentURLs where !FileManager.default.fileExists(
-            atPath: contentURL.appendingPathExtension("expiration").path
+            atPath: contentURL.appendingPathExtension(BibleContentStoragePath.expirationFileExtension).path
         ) {
-            try? FileManager.default.removeItem(at: contentURL)
+            removeCacheEntry(at: contentURL)
         }
     }
 
@@ -227,7 +248,7 @@ struct BibleContentStorage: Sendable {
     }
 
     func remove(_ resource: BibleContentStorageResource) throws {
-        try FileManager.default.removeItem(at: url(for: resource))
+        try removeItem(at: url(for: resource))
     }
 
     private func expirationResource(for resource: BibleContentStorageResource) -> BibleContentStorageResource {
@@ -247,5 +268,16 @@ struct BibleContentStorage: Sendable {
 
     private func data(at url: URL) -> Data? {
         try? Data(contentsOf: url)
+    }
+
+    private func removeCacheEntry(at contentURL: URL) {
+        try? removeItem(at: contentURL)
+        try? removeItem(
+            at: contentURL.appendingPathExtension(BibleContentStoragePath.expirationFileExtension)
+        )
+    }
+
+    private func removeItem(at url: URL) throws {
+        try FileManager.default.removeItem(at: url)
     }
 }

--- a/Sources/YouVersionPlatformCore/Bible/BibleContentStorage.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleContentStorage.swift
@@ -25,8 +25,14 @@ struct DefaultBibleContentDirectoryProvider: BibleContentDirectoryProviding {
 enum BibleContentStorageResource: Sendable {
     case versionDirectory(versionId: Int)
     case versionMetadata(versionId: Int)
+    case versionMetadataExpiration(versionId: Int)
     case chaptersDirectory(versionId: Int)
     case chapter(versionId: Int, chapterPassageId: String)
+    case chapterExpiration(versionId: Int, chapterPassageId: String)
+}
+
+private struct BibleContentCacheExpiration: Codable {
+    let expirationDate: Date?
 }
 
 struct BibleContentStorage: Sendable {
@@ -76,12 +82,18 @@ struct BibleContentStorage: Sendable {
         case let .versionMetadata(versionId):
             url(for: .versionDirectory(versionId: versionId))
                 .appending(path: "BibleVersionMetadata_v1", directoryHint: .notDirectory)
+        case let .versionMetadataExpiration(versionId):
+            url(for: .versionMetadata(versionId: versionId))
+                .appendingPathExtension("expiration")
         case let .chaptersDirectory(versionId):
             url(for: .versionDirectory(versionId: versionId))
                 .appending(path: "Chapters", directoryHint: .isDirectory)
         case let .chapter(versionId, chapterPassageId):
             url(for: .chaptersDirectory(versionId: versionId))
                 .appending(path: chapterPassageId, directoryHint: .notDirectory)
+        case let .chapterExpiration(versionId, chapterPassageId):
+            url(for: .chapter(versionId: versionId, chapterPassageId: chapterPassageId))
+                .appendingPathExtension("expiration")
         }
     }
 
@@ -131,7 +143,84 @@ struct BibleContentStorage: Sendable {
         try write(JSONEncoder().encode(value), to: resource, isExcludedFromBackup: isExcludedFromBackup)
     }
 
-    func contains(_ resource: BibleContentStorageResource) -> Bool {
+    func expirationDate(for resource: BibleContentStorageResource) -> Date? {
+        cacheExpiration(for: resource)?.expirationDate
+    }
+
+    func isExpired(_ resource: BibleContentStorageResource, currentDate: Date) -> Bool {
+        let expirationMetadataResource = expirationResource(for: resource)
+        guard hasResource(expirationMetadataResource) else {
+            return true
+        }
+        guard let cacheExpiration = decoded(
+            BibleContentCacheExpiration.self,
+            for: expirationMetadataResource
+        ) else {
+            return true
+        }
+        if let expirationDate = cacheExpiration.expirationDate {
+            return expirationDate <= currentDate
+        }
+        return false
+    }
+
+    func writeExpirationDate(_ expirationDate: Date?, for resource: BibleContentStorageResource) throws {
+        try writeEncoded(
+            BibleContentCacheExpiration(expirationDate: expirationDate),
+            to: expirationResource(for: resource)
+        )
+    }
+
+    func removeCachedResource(_ resource: BibleContentStorageResource) {
+        try? remove(resource)
+        try? remove(expirationResource(for: resource))
+    }
+
+    func removeExpiredCachedResources(currentDate: Date) {
+        guard storageKind == .cache,
+              let enumerator = FileManager.default.enumerator(
+                at: directoryProvider.rootURL(for: storageKind),
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles]
+              ) else {
+            return
+        }
+
+        let urls = enumerator.compactMap { $0 as? URL }
+        let expirationURLs = urls.filter { $0.pathExtension == "expiration" }
+        for expirationURL in expirationURLs {
+            guard let cacheExpiration = data(at: expirationURL).flatMap({
+                try? JSONDecoder().decode(BibleContentCacheExpiration.self, from: $0)
+            }) else {
+                try? FileManager.default.removeItem(at: expirationURL.deletingPathExtension())
+                try? FileManager.default.removeItem(at: expirationURL)
+                continue
+            }
+            guard let expirationDate = cacheExpiration.expirationDate else {
+                continue
+            }
+            guard expirationDate <= currentDate else {
+                continue
+            }
+            try? FileManager.default.removeItem(at: expirationURL.deletingPathExtension())
+            try? FileManager.default.removeItem(at: expirationURL)
+        }
+
+        let contentURLs = urls.filter { url in
+            guard (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true else {
+                return false
+            }
+            return url.lastPathComponent == "BibleVersionMetadata_v1"
+                || (url.pathComponents.contains("Chapters") && url.pathExtension != "expiration")
+        }
+        for contentURL in contentURLs where !FileManager.default.fileExists(
+            atPath: contentURL.appendingPathExtension("expiration").path
+        ) {
+            try? FileManager.default.removeItem(at: contentURL)
+        }
+    }
+
+    func hasResource(_ resource: BibleContentStorageResource) -> Bool {
         FileManager.default.fileExists(atPath: url(for: resource).path)
     }
 
@@ -145,5 +234,24 @@ struct BibleContentStorage: Sendable {
 
     func remove(_ resource: BibleContentStorageResource) throws {
         try FileManager.default.removeItem(at: url(for: resource))
+    }
+
+    private func expirationResource(for resource: BibleContentStorageResource) -> BibleContentStorageResource {
+        switch resource {
+        case let .versionMetadata(versionId):
+            .versionMetadataExpiration(versionId: versionId)
+        case let .chapter(versionId, chapterPassageId):
+            .chapterExpiration(versionId: versionId, chapterPassageId: chapterPassageId)
+        case .versionDirectory, .chaptersDirectory, .versionMetadataExpiration, .chapterExpiration:
+            resource
+        }
+    }
+
+    private func cacheExpiration(for resource: BibleContentStorageResource) -> BibleContentCacheExpiration? {
+        decoded(BibleContentCacheExpiration.self, for: expirationResource(for: resource))
+    }
+
+    private func data(at url: URL) -> Data? {
+        try? Data(contentsOf: url)
     }
 }

--- a/Sources/YouVersionPlatformCore/Bible/BibleContentStorage.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleContentStorage.swift
@@ -32,7 +32,7 @@ enum BibleContentStorageResource: Sendable {
 }
 
 private struct BibleContentCacheExpiration: Codable {
-    let expirationDate: Date?
+    let expirationDate: Date
 }
 
 struct BibleContentStorage: Sendable {
@@ -158,13 +158,10 @@ struct BibleContentStorage: Sendable {
         ) else {
             return true
         }
-        if let expirationDate = cacheExpiration.expirationDate {
-            return expirationDate <= currentDate
-        }
-        return false
+        return cacheExpiration.expirationDate <= currentDate
     }
 
-    func writeExpirationDate(_ expirationDate: Date?, for resource: BibleContentStorageResource) throws {
+    func writeExpirationDate(_ expirationDate: Date, for resource: BibleContentStorageResource) throws {
         try writeEncoded(
             BibleContentCacheExpiration(expirationDate: expirationDate),
             to: expirationResource(for: resource)
@@ -196,10 +193,7 @@ struct BibleContentStorage: Sendable {
                 try? FileManager.default.removeItem(at: expirationURL)
                 continue
             }
-            guard let expirationDate = cacheExpiration.expirationDate else {
-                continue
-            }
-            guard expirationDate <= currentDate else {
+            guard cacheExpiration.expirationDate <= currentDate else {
                 continue
             }
             try? FileManager.default.removeItem(at: expirationURL.deletingPathExtension())

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -86,7 +86,7 @@ actor BibleVersionDiskCache {
         storage.hasResource(.versionMetadata(versionId: id))
     }
 
-    func addVersion(_ version: BibleVersion, expirationDate: Date? = nil) {
+    func addVersion(_ version: BibleVersion, expirationDate: Date) {
         let resource = BibleContentStorageResource.versionMetadata(versionId: version.id)
         do {
             try storage.writeEncoded(version, to: resource)
@@ -285,9 +285,13 @@ public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol 
         // Otherwise, create a new fetch task
         let task = Task { [provider, memoryCache, diskCache] in
             let response = try await provider.version(withId: id)
-            async let memory: Void = memoryCache.addVersion(response.value, expirationDate: response.expirationDate)
-            async let disk: Void = diskCache.addVersion(response.value, expirationDate: response.expirationDate)
-            _ = await (memory, disk)
+            if response.isCacheable {
+                let expirationDate = response.expirationDate
+                    ?? currentDate.addingTimeInterval(BibleContentCachePolicy.defaultDuration)
+                async let memory: Void = memoryCache.addVersion(response.value, expirationDate: expirationDate)
+                async let disk: Void = diskCache.addVersion(response.value, expirationDate: expirationDate)
+                _ = await (memory, disk)
+            }
             return response.value
         }
 

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -89,8 +89,8 @@ actor BibleVersionDiskCache {
     func addVersion(_ version: BibleVersion, expirationDate: Date) {
         let resource = BibleContentStorageResource.versionMetadata(versionId: version.id)
         do {
-            try storage.writeEncoded(version, to: resource)
             try storage.writeExpirationDate(expirationDate, for: resource)
+            try storage.writeEncoded(version, to: resource)
         } catch {
             storage.removeCachedResource(resource)
             YouVersionPlatformLogger.notice(

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -207,13 +207,13 @@ actor BibleVersionDownloadCache {
 }
 
 protocol BibleVersionProviding: Sendable {
-    func version(withId id: Int) async throws -> CachedBibleContent<BibleVersion>
+    func version(withId id: Int) async throws -> BibleContentResponse<BibleVersion>
 }
 
 final class BibleVersionAPI: BibleVersionProviding {
     init() {}
 
-    func version(withId id: Int) async throws -> CachedBibleContent<BibleVersion> {
+    func version(withId id: Int) async throws -> BibleContentResponse<BibleVersion> {
         try await YouVersionAPI.Bible.versionResponse(withId: id)
     }
 }
@@ -304,13 +304,11 @@ public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol 
         // Otherwise, create a new fetch task
         let task = Task { [provider, memoryCache, diskCache] in
             let response = try await provider.version(withId: id)
-            let expirationDate = response.expirationDate
-                ?? currentDate.addingTimeInterval(BibleContentCachePolicy.defaultDuration)
 
-            await memoryCache.addVersion(response.value, expirationDate: expirationDate)
+            await memoryCache.addVersion(response.value, expirationDate: response.expirationDate)
 
             if response.isCacheable {
-                await diskCache.addVersion(response.value, expirationDate: expirationDate)
+                await diskCache.addVersion(response.value, expirationDate: response.expirationDate)
             }
             return response.value
         }

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -29,14 +29,21 @@ public protocol BibleVersionRepositoryProtocol: Sendable {
 actor BibleVersionMemoryCache {
     init() {}
 
-    private var cache: [Int: BibleVersion] = [:]
+    private var cache: [Int: CachedBibleContent<BibleVersion>] = [:]
 
-    func version(withId id: Int) -> BibleVersion? {
-        cache[id]
+    func version(withId id: Int, currentDate: Date) -> BibleVersion? {
+        guard let cached = cache[id] else {
+            return nil
+        }
+        if let expirationDate = cached.expirationDate, expirationDate <= currentDate {
+            cache[id] = nil
+            return nil
+        }
+        return cached.value
     }
 
-    func addVersion(_ version: BibleVersion) {
-        cache[version.id] = version
+    func addVersion(_ version: BibleVersion, expirationDate: Date? = nil) {
+        cache[version.id] = CachedBibleContent(value: version, expirationDate: expirationDate)
     }
 
     func removeVersion(withId id: Int) {
@@ -56,18 +63,36 @@ actor BibleVersionDiskCache {
         self.storage = BibleContentStorage(storageKind: .cache, directoryProvider: directoryProvider)
     }
 
-    func version(withId id: Int) -> BibleVersion? {
-        storage.decoded(BibleVersion.self, for: .versionMetadata(versionId: id))
+    func version(withId id: Int, currentDate: Date = Date()) -> BibleVersion? {
+        cachedVersion(withId: id, currentDate: currentDate)?.value
+    }
+
+    func cachedVersion(withId id: Int, currentDate: Date) -> CachedBibleContent<BibleVersion>? {
+        let resource = BibleContentStorageResource.versionMetadata(versionId: id)
+        guard !storage.isExpired(resource, currentDate: currentDate) else {
+            storage.removeCachedResource(resource)
+            return nil
+        }
+        guard let version = storage.decoded(BibleVersion.self, for: resource) else {
+            return nil
+        }
+        return CachedBibleContent(
+            value: version,
+            expirationDate: storage.expirationDate(for: resource)
+        )
     }
 
     nonisolated func containsVersion(withId id: Int) -> Bool {
-        storage.contains(.versionMetadata(versionId: id))
+        storage.hasResource(.versionMetadata(versionId: id))
     }
 
-    func addVersion(_ version: BibleVersion) {
+    func addVersion(_ version: BibleVersion, expirationDate: Date? = nil) {
+        let resource = BibleContentStorageResource.versionMetadata(versionId: version.id)
         do {
-            try storage.writeEncoded(version, to: .versionMetadata(versionId: version.id))
+            try storage.writeEncoded(version, to: resource)
+            try storage.writeExpirationDate(expirationDate, for: resource)
         } catch {
+            storage.removeCachedResource(resource)
             YouVersionPlatformLogger.notice(
                 "BibleVersionDiskCache failed to write metadata for \(version.id): \(error.localizedDescription)",
                 category: "VersionCache"
@@ -86,7 +111,8 @@ actor BibleVersionDiskCache {
         }
     }
 
-    func removeUnpermittedVersions(permittedIds: Set<Int>) {
+    func removeUnpermittedVersions(permittedIds: Set<Int>, currentDate: Date = Date()) {
+        storage.removeExpiredCachedResources(currentDate: currentDate)
         let cached = storage.versionDirectoryIds
         for id in cached where !permittedIds.contains(id) {
             YouVersionPlatformLogger.notice(
@@ -107,7 +133,7 @@ actor BibleVersionDownloadCache {
     }
 
     nonisolated func containsVersion(withId id: Int) -> Bool {
-        storage.contains(.versionMetadata(versionId: id))
+        storage.hasResource(.versionMetadata(versionId: id))
     }
 
     func version(withId id: Int) -> BibleVersion? {
@@ -162,14 +188,14 @@ actor BibleVersionDownloadCache {
 }
 
 protocol BibleVersionProviding: Sendable {
-    func version(withId id: Int) async throws -> BibleVersion
+    func version(withId id: Int) async throws -> CachedBibleContent<BibleVersion>
 }
 
 final class BibleVersionAPI: BibleVersionProviding {
     init() {}
 
-    func version(withId id: Int) async throws -> BibleVersion {
-        try await YouVersionAPI.Bible.version(withId: id)
+    func version(withId id: Int) async throws -> CachedBibleContent<BibleVersion> {
+        try await YouVersionAPI.Bible.versionResponse(withId: id)
     }
 }
 
@@ -217,13 +243,17 @@ public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol 
     }
 
     public func versionIfCached(_ id: Int) async throws -> BibleVersion? {
-        if let cached = await memoryCache.version(withId: id) {
+        try await versionIfCached(id, currentDate: Date())
+    }
+
+    func versionIfCached(_ id: Int, currentDate: Date) async throws -> BibleVersion? {
+        if let cached = await memoryCache.version(withId: id, currentDate: currentDate) {
             return cached
         }
 
-        if let cached = await diskCache.version(withId: id) {
-            await memoryCache.addVersion(cached)
-            return cached
+        if let cached = await diskCache.cachedVersion(withId: id, currentDate: currentDate) {
+            await memoryCache.addVersion(cached.value, expirationDate: cached.expirationDate)
+            return cached.value
         }
 
         if let downloaded = await downloadCache.version(withId: id) {
@@ -235,8 +265,12 @@ public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol 
     }
 
     public func version(withId id: Int) async throws -> BibleVersion {
+        try await version(withId: id, currentDate: Date())
+    }
+
+    func version(withId id: Int, currentDate: Date) async throws -> BibleVersion {
         do {
-            if let version = try await versionIfCached(id) {
+            if let version = try await versionIfCached(id, currentDate: currentDate) {
                 return version
             }
         } catch {
@@ -250,11 +284,11 @@ public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol 
 
         // Otherwise, create a new fetch task
         let task = Task { [provider, memoryCache, diskCache] in
-            let version = try await provider.version(withId: id)
-            async let memory: Void = memoryCache.addVersion(version)
-            async let disk: Void = diskCache.addVersion(version)
+            let response = try await provider.version(withId: id)
+            async let memory: Void = memoryCache.addVersion(response.value, expirationDate: response.expirationDate)
+            async let disk: Void = diskCache.addVersion(response.value, expirationDate: response.expirationDate)
             _ = await (memory, disk)
-            return version
+            return response.value
         }
 
         inFlightTasks[id] = task
@@ -263,9 +297,7 @@ public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol 
             inFlightTasks[id] = nil
         }
 
-        let version = try await task.value
-        await memoryCache.addVersion(version)
-        return version
+        return try await task.value
     }
 
     public func containsVersion(withId id: Int) -> Bool {
@@ -319,8 +351,15 @@ public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol 
     }
 
     public func removeUnpermittedVersions(permittedIds: Set<Int>) async {
+        await removeUnpermittedVersions(permittedIds: permittedIds, currentDate: Date())
+    }
+
+    func removeUnpermittedVersions(permittedIds: Set<Int>, currentDate: Date) async {
         async let memory: Void = memoryCache.removeUnpermittedVersions(permittedIds: permittedIds)
-        async let disk: Void = diskCache.removeUnpermittedVersions(permittedIds: permittedIds)
+        async let disk: Void = diskCache.removeUnpermittedVersions(
+            permittedIds: permittedIds,
+            currentDate: currentDate
+        )
         async let download: Void = downloadCache.removeUnpermittedVersions(permittedIds: permittedIds)
         _ = await (memory, disk, download)
     }

--- a/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift
@@ -57,50 +57,81 @@ actor BibleVersionMemoryCache {
 
 /// Manages a medium-duration cache of Bible version metadata; it's not in-memory therefore will survive the app being terminated.
 actor BibleVersionDiskCache {
+    private let coordinator: BibleContentCacheCoordinator
     private let storage: BibleContentStorage
 
-    init(directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider()) {
+    init(
+        directoryProvider: BibleContentDirectoryProviding = DefaultBibleContentDirectoryProvider(),
+        coordinator: BibleContentCacheCoordinator = .shared
+    ) {
+        self.coordinator = coordinator
         self.storage = BibleContentStorage(storageKind: .cache, directoryProvider: directoryProvider)
     }
 
-    func version(withId id: Int, currentDate: Date = Date()) -> BibleVersion? {
-        cachedVersion(withId: id, currentDate: currentDate)?.value
+    func version(withId id: Int, currentDate: Date = Date()) async -> BibleVersion? {
+        await cachedVersion(withId: id, currentDate: currentDate)?.value
     }
 
-    func cachedVersion(withId id: Int, currentDate: Date) -> CachedBibleContent<BibleVersion>? {
+    func cachedVersion(withId id: Int, currentDate: Date) async -> CachedBibleContent<BibleVersion>? {
         let resource = BibleContentStorageResource.versionMetadata(versionId: id)
-        guard !storage.isExpired(resource, currentDate: currentDate) else {
-            storage.removeCachedResource(resource)
-            return nil
+        return await coordinator.perform {
+            guard !storage.isExpired(resource, currentDate: currentDate) else {
+                storage.removeCacheEntry(resource)
+                return nil
+            }
+            guard let version = storage.decoded(BibleVersion.self, for: resource) else {
+                return nil
+            }
+            return CachedBibleContent(
+                value: version,
+                expirationDate: storage.expirationDate(for: resource)
+            )
         }
-        guard let version = storage.decoded(BibleVersion.self, for: resource) else {
-            return nil
-        }
-        return CachedBibleContent(
-            value: version,
-            expirationDate: storage.expirationDate(for: resource)
-        )
     }
 
     nonisolated func containsVersion(withId id: Int) -> Bool {
         storage.hasResource(.versionMetadata(versionId: id))
     }
 
-    func addVersion(_ version: BibleVersion, expirationDate: Date) {
+    func addVersion(_ version: BibleVersion, expirationDate: Date) async {
         let resource = BibleContentStorageResource.versionMetadata(versionId: version.id)
-        do {
-            try storage.writeExpirationDate(expirationDate, for: resource)
-            try storage.writeEncoded(version, to: resource)
-        } catch {
-            storage.removeCachedResource(resource)
-            YouVersionPlatformLogger.notice(
-                "BibleVersionDiskCache failed to write metadata for \(version.id): \(error.localizedDescription)",
-                category: "VersionCache"
-            )
+        await coordinator.perform {
+            do {
+                try storage.writeExpirationDate(expirationDate, for: resource)
+                try storage.writeEncoded(version, to: resource)
+            } catch {
+                storage.removeCacheEntry(resource)
+                YouVersionPlatformLogger.notice(
+                    "BibleVersionDiskCache failed to write metadata for \(version.id): \(error.localizedDescription)",
+                    category: "VersionCache"
+                )
+            }
         }
     }
 
-    func removeVersion(withId id: Int) {
+    func removeVersion(withId id: Int) async {
+        let storage = storage
+        await coordinator.perform {
+            Self.removeVersionFromStorage(withId: id, storage: storage)
+        }
+    }
+
+    func removeUnpermittedVersions(permittedIds: Set<Int>, currentDate: Date = Date()) async {
+        let storage = storage
+        await coordinator.perform {
+            storage.removeExpiredCachedResources(currentDate: currentDate)
+            let cached = storage.versionDirectoryIds
+            for id in cached where !permittedIds.contains(id) {
+                YouVersionPlatformLogger.notice(
+                    "Removing cached Bible version \(id) because it is no longer permitted",
+                    category: "VersionCache"
+                )
+                Self.removeVersionFromStorage(withId: id, storage: storage)
+            }
+        }
+    }
+
+    private static func removeVersionFromStorage(withId id: Int, storage: BibleContentStorage) {
         do {
             try storage.remove(.versionDirectory(versionId: id))
         } catch {
@@ -108,18 +139,6 @@ actor BibleVersionDiskCache {
                 "BibleVersionDiskCache got error while removing: \(error.localizedDescription)",
                 category: "VersionCache"
             )
-        }
-    }
-
-    func removeUnpermittedVersions(permittedIds: Set<Int>, currentDate: Date = Date()) {
-        storage.removeExpiredCachedResources(currentDate: currentDate)
-        let cached = storage.versionDirectoryIds
-        for id in cached where !permittedIds.contains(id) {
-            YouVersionPlatformLogger.notice(
-                "Removing cached Bible version \(id) because it is no longer permitted",
-                category: "VersionCache"
-            )
-            removeVersion(withId: id)
         }
     }
 }
@@ -285,12 +304,13 @@ public actor BibleVersionRepository: Observable, BibleVersionRepositoryProtocol 
         // Otherwise, create a new fetch task
         let task = Task { [provider, memoryCache, diskCache] in
             let response = try await provider.version(withId: id)
+            let expirationDate = response.expirationDate
+                ?? currentDate.addingTimeInterval(BibleContentCachePolicy.defaultDuration)
+
+            await memoryCache.addVersion(response.value, expirationDate: expirationDate)
+
             if response.isCacheable {
-                let expirationDate = response.expirationDate
-                    ?? currentDate.addingTimeInterval(BibleContentCachePolicy.defaultDuration)
-                async let memory: Void = memoryCache.addVersion(response.value, expirationDate: expirationDate)
-                async let disk: Void = diskCache.addVersion(response.value, expirationDate: expirationDate)
-                _ = await (memory, disk)
+                await diskCache.addVersion(response.value, expirationDate: expirationDate)
             }
             return response.value
         }

--- a/Sources/YouVersionPlatformCore/Bible/CachedBibleContent.swift
+++ b/Sources/YouVersionPlatformCore/Bible/CachedBibleContent.swift
@@ -6,13 +6,12 @@ import FoundationNetworking
 struct CachedBibleContent<Value: Sendable>: Sendable {
     let value: Value
     let expirationDate: Date?
-    let isCacheable: Bool
+}
 
-    init(value: Value, expirationDate: Date?, isCacheable: Bool = true) {
-        self.value = value
-        self.expirationDate = expirationDate
-        self.isCacheable = isCacheable
-    }
+struct BibleContentResponse<Value: Sendable>: Sendable {
+    let value: Value
+    let expirationDate: Date
+    let isCacheable: Bool
 }
 
 enum BibleContentCachePolicy {
@@ -27,7 +26,7 @@ extension HTTPURLResponse {
         })
     }
 
-    func cacheExpirationDate(currentDate: Date = Date()) -> Date? {
+    func cacheExpirationDate(currentDate: Date = Date()) -> Date {
         let maxAge = cacheControlDirectives
             .first { $0.lowercased().hasPrefix("max-age=") }?
             .split(separator: "=", maxSplits: 1)

--- a/Sources/YouVersionPlatformCore/Bible/CachedBibleContent.swift
+++ b/Sources/YouVersionPlatformCore/Bible/CachedBibleContent.swift
@@ -6,25 +6,50 @@ import FoundationNetworking
 struct CachedBibleContent<Value: Sendable>: Sendable {
     let value: Value
     let expirationDate: Date?
+    let isCacheable: Bool
+
+    init(value: Value, expirationDate: Date?, isCacheable: Bool = true) {
+        self.value = value
+        self.expirationDate = expirationDate
+        self.isCacheable = isCacheable
+    }
+}
+
+enum BibleContentCachePolicy {
+    static let defaultDuration: TimeInterval = 7 * 24 * 60 * 60
 }
 
 extension HTTPURLResponse {
-    func cacheExpirationDate(currentDate: Date = Date()) -> Date? {
-        guard let cacheControl = value(forHTTPHeaderField: "Cache-Control") else {
-            return nil
-        }
+    var allowsCaching: Bool {
+        !cacheControlDirectives.contains(where: {
+            let directiveName = $0.split(separator: "=", maxSplits: 1).first?.lowercased()
+            return directiveName == "no-cache" || directiveName == "no-store"
+        })
+    }
 
-        let maxAge = cacheControl
-            .split(separator: ",")
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+    func cacheExpirationDate(currentDate: Date = Date()) -> Date? {
+        let maxAge = cacheControlDirectives
             .first { $0.lowercased().hasPrefix("max-age=") }?
             .split(separator: "=", maxSplits: 1)
             .last?
             .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
 
-        guard let maxAge, let seconds = TimeInterval(maxAge), seconds >= 0 else {
-            return nil
+        let maximumAge: TimeInterval
+        if let maxAge, let parsedMaximumAge = TimeInterval(maxAge), parsedMaximumAge >= 0 {
+            maximumAge = parsedMaximumAge
+        } else {
+            maximumAge = BibleContentCachePolicy.defaultDuration
         }
-        return currentDate.addingTimeInterval(seconds)
+
+        let responseAge = value(forHTTPHeaderField: "Age")
+            .flatMap(TimeInterval.init) ?? 0
+        let remainingLifetime = max(0, maximumAge - max(0, responseAge))
+        return currentDate.addingTimeInterval(remainingLifetime)
+    }
+
+    private var cacheControlDirectives: [String] {
+        value(forHTTPHeaderField: "Cache-Control")?
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } ?? []
     }
 }

--- a/Sources/YouVersionPlatformCore/Bible/CachedBibleContent.swift
+++ b/Sources/YouVersionPlatformCore/Bible/CachedBibleContent.swift
@@ -1,0 +1,30 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct CachedBibleContent<Value: Sendable>: Sendable {
+    let value: Value
+    let expirationDate: Date?
+}
+
+extension HTTPURLResponse {
+    func cacheExpirationDate(currentDate: Date = Date()) -> Date? {
+        guard let cacheControl = value(forHTTPHeaderField: "Cache-Control") else {
+            return nil
+        }
+
+        let maxAge = cacheControl
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first { $0.lowercased().hasPrefix("max-age=") }?
+            .split(separator: "=", maxSplits: 1)
+            .last?
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+
+        guard let maxAge, let seconds = TimeInterval(maxAge), seconds >= 0 else {
+            return nil
+        }
+        return currentDate.addingTimeInterval(seconds)
+    }
+}

--- a/Sources/YouVersionPlatformCore/Bible/DeprecatedBibleAPI.swift
+++ b/Sources/YouVersionPlatformCore/Bible/DeprecatedBibleAPI.swift
@@ -75,7 +75,7 @@ public actor VersionDiskCache: BibleVersionCaching {
     }
 
     public func addVersion(_ version: BibleVersion) async {
-        await inner.addVersion(version)
+        await inner.addVersion(version, expirationDate: .distantFuture)
     }
 
     public func removeVersion(withId versionId: Int) async {

--- a/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
@@ -8,11 +8,18 @@ final class BibleChapterAPIRequestCounter: BibleChapterContentProviding, @unchec
     private(set) var requestedReferences: [BibleReference] = []
     var result: String
     var expirationDate: Date?
+    var isCacheable: Bool
     var error: Error?
 
-    init(result: String, expirationDate: Date? = nil, error: Error? = nil) {
+    init(
+        result: String,
+        expirationDate: Date? = .distantFuture,
+        isCacheable: Bool = true,
+        error: Error? = nil
+    ) {
         self.result = result
         self.expirationDate = expirationDate
+        self.isCacheable = isCacheable
         self.error = error
     }
 
@@ -21,7 +28,11 @@ final class BibleChapterAPIRequestCounter: BibleChapterContentProviding, @unchec
         if let error {
             throw error
         }
-        return CachedBibleContent(value: result, expirationDate: expirationDate)
+        return CachedBibleContent(
+            value: result,
+            expirationDate: expirationDate,
+            isCacheable: isCacheable
+        )
     }
 
     var callCount: Int { requestedReferences.count }
@@ -58,7 +69,11 @@ struct BibleChapterRepositoryTests {
         let (repository, api, storage) = try makeRepository()
         defer { storage.remove() }
         let diskCache = BibleChapterDiskCache(directoryProvider: storage.provider)
-        await diskCache.addChapterContent("<div>disk</div>", reference: reference)
+        await diskCache.addChapterContent(
+            "<div>disk</div>",
+            reference: reference,
+            expirationDate: .distantFuture
+        )
 
         let content = try await repository.chapter(withReference: reference)
         await diskCache.removeVersion(withId: reference.versionId)
@@ -112,6 +127,54 @@ struct BibleChapterRepositoryTests {
         #expect(first == "<div>server</div>")
         #expect(second == "<div>server</div>")
         #expect(api.callCount == 1)
+    }
+
+    @Test
+    func chapterCachesResponseWithoutExpirationForDefaultDuration() async throws {
+        let currentDate = Date(timeIntervalSince1970: 1_000)
+        let api = BibleChapterAPIRequestCounter(
+            result: "<div>first</div>",
+            expirationDate: nil
+        )
+        let (repository, _, storage) = try makeRepository(apiCounter: api)
+        defer { storage.remove() }
+        let diskCache = BibleChapterDiskCache(directoryProvider: storage.provider)
+
+        let first = try await repository.chapter(withReference: reference, currentDate: currentDate)
+        api.result = "<div>second</div>"
+        let second = try await repository.chapter(
+            withReference: reference,
+            currentDate: currentDate.addingTimeInterval(BibleContentCachePolicy.defaultDuration - 1)
+        )
+
+        #expect(first == "<div>first</div>")
+        #expect(second == "<div>first</div>")
+        #expect(api.callCount == 1)
+        #expect(
+            await diskCache.chapterContent(withReference: reference, currentDate: currentDate)
+                == "<div>first</div>"
+        )
+    }
+
+    @Test
+    func chapterDoesNotCacheResponseThatForbidsCaching() async throws {
+        let api = BibleChapterAPIRequestCounter(
+            result: "<div>first</div>",
+            expirationDate: .distantFuture,
+            isCacheable: false
+        )
+        let (repository, _, storage) = try makeRepository(apiCounter: api)
+        defer { storage.remove() }
+        let diskCache = BibleChapterDiskCache(directoryProvider: storage.provider)
+
+        let first = try await repository.chapter(withReference: reference)
+        api.result = "<div>second</div>"
+        let second = try await repository.chapter(withReference: reference)
+
+        #expect(first == "<div>first</div>")
+        #expect(second == "<div>second</div>")
+        #expect(api.callCount == 2)
+        #expect(await diskCache.chapterContent(withReference: reference) == nil)
     }
 
     @Test
@@ -169,7 +232,11 @@ struct BibleChapterRepositoryTests {
         defer { storage.remove() }
         let diskCache = BibleChapterDiskCache(directoryProvider: storage.provider)
 
-        await diskCache.addChapterContent("<div>disk</div>", reference: reference)
+        await diskCache.addChapterContent(
+            "<div>disk</div>",
+            reference: reference,
+            expirationDate: .distantFuture
+        )
         try writeDownloadedChapterContent("<div>download</div>", reference: reference, storage: storage)
 
         let diskContent = try await repository.chapter(withReference: reference)

--- a/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
@@ -157,7 +157,7 @@ struct BibleChapterRepositoryTests {
     }
 
     @Test
-    func chapterDoesNotCacheResponseThatForbidsCaching() async throws {
+    func chapterCachesResponseThatForbidsPersistentCachingInMemoryOnly() async throws {
         let api = BibleChapterAPIRequestCounter(
             result: "<div>first</div>",
             expirationDate: .distantFuture,
@@ -172,8 +172,8 @@ struct BibleChapterRepositoryTests {
         let second = try await repository.chapter(withReference: reference)
 
         #expect(first == "<div>first</div>")
-        #expect(second == "<div>second</div>")
-        #expect(api.callCount == 2)
+        #expect(second == "<div>first</div>")
+        #expect(api.callCount == 1)
         #expect(await diskCache.chapterContent(withReference: reference) == nil)
     }
 

--- a/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
@@ -7,13 +7,13 @@ import Testing
 final class BibleChapterAPIRequestCounter: BibleChapterContentProviding, @unchecked Sendable {
     private(set) var requestedReferences: [BibleReference] = []
     var result: String
-    var expirationDate: Date?
+    var expirationDate: Date
     var isCacheable: Bool
     var error: Error?
 
     init(
         result: String,
-        expirationDate: Date? = .distantFuture,
+        expirationDate: Date = .distantFuture,
         isCacheable: Bool = true,
         error: Error? = nil
     ) {
@@ -23,12 +23,12 @@ final class BibleChapterAPIRequestCounter: BibleChapterContentProviding, @unchec
         self.error = error
     }
 
-    func chapterContent(for reference: BibleReference) async throws -> CachedBibleContent<String> {
+    func chapterContent(for reference: BibleReference) async throws -> BibleContentResponse<String> {
         requestedReferences.append(reference)
         if let error {
             throw error
         }
-        return CachedBibleContent(
+        return BibleContentResponse(
             value: result,
             expirationDate: expirationDate,
             isCacheable: isCacheable
@@ -127,33 +127,6 @@ struct BibleChapterRepositoryTests {
         #expect(first == "<div>server</div>")
         #expect(second == "<div>server</div>")
         #expect(api.callCount == 1)
-    }
-
-    @Test
-    func chapterCachesResponseWithoutExpirationForDefaultDuration() async throws {
-        let currentDate = Date(timeIntervalSince1970: 1_000)
-        let api = BibleChapterAPIRequestCounter(
-            result: "<div>first</div>",
-            expirationDate: nil
-        )
-        let (repository, _, storage) = try makeRepository(apiCounter: api)
-        defer { storage.remove() }
-        let diskCache = BibleChapterDiskCache(directoryProvider: storage.provider)
-
-        let first = try await repository.chapter(withReference: reference, currentDate: currentDate)
-        api.result = "<div>second</div>"
-        let second = try await repository.chapter(
-            withReference: reference,
-            currentDate: currentDate.addingTimeInterval(BibleContentCachePolicy.defaultDuration - 1)
-        )
-
-        #expect(first == "<div>first</div>")
-        #expect(second == "<div>first</div>")
-        #expect(api.callCount == 1)
-        #expect(
-            await diskCache.chapterContent(withReference: reference, currentDate: currentDate)
-                == "<div>first</div>"
-        )
     }
 
     @Test

--- a/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleChapterRepositoryTests.swift
@@ -7,19 +7,21 @@ import Testing
 final class BibleChapterAPIRequestCounter: BibleChapterContentProviding, @unchecked Sendable {
     private(set) var requestedReferences: [BibleReference] = []
     var result: String
+    var expirationDate: Date?
     var error: Error?
 
-    init(result: String, error: Error? = nil) {
+    init(result: String, expirationDate: Date? = nil, error: Error? = nil) {
         self.result = result
+        self.expirationDate = expirationDate
         self.error = error
     }
 
-    func chapterContent(for reference: BibleReference) async throws -> String {
+    func chapterContent(for reference: BibleReference) async throws -> CachedBibleContent<String> {
         requestedReferences.append(reference)
         if let error {
             throw error
         }
-        return result
+        return CachedBibleContent(value: result, expirationDate: expirationDate)
     }
 
     var callCount: Int { requestedReferences.count }
@@ -110,6 +112,27 @@ struct BibleChapterRepositoryTests {
         #expect(first == "<div>server</div>")
         #expect(second == "<div>server</div>")
         #expect(api.callCount == 1)
+    }
+
+    @Test
+    func chapterRefetchesAfterCachedResponseExpires() async throws {
+        let initialDate = Date(timeIntervalSince1970: 1_000)
+        let expiredDate = initialDate.addingTimeInterval(61)
+        let api = BibleChapterAPIRequestCounter(
+            result: "<div>first</div>",
+            expirationDate: initialDate.addingTimeInterval(60)
+        )
+        let (repository, _, storage) = try makeRepository(apiCounter: api)
+        defer { storage.remove() }
+
+        let first = try await repository.chapter(withReference: reference, currentDate: initialDate)
+        api.result = "<div>second</div>"
+        api.expirationDate = expiredDate.addingTimeInterval(120)
+        let second = try await repository.chapter(withReference: reference, currentDate: expiredDate)
+
+        #expect(first == "<div>first</div>")
+        #expect(second == "<div>second</div>")
+        #expect(api.callCount == 2)
     }
 
     @Test

--- a/Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift
@@ -264,6 +264,26 @@ struct BibleContentStorageTests {
     }
 
     @Test
+    func cleanupDuringCacheWritePreservesContentWrittenAfterExpirationMetadata() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+        let storage = BibleContentStorage(storageKind: .cache, directoryProvider: temporaryStorage.provider)
+        let chapterResource = BibleContentStorageResource.chapter(
+            versionId: 206,
+            chapterPassageId: "GEN.1"
+        )
+        let currentDate = Date(timeIntervalSince1970: 10_000)
+        let expirationDate = currentDate.addingTimeInterval(60)
+
+        try storage.writeExpirationDate(expirationDate, for: chapterResource)
+        storage.removeExpiredCachedResources(currentDate: currentDate)
+        try storage.writeString("fresh chapter content", to: chapterResource)
+
+        #expect(storage.string(for: chapterResource) == "fresh chapter content")
+        #expect(storage.expirationDate(for: chapterResource) == expirationDate)
+    }
+
+    @Test
     func removeDeletesResourceDirectory() throws {
         let temporaryStorage = try TemporaryStorage()
         defer { temporaryStorage.remove() }

--- a/Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift
@@ -139,15 +139,15 @@ struct BibleContentStorageTests {
     }
 
     @Test
-    func containsChecksPresenceWithoutDecoding() throws {
+    func hasResourceChecksPresenceWithoutDecoding() throws {
         let temporaryStorage = try TemporaryStorage()
         defer { temporaryStorage.remove() }
 
         let storage = BibleContentStorage(storageKind: .cache, directoryProvider: temporaryStorage.provider)
         try temporaryStorage.write(Data("not json".utf8), to: storage.url(for: .versionMetadata(versionId: 206)))
 
-        #expect(storage.contains(.versionMetadata(versionId: 206)))
-        #expect(storage.contains(.versionMetadata(versionId: 999)) == false)
+        #expect(storage.hasResource(.versionMetadata(versionId: 206)))
+        #expect(storage.hasResource(.versionMetadata(versionId: 999)) == false)
     }
 
     @Test
@@ -198,6 +198,72 @@ struct BibleContentStorageTests {
     }
 
     @Test
+    func expirationDateRoundTripsAndRemovesWithCachedResource() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+        let storage = BibleContentStorage(storageKind: .cache, directoryProvider: temporaryStorage.provider)
+        let resource = BibleContentStorageResource.chapter(versionId: 206, chapterPassageId: "GEN.1")
+        let expirationDate = Date(timeIntervalSince1970: 10_000)
+
+        try storage.writeString("chapter content", to: resource)
+        try storage.writeExpirationDate(expirationDate, for: resource)
+
+        #expect(storage.expirationDate(for: resource) == expirationDate)
+        #expect(storage.isExpired(resource, currentDate: expirationDate.addingTimeInterval(-1)) == false)
+        #expect(storage.isExpired(resource, currentDate: expirationDate))
+
+        storage.removeCachedResource(resource)
+
+        #expect(storage.hasResource(resource) == false)
+        #expect(storage.expirationDate(for: resource) == nil)
+    }
+
+    @Test
+    func cachedFilesWithoutExpirationMetadataAreExpiredAndRemoved() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+        let storage = BibleContentStorage(storageKind: .cache, directoryProvider: temporaryStorage.provider)
+        let chapterResource = BibleContentStorageResource.chapter(
+            versionId: 206,
+            chapterPassageId: "GEN.1"
+        )
+        let versionResource = BibleContentStorageResource.versionMetadata(versionId: 206)
+        let currentDate = Date(timeIntervalSince1970: 10_000)
+
+        try storage.writeString("legacy chapter content", to: chapterResource)
+        try storage.write(Self.fixtureData(), to: versionResource)
+
+        #expect(storage.isExpired(chapterResource, currentDate: currentDate))
+        #expect(storage.isExpired(versionResource, currentDate: currentDate))
+
+        storage.removeExpiredCachedResources(currentDate: currentDate)
+
+        #expect(storage.hasResource(chapterResource) == false)
+        #expect(storage.hasResource(versionResource) == false)
+    }
+
+    @Test
+    func removeExpiredCachedResourcesPreservesUnexpiredChapter() throws {
+        let temporaryStorage = try TemporaryStorage()
+        defer { temporaryStorage.remove() }
+        let storage = BibleContentStorage(storageKind: .cache, directoryProvider: temporaryStorage.provider)
+        let chapterResource = BibleContentStorageResource.chapter(
+            versionId: 206,
+            chapterPassageId: "GEN.1"
+        )
+        let currentDate = Date(timeIntervalSince1970: 10_000)
+        let expirationDate = currentDate.addingTimeInterval(60)
+
+        try storage.writeString("fresh chapter content", to: chapterResource)
+        try storage.writeExpirationDate(expirationDate, for: chapterResource)
+
+        storage.removeExpiredCachedResources(currentDate: currentDate)
+
+        #expect(storage.string(for: chapterResource) == "fresh chapter content")
+        #expect(storage.expirationDate(for: chapterResource) == expirationDate)
+    }
+
+    @Test
     func removeDeletesResourceDirectory() throws {
         let temporaryStorage = try TemporaryStorage()
         defer { temporaryStorage.remove() }
@@ -207,8 +273,8 @@ struct BibleContentStorageTests {
 
         try storage.remove(.versionDirectory(versionId: 206))
 
-        #expect(storage.contains(.chapter(versionId: 206, chapterPassageId: "GEN.1")) == false)
-        #expect(storage.contains(.versionDirectory(versionId: 206)) == false)
+        #expect(storage.hasResource(.chapter(versionId: 206, chapterPassageId: "GEN.1")) == false)
+        #expect(storage.hasResource(.versionDirectory(versionId: 206)) == false)
     }
 
     private static func fixtureData() throws -> Data {

--- a/Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleContentStorageTests.swift
@@ -212,7 +212,7 @@ struct BibleContentStorageTests {
         #expect(storage.isExpired(resource, currentDate: expirationDate.addingTimeInterval(-1)) == false)
         #expect(storage.isExpired(resource, currentDate: expirationDate))
 
-        storage.removeCachedResource(resource)
+        storage.removeCacheEntry(resource)
 
         #expect(storage.hasResource(resource) == false)
         #expect(storage.expirationDate(for: resource) == nil)

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionAPITests.swift
@@ -7,6 +7,62 @@ import Testing
 
 @Suite(.serialized) struct BibleVersionAPITests {
 
+    @Test func cacheExpirationSubtractsResponseAge() throws {
+        let currentDate = Date(timeIntervalSince1970: 10_000)
+        let response = try #require(HTTPURLResponse(
+            url: URL(string: "https://example.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: [
+                "Cache-Control": "public, max-age=86400",
+                "Age": "3600"
+            ]
+        ))
+
+        #expect(response.cacheExpirationDate(currentDate: currentDate) == currentDate.addingTimeInterval(82_800))
+    }
+
+    @Test func cacheExpirationUsesDefaultDurationWithoutUsableMaxAge() throws {
+        let currentDate = Date(timeIntervalSince1970: 10_000)
+        let url = URL(string: "https://example.com")!
+        let headers = [
+            [:],
+            ["Cache-Control": "public"],
+            ["Cache-Control": "public, max-age=invalid"]
+        ]
+
+        for headerFields in headers {
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: headerFields
+            ))
+            #expect(
+                response.cacheExpirationDate(currentDate: currentDate)
+                    == currentDate.addingTimeInterval(BibleContentCachePolicy.defaultDuration)
+            )
+        }
+    }
+
+    @Test func explicitNoCacheDirectivesDisableCaching() throws {
+        let url = URL(string: "https://example.com")!
+        let headers = [
+            ["Cache-Control": "public, max-age=60, no-store"],
+            ["Cache-Control": "public, max-age=60, no-cache=\"Set-Cookie\""]
+        ]
+
+        for headerFields in headers {
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: headerFields
+            ))
+            #expect(response.allowsCaching == false)
+        }
+    }
+
     @MainActor
     @Test func metadataForVersionDecodes() async throws {
         let (session, token) = HTTPMocking.makeSession()
@@ -99,6 +155,35 @@ import Testing
 
         #expect(expirationDate >= beforeRequestDate.addingTimeInterval(60))
         #expect(expirationDate <= Date().addingTimeInterval(60))
+    }
+
+    @MainActor
+    @Test func versionResponseIsNotCacheableWhenEitherResponseForbidsCaching() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+        let basic = Data(#"{"id":1,"title":"Test","language_tag":"en"}"#.utf8)
+        let index = Data(#"{"text_direction":"ltr","books":[]}"#.utf8)
+
+        HTTPMocking.setHandler(token: token) { request in
+            let isIndex = request.url?.path.contains("/index") == true
+            let headers = isIndex ? ["Cache-Control": "no-store"] : ["Cache-Control": "public, max-age=120"]
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: headers
+            )!
+            return (isIndex ? index : basic, response)
+        }
+
+        let response = try await YouVersionAPI.Bible.versionResponse(
+            withId: 1,
+            accessToken: "swift-test-suite",
+            session: session
+        )
+
+        #expect(response.isCacheable == false)
+        #expect(response.expirationDate != nil)
     }
 
     @MainActor

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionAPITests.swift
@@ -151,7 +151,7 @@ import Testing
             accessToken: "swift-test-suite",
             session: session
         )
-        let expirationDate = try #require(response.expirationDate)
+        let expirationDate = response.expirationDate
 
         #expect(expirationDate >= beforeRequestDate.addingTimeInterval(60))
         #expect(expirationDate <= Date().addingTimeInterval(60))
@@ -183,7 +183,6 @@ import Testing
         )
 
         #expect(response.isCacheable == false)
-        #expect(response.expirationDate != nil)
     }
 
     @MainActor
@@ -237,7 +236,7 @@ import Testing
             accessToken: "swift-test-suite",
             session: session
         )
-        let expirationDate = try #require(response.expirationDate)
+        let expirationDate = response.expirationDate
 
         #expect(response.value == "<div>ok</div>")
         #expect(expirationDate >= beforeRequestDate.addingTimeInterval(86_400))

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionAPITests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionAPITests.swift
@@ -71,6 +71,37 @@ import Testing
     }
 
     @MainActor
+    @Test func versionResponseUsesEarliestCacheExpiration() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+        let basic = Data(#"{"id":1,"title":"Test","language_tag":"en"}"#.utf8)
+        let index = Data(#"{"text_direction":"ltr","books":[]}"#.utf8)
+
+        HTTPMocking.setHandler(token: token) { request in
+            let isIndex = request.url?.path.contains("/index") == true
+            let headers = ["Cache-Control": isIndex ? "public, max-age=60" : "public, max-age=120"]
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: headers
+            )!
+            return (isIndex ? index : basic, response)
+        }
+
+        let beforeRequestDate = Date()
+        let response = try await YouVersionAPI.Bible.versionResponse(
+            withId: 1,
+            accessToken: "swift-test-suite",
+            session: session
+        )
+        let expirationDate = try #require(response.expirationDate)
+
+        #expect(expirationDate >= beforeRequestDate.addingTimeInterval(60))
+        #expect(expirationDate <= Date().addingTimeInterval(60))
+    }
+
+    @MainActor
     @Test func chapterSuccessParsesContent() async throws {
         let (session, token) = HTTPMocking.makeSession()
         defer { HTTPMocking.clear(token: token) }
@@ -96,6 +127,36 @@ import Testing
         #expect(queryItems.contains(where: { $0.name == "format" && $0.value == "html" }))
         #expect(queryItems.contains(where: { $0.name == "include_notes" && $0.value == "true" }))
         #expect(queryItems.contains(where: { $0.name == "include_headings" && $0.value == "true" }))
+    }
+
+    @MainActor
+    @Test func chapterResponseIncludesCacheExpiration() async throws {
+        let (session, token) = HTTPMocking.makeSession()
+        defer { HTTPMocking.clear(token: token) }
+        let json = Data(#"{"content":"<div>ok</div>"}"#.utf8)
+
+        HTTPMocking.setHandler(token: token) { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Cache-Control": "public, max-age=86400"]
+            )!
+            return (json, response)
+        }
+
+        let beforeRequestDate = Date()
+        let reference = BibleReference(versionId: 1, bookId: "GEN", chapter: 1)
+        let response = try await YouVersionAPI.Bible.chapterResponse(
+            reference: reference,
+            accessToken: "swift-test-suite",
+            session: session
+        )
+        let expirationDate = try #require(response.expirationDate)
+
+        #expect(response.value == "<div>ok</div>")
+        #expect(expirationDate >= beforeRequestDate.addingTimeInterval(86_400))
+        #expect(expirationDate <= Date().addingTimeInterval(86_400))
     }
 
     @MainActor

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
@@ -168,7 +168,7 @@ struct BibleVersionRepositoryTests {
     }
 
     @Test
-    func versionDoesNotCacheResponseThatForbidsCaching() async throws {
+    func versionCachesResponseThatForbidsPersistentCachingInMemoryOnly() async throws {
         let api = BibleVersionAPIRequestCounter(
             result: Self.fixture,
             expirationDate: .distantFuture,
@@ -181,7 +181,7 @@ struct BibleVersionRepositoryTests {
         _ = try await repository.version(withId: Self.fixture.id)
         _ = try await repository.version(withId: Self.fixture.id)
 
-        #expect(api.callCount == 2)
+        #expect(api.callCount == 1)
         #expect(await diskCache.version(withId: Self.fixture.id) == nil)
     }
 
@@ -376,5 +376,44 @@ struct BibleVersionRepositoryTests {
 
         #expect(await versionCache.version(withId: Self.fixture.id, currentDate: currentDate) == nil)
         #expect(await chapterCache.chapterContent(withReference: reference, currentDate: currentDate) == nil)
+    }
+
+    @Test
+    func cleanupAndChapterReplacementLeaveTheFreshEntryCached() async throws {
+        let currentDate = Date(timeIntervalSince1970: 2_000)
+        let storage = try RepositoryTemporaryStorage()
+        defer { storage.remove() }
+        let coordinator = BibleContentCacheCoordinator()
+        let versionCache = BibleVersionDiskCache(
+            directoryProvider: storage.provider,
+            coordinator: coordinator
+        )
+        let chapterCache = BibleChapterDiskCache(
+            directoryProvider: storage.provider,
+            coordinator: coordinator
+        )
+        let reference = BibleReference(versionId: Self.fixture.id, bookId: "GEN", chapter: 1)
+
+        await chapterCache.addChapterContent(
+            "<div>expired</div>",
+            reference: reference,
+            expirationDate: currentDate.addingTimeInterval(-1)
+        )
+
+        async let cleanup: Void = versionCache.removeUnpermittedVersions(
+            permittedIds: [Self.fixture.id],
+            currentDate: currentDate
+        )
+        async let replacement: Void = chapterCache.addChapterContent(
+            "<div>fresh</div>",
+            reference: reference,
+            expirationDate: currentDate.addingTimeInterval(60)
+        )
+        _ = await (cleanup, replacement)
+
+        #expect(
+            await chapterCache.chapterContent(withReference: reference, currentDate: currentDate)
+                == "<div>fresh</div>"
+        )
     }
 }

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
@@ -7,13 +7,13 @@ import Testing
 final class BibleVersionAPIRequestCounter: BibleVersionProviding, @unchecked Sendable {
     private(set) var requestedIds: [Int] = []
     var result: BibleVersion
-    var expirationDate: Date?
+    var expirationDate: Date
     var isCacheable: Bool
     var error: Error?
 
     init(
         result: BibleVersion,
-        expirationDate: Date? = .distantFuture,
+        expirationDate: Date = .distantFuture,
         isCacheable: Bool = true,
         error: Error? = nil
     ) {
@@ -23,12 +23,12 @@ final class BibleVersionAPIRequestCounter: BibleVersionProviding, @unchecked Sen
         self.error = error
     }
 
-    func version(withId id: Int) async throws -> CachedBibleContent<BibleVersion> {
+    func version(withId id: Int) async throws -> BibleContentResponse<BibleVersion> {
         requestedIds.append(id)
         if let error {
             throw error
         }
-        return CachedBibleContent(
+        return BibleContentResponse(
             value: result,
             expirationDate: expirationDate,
             isCacheable: isCacheable
@@ -144,27 +144,6 @@ struct BibleVersionRepositoryTests {
         #expect(second.id == Self.fixture.id)
         #expect(second.readerFooter == Self.fixture.readerFooter)
         #expect(api.callCount == 1)
-    }
-
-    @Test
-    func versionCachesResponseWithoutExpirationForDefaultDuration() async throws {
-        let currentDate = Date(timeIntervalSince1970: 1_000)
-        let api = BibleVersionAPIRequestCounter(
-            result: Self.fixture,
-            expirationDate: nil
-        )
-        let (repository, _, storage) = try makeRepository(apiRequestCounter: api)
-        defer { storage.remove() }
-        let diskCache = BibleVersionDiskCache(directoryProvider: storage.provider)
-
-        _ = try await repository.version(withId: Self.fixture.id, currentDate: currentDate)
-        _ = try await repository.version(
-            withId: Self.fixture.id,
-            currentDate: currentDate.addingTimeInterval(BibleContentCachePolicy.defaultDuration - 1)
-        )
-
-        #expect(api.callCount == 1)
-        #expect(await diskCache.version(withId: Self.fixture.id, currentDate: currentDate)?.id == Self.fixture.id)
     }
 
     @Test

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
@@ -7,19 +7,21 @@ import Testing
 final class BibleVersionAPIRequestCounter: BibleVersionProviding, @unchecked Sendable {
     private(set) var requestedIds: [Int] = []
     var result: BibleVersion
+    var expirationDate: Date?
     var error: Error?
 
-    init(result: BibleVersion, error: Error? = nil) {
+    init(result: BibleVersion, expirationDate: Date? = nil, error: Error? = nil) {
         self.result = result
+        self.expirationDate = expirationDate
         self.error = error
     }
 
-    func version(withId id: Int) async throws -> BibleVersion {
+    func version(withId id: Int) async throws -> CachedBibleContent<BibleVersion> {
         requestedIds.append(id)
         if let error {
             throw error
         }
-        return result
+        return CachedBibleContent(value: result, expirationDate: expirationDate)
     }
 
     var callCount: Int { requestedIds.count }
@@ -131,6 +133,26 @@ struct BibleVersionRepositoryTests {
         #expect(second.id == Self.fixture.id)
         #expect(second.readerFooter == Self.fixture.readerFooter)
         #expect(api.callCount == 1)
+    }
+
+    @Test
+    func versionRefetchesAfterCachedResponseExpires() async throws {
+        let initialDate = Date(timeIntervalSince1970: 1_000)
+        let expiredDate = initialDate.addingTimeInterval(61)
+        let api = BibleVersionAPIRequestCounter(
+            result: Self.fixture,
+            expirationDate: initialDate.addingTimeInterval(60)
+        )
+        let (repository, _, storage) = try makeRepository(apiRequestCounter: api)
+        defer { storage.remove() }
+        let diskCache = BibleVersionDiskCache(directoryProvider: storage.provider)
+
+        _ = try await repository.version(withId: Self.fixture.id, currentDate: initialDate)
+        api.expirationDate = expiredDate.addingTimeInterval(60)
+        _ = try await repository.version(withId: Self.fixture.id, currentDate: expiredDate)
+
+        #expect(api.callCount == 2)
+        #expect(await diskCache.version(withId: Self.fixture.id, currentDate: expiredDate)?.id == Self.fixture.id)
     }
 
     @Test
@@ -279,5 +301,30 @@ struct BibleVersionRepositoryTests {
 
         _ = try await repository.version(withId: Self.fixture.id)
         #expect(api.callCount == 2)
+    }
+
+    @Test
+    func removeUnpermittedVersionsAlsoRemovesExpiredCachedFiles() async throws {
+        let currentDate = Date(timeIntervalSince1970: 2_000)
+        let (repository, _, storage) = try makeRepository()
+        defer { storage.remove() }
+        let versionCache = BibleVersionDiskCache(directoryProvider: storage.provider)
+        let chapterCache = BibleChapterDiskCache(directoryProvider: storage.provider)
+        let reference = BibleReference(versionId: Self.fixture.id, bookId: "GEN", chapter: 1)
+
+        await versionCache.addVersion(Self.fixture, expirationDate: currentDate.addingTimeInterval(-1))
+        await chapterCache.addChapterContent(
+            "<div>expired</div>",
+            reference: reference,
+            expirationDate: currentDate.addingTimeInterval(-1)
+        )
+
+        await repository.removeUnpermittedVersions(
+            permittedIds: [Self.fixture.id],
+            currentDate: currentDate
+        )
+
+        #expect(await versionCache.version(withId: Self.fixture.id, currentDate: currentDate) == nil)
+        #expect(await chapterCache.chapterContent(withReference: reference, currentDate: currentDate) == nil)
     }
 }

--- a/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleVersionRepositoryTests.swift
@@ -8,11 +8,18 @@ final class BibleVersionAPIRequestCounter: BibleVersionProviding, @unchecked Sen
     private(set) var requestedIds: [Int] = []
     var result: BibleVersion
     var expirationDate: Date?
+    var isCacheable: Bool
     var error: Error?
 
-    init(result: BibleVersion, expirationDate: Date? = nil, error: Error? = nil) {
+    init(
+        result: BibleVersion,
+        expirationDate: Date? = .distantFuture,
+        isCacheable: Bool = true,
+        error: Error? = nil
+    ) {
         self.result = result
         self.expirationDate = expirationDate
+        self.isCacheable = isCacheable
         self.error = error
     }
 
@@ -21,7 +28,11 @@ final class BibleVersionAPIRequestCounter: BibleVersionProviding, @unchecked Sen
         if let error {
             throw error
         }
-        return CachedBibleContent(value: result, expirationDate: expirationDate)
+        return CachedBibleContent(
+            value: result,
+            expirationDate: expirationDate,
+            isCacheable: isCacheable
+        )
     }
 
     var callCount: Int { requestedIds.count }
@@ -71,7 +82,7 @@ struct BibleVersionRepositoryTests {
         let (repository, api, storage) = try makeRepository()
         defer { storage.remove() }
         let diskCache = BibleVersionDiskCache(directoryProvider: storage.provider)
-        await diskCache.addVersion(Self.fixture)
+        await diskCache.addVersion(Self.fixture, expirationDate: .distantFuture)
 
         let cached = try await repository.versionIfCached(Self.fixture.id)
         await diskCache.removeVersion(withId: Self.fixture.id)
@@ -133,6 +144,45 @@ struct BibleVersionRepositoryTests {
         #expect(second.id == Self.fixture.id)
         #expect(second.readerFooter == Self.fixture.readerFooter)
         #expect(api.callCount == 1)
+    }
+
+    @Test
+    func versionCachesResponseWithoutExpirationForDefaultDuration() async throws {
+        let currentDate = Date(timeIntervalSince1970: 1_000)
+        let api = BibleVersionAPIRequestCounter(
+            result: Self.fixture,
+            expirationDate: nil
+        )
+        let (repository, _, storage) = try makeRepository(apiRequestCounter: api)
+        defer { storage.remove() }
+        let diskCache = BibleVersionDiskCache(directoryProvider: storage.provider)
+
+        _ = try await repository.version(withId: Self.fixture.id, currentDate: currentDate)
+        _ = try await repository.version(
+            withId: Self.fixture.id,
+            currentDate: currentDate.addingTimeInterval(BibleContentCachePolicy.defaultDuration - 1)
+        )
+
+        #expect(api.callCount == 1)
+        #expect(await diskCache.version(withId: Self.fixture.id, currentDate: currentDate)?.id == Self.fixture.id)
+    }
+
+    @Test
+    func versionDoesNotCacheResponseThatForbidsCaching() async throws {
+        let api = BibleVersionAPIRequestCounter(
+            result: Self.fixture,
+            expirationDate: .distantFuture,
+            isCacheable: false
+        )
+        let (repository, _, storage) = try makeRepository(apiRequestCounter: api)
+        defer { storage.remove() }
+        let diskCache = BibleVersionDiskCache(directoryProvider: storage.provider)
+
+        _ = try await repository.version(withId: Self.fixture.id)
+        _ = try await repository.version(withId: Self.fixture.id)
+
+        #expect(api.callCount == 2)
+        #expect(await diskCache.version(withId: Self.fixture.id) == nil)
     }
 
     @Test
@@ -214,7 +264,7 @@ struct BibleVersionRepositoryTests {
 
         #expect(diskCache.containsVersion(withId: Self.fixture.id) == false)
 
-        await diskCache.addVersion(Self.fixture)
+        await diskCache.addVersion(Self.fixture, expirationDate: .distantFuture)
 
         #expect(diskCache.containsVersion(withId: Self.fixture.id))
     }

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
@@ -418,7 +418,7 @@ let previousChapterCases: [PreviousChapterCase] = [
             chapterPassageId: chapterReference.chapterPassageId
         )
         try storage.writeString(html, to: resource)
-        try storage.writeExpirationDate(nil, for: resource)
+        try storage.writeExpirationDate(.distantFuture, for: resource)
         let viewModel = BibleReaderViewModel(reference: chapterReference)
 
         let text = await viewModel.shareableVerseText(references: [verseReference])
@@ -449,7 +449,7 @@ let previousChapterCases: [PreviousChapterCase] = [
             chapterPassageId: chapterReference.chapterPassageId
         )
         try storage.writeString(html, to: resource)
-        try storage.writeExpirationDate(nil, for: resource)
+        try storage.writeExpirationDate(.distantFuture, for: resource)
         let viewModel = BibleReaderViewModelTestSupport.makeViewModel(reference: chapterReference)
         viewModel.versionsViewModel.switchToVersion(
             BibleReaderViewModelTestSupport.makeBibleVersion(id: versionId)

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModel+NavigationTests.swift
@@ -413,11 +413,12 @@ let previousChapterCases: [PreviousChapterCase] = [
         </div>
         """
         let storage = BibleContentStorage(storageKind: .cache)
-        let chapterPassageId = chapterReference.chapterPassageId
-        try storage.writeString(
-            html,
-            to: .chapter(versionId: versionId, chapterPassageId: chapterPassageId)
+        let resource = BibleContentStorageResource.chapter(
+            versionId: versionId,
+            chapterPassageId: chapterReference.chapterPassageId
         )
+        try storage.writeString(html, to: resource)
+        try storage.writeExpirationDate(nil, for: resource)
         let viewModel = BibleReaderViewModel(reference: chapterReference)
 
         let text = await viewModel.shareableVerseText(references: [verseReference])
@@ -443,11 +444,12 @@ let previousChapterCases: [PreviousChapterCase] = [
         </div>
         """
         let storage = BibleContentStorage(storageKind: .cache)
-        let chapterPassageId = chapterReference.chapterPassageId
-        try storage.writeString(
-            html,
-            to: .chapter(versionId: versionId, chapterPassageId: chapterPassageId)
+        let resource = BibleContentStorageResource.chapter(
+            versionId: versionId,
+            chapterPassageId: chapterReference.chapterPassageId
         )
+        try storage.writeString(html, to: resource)
+        try storage.writeExpirationDate(nil, for: resource)
         let viewModel = BibleReaderViewModelTestSupport.makeViewModel(reference: chapterReference)
         viewModel.versionsViewModel.switchToVersion(
             BibleReaderViewModelTestSupport.makeBibleVersion(id: versionId)


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds HTTP cache-control-aware expiration to Bible chapter and version metadata caches.
- Propagates cacheability and expiration metadata from HTTP responses.
- Adds expiration sidecars and coordinated disk-cache maintenance.
- Updates repository memory and disk cache behavior plus coverage for expiration and cleanup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/Bible/BibleContentStorage.swift | Adds expiration sidecars, cache cleanup, and shared coordination primitives. |
| Sources/YouVersionPlatformCore/Bible/BibleChapterRepository.swift | Makes chapter memory and disk caching honor response expiration and persistence directives. |
| Sources/YouVersionPlatformCore/Bible/BibleVersionRepository.swift | Applies response expiration and cacheability to version metadata caching. |
| Sources/YouVersionPlatformCore/Bible/CachedBibleContent.swift | Defines cache response metadata and parses HTTP cache-control lifetime directives. |
| Sources/YouVersionPlatformCore/APIs/Bible/BibleVersionAPI.swift | Preserves response cache metadata while combining Bible version metadata and index responses. |

<sub>Reviews (4): Last reviewed commit: ["fix: expiration dates no longer optional"](https://github.com/youversion/platform-sdk-swift/commit/d899566a2c93b9bd1fb92dc7f1dc16e0312b8081) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50875439)</sub>

**Context used:**

- Context used - Be encouraging with your comments. ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Core Bible Domain](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-swift/-/docs/core-bible-domain.md)

<!-- /greptile_comment -->