### PR TITLE
fix(ci): fail closed on permission-lookup errors; use pull_request_target

### DIFF
--- a/.github/workflows/browserstack-pr-build.yml
+++ b/.github/workflows/browserstack-pr-build.yml
@@ -8,9 +8,30 @@ name: BrowserStack App Live PR Build
 # approved commenter explicitly authorizes the current same-repository PR head;
 # the PR author does not also need automation-repository access. Test automation
 # and App Automate execution are deliberately out of scope.
+#
+# pull_request_target, NOT pull_request: this workflow consumes
+# AUTOMATION_DISPATCH_TOKEN. A plain `pull_request` trigger runs the workflow
+# definition AS IT EXISTS ON THE PR HEAD — for a same-repository PR (not just
+# forks) that means a PR author could edit this very file to exfiltrate the
+# secret before the authorization check below ever runs, since the check
+# itself is the first code that touches the token. That matters here
+# specifically because "can push a branch to this repo" and "is an approved
+# collaborator on platform_swift_sdk_automation" are different, and narrower,
+# sets of people — the whole point of the check this trigger type protects.
+# pull_request_target always runs the version of this file committed to the
+# base branch, so a PR cannot rewrite the logic that guards its own token
+# access. This workflow never checks out or executes the PR's application
+# code — it only reads github.event.pull_request JSON metadata and dispatches
+# a REMOTE build by value — so pull_request_target's usual "don't run
+# untrusted code" caveat doesn't apply here. Trade-off: unlike pull_request,
+# pull_request_target only runs the version already merged to the base
+# branch, so this specific workflow file can no longer prove itself by
+# triggering on its own PR being opened — verify future changes via a
+# follow-up PR (or an /app-live comment, which already only ever loaded from
+# the default branch).
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
   issue_comment:
     types: [created]
@@ -34,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 55
     if: >-
-      github.event_name == 'pull_request' ||
+      github.event_name == 'pull_request_target' ||
       (github.event.issue.pull_request && github.event.comment.body == '/app-live')
 
     steps:
@@ -49,7 +70,7 @@ jobs:
           # GITHUB_EVENT_PATH is the runner-provided default env var; the
           # ${{ github.event_path }} expression resolved to an empty string
           # here at runtime, which broke this step.
-          if [ "$EVENT_NAME" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
             PR_JSON=$(jq '.pull_request' "$GITHUB_EVENT_PATH")
           else
             PR_NUMBER=$(jq -r '.issue.number' "$GITHUB_EVENT_PATH")
@@ -78,9 +99,20 @@ jobs:
           TRIGGER_ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
+          # The collaborator-permission endpoint can fail (404, transient
+          # error, a caller-permission edge case) instead of cleanly
+          # returning "none" for an unauthorized actor. Under `set -e` that
+          # would kill this step before the case statement below ever runs,
+          # turning "not authorized" into a misleading job failure instead of
+          # the intended silent skip. Treat any lookup failure the same as an
+          # explicit denial — fail closed, never fail loud.
+          #
+          # stderr is left unredirected so a lookup failure's actual error
+          # (rate limit, network, unexpected shape) still lands in this
+          # step's log for diagnosis — only stdout feeds PERMISSION.
           PERMISSION=$(gh api \
             "repos/$AUTOMATION_REPO/collaborators/$TRIGGER_ACTOR/permission" \
-            --jq '.permission')
+            --jq '.permission') || PERMISSION=""
 
           case "$PERMISSION" in
             admin|maintain|write)
@@ -89,7 +121,11 @@ jobs:
               ;;
             *)
               echo "allowed=false" >> "$GITHUB_OUTPUT"
-              echo "::notice::Trigger actor '$TRIGGER_ACTOR' has '$PERMISSION' access to $AUTOMATION_REPO; App Live build skipped."
+              if [ -z "$PERMISSION" ]; then
+                echo "::notice::Could not confirm '$TRIGGER_ACTOR' has access to $AUTOMATION_REPO (lookup failed) — App Live build skipped."
+              else
+                echo "::notice::Trigger actor '$TRIGGER_ACTOR' has '$PERMISSION' access to $AUTOMATION_REPO; App Live build skipped."
+              fi
               ;;
           esac
 


### PR DESCRIPTION
## What

Two hardening fixes to the App Live PR bridge (`#226`/`#228`), found while porting this same workflow to `platform-sdk-kotlin` and `platform-sdk-reactnative-expo` — both apply here identically since that code was copied verbatim from this file.

**1. (P0/security) PAT reaches a PR-controlled workflow.** `pull_request` runs the workflow definition *as committed on the PR head*, and this workflow injects `AUTOMATION_DISPATCH_TOKEN` into the very first step that touches authorization. A same-repository PR author — anyone who can push a branch here, which is a broader group than "approved collaborator on `platform_swift_sdk_automation`" — could edit this file in their own PR to exfiltrate the secret before the authorization check's own logic ever runs. The check can't guard against modifications to itself.

Switched to `pull_request_target`, which always runs the base branch's version of this file, so a PR cannot rewrite the code that gates its own token access. Safe here specifically because this workflow never checks out or executes the PR's application code — it only reads `github.event.pull_request` JSON metadata and dispatches a remote build by value, so `pull_request_target`'s usual "don't run untrusted code" caveat doesn't apply.

**Trade-off:** `pull_request_target`-triggered workflows only run the version already on the base branch, so this workflow can no longer prove itself by triggering on its own PR being opened (that's why this PR itself won't show a self-test "Build SampleApp for App Live" run — expected, not a failure). Once merged, verify future changes via a follow-up PR, or via `/app-live` on any open PR (that path already only ever loaded from the default branch, so it's unaffected either way).

**2. (P1) Permission-lookup failure fails the job instead of skipping cleanly.** `gh api .../collaborators/$ACTOR/permission` can fail — verified independently: a 404-shaped response makes `gh` exit nonzero — instead of returning `"none"` for an unauthorized actor. Under `set -e` that killed the step before the `case` statement's `allowed=false` branch ever ran, turning "not authorized" into a misleading job failure instead of the intended silent skip. Now defaults `PERMISSION` to empty (denied) on any lookup failure — fail closed, never fail loud.

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/browserstack-pr-build.yml'))"` — parses.
- The `set -e` / `||` fallback behavior for finding 2 was verified in isolation (a failing command substitution followed by `|| VAR=""` does not trigger `errexit`, confirmed with a minimal repro).
- Finding 1's `pull_request_target` swap is a trigger-type change only — no other step logic changes beyond the `pull_request` → `pull_request_target` string comparisons, kept 1:1.

Ticket: YPE-3011

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the App Live PR bridge by ensuring pull-request code cannot modify the workflow that receives the automation token and by treating permission-lookup failures as authorization denials.
- Changes the automatic trigger from `pull_request` to `pull_request_target` and consistently updates event-name handling.
- Preserves the same-repository, open-PR, and automation-repository permission gates before dispatch.
- Converts failed collaborator-permission lookups into a clean, diagnostic skip rather than a failed job.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and strengthens both workflow-definition trust and permission-lookup failure handling.

The base-branch workflow performs the authorization gate, PR-controlled values remain data rather than locally executed code, and lookup failures deny access before any remote build dispatch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/browserstack-pr-build.yml | Safely changes the PR trigger to use the trusted base-branch workflow and makes permission lookup errors fail closed without exposing an authorization bypass. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Event[PR opened or /app-live comment] --> Base[Load base-branch workflow]
  Base --> Context[Read current PR metadata]
  Context --> Eligible{Same repository and open?}
  Eligible -- No --> Skip[Skip build]
  Eligible -- Yes --> Lookup[Look up actor permission]
  Lookup --> Allowed{Permission confirmed?}
  Allowed -- No or lookup error --> Skip
  Allowed -- Yes --> Dispatch[Dispatch immutable PR head SHA]
  Dispatch --> Remote[Remote App Live build]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): fail closed on permission-looku..."](https://github.com/youversion/platform-sdk-swift/commit/5ff24a1497a829668a2a42d7f22cd013258c805c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51331021)</sub>

<!-- /greptile_comment -->