### PR TITLE
feat: add 2 more accessibility labels

### DIFF
--- a/Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift
@@ -149,6 +149,7 @@ public struct BibleReaderBookAndChapterPickerView: View {
                         .renderingMode(.template)
                     chapterListButton(Text(img))
                 }
+                .accessibilityLabel(String.localized("reader.learnMore"))
                 .buttonStyle(.plain)
             }
             ForEach(Array(chapters.enumerated()), id: \.offset) { idx, label in

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderNavButtons.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderNavButtons.swift
@@ -18,6 +18,7 @@ struct BibleReaderNavButtons: View {
                         .font(.system(size: 16, weight: .medium))
                 }
             }
+            .accessibilityLabel(String.localized("generic.back"))
             Spacer()
             Button(action: viewModel.goToNextChapter) {
                 ZStack {

--- a/Sources/YouVersionPlatformReader/Components/BibleReaderNavButtons.swift
+++ b/Sources/YouVersionPlatformReader/Components/BibleReaderNavButtons.swift
@@ -18,7 +18,6 @@ struct BibleReaderNavButtons: View {
                         .font(.system(size: 16, weight: .medium))
                 }
             }
-            .accessibilityLabel(String.localized("generic.back"))
             Spacer()
             Button(action: viewModel.goToNextChapter) {
                 ZStack {

--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift
@@ -17,6 +17,7 @@ struct BibleReaderFontListView: View {
                         Image(systemName: "chevron.backward")
                             .font(.system(size: 24, weight: .semibold))
                     }
+                    .accessibilityLabel(String.localized("generic.back"))
                     .padding()
                     Spacer()
                 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves VoiceOver support for two existing reader controls.
- Labels the book-introduction icon in the book and chapter picker.
- Labels the font-list control that returns to font settings.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the outstanding previous-chapter button is given a label that accurately describes chapter navigation.

The current previous-chapter control still invokes chapter navigation from an unlabeled backward-chevron button, leaving VoiceOver users with the misleading “Back” announcement reported previously.

**Files Needing Attention:** Sources/YouVersionPlatformReader/Components/BibleReaderNavButtons.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/Components/BibleReaderBookAndChapterPickerView.swift | Adds a localized accessibility label to the optional book-introduction control. |
| Sources/YouVersionPlatformReader/Sheets/BibleReaderFontListView.swift | Adds a localized Back accessibility label to the font-list sheet’s actual back-navigation control. |

<sub>Reviews (2): Last reviewed commit: ["fix: undo label since we need to localiz..."](https://github.com/youversion/platform-sdk-swift/commit/26eb3f28dad3bfbe961f289d0711271c9e3d2ad9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52326453)</sub>

**Context used:**

- Knowledge Base — [Reader Components and Sheets](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-swift/-/docs/reader-components-sheets.md)

<!-- /greptile_comment -->