### PR TITLE
fix(reader): migrate legacy line spacing settings

### DIFF
--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -346,7 +346,7 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         }
         // else: no saved theme yet — userSelectedTheme stays nil and colorTheme
         // tracks the device's system color scheme until the user picks one.
-        if savedValue.lineSpacing != lineSpacing {
+        if let savedLineSpacing = savedValue.lineSpacing, savedLineSpacing != lineSpacing {
             saveUserSettingsToStorage()
         }
     }

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -340,12 +340,15 @@ final class BibleReaderViewModel: ReaderThemeProviding {
             ReaderFonts.defaultFontFamily
         }
         fontSize = ReaderFonts.nextLargerSize(currentSize: (savedValue.fontSize ?? ReaderFonts.defaultFontSize) - 0.001)
-        lineSpacing = ReaderFonts.nextLineSpacing(currentSpacing: (savedValue.lineSpacing ?? ReaderFonts.defaultLineSpacing) - 0.001)
+        lineSpacing = ReaderFonts.lineSpacing(forStoredValue: savedValue.lineSpacing)
         if let savedThemeId = savedValue.colorTheme {
             userSelectedTheme = ReaderTheme.theme(withId: savedThemeId)
         }
         // else: no saved theme yet — userSelectedTheme stays nil and colorTheme
         // tracks the device's system color scheme until the user picks one.
+        if savedValue.lineSpacing != lineSpacing {
+            saveUserSettingsToStorage()
+        }
     }
 
     func saveUserSettingsToStorage() {

--- a/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/ReaderFonts.swift
@@ -100,6 +100,7 @@ public enum ReaderFonts {
 
     static let availableSizes: [CGFloat] = [9, 12, 15, 18, 21, 24, 27]
     static let lineSpacingOptions: [CGFloat] = [0.3, 0.4, 0.6]
+    private static let legacyLineSpacingOptions: [CGFloat] = [6, 12, 18]
 
     // MARK: - Default Values
 
@@ -121,5 +122,18 @@ public enum ReaderFonts {
         lineSpacingOptions.filter { $0 > currentSpacing }.min()
         ?? lineSpacingOptions.min()
         ?? defaultLineSpacing
+    }
+
+    static func lineSpacing(forStoredValue storedValue: CGFloat?) -> CGFloat {
+        guard let storedValue else {
+            return defaultLineSpacing
+        }
+        if lineSpacingOptions.contains(storedValue) {
+            return storedValue
+        }
+        if let legacyIndex = legacyLineSpacingOptions.firstIndex(of: storedValue) {
+            return lineSpacingOptions[legacyIndex]
+        }
+        return defaultLineSpacing
     }
 }

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelPersistenceTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelPersistenceTests.swift
@@ -107,6 +107,7 @@ import Testing
         let viewModel = Support.makeViewModel()
 
         #expect(viewModel.textOptions.fontSize == 18)
+        #expect(viewModel.textOptions.lineSpacing == ReaderFonts.defaultLineSpacing)
 
         viewModel.decreaseFontSize()
         #expect(viewModel.textOptions.fontSize == 15)
@@ -149,6 +150,84 @@ import Testing
         #expect(viewModel.textOptions.fontFamily == ReaderFonts.defaultFontFamily)
         #expect(viewModel.textOptions.fontSize == 15)
         #expect(viewModel.colorTheme == ReaderTheme.theme(withId: 6))
+    }
+
+    @Test
+    func currentLineSpacingValuesRestoreWithoutModification() throws {
+        for lineSpacing in ReaderFonts.lineSpacingOptions {
+            Support.clearReaderDefaults()
+            let settings = StoredReaderSettings(
+                fontFamily: "Georgia",
+                fontSize: 15,
+                lineSpacing: lineSpacing,
+                colorTheme: 6
+            )
+            let savedData = try JSONEncoder().encode(settings)
+            UserDefaults.standard.set(savedData, forKey: Support.readerSettingsKey)
+
+            let viewModel = Support.makeViewModel()
+
+            #expect(viewModel.textOptions.lineSpacing == lineSpacing)
+            #expect(UserDefaults.standard.data(forKey: Support.readerSettingsKey) == savedData)
+        }
+    }
+
+    @Test
+    func legacyLineSpacingValuesMigrateAndPersist() throws {
+        let migrations: [(legacy: CGFloat, current: CGFloat)] = [
+            (6, 0.3),
+            (12, 0.4),
+            (18, 0.6),
+        ]
+
+        for migration in migrations {
+            Support.clearReaderDefaults()
+            let settings = StoredReaderSettings(
+                fontFamily: "Georgia",
+                fontSize: 15,
+                lineSpacing: migration.legacy,
+                colorTheme: 6
+            )
+            UserDefaults.standard.set(try JSONEncoder().encode(settings), forKey: Support.readerSettingsKey)
+
+            let viewModel = Support.makeViewModel()
+            let migratedSettings = try storedReaderSettings()
+
+            #expect(viewModel.textOptions.lineSpacing == migration.current)
+            #expect(migratedSettings.lineSpacing == migration.current)
+        }
+    }
+
+    @Test
+    func invalidLineSpacingValuesFallBackToDefaultAndPersist() throws {
+        for invalidLineSpacing: CGFloat in [-1, 0, 0.5, 999] {
+            Support.clearReaderDefaults()
+            let settings = StoredReaderSettings(
+                fontFamily: "Georgia",
+                fontSize: 15,
+                lineSpacing: invalidLineSpacing,
+                colorTheme: 6
+            )
+            UserDefaults.standard.set(try JSONEncoder().encode(settings), forKey: Support.readerSettingsKey)
+
+            let viewModel = Support.makeViewModel()
+            let migratedSettings = try storedReaderSettings()
+
+            #expect(viewModel.textOptions.lineSpacing == ReaderFonts.defaultLineSpacing)
+            #expect(migratedSettings.lineSpacing == ReaderFonts.defaultLineSpacing)
+        }
+    }
+
+    @Test
+    func malformedStoredSettingsUseFreshDefaults() {
+        Support.clearReaderDefaults()
+        UserDefaults.standard.set(Data("not json".utf8), forKey: Support.readerSettingsKey)
+
+        let viewModel = Support.makeViewModel()
+
+        #expect(viewModel.textOptions.fontFamily == ReaderFonts.defaultFontFamily)
+        #expect(viewModel.textOptions.fontSize == ReaderFonts.defaultFontSize)
+        #expect(viewModel.textOptions.lineSpacing == ReaderFonts.defaultLineSpacing)
     }
 
     @Test
@@ -218,5 +297,10 @@ import Testing
 
         viewModel.cycleLineSpacing()
         #expect(viewModel.textOptions.lineSpacing == 0.3)
+    }
+
+    private func storedReaderSettings() throws -> StoredReaderSettings {
+        let data = try #require(UserDefaults.standard.data(forKey: Support.readerSettingsKey))
+        return try JSONDecoder().decode(StoredReaderSettings.self, from: data)
     }
 }

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelPersistenceTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelPersistenceTests.swift
@@ -173,6 +173,24 @@ import Testing
     }
 
     @Test
+    func missingLineSpacingUsesDefaultWithoutModifyingStoredSettings() throws {
+        Support.clearReaderDefaults()
+        let settings = StoredReaderSettings(
+            fontFamily: "Georgia",
+            fontSize: 15,
+            lineSpacing: nil,
+            colorTheme: 6
+        )
+        let savedData = try JSONEncoder().encode(settings)
+        UserDefaults.standard.set(savedData, forKey: Support.readerSettingsKey)
+
+        let viewModel = Support.makeViewModel()
+
+        #expect(viewModel.textOptions.lineSpacing == ReaderFonts.defaultLineSpacing)
+        #expect(UserDefaults.standard.data(forKey: Support.readerSettingsKey) == savedData)
+    }
+
+    @Test
     func legacyLineSpacingValuesMigrateAndPersist() throws {
         let migrations: [(legacy: CGFloat, current: CGFloat)] = [
             (6, 0.3),
@@ -221,13 +239,15 @@ import Testing
     @Test
     func malformedStoredSettingsUseFreshDefaults() {
         Support.clearReaderDefaults()
-        UserDefaults.standard.set(Data("not json".utf8), forKey: Support.readerSettingsKey)
+        let malformedData = Data("not json".utf8)
+        UserDefaults.standard.set(malformedData, forKey: Support.readerSettingsKey)
 
         let viewModel = Support.makeViewModel()
 
         #expect(viewModel.textOptions.fontFamily == ReaderFonts.defaultFontFamily)
         #expect(viewModel.textOptions.fontSize == ReaderFonts.defaultFontSize)
         #expect(viewModel.textOptions.lineSpacing == ReaderFonts.defaultLineSpacing)
+        #expect(UserDefaults.standard.data(forKey: Support.readerSettingsKey) == malformedData)
     }
 
     @Test

--- a/Tests/YouVersionPlatformReaderTests/ReaderFontsTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/ReaderFontsTests.swift
@@ -86,6 +86,13 @@ struct ReaderFontsTests {
         #expect(ReaderFonts.nextLineSpacing(currentSpacing: ReaderFonts.lineSpacingOptions.last!) == ReaderFonts.lineSpacingOptions[0])
         #expect(ReaderFonts.nextLineSpacing(currentSpacing: 999) == ReaderFonts.lineSpacingOptions.first)
     }
+
+    @Test
+    func nonFiniteStoredLineSpacingFallsBackToDefault() {
+        #expect(ReaderFonts.lineSpacing(forStoredValue: .nan) == ReaderFonts.defaultLineSpacing)
+        #expect(ReaderFonts.lineSpacing(forStoredValue: .infinity) == ReaderFonts.defaultLineSpacing)
+        #expect(ReaderFonts.lineSpacing(forStoredValue: -.infinity) == ReaderFonts.defaultLineSpacing)
+    }
 }
 
 private func debugDescription(of font: Font) -> String {


### PR DESCRIPTION
## Summary

- restore current line-spacing multipliers without modifying valid persisted settings
- migrate legacy point values by their matching option level: `6` to `0.3`, `12` to `0.4`, and `18` to `0.6`
- normalize invalid decodable values to the `0.4` default and persist migrations once
- restore coverage for fresh defaults and add current, legacy, malformed, and out-of-range persistence cases

## Root cause

The typography update changed line-spacing storage from point values (`6`, `12`, `18`) to font-size multipliers (`0.3`, `0.4`, `0.6`). Settings loading continued to pass persisted values through the control-cycling helper. Because every legacy value was greater than the largest multiplier, each one wrapped to `0.3`, losing the user's selected spacing level on upgrade.

## Impact

Users upgrading from a pre-5.3.0 SDK retain the corresponding compact, default, or spacious setting. Once read, legacy values are rewritten in the current format so future launches no longer need migration.

## Validation

- `swift test` (532 tests)
- `swiftlint --strict`
- `scripts/check-api-stability.sh check`
- Sample App simulator build using the `SampleApp` scheme on iPhone 17
