### PR TITLE
fix(ui): load Bible version statistics once

### DIFF
--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift
@@ -8,9 +8,6 @@ extension BibleVersionsViewModel {
 
     public var bibleVersionStatisticsPromo: String {
         guard let versions = cachedPermittedVersions, !versions.isEmpty else {
-            Task {
-                await permittedVersions()
-            }
             return ""
         }
 

--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift
@@ -216,21 +216,35 @@ public final class BibleVersionsViewModel {
     
     /// Holds minimal information about all Bible versions available to this app, in all languages.
     private(set) var cachedPermittedVersions: [YouVersionAPI.Bible.BibleVersionMinimalInfo]?
+    private var hasAttemptedPermittedVersionsLoad = false
     
     /// Returns minimal information about all Bible versions available to this app, in all languages.
     /// On error or when offline, returns nil
     func permittedVersions() async -> [YouVersionAPI.Bible.BibleVersionMinimalInfo]? {
+        await permittedVersions {
+            try await YouVersionAPI.Bible.permittedVersions()
+        }
+    }
+
+    /// Returns permitted versions from the provided source at most once for this model instance.
+    func permittedVersions(
+        using versions: () async throws -> [YouVersionAPI.Bible.BibleVersionMinimalInfo]
+    ) async -> [YouVersionAPI.Bible.BibleVersionMinimalInfo]? {
         if let cachedPermittedVersions {
             return cachedPermittedVersions
         }
-        
-        let fetched = try? await YouVersionAPI.Bible.permittedVersions()
-        let versions = fetched?.filter { isPermitted(versionId: $0.id, languageTag: $0.languageTag) }
-
-        if let versions, cachedPermittedVersions == nil {
-            cachedPermittedVersions = versions
+        guard !hasAttemptedPermittedVersionsLoad else {
+            return nil
         }
-        return versions
+        hasAttemptedPermittedVersionsLoad = true
+
+        let fetched = try? await versions()
+        let permittedVersions = fetched?.filter { isPermitted(versionId: $0.id, languageTag: $0.languageTag) }
+
+        if let permittedVersions, cachedPermittedVersions == nil {
+            cachedPermittedVersions = permittedVersions
+        }
+        return permittedVersions
     }
     
     private var languageTagsBeingFetched: Set<String> = []

--- a/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
@@ -59,6 +59,27 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
 }
 
 @MainActor
+private final class TestGate {
+    private var isOpen = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func open() {
+        isOpen = true
+        continuations.forEach { $0.resume() }
+        continuations.removeAll()
+    }
+}
+
+@MainActor
 @Suite(.serialized) struct BibleVersionsViewModelTests {
     @Test
     func initUsesSharedRepositoryByDefault() {
@@ -141,6 +162,40 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
 
         #expect(firstResult == nil)
         #expect(secondResult == nil)
+        #expect(loadCount == 1)
+    }
+
+    @Test
+    func permittedVersionsAllowsOneConcurrentAttemptAndCachesEmptySuccess() async {
+        let viewModel = BibleVersionsViewModel()
+        let loadStarted = TestGate()
+        let loadCanFinish = TestGate()
+        var loadCount = 0
+
+        let firstLoad = Task {
+            await viewModel.permittedVersions {
+                loadCount += 1
+                loadStarted.open()
+                await loadCanFinish.wait()
+                return []
+            }
+        }
+        await loadStarted.wait()
+
+        let concurrentResult = await viewModel.permittedVersions {
+            loadCount += 1
+            return []
+        }
+        loadCanFinish.open()
+        let firstResult = await firstLoad.value
+        let cachedResult = await viewModel.permittedVersions {
+            loadCount += 1
+            return []
+        }
+
+        #expect(concurrentResult == nil)
+        #expect(firstResult == [])
+        #expect(cachedResult == [])
         #expect(loadCount == 1)
     }
 

--- a/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
+++ b/Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift
@@ -111,6 +111,40 @@ private actor MockBibleVersionRepository: BibleVersionRepositoryProtocol {
     }
 
     @Test
+    func statisticsPromoReadsDoNotLoadPermittedVersions() async {
+        let viewModel = BibleVersionsViewModel()
+        var loadCount = 0
+
+        #expect(viewModel.bibleVersionStatisticsPromo.isEmpty)
+        #expect(viewModel.bibleVersionStatisticsPromo.isEmpty)
+        await Task.yield()
+        _ = await viewModel.permittedVersions {
+            loadCount += 1
+            return []
+        }
+
+        #expect(loadCount == 1)
+    }
+
+    @Test
+    func permittedVersionsDoesNotRetryAfterFailure() async {
+        let viewModel = BibleVersionsViewModel()
+        var loadCount = 0
+
+        func unavailableVersions() async throws -> [YouVersionAPI.Bible.BibleVersionMinimalInfo] {
+            loadCount += 1
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let firstResult = await viewModel.permittedVersions(using: unavailableVersions)
+        let secondResult = await viewModel.permittedVersions(using: unavailableVersions)
+
+        #expect(firstResult == nil)
+        #expect(secondResult == nil)
+        #expect(loadCount == 1)
+    }
+
+    @Test
     func excludedVersionIsNotPermitted() {
         let originalAppKey = YouVersionPlatformConfiguration.appKey
         YouVersionPlatformConfiguration.configure(


### PR DESCRIPTION
## Summary

- make `bibleVersionStatisticsPromo` a side-effect-free computed property
- limit permitted-version loading to one attempt per `BibleVersionsViewModel` instance
- cover repeated property reads, simultaneous calls, empty success, and offline/failure behavior with regression tests

## Root cause

SwiftUI repeatedly evaluates computed properties while rendering. The statistics promo getter created a new unstructured task whenever permitted versions were unavailable. Failed requests were not cached, so every later read could start another request, causing continuous retries while offline.

## Developer impact

Permitted versions now load only from explicit view-model lifecycle entry points. A successful result, including an empty list, is cached. A failed attempt remains terminal for that view-model instance, preventing background retry loops while preserving the existing empty promo text.

## Validation

- `swift test` — 531 tests passed
- `swiftlint --strict` — 0 violations
- `scripts/check-api-stability.sh check` — passed for all modules
- Greptile review completed; retry recommendation rejected because it conflicts with the one-attempt requirement

Supersedes #240 after renaming the head branch to the permanent Jira ticket.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes network side effects from the statistics-promo getter and limits permitted-version loading to one attempt per view-model instance.

- Moves loading responsibility to explicit lifecycle and picker entry points.
- Caches successful results, including empty arrays.
- Adds regression coverage for repeated reads, concurrent calls, empty success, and offline failure.
- The terminal-attempt state currently also treats lifecycle cancellation as a completed attempt.

<h3>Confidence Score: 4/5</h3>

The lifecycle-cancellation path should be fixed before merging because it can permanently suppress permitted-version statistics for a surviving view-model instance.

The attempt flag is committed before an awaited throwing operation and all errors are erased, so cancellation of the SwiftUI lifecycle task leaves later calls unable to perform the intended first completed load.

**Files Needing Attention:** Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift and Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel+VersionsList.swift | Removes the unstructured loading task from the computed promo property, making repeated reads side-effect free. |
| Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift | Adds single-attempt loading and empty-result caching, but marks a cancelled request as the model's terminal attempt. |
| Tests/YouVersionPlatformUITests/BibleVersionsViewModelTests.swift | Covers repeated reads, ordinary failure, concurrent calls, and empty success, but not cancellation of the first attempt. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20youversion%2Fplatform-sdk-swift%20PR%20%23246%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=youversion%2Fplatform-sdk-swift&pr=246&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%3A239-241%0A**Cancellation%20consumes%20the%20load%20attempt**%0A%0AWhen%20SwiftUI%20cancels%20the%20initial%20lifecycle%20task%20while%20the%20request%20is%20in%20flight%2C%20setting%20%60hasAttemptedPermittedVersionsLoad%60%20before%20the%20await%20and%20swallowing%20the%20cancellation%20as%20%60nil%60%20makes%20the%20attempt%20terminal%2C%20causing%20the%20statistics%20promo%20to%20remain%20empty%20for%20the%20lifetime%20of%20the%20surviving%20view-model%20instance.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youversion%2Fplatform-sdk-swift&pr=246&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%3A239-241%0A**Cancellation%20consumes%20the%20load%20attempt**%0A%0AWhen%20SwiftUI%20cancels%20the%20initial%20lifecycle%20task%20while%20the%20request%20is%20in%20flight%2C%20setting%20%60hasAttemptedPermittedVersionsLoad%60%20before%20the%20await%20and%20swallowing%20the%20cancellation%20as%20%60nil%60%20makes%20the%20attempt%20terminal%2C%20causing%20the%20statistics%20promo%20to%20remain%20empty%20for%20the%20lifetime%20of%20the%20surviving%20view-model%20instance.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=246&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-swift%22%20on%20the%20existing%20branch%20%22YPE-4950-bible-version-statistics-promo-single-task%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22YPE-4950-bible-version-statistics-promo-single-task%22.%0A%0A%23%23%23%20Issue%201%0ASources%2FYouVersionPlatformUI%2FViews%2FVersionPicking%2FBibleVersionsViewModel.swift%3A239-241%0A**Cancellation%20consumes%20the%20load%20attempt**%0A%0AWhen%20SwiftUI%20cancels%20the%20initial%20lifecycle%20task%20while%20the%20request%20is%20in%20flight%2C%20setting%20%60hasAttemptedPermittedVersionsLoad%60%20before%20the%20await%20and%20swallowing%20the%20cancellation%20as%20%60nil%60%20makes%20the%20attempt%20terminal%2C%20causing%20the%20statistics%20promo%20to%20remain%20empty%20for%20the%20lifetime%20of%20the%20surviving%20view-model%20instance.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youversion%2Fplatform-sdk-swift&pr=246&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsViewModel.swift:239-241
**Cancellation consumes the load attempt**

When SwiftUI cancels the initial lifecycle task while the request is in flight, setting `hasAttemptedPermittedVersionsLoad` before the await and swallowing the cancellation as `nil` makes the attempt terminal, causing the statistics promo to remain empty for the lifetime of the surviving view-model instance.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover permitted versions reque..."](https://github.com/youversion/platform-sdk-swift/commit/d5d27990ec2ecfc35d7f71130d3a76eb6115279d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53193565)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Version Picking Flow](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-swift/-/docs/ui-version-picking.md)

<!-- /greptile_comment -->