### PR TITLE
fix: disable the font size buttons when appropriate

### DIFF
--- a/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift
+++ b/Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift
@@ -113,6 +113,8 @@ struct BibleReaderFontSettingsView: View {
                     HalfRoundedRectangleShape(side: .left)
                         .fill(viewModel.readerButtonPrimaryColor)
                 )
+                .opacity(viewModel.canDecreaseFontSize ? 1 : 0.4)
+                .disabled(!viewModel.canDecreaseFontSize)
 
                 Rectangle()
                     .frame(width: 2, height: 40)
@@ -133,6 +135,8 @@ struct BibleReaderFontSettingsView: View {
                     HalfRoundedRectangleShape(side: .right)
                         .fill(viewModel.readerButtonPrimaryColor)
                 )
+                .opacity(viewModel.canIncreaseFontSize ? 1 : 0.4)
+                .disabled(!viewModel.canIncreaseFontSize)
             }
 
             Spacer()

--- a/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
+++ b/Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift
@@ -260,6 +260,14 @@ final class BibleReaderViewModel: ReaderThemeProviding {
         )
     }
 
+    var canDecreaseFontSize: Bool {
+        ReaderFonts.nextSmallerSize(currentSize: textOptions.fontSize) != nil
+    }
+
+    var canIncreaseFontSize: Bool {
+        ReaderFonts.nextLargerSize(currentSize: textOptions.fontSize) != nil
+    }
+
     /// Aligns the reader's reference to a newly picked version and triggers a
     /// header selection change to load its content. No-ops when the reference's
     /// versionId already matches — this is the guard that prevents

--- a/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelPersistenceTests.swift
+++ b/Tests/YouVersionPlatformReaderTests/BibleReaderViewModelPersistenceTests.swift
@@ -125,6 +125,28 @@ import Testing
     }
 
     @Test
+    func fontSizeControlAvailabilityTracksSizeBoundaries() throws {
+        Support.clearReaderDefaults()
+        let viewModel = Support.makeViewModel()
+        let minimumFontSize = try #require(ReaderFonts.availableSizes.min())
+        let maximumFontSize = try #require(ReaderFonts.availableSizes.max())
+
+        viewModel.setFont(size: minimumFontSize)
+        #expect(viewModel.canDecreaseFontSize == false)
+        #expect(viewModel.canIncreaseFontSize)
+
+        viewModel.increaseFontSize()
+        #expect(viewModel.canDecreaseFontSize)
+
+        viewModel.setFont(size: maximumFontSize)
+        #expect(viewModel.canDecreaseFontSize)
+        #expect(viewModel.canIncreaseFontSize == false)
+
+        viewModel.decreaseFontSize()
+        #expect(viewModel.canIncreaseFontSize)
+    }
+
+    @Test
     func openFontSettingsShowsFontSettings() {
         let viewModel = Support.makeViewModel()
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR disables and visually dims the font-size decrease and increase buttons when the reader reaches its supported size boundaries.
- Adds view-model properties derived from the existing font-size stepping helpers.
- Connects those properties to the corresponding SwiftUI controls.
- Adds tests covering minimum, maximum, and post-step availability.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the controls consistently reflecting the existing font-size boundary behavior.

The availability properties and mutation actions use identical size-navigation helpers, SwiftUI observes the underlying font-size state, and the new tests cover both boundaries.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/YouVersionPlatformReader/Sheets/BibleReaderFontSettingsView.swift | Applies matching disabled and opacity states directly to the decrease and increase buttons at their respective boundaries. |
| Sources/YouVersionPlatformReader/ViewModels/BibleReaderViewModel.swift | Exposes reactive availability properties using the same next-size helpers as the font-size actions. |
| Tests/YouVersionPlatformReaderTests/BibleReaderViewModelPersistenceTests.swift | Verifies control availability at both supported size boundaries and after stepping away from each boundary. |

<sub>Reviews (1): Last reviewed commit: ["fix: disable the font size buttons when ..."](https://github.com/youversion/platform-sdk-swift/commit/983152028baa8df28c2e1dc31812bd951958c48b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54434850)</sub>

**Context used:**

- Knowledge Base — [Reader Components and Sheets](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-swift/-/docs/reader-components-sheets.md)

<!-- /greptile_comment -->