### PR TITLE
fix(ui): load Bible version statistics once

### DIFF
--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
@@ -8,9 +8,6 @@ extension BibleVersionsViewModel {
 
     public var bibleVersionStatisticsPromo: String {
         guard let versions = cachedPermittedVersions, !versions.isEmpty else {
-            Task {
-                await permittedVersions()
-            }
             return ""
         }
 

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -216,21 +216,35 @@ public final class BibleVersionsViewModel {
     
     /// Holds minimal information about all Bible versions available to this app, in all languages.
     private(set) var cachedPermittedVersions: [YouVersionAPI.Bible.BibleVersionMinimalInfo]?
+    private var hasAttemptedPermittedVersionsLoad = false
     
     /// Returns minimal information about all Bible versions available to this app, in all languages.
     /// On error or when offline, returns nil
     func permittedVersions() async -> [YouVersionAPI.Bible.BibleVersionMinimalInfo]? {
+        await permittedVersions {
+            try await YouVersionAPI.Bible.permittedVersions()
+        }
+    }
+
+    /// Returns permitted versions from the provided source at most once for this model instance.
+    func permittedVersions(
+        using versions: () async throws -> [YouVersionAPI.Bible.BibleVersionMinimalInfo]
+    ) async -> [YouVersionAPI.Bible.BibleVersionMinimalInfo]? {
         if let cachedPermittedVersions {
             return cachedPermittedVersions
         }
-        
-        let fetched = try? await YouVersionAPI.Bible.permittedVersions()
-        let versions = fetched?.filter { isPermitted(versionId: $0.id, languageTag: $0.languageTag) }
-
-        if let versions, cachedPermittedVersions == nil {
-            cachedPermittedVersions = versions
+        guard !hasAttemptedPermittedVersionsLoad else {
+            return nil
         }
-        return versions
+        hasAttemptedPermittedVersionsLoad = true
+
+        let fetched = try? await versions()
+        let permittedVersions = fetched?.filter { isPermitted(versionId: $0.id, languageTag: $0.languageTag) }
+
+        if let permittedVersions, cachedPermittedVersions == nil {
+            cachedPermittedVersions = permittedVersions
+        }
+        return permittedVersions
     }
     
     private var languageTagsBeingFetched: Set<String> = []

--- a/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
@@ -59,6 +59,27 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
 }
 
 @MainActor
+private final class TestGate {
+    private var isOpen = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func open() {
+        isOpen = true
+        continuations.forEach { $0.resume() }
+        continuations.removeAll()
+    }
+}
+
+@MainActor
 @Suite(.serialized) struct BibleVersionsViewModelTests {
     @Test
     func initUsesSharedRepositoryByDefault() {
@@ -141,6 +162,40 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
 
         #expect(firstResult == nil)
         #expect(secondResult == nil)
+        #expect(loadCount == 1)
+    }
+
+    @Test
+    func permittedVersionsAllowsOneConcurrentAttemptAndCachesEmptySuccess() async {
+        let viewModel = BibleVersionsViewModel()
+        let loadStarted = TestGate()
+        let loadCanFinish = TestGate()
+        var loadCount = 0
+
+        let firstLoad = Task {
+            await viewModel.permittedVersions {
+                loadCount += 1
+                loadStarted.open()
+                await loadCanFinish.wait()
+                return []
+            }
+        }
+        await loadStarted.wait()
+
+        let concurrentResult = await viewModel.permittedVersions {
+            loadCount += 1
+            return []
+        }
+        loadCanFinish.open()
+        let firstResult = await firstLoad.value
+        let cachedResult = await viewModel.permittedVersions {
+            loadCount += 1
+            return []
+        }
+
+        #expect(concurrentResult == nil)
+        #expect(firstResult == [])
+        #expect(cachedResult == [])
         #expect(loadCount == 1)
     }
 

--- a/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
@@ -111,6 +111,40 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
     }
 
     @Test
+    func statisticsPromoReadsDoNotLoadPermittedVersions() async {
+        let viewModel = BibleVersionsViewModel()
+        var loadCount = 0
+
+        #expect(viewModel.bibleVersionStatisticsPromo.isEmpty)
+        #expect(viewModel.bibleVersionStatisticsPromo.isEmpty)
+        await Task.yield()
+        _ = await viewModel.permittedVersions {
+            loadCount += 1
+            return []
+        }
+
+        #expect(loadCount == 1)
+    }
+
+    @Test
+    func permittedVersionsDoesNotRetryAfterFailure() async {
+        let viewModel = BibleVersionsViewModel()
+        var loadCount = 0
+
+        func unavailableVersions() async throws -> [YouVersionAPI.Bible.BibleVersionMinimalInfo] {
+            loadCount += 1
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let firstResult = await viewModel.permittedVersions(using: unavailableVersions)
+        let secondResult = await viewModel.permittedVersions(using: unavailableVersions)
+
+        #expect(firstResult == nil)
+        #expect(secondResult == nil)
+        #expect(loadCount == 1)
+    }
+
+    @Test
     func excludedVersionIsNotPermitted() {
         let originalAppKey = YouVersionPlatformConfiguration.appKey
         YouVersionPlatformConfiguration.configure(


### PR DESCRIPTION
## Summary

- make `bibleVersionStatisticsPromo` a side-effect-free computed property
- limit permitted-version loading to one attempt per `BibleVersionsViewModel` instance
- cover repeated property reads and offline/failure behavior with regression tests

## Root cause

SwiftUI repeatedly evaluates computed properties while rendering. The statistics promo getter created a new unstructured task whenever permitted versions were unavailable. Failed requests were not cached, so every later read could start another request, causing continuous retries while offline.

## Developer impact

Permitted versions now load only from explicit view-model lifecycle entry points. A successful result, including an empty list, is cached. A failed attempt remains terminal for that view-model instance, preventing background retry loops while preserving the existing empty promo text.

## Validation

- `swift test` — 530 tests passed
- `swift test --filter BibleVersionsViewModelTests` — 10 tests passed
- `swiftlint --strict` — 0 violations
- `scripts/check-api-stability.sh check` — passed for all modules