### PR TITLE
fix: RTL layout and chevron directions

### DIFF
--- a/Examples/SampleApp.xcodeproj/project.pbxproj
+++ b/Examples/SampleApp.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 				de,
 				"es-MX",
 				fr,
+				ar,
 			);
 			mainGroup = 509A682E2E0CB1EE00B0F85E;
 			minimizedProjectReferenceProxies = 1;

--- a/Examples/SampleApp.xcodeproj/project.pbxproj
+++ b/Examples/SampleApp.xcodeproj/project.pbxproj
@@ -268,7 +268,7 @@
 				DEVELOPMENT_TEAM = AM88PVBRSG;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleLocalizations = "en de es-MX fr";
+				INFOPLIST_KEY_CFBundleLocalizations = "en de es-MX fr ar";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -299,7 +299,7 @@
 				DEVELOPMENT_TEAM = AM88PVBRSG;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleLocalizations = "en de es-MX fr";
+				INFOPLIST_KEY_CFBundleLocalizations = "en de es-MX fr ar";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Examples/SampleApp/Localizable.xcstrings
+++ b/Examples/SampleApp/Localizable.xcstrings
@@ -1,0 +1,216 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "app.name" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "تطبيق نموذجي" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Beispiel-App" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Sample App" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "App de ejemplo" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Application exemple" } }
+      }
+    },
+    "app.sign_in_prompt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "سجّل الدخول لعرض تظليلات YouVersion الخاصة بك في هذا التطبيق النموذجي." } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Melde dich an, um deine YouVersion-Markierungen in dieser Beispiel-App zu sehen." } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Sign in to see your YouVersion highlights in this Sample App." } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Inicia sesión para ver tus subrayados de YouVersion en esta app de ejemplo." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Connectez-vous pour voir vos surlignages YouVersion dans cette application exemple." } }
+      }
+    },
+    "navigate.footer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "اضغط على مقطع للانتقال بالقارئ إليه في علامة تبويب الكتاب المقدس من دون إعادة إنشائه." } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Tippe auf eine Bibelstelle, um den Reader im Tab „Bibel“ dorthin zu bewegen, ohne ihn neu zu erstellen." } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Tapping a passage drives the reader in the Bible tab — it isn't recreated." } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Toca un pasaje para dirigir el lector en la pestaña Biblia sin volver a crearlo." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Touchez un passage pour déplacer le lecteur dans l’onglet Bible sans le recréer." } }
+      }
+    },
+    "navigate.genesis_1_whole_chapter" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "التكوين 1 — الأصحاح كاملًا" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "1. Mose 1 — ganzes Kapitel" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Genesis 1 — whole chapter" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Génesis 1 — capítulo completo" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Genèse 1 — chapitre entier" } }
+      }
+    },
+    "navigate.john_3_16_focused" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "يوحنا 3:16 — مع التركيز عليها" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Johannes 3,16 — hervorgehoben" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "John 3:16 — focused" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Juan 3:16 — resaltado" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Jean 3:16 — mis en évidence" } }
+      }
+    },
+    "navigate.john_3_16_full_chapter" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "يوحنا 3:16 — الأصحاح كاملًا، مع الانتقال إلى الآية" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Johannes 3,16 — ganzes Kapitel, zum Vers gescrollt" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "John 3:16 — full chapter, scrolled to the verse" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Juan 3:16 — capítulo completo, desplazado al versículo" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Jean 3:16 — chapitre entier, positionné sur le verset" } }
+      }
+    },
+    "navigate.psalm_119_105_full_chapter" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "مزمور 119:105 — الأصحاح كاملًا، مع الانتقال إلى الآية" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Psalm 119,105 — ganzes Kapitel, zum Vers gescrollt" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Psalm 119:105 — full chapter, scrolled to the verse" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Salmos 119:105 — capítulo completo, desplazado al versículo" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Psaume 119:105 — chapitre entier, positionné sur le verset" } }
+      }
+    },
+    "navigate.romans_8_28_verse_range" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "رومية 8:28 — نطاق الآية فقط" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Römer 8,28 — nur der Versbereich" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Romans 8:28 — just the verse range" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Romanos 8:28 — solo el rango de versículos" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Romains 8:28 — uniquement le passage" } }
+      }
+    },
+    "navigate.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "التنقل" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Navigation" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Navigate" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Navegar" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Navigation" } }
+      }
+    },
+    "profile.highlights_permission_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "تعذّر الحصول على إذن التظليلات: %@" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Berechtigung für Markierungen fehlgeschlagen: %@" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Highlights permission failed: %@" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "No se pudo obtener el permiso para subrayados: %@" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Échec de l’autorisation d’accès aux surlignages : %@" } }
+      }
+    },
+    "profile.highlights_permission_granted" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "إذن التظليلات: تم منحه" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Berechtigung für Markierungen: erteilt" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Highlights permission: granted" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Permiso para subrayados: concedido" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Autorisation d’accès aux surlignages : accordée" } }
+      }
+    },
+    "profile.no_email" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "(لا يوجد بريد إلكتروني)" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "(keine E-Mail-Adresse)" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "(no email)" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "(sin correo electrónico)" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "(aucune adresse e-mail)" } }
+      }
+    },
+    "profile.no_name" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "(لا يوجد اسم)" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "(kein Name)" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "(no name)" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "(sin nombre)" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "(aucun nom)" } }
+      }
+    },
+    "profile.request_highlights_permission" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "طلب إذن التظليلات" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Berechtigung für Markierungen anfordern" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Request highlights permission" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Solicitar permiso para subrayados" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Demander l’accès aux surlignages" } }
+      }
+    },
+    "profile.sign_out" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "تسجيل الخروج" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Abmelden" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Sign out" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Cerrar sesión" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Se déconnecter" } }
+      }
+    },
+    "profile.signed_in_as" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "تم تسجيل دخولك باسم:" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Du bist angemeldet als:" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "You are signed in as:" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Iniciaste sesión como:" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Vous êtes connecté en tant que :" } }
+      }
+    },
+    "tab.bible" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "الكتاب المقدس" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Bibel" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Bible" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Biblia" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Bible" } }
+      }
+    },
+    "tab.card" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "بطاقة" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Karte" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Card" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Tarjeta" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Carte" } }
+      }
+    },
+    "tab.navigate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "التنقل" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Navigation" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Navigate" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Navegar" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Navigation" } }
+      }
+    },
+    "tab.profile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "الملف الشخصي" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Profil" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Profile" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Perfil" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Profil" } }
+      }
+    },
+    "tab.votd" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "آية اليوم" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Vers des Tages" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "VOTD" } },
+        "es-MX" : { "stringUnit" : { "state" : "translated", "value" : "Versículo del día" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Verset du jour" } }
+      }
+    }
+  },
+  "version" : "1.1"
+}

--- a/Examples/SampleApp/NavigateView.swift
+++ b/Examples/SampleApp/NavigateView.swift
@@ -10,31 +10,31 @@ struct NavigateView: View {
 
     private let examples: [(title: String, reference: BibleReference, showsFullChapter: Bool, shouldFocus: Bool)] = [
         (
-            "John 3:16 — full chapter, scrolled to the verse",
+            String(localized: "navigate.john_3_16_full_chapter"),
             BibleReference(versionId: 3034, bookId: "JHN", chapter: 3, verse: 16),
             true,
             false
         ),
         (
-            "John 3:16 — focused",
+            String(localized: "navigate.john_3_16_focused"),
             BibleReference(versionId: 3034, bookId: "JHN", chapter: 3, verse: 16),
             true,
             true
         ),
         (
-            "Psalm 119:105 — full chapter, scrolled to the verse",
+            String(localized: "navigate.psalm_119_105_full_chapter"),
             BibleReference(versionId: 3034, bookId: "PSA", chapter: 119, verse: 105),
             true,
             false
         ),
         (
-            "Romans 8:28 — just the verse range",
+            String(localized: "navigate.romans_8_28_verse_range"),
             BibleReference(versionId: 3034, bookId: "ROM", chapter: 8, verse: 28),
             false,
             false
         ),
         (
-            "Genesis 1 — whole chapter",
+            String(localized: "navigate.genesis_1_whole_chapter"),
             BibleReference(versionId: 3034, bookId: "GEN", chapter: 1),
             true,
             false
@@ -56,10 +56,10 @@ struct NavigateView: View {
                         }
                     }
                 } footer: {
-                    Text("Tapping a passage drives the reader in the Bible tab — it isn't recreated.")
+                    Text("navigate.footer")
                 }
             }
-            .navigationTitle("Navigate")
+            .navigationTitle("navigate.title")
         }
     }
 }

--- a/Examples/SampleApp/ProfileView.swift
+++ b/Examples/SampleApp/ProfileView.swift
@@ -12,15 +12,15 @@ struct ProfileView: View {
     var body: some View {
         VStack {
             if isSignedIn {
-                Text("You are signed in as: ")
+                Text("profile.signed_in_as")
                     .padding()
-                Text(YouVersionAPI.Users.currentUserName ?? "(no name)")
-                Text(YouVersionAPI.Users.currentUserEmail ?? "(no email)")
+                Text(YouVersionAPI.Users.currentUserName ?? String(localized: "profile.no_name"))
+                Text(YouVersionAPI.Users.currentUserEmail ?? String(localized: "profile.no_email"))
                     .padding(.bottom)
                 if hasHighlightsPermission {
-                    Text("Highlights permission: granted")
+                    Text("profile.highlights_permission_granted")
                 } else {
-                    Button("Request highlights permission") {
+                    Button("profile.request_highlights_permission") {
                         requestHighlightsPermission()
                     }
                 }
@@ -29,7 +29,7 @@ struct ProfileView: View {
                         .font(.footnote)
                         .padding(.vertical)
                 }
-                Button("Sign out") {
+                Button("profile.sign_out") {
                     doSignOut()
                 }
                 .padding(.top)
@@ -85,7 +85,10 @@ struct ProfileView: View {
                 _ = try await session.requestDataExchange(permissions: ["highlights"])
                 hasHighlightsPermission = YouVersionAPI.hasPermission("highlights")
             } catch {
-                dataExchangeStatusText = "Highlights permission failed: \(error.localizedDescription)"
+                dataExchangeStatusText = String(
+                    format: String(localized: "profile.highlights_permission_failed"),
+                    error.localizedDescription
+                )
             }
         }
     }

--- a/Examples/SampleApp/SampleApp.swift
+++ b/Examples/SampleApp/SampleApp.swift
@@ -11,8 +11,8 @@ struct SampleApp: App {
         // Get your app key from https://platform.youversion.com/
         YouVersionPlatformConfiguration.configure(
             appKey: <#Your App Key#>,
-            appName: "Sample App",
-            signInPromptMessage: "Sign in to see your YouVersion highlights in this Sample App."
+            appName: String(localized: "app.name"),
+            signInPromptMessage: String(localized: "app.sign_in_prompt")
         )
     }
 
@@ -21,31 +21,31 @@ struct SampleApp: App {
             TabView(selection: $selectedTab) {
                 BibleReaderView.restoringLastPassage(readerNavigation: readerNavigation)
                 .tabItem {
-                    Label("Bible", systemImage: "book.closed.fill")
+                    Label("tab.bible", systemImage: "book.closed.fill")
                 }
                 .tag(0)
 
                 NavigateView(navigation: readerNavigation, onNavigate: { selectedTab = 0 })
                     .tabItem {
-                        Label("Navigate", systemImage: "arrow.uturn.right")
+                        Label("tab.navigate", systemImage: "arrow.uturn.right")
                     }
                     .tag(1)
 
                 VotdContainerView()
                     .tabItem {
-                        Label("VOTD", systemImage: "sun.max.fill")
+                        Label("tab.votd", systemImage: "sun.max.fill")
                     }
                     .tag(2)
 
                 CardView()
                     .tabItem {
-                        Label("Card", systemImage: "doc.plaintext")
+                        Label("tab.card", systemImage: "doc.plaintext")
                     }
                     .tag(3)
 
                 ProfileView()
                     .tabItem {
-                        Label("Profile", systemImage: "person.fill")
+                        Label("tab.profile", systemImage: "person.fill")
                     }
                     .tag(4)
             }

--- a/Examples/SampleApp/ar.lproj/Localizable.strings
+++ b/Examples/SampleApp/ar.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+/* Dummy file to ensure Arabic localization is recognized */

--- a/Examples/SampleApp/ar.lproj/Localizable.strings
+++ b/Examples/SampleApp/ar.lproj/Localizable.strings
@@ -1,1 +1,0 @@
-/* Dummy file to ensure Arabic localization is recognized */

--- a/Examples/SampleApp/de.lproj/Localizable.strings
+++ b/Examples/SampleApp/de.lproj/Localizable.strings
@@ -1,1 +1,0 @@
-/* Dummy file to ensure German localization is recognized */

--- a/Examples/SampleApp/es-MX.lproj/Localizable.strings
+++ b/Examples/SampleApp/es-MX.lproj/Localizable.strings
@@ -1,1 +1,0 @@
-/* Dummy file to ensure Spanish (Latin America) localization is recognized */

--- a/Examples/SampleApp/fr.lproj/Localizable.strings
+++ b/Examples/SampleApp/fr.lproj/Localizable.strings
@@ -1,1 +1,0 @@
-/* Dummy file to ensure French localization is recognized */

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderNavButtons.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderNavButtons.swift
@@ -13,7 +13,7 @@ struct BibleReaderNavButtons: View {
                         .fill(viewModel.readerCanvasPrimaryColor)
                         .shadow(color: viewModel.readerDropShadowColor, radius: 2, x: 0, y: 2)
                         .frame(width: 42, height: 42)
-                    Image(systemName: "chevron.left")
+                    Image(systemName: "chevron.backward")
                         .foregroundStyle(viewModel.readerTextPrimaryColor)
                         .font(.system(size: 16, weight: .medium))
                 }
@@ -25,7 +25,7 @@ struct BibleReaderNavButtons: View {
                         .fill(viewModel.readerCanvasPrimaryColor)
                         .shadow(color: viewModel.readerDropShadowColor, radius: 2, x: 0, y: 2)
                         .frame(width: 42, height: 42)
-                    Image(systemName: "chevron.right")
+                    Image(systemName: "chevron.forward")
                         .foregroundStyle(viewModel.readerTextPrimaryColor)
                         .font(.system(size: 16, weight: .medium))
                 }

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift
@@ -14,7 +14,7 @@ struct BibleReaderFontListView: View {
                     Button {
                         viewModel.showingFontList = false
                     } label: {
-                        Image(systemName: "chevron.left")
+                        Image(systemName: "chevron.backward")
                             .font(.system(size: 24, weight: .semibold))
                     }
                     .padding()

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift
@@ -30,7 +30,7 @@ struct BibleReaderFontSettingsView: View {
                     .font(ReaderFonts.displayFont(familyName: family, size: 22))
             }
             Spacer()
-            Image(systemName: "chevron.right")
+            Image(systemName: "chevron.forward")
                 .font(.system(size: 18))
         }
         .foregroundStyle(viewModel.readerTextPrimaryColor)

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionOverviewListItem.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionOverviewListItem.swift
@@ -42,7 +42,7 @@ struct BibleVersionOverviewListItem: View, AbbreviationSplitting {
                 .font(.body)
 
             Spacer()
-            Image(systemName: "chevron.right")
+            Image(systemName: "chevron.forward")
                 .foregroundStyle(viewModel.readerTextPrimaryColor)
         }
         .contentShape(Rectangle())

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift
@@ -113,7 +113,7 @@ public struct BibleVersionsListView: View {
                     Capsule()
                         .fill(viewModel.readerButtonPrimaryColor)
                 )
-            Image(systemName: "chevron.right")
+            Image(systemName: "chevron.forward")
             Spacer()
         }
         .padding()

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/CustomBackButton.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/CustomBackButton.swift
@@ -31,7 +31,7 @@ private struct CustomBackButtonModifier: ViewModifier {
                         Button {
                             action()
                         } label: {
-                            Image(systemName: "chevron.left")
+                            Image(systemName: "chevron.backward")
                                 .font(.system(size: 16, weight: .semibold))
                         }
                         .accessibilityLabel(String.localized("generic.back"))


### PR DESCRIPTION
Fix SampleApp and BibleReader glitches seen in RTL languages such as Arabic

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR improves right-to-left presentation in the Bible Reader and SampleApp.
- Replaces directional chevrons with layout-aware forward and backward symbols.
- Migrates SampleApp copy to a string catalog with Arabic, German, English, Mexican Spanish, and French translations.
- Declares Arabic consistently in the project and both target build configurations.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Examples/SampleApp.xcodeproj/project.pbxproj | Arabic is consistently included in known regions and both Debug and Release bundle-localization declarations. |
| Examples/SampleApp/Localizable.xcstrings | Adds a consolidated SampleApp catalog with complete locale entries for the newly localized keys. |
| Examples/SampleApp/SampleApp.swift | Replaces SampleApp configuration and tab copy with localized catalog values. |
| Sources/YouVersionPlatformReader/Components/BibleReaderNavButtons.swift | Uses layout-direction-aware symbols for previous and next chapter controls. |
| Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift | Makes the font-list back indicator follow the interface layout direction. |
| Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift | Makes the font-list disclosure indicator follow the interface layout direction. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionOverviewListItem.swift | Makes version-row disclosure indicators layout-direction aware. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift | Makes the language-row disclosure indicator layout-direction aware. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/CustomBackButton.swift | Makes the custom navigation back indicator layout-direction aware. |

<sub>Reviews (3): Last reviewed commit: ["feat: switch to xcstrings and add AI-tra..."](https://github.com/youversion/platform-sdk-swift/commit/38ea44d3970881b51f4cfcbfdb50e85edb9743b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51874973)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Package Structure](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-swift/-/docs/package-structure.md)
- Knowledge Base — [Version Picking Flow](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-swift/-/docs/ui-version-picking.md)
- Knowledge Base — [Reader Components and Sheets](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-swift/-/docs/reader-components-sheets.md)
</details>

<!-- /greptile_comment -->