### PR TITLE
fix: match collectible terms across straight and typographic quotes

### DIFF
--- a/Sources/YouVersionPlatformCore/Bible/BibleTermHighlight.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleTermHighlight.swift
@@ -5,8 +5,8 @@ import Foundation
 public struct BibleTermHighlight: CustomDebugStringConvertible, Sendable, Equatable, Identifiable {
     /// The verse the term appears in.
     public let reference: BibleReference
-    /// The exact term to match within the verse text. Matching is case-insensitive,
-    /// first occurrence.
+    /// The term to match within the verse text. Matching is case-insensitive and
+    /// insensitive to quote shape, first occurrence.
     public let term: String
     /// A hex background color value for the highlight, e.g. "#E7F2FD".
     public let color: String
@@ -52,12 +52,16 @@ public struct BibleTermHighlight: CustomDebugStringConvertible, Sendable, Equata
     /// The match must be bounded by non-alphanumeric characters (or string ends) on both
     /// sides, so a short term like "son" does not match inside "person". Internal
     /// whitespace in multi-word terms (e.g. "Sea of Galilee") is preserved.
+    ///
+    /// Quote characters are compared by shape, so a term written with a straight
+    /// apostrophe (`lions'`) matches verse text rendered with a typographic one
+    /// (`lions’`), and vice versa. The returned range always indexes `text`.
     public static func firstMatchRange(of term: String, in text: String) -> Range<String.Index>? {
         guard !term.isEmpty else {
             return nil
         }
         var searchStart = text.startIndex
-        while let range = text.range(of: term, options: .caseInsensitive, range: searchStart..<text.endIndex) {
+        while searchStart < text.endIndex, let range = matchRange(of: term, in: text, from: searchStart) {
             let precededByWordChar = range.lowerBound > text.startIndex
                 && text[text.index(before: range.lowerBound)].isWordCharacter
             let followedByWordChar = range.upperBound < text.endIndex
@@ -65,12 +69,36 @@ public struct BibleTermHighlight: CustomDebugStringConvertible, Sendable, Equata
             if !precededByWordChar && !followedByWordChar {
                 return range
             }
-            guard range.lowerBound < text.endIndex else {
-                break
-            }
             searchStart = text.index(after: range.lowerBound)
         }
         return nil
+    }
+
+    /// Scans forward from `searchStart` for the first quote-insensitive, case-insensitive
+    /// occurrence of `term`, returning its range in `text` without regard to word boundaries.
+    private static func matchRange(of term: String, in text: String, from searchStart: String.Index) -> Range<String.Index>? {
+        var candidate = searchStart
+        while candidate < text.endIndex {
+            if let end = matchEnd(of: term, in: text, startingAt: candidate) {
+                return candidate..<end
+            }
+            candidate = text.index(after: candidate)
+        }
+        return nil
+    }
+
+    /// Returns the index just past `term` when it matches `text` starting exactly at
+    /// `start`, or `nil` if it does not. Comparison folds quote shapes and case.
+    private static func matchEnd(of term: String, in text: String, startingAt start: String.Index) -> String.Index? {
+        var textIndex = start
+        for termCharacter in term {
+            guard textIndex < text.endIndex,
+                  text[textIndex].isEquivalent(to: termCharacter) else {
+                return nil
+            }
+            textIndex = text.index(after: textIndex)
+        }
+        return textIndex
     }
 
     /// Whether this highlight applies to the given verse (matching version, book,
@@ -87,5 +115,22 @@ private extension Character {
     /// A character that can be part of a word for boundary detection (letter or number).
     var isWordCharacter: Bool {
         isLetter || isNumber
+    }
+
+    var quoteFolded: Character {
+        switch self {
+        case "\u{2018}", "\u{2019}", "\u{02BC}", "\u{FF07}":
+            return "'"
+        case "\u{201C}", "\u{201D}", "\u{FF02}":
+            return "\""
+        default:
+            return self
+        }
+    }
+
+    func isEquivalent(to other: Character) -> Bool {
+        let folded = quoteFolded
+        let otherFolded = other.quoteFolded
+        return folded == otherFolded || folded.lowercased() == otherFolded.lowercased()
     }
 }

--- a/Sources/YouVersionPlatformCore/Bible/BibleTermHighlight.swift
+++ b/Sources/YouVersionPlatformCore/Bible/BibleTermHighlight.swift
@@ -53,15 +53,32 @@ public struct BibleTermHighlight: CustomDebugStringConvertible, Sendable, Equata
     /// sides, so a short term like "son" does not match inside "person". Internal
     /// whitespace in multi-word terms (e.g. "Sea of Galilee") is preserved.
     ///
-    /// Quote characters are compared by shape, so a term written with a straight
-    /// apostrophe (`lions'`) matches verse text rendered with a typographic one
-    /// (`lions’`), and vice versa. The returned range always indexes `text`.
+    /// A term containing a quote also matches text that uses the opposite quote shape,
+    /// so a term written with a straight apostrophe (`lions'`) matches verse text
+    /// rendered with a typographic one (`lions’`), and vice versa. The returned range
+    /// always indexes `text`.
     public static func firstMatchRange(of term: String, in text: String) -> Range<String.Index>? {
         guard !term.isEmpty else {
             return nil
         }
+        if let range = wholeWordRange(of: term, in: text, using: foundationRange) {
+            return range
+        }
+        guard term.contains(where: \.isQuote) else {
+            return nil
+        }
+        return wholeWordRange(of: term, in: text, using: quoteFoldedRange)
+    }
+
+    /// Walks candidate matches produced by `nextRange`, returning the first bounded by
+    /// non-word characters on both sides.
+    private static func wholeWordRange(
+        of term: String,
+        in text: String,
+        using nextRange: (String, String, String.Index) -> Range<String.Index>?
+    ) -> Range<String.Index>? {
         var searchStart = text.startIndex
-        while searchStart < text.endIndex, let range = matchRange(of: term, in: text, from: searchStart) {
+        while searchStart < text.endIndex, let range = nextRange(term, text, searchStart) {
             let precededByWordChar = range.lowerBound > text.startIndex
                 && text[text.index(before: range.lowerBound)].isWordCharacter
             let followedByWordChar = range.upperBound < text.endIndex
@@ -74,9 +91,15 @@ public struct BibleTermHighlight: CustomDebugStringConvertible, Sendable, Equata
         return nil
     }
 
-    /// Scans forward from `searchStart` for the first quote-insensitive, case-insensitive
-    /// occurrence of `term`, returning its range in `text` without regard to word boundaries.
-    private static func matchRange(of term: String, in text: String, from searchStart: String.Index) -> Range<String.Index>? {
+    /// Foundation's case-insensitive search, which applies full Unicode case folding
+    /// (so `straße` matches `STRASSE`) but compares quote shapes literally.
+    private static func foundationRange(of term: String, in text: String, from searchStart: String.Index) -> Range<String.Index>? {
+        text.range(of: term, options: .caseInsensitive, range: searchStart..<text.endIndex)
+    }
+
+    /// Scans forward for the first occurrence of `term` comparing quote shapes as equal.
+    /// Used only when Foundation finds nothing and the term contains a quote.
+    private static func quoteFoldedRange(of term: String, in text: String, from searchStart: String.Index) -> Range<String.Index>? {
         var candidate = searchStart
         while candidate < text.endIndex {
             if let end = matchEnd(of: term, in: text, startingAt: candidate) {
@@ -117,6 +140,13 @@ private extension Character {
         isLetter || isNumber
     }
 
+    /// Whether this character is a quote in any of the shapes `quoteFolded` collapses.
+    var isQuote: Bool {
+        quoteFolded == "'" || quoteFolded == "\""
+    }
+
+    /// The straight equivalent of a typographic quote, so apostrophes and quotation
+    /// marks compare equal regardless of which form the source text uses.
     var quoteFolded: Character {
         switch self {
         case "\u{2018}", "\u{2019}", "\u{02BC}", "\u{FF07}":
@@ -128,6 +158,7 @@ private extension Character {
         }
     }
 
+    /// Whether two characters match for term searching, ignoring case and quote shape.
     func isEquivalent(to other: Character) -> Bool {
         let folded = quoteFolded
         let otherFolded = other.quoteFolded

--- a/Tests/YouVersionPlatformCoreTests/BibleTermHighlightsCacheTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleTermHighlightsCacheTests.swift
@@ -146,6 +146,16 @@ struct BibleTermHighlightsCacheTests {
     }
 
     @Test
+    func preservesUnicodeCaseFoldingAcrossDifferingCharacterCounts() {
+        // Quote folding must not regress Foundation's full case folding, where one
+        // grapheme folds to several characters.
+        let sharpS = BibleTermHighlight(ref(1), term: "stra\u{00DF}e", color: "#FFCC00", id: "9")
+        #expect(sharpS.firstMatchRange(in: "the STRASSE gate") != nil)
+        let ligature = BibleTermHighlight(ref(1), term: "FISH", color: "#FFCC00", id: "10")
+        #expect(ligature.firstMatchRange(in: "a \u{FB01}sh and bread") != nil)
+    }
+
+    @Test
     func matchesCurlyDoubleQuotes() {
         let h = BibleTermHighlight(ref(1), term: "\"Immanuel\"", color: "#FFCC00", id: "3")
         let text = "they shall call his name \u{201C}Immanuel\u{201D} among them"

--- a/Tests/YouVersionPlatformCoreTests/BibleTermHighlightsCacheTests.swift
+++ b/Tests/YouVersionPlatformCoreTests/BibleTermHighlightsCacheTests.swift
@@ -96,6 +96,63 @@ struct BibleTermHighlightsCacheTests {
     }
 
     @Test
+    func matchesStraightApostropheTermAgainstTypographicText() {
+        let h = BibleTermHighlight(ref(1), term: "Queen Esther's", color: "#FFCC00", id: "25")
+        let text = "So the king and Haman went to dine with Queen Esther\u{2019}s banquet"
+        let range = h.firstMatchRange(in: text)
+        #expect(range != nil)
+        #expect(range.map { String(text[$0]) } == "Queen Esther\u{2019}s")
+    }
+
+    @Test
+    func matchesTermEndingInApostrophe() {
+        let h = BibleTermHighlight(ref(7), term: "lions'", color: "#FFCC00", id: "45")
+        let text = "shall be cast into the lions\u{2019} den"
+        let range = h.firstMatchRange(in: text)
+        #expect(range != nil)
+        #expect(range.map { String(text[$0]) } == "lions\u{2019}")
+    }
+
+    @Test
+    func matchesTypographicTermAgainstStraightText() {
+        // The fold works in both directions, whichever form each source uses.
+        let h = BibleTermHighlight(ref(7), term: "lions\u{2019}", color: "#FFCC00", id: "45")
+        let text = "shall be cast into the lions' den"
+        #expect(h.firstMatchRange(in: text).map { String(text[$0]) } == "lions'")
+    }
+
+    @Test
+    func returnedRangeIndexesOriginalText() {
+        // The renderer maps this range to offsets in the very string passed in, so the
+        // range must slice back to the matched term without drift.
+        let h = BibleTermHighlight(ref(1), term: "Queen Esther's", color: "#FFCC00", id: "25")
+        let text = "dine with Queen Esther\u{2019}s banquet today"
+        let range = h.firstMatchRange(in: text)
+        #expect(range != nil)
+        guard let range else {
+            return
+        }
+        #expect(text.distance(from: text.startIndex, to: range.lowerBound) == 10)
+        #expect(String(text[range]) == "Queen Esther\u{2019}s")
+    }
+
+    @Test
+    func quoteFoldingStillRespectsWordBoundaries() {
+        // Folding must not loosen the whole-word rule.
+        let h = BibleTermHighlight(ref(7), term: "son's", color: "#FFCC00", id: "1")
+        #expect(h.firstMatchRange(in: "the person\u{2019}s cloak") == nil)
+        let text = "her son\u{2019}s cloak"
+        #expect(h.firstMatchRange(in: text).map { String(text[$0]) } == "son\u{2019}s")
+    }
+
+    @Test
+    func matchesCurlyDoubleQuotes() {
+        let h = BibleTermHighlight(ref(1), term: "\"Immanuel\"", color: "#FFCC00", id: "3")
+        let text = "they shall call his name \u{201C}Immanuel\u{201D} among them"
+        #expect(h.firstMatchRange(in: text).map { String(text[$0]) } == "\u{201C}Immanuel\u{201D}")
+    }
+
+    @Test
     func noMatchWhenAbsent() {
         let h = BibleTermHighlight(ref(26), term: "Bethlehem", color: "#FFCC00", id: "5")
         #expect(h.firstMatchRange(in: "God sent the angel Gabriel to Nazareth") == nil)

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelSignInTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelSignInTests.swift
@@ -26,6 +26,10 @@ import Testing
     @Test
     func handleVerseTapDoesNothingWhenUnsignedOutAndSignInDisabled() {
         Support.clearReaderDefaults()
+        YouVersionPlatformConfiguration.configure(appKey: "test-app", isSignInEnabled: false)
+        defer {
+            YouVersionPlatformConfiguration.configure(appKey: "test-app", isSignInEnabled: true)
+        }
         let viewModel = Support.makeViewModel(isSignedIn: false)
 
         viewModel.handleVerseTap(
@@ -37,7 +41,6 @@ import Testing
         #expect(viewModel.showingSignInSheet == false)
         #expect(viewModel.showingVerseActionsDrawer == false)
         #expect(viewModel.selectedVerses.isEmpty)
-        YouVersionPlatformConfiguration.configure(appKey: "test-app", isSignInEnabled: true)
     }
 
     @Test


### PR DESCRIPTION
Fixes the apostrophe half of [BL-2078](https://lifechurch.atlassian.net/browse/BL-2078).

## Problem

Collectible terms whose `termText` contains a straight apostrophe (U+0027) never highlighted in the reader, so they couldn't be tapped or collected:

| Collectible | Verse | `termText` |
| --- | --- | --- |
| Esther (25) | Esther 7:1 | `Queen Esther's` |
| Lion (45) | Daniel 6:7 | `lions'` |

Rendered verse text uses the typographic apostrophe (U+2019) — `BibleTextNodeParser` converts `&rsquo;` to `’` during parse — but `firstMatchRange` did a literal substring match, so the comparison failed and no highlight was scheduled.

## Fix

`firstMatchRange(of:in:)` now compares characters with quote shapes folded, so a term written with either apostrophe form matches text using the other. Curly double quotes and the fullwidth/modifier-letter variants fold too.

Unchanged: case-insensitivity, the whole-word boundary rule, and both public signatures (`scripts/check-api-stability.sh check` passes).

The returned range still indexes the **original** string. This matters — `applyTermHighlights` in `BibleTextView+Rendering.swift` converts the range to integer offsets and re-derives `AttributedString` indices, so matching against a stripped or normalized copy would silently misplace every highlight after the verse's first punctuation mark. That's why this folds per-character rather than normalizing the strings; `returnedRangeIndexesOriginalText` locks the guarantee in.

## Tests

6 new cases in `BibleTermHighlightsCacheTests`: both ticket cases, the reverse fold direction, the index-space guarantee, curly double quotes, and a regression guard that folding doesn't loosen word boundaries (`son's` still must not match inside `person’s`).

- `swift test --filter BibleTermHighlightsCacheTests` — 17/17 pass
- `swiftlint --strict` — clean
- `scripts/check-api-stability.sh check` — passes on all three modules

Full `swift test` has one failure, `handleVerseTapDoesNothingWhenUnsignedOutAndSignInDisabled` in `BibleReaderViewModelSignInTests`. It's pre-existing and unrelated — verified by stashing these changes and re-running on a clean tree, where it fails identically.

## Not covered here

**Thomas (12, John 20:24)** from the same ticket is *not* fixed. Its `termText` is `Thomas (also known as Didymus)`, which doesn't occur verbatim in the verse — the parenthetical gloss wording varies by translation ("also called Didymus", "called the Twin"). No punctuation folding can bridge that; it needs a `collectibles.json` data fix (`termText` → `Thomas`) in the app repo.

Beatitudes (28) and Ten Commandments (41) have `termText: null` and remain out of scope per the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BL-2078]: https://lifechurch.atlassian.net/browse/BL-2078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds quote-shape-insensitive collectible-term matching while retaining ranges into the original verse text, and it makes the sign-in-disabled test restore global configuration with `defer`.
- Adds a Foundation matching fast path followed by per-character quote folding.
- Covers straight and typographic apostrophes, curly double quotes, boundaries, original-string indices, and standalone Unicode case folds.
- Restores sign-in configuration even if the affected reader test exits early.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because collectible terms requiring both quote folding and a length-changing Unicode case fold still fail to highlight.

The Foundation fast path preserves full Unicode case folding, but any quote-shape mismatch enters a one-`Character`-at-a-time fallback that cannot match expansions such as `ß` to `SS`.

**Files Needing Attention:** Sources/YouVersionPlatformCore/Bible/BibleTermHighlight.swift and Tests/YouVersionPlatformCoreTests/BibleTermHighlightsCacheTests.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformCore/Bible/BibleTermHighlight.swift | Adds quote-shape folding, but the fallback still loses full Unicode case folding when both transformations are needed. |
| Tests/YouVersionPlatformCoreTests/BibleTermHighlightsCacheTests.swift | Adds focused quote and Unicode regression coverage, but does not combine quote mismatch with a length-changing case fold. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelSignInTests.swift | Uses `defer` to reliably restore the global sign-in configuration after the test. |

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0ASources%2FYouVersionPlatformCore%2FBible%2FBibleTermHighlight.swift%3A70%0A**Combined%20Unicode%20folding%20still%20fails**%0A%0AWhen%20a%20term%20requires%20both%20quote-shape%20folding%20and%20a%20length-changing%20Unicode%20case%20fold%2C%20such%20as%20%60stra%C3%9Fe's%60%20against%20%60STRASSE%E2%80%99S%60%2C%20the%20quote%20fallback%20compares%20one%20%60Character%60%20from%20each%20string%20at%20a%20time%20and%20fails%20at%20%60%C3%9F%60%20versus%20%60S%60%2C%20leaving%20the%20collectible%20unhighlighted%20and%20untappable.%20The%20separate%20Unicode%20regression%20tests%20stay%20on%20the%20Foundation%20path%20because%20their%20inputs%20do%20not%20contain%20mismatched%20quote%20shapes%3B%20adding%20a%20combined%20case%20would%20help%20lock%20in%20the%20fix.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youversion%2Fplatform-sdk-swift&pr=231&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0ASources%2FYouVersionPlatformCore%2FBible%2FBibleTermHighlight.swift%3A70%0A**Combined%20Unicode%20folding%20still%20fails**%0A%0AWhen%20a%20term%20requires%20both%20quote-shape%20folding%20and%20a%20length-changing%20Unicode%20case%20fold%2C%20such%20as%20%60stra%C3%9Fe's%60%20against%20%60STRASSE%E2%80%99S%60%2C%20the%20quote%20fallback%20compares%20one%20%60Character%60%20from%20each%20string%20at%20a%20time%20and%20fails%20at%20%60%C3%9F%60%20versus%20%60S%60%2C%20leaving%20the%20collectible%20unhighlighted%20and%20untappable.%20The%20separate%20Unicode%20regression%20tests%20stay%20on%20the%20Foundation%20path%20because%20their%20inputs%20do%20not%20contain%20mismatched%20quote%20shapes%3B%20adding%20a%20combined%20case%20would%20help%20lock%20in%20the%20fix.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=231&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22ss%2Ffix-collectibles-with-punctuation-BL-2078%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ss%2Ffix-collectibles-with-punctuation-BL-2078%22.%0A%0A%23%23%23%20Issue%201%0ASources%2FYouVersionPlatformCore%2FBible%2FBibleTermHighlight.swift%3A70%0A**Combined%20Unicode%20folding%20still%20fails**%0A%0AWhen%20a%20term%20requires%20both%20quote-shape%20folding%20and%20a%20length-changing%20Unicode%20case%20fold%2C%20such%20as%20%60stra%C3%9Fe's%60%20against%20%60STRASSE%E2%80%99S%60%2C%20the%20quote%20fallback%20compares%20one%20%60Character%60%20from%20each%20string%20at%20a%20time%20and%20fails%20at%20%60%C3%9F%60%20versus%20%60S%60%2C%20leaving%20the%20collectible%20unhighlighted%20and%20untappable.%20The%20separate%20Unicode%20regression%20tests%20stay%20on%20the%20Foundation%20path%20because%20their%20inputs%20do%20not%20contain%20mismatched%20quote%20shapes%3B%20adding%20a%20combined%20case%20would%20help%20lock%20in%20the%20fix.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youversion%2Fplatform-sdk-swift&pr=231&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
Sources/YouVersionPlatformCore/Bible/BibleTermHighlight.swift:70
**Combined Unicode folding still fails**

When a term requires both quote-shape folding and a length-changing Unicode case fold, such as `straße's` against `STRASSE’S`, the quote fallback compares one `Character` from each string at a time and fails at `ß` versus `S`, leaving the collectible unhighlighted and untappable. The separate Unicode regression tests stay on the Foundation path because their inputs do not contain mismatched quote shapes; adding a combined case would help lock in the fix.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: preserve Unicode case folding when ..."](https://github.com/youversion/platform-sdk-swift/commit/fb2344abd555a892161becc49fbfde6667d24ca4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51940426)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Core Bible Domain](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-swift/-/docs/core-bible-domain.md)

<!-- /greptile_comment -->