### PR TITLE
test: turn tab tint red to verify the App Live PR bridge (YPE-3011)

### DIFF
--- a/Examples/SampleApp/SampleApp.swift
+++ b/Examples/SampleApp/SampleApp.swift
@@ -49,6 +49,7 @@ struct SampleApp: App {
                     }
                     .tag(4)
             }
+            .tint(.red)
         }
     }
 }


### PR DESCRIPTION
**Do not merge.** Post-merge verification PR for the BrowserStack App Live bridge (#226, YPE-3011).

Changes the SampleApp tab tint to red so the resulting App Live build is visually unmistakable. Expected: the "Build SampleApp for App Live" check dispatches this PR's exact head SHA, the automation run is named `swift-YPE-3011-<N>`, and the check summary links the run and the App Live `bs://` id. Will be closed unmerged once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This temporary verification PR changes the SampleApp’s tab-view tint to red so its BrowserStack App Live build is visually distinguishable.
- Applies a red tint to the SampleApp `TabView`.
- Leaves SDK targets and production behavior unchanged.

<h3>Confidence Score: 5/5</h3>

The code change appears safe for its stated temporary verification purpose, although the PR description explicitly says it must be closed without merging.

The only change applies an intentional visual tint to the example app and does not alter SDK behavior or introduce an actionable failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Examples/SampleApp/SampleApp.swift | Adds the intentional red tint used to identify this temporary App Live verification build; no actionable defect found. |

<sub>Reviews (1): Last reviewed commit: ["test: turn tab tint red to verify the Ap..."](https://github.com/youversion/platform-sdk-swift/commit/b4e25532dadb2bea6a8767f684c550fb42de555c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51231540)</sub>

<!-- /greptile_comment -->