### PR TITLE
fix(ui): align default poetry indentation

### DIFF
--- a/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRenderingStyles.swift
+++ b/Sources/YouVersionPlatformUI/Views/Rendering/BibleVersionRenderingStyles.swift
@@ -187,7 +187,7 @@ final class BibleVersionRenderingStyles {
                 stateDown.alignment = .trailing
                 stateDown.currentFont = .font100emItalic
 
-            case "q1", "iq1":
+            case "q", "q1", "iq", "iq1":
                 stateUp.firstLineHeadIndent = 0
                 stateUp.headIndent = 2
                 
@@ -238,10 +238,6 @@ final class BibleVersionRenderingStyles {
                 
             case "pr":
                 stateDown.alignment = .trailing
-
-            case "iq", "q":
-                stateUp.firstLineHeadIndent = 0
-                stateUp.headIndent = 0
 
             case "iot":
                 stateDown.currentFont = .font100em500

--- a/Tests/YouVersionPlatformUITests/BibleVersionRenderingTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionRenderingTests.swift
@@ -255,6 +255,25 @@ import Testing
         #expect(hasScriptureContaining(blocks, text: "First verse text."))
     }
 
+    @Test(arguments: ["q", "q1", "iq", "iq1"])
+    func testDefaultPoetryLevelUsesFirstLevelIndent(paragraphClass: String) async throws {
+        let html = """
+        <div>
+            <div class="\(paragraphClass)">
+                <span class="yv-v" v="1"></span>
+                <span class="yv-vlbl">1</span>
+                Poetry text.
+            </div>
+        </div>
+        """
+        let reference = BibleReference(versionId: defaultVersionId, bookId: "PSA", chapter: 1, verse: 1)
+
+        let blocks = try await renderBlocks(html: html, reference: reference)
+        let poetryBlock = try block(blocks, containingText: "Poetry text.")
+        #expect(poetryBlock.firstLineHeadIndent == 0)
+        #expect(poetryBlock.headIndent == 2)
+    }
+
     // MARK: - firstVerse (scroll-to-verse support)
 
     private func block(_ blocks: [BibleTextBlock], containingText text: String) throws -> BibleTextBlock {


### PR DESCRIPTION
## Summary

- treat unnumbered `q` and `iq` USFM paragraph markers as first-level poetry, matching `q1` and `iq1`
- add parameterized rendering coverage for all four equivalent markers

## Root cause and impact

The rendering style switch handled `q` and `iq` separately from their explicit level-one forms and assigned them zero head indentation. Since USFM defines an omitted level as level one, common poetry encoded with unnumbered markers rendered flush-left while explicitly numbered poetry was indented.

## Validation

- `swift test` (529 tests passed)
- `swiftlint --strict` (0 violations)
- `scripts/check-api-stability.sh check` (passed for all three modules)
