### PR TITLE
fix(reader): restore saved Bible fallback

### DIFF
--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -30,6 +30,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
     private let userDefaultsKeyForBibleReference = "bible-reader-view--reference"
     private let userDefaultsKeyForBibleDisplayIntro = "bible-reader-view--displayintro"
     private let userDefaultsKeyForShowsFullChapter = "bible-reader-view--showsfullchapter"
+    private let userDefaultsKeyForMyVersions = "bible-reader-view--my-versions"
     private let userDefaultsKeyForReaderSettings = "bible-reader-view--readersettings"
     var reference: BibleReference {
         didSet {
@@ -176,6 +177,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         authentication: BibleReaderAuthentication?
     ) {
         let authentication = authentication ?? .default
+        let savedVersionIds = UserDefaults.standard.array(forKey: userDefaultsKeyForMyVersions) as? [Int] ?? []
         if let initialReference {
             self.reference = initialReference
             self.showBookIntro = false
@@ -187,8 +189,11 @@ final class BibleReaderViewModel: ReaderThemeProviding {
                 self.showBookIntro = UserDefaults.standard.bool(forKey: userDefaultsKeyForBibleDisplayIntro)
                 self.showsFullChapter = UserDefaults.standard.bool(forKey: userDefaultsKeyForShowsFullChapter)
             } else {
-                // no saved reference, so, pick a downloaded version, else a safe default.
-                let versionId = BibleVersionRepository.shared.downloadedVersionIds.first ?? 3034
+                // no saved reference, so, pick a downloaded or saved version, else a safe default.
+                let versionId = Self.defaultVersionId(
+                    downloadedVersionIds: BibleVersionRepository.shared.downloadedVersionIds,
+                    savedVersionIds: savedVersionIds
+                )
                 self.reference = BibleReference(versionId: versionId, bookId: "JHN", chapter: 1)
                 self.showBookIntro = false
                 self.showsFullChapter = showsFullChapter
@@ -221,6 +226,11 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         if initialReference != nil {
             setScrollTarget()
         }
+    }
+
+    /// Returns the preferred initial version ID when no Bible reference has been saved.
+    static func defaultVersionId(downloadedVersionIds: [Int], savedVersionIds: [Int]) -> Int {
+        downloadedVersionIds.first ?? savedVersionIds.first ?? 3034
     }
 
     // Reacts to BibleVersionsViewModel.currentVersion changes by updating

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelPersistenceTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelPersistenceTests.swift
@@ -85,6 +85,46 @@ import Testing
     }
 
     @Test
+    func initWithoutSavedReferenceUsesFirstSavedVersion() {
+        Support.clearReaderDefaults()
+        UserDefaults.standard.set([111, 222], forKey: Support.myVersionsKey)
+
+        let viewModel = Support.makeViewModel(reference: nil)
+
+        #expect(viewModel.reference == BibleReference(versionId: 111, bookId: "JHN", chapter: 1))
+    }
+
+    @Test
+    func defaultVersionPrefersFirstDownloadedVersion() {
+        let versionId = BibleReaderViewModel.defaultVersionId(
+            downloadedVersionIds: [333, 444],
+            savedVersionIds: [111, 222]
+        )
+
+        #expect(versionId == 333)
+    }
+
+    @Test
+    func defaultVersionPrefersFirstSavedVersionWhenNothingIsDownloaded() {
+        let versionId = BibleReaderViewModel.defaultVersionId(
+            downloadedVersionIds: [],
+            savedVersionIds: [111, 222]
+        )
+
+        #expect(versionId == 111)
+    }
+
+    @Test
+    func defaultVersionUsesBSBWhenNoPreferredVersionExists() {
+        let versionId = BibleReaderViewModel.defaultVersionId(
+            downloadedVersionIds: [],
+            savedVersionIds: []
+        )
+
+        #expect(versionId == 3034)
+    }
+
+    @Test
     func referenceAndShowBookIntroPersistWhenChanged() {
         Support.clearReaderDefaults()
         let viewModel = Support.makeViewModel(

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelTestSupport.swift
@@ -80,6 +80,7 @@ enum BibleReaderViewModelTestSupport {
     static let referenceKey = "bible-reader-view--reference"
     static let displayIntroKey = "bible-reader-view--displayintro"
     static let showsFullChapterKey = "bible-reader-view--showsfullchapter"
+    static let myVersionsKey = "bible-reader-view--my-versions"
     static let readerSettingsKey = "bible-reader-view--readersettings"
 
     @MainActor
@@ -166,6 +167,7 @@ enum BibleReaderViewModelTestSupport {
         UserDefaults.standard.removeObject(forKey: referenceKey)
         UserDefaults.standard.removeObject(forKey: displayIntroKey)
         UserDefaults.standard.removeObject(forKey: showsFullChapterKey)
+        UserDefaults.standard.removeObject(forKey: myVersionsKey)
         UserDefaults.standard.removeObject(forKey: readerSettingsKey)
     }
 


### PR DESCRIPTION
## What changed

- restore the saved “My Versions” candidate when the reader has no explicit or last-viewed reference
- preserve the historical precedence: downloaded version, then first saved version, then BSB (3034)
- add regression coverage for persisted restoration, source precedence, ordering, and the empty fallback

## Root cause

When `BibleVersionsViewModel` was extracted in commit `254b3b8`, `savedIds.first` was dropped from `BibleReaderViewModel`’s initial reference selection. Because BSB 3034 usually loads successfully, the downstream fallback chain never had a chance to consider the user’s saved versions.

Saved IDs remain candidates rather than being trusted as valid. The existing `BibleVersionsViewModel` loader validates the candidate and, on failure, continues through its permitted/downloaded/language fallback behavior.

## Validation

- `swift test` — 532 tests passed
- `swiftlint --strict --no-cache` — 0 violations
- `scripts/check-api-stability.sh check` — passed
- SampleApp build for iPhone Simulator — passed

Jira: YPE-4953