### PR TITLE
fix(versions): improve search empty state

### DIFF
--- a/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift
+++ b/Sources/YouVersionPlatformUI/Views/VersionPicking/BibleVersionsListView.swift
@@ -21,20 +21,26 @@ public struct BibleVersionsListView: View {
             }
             Group {
                 if let versions = filteredVersions {
-                    List(versions, id: \.id) { version in
-                        Button {
-                            viewModel.handleVersionPickerTap(version.id)
-                        } label: {
-                            BibleVersionOverviewListItem(version: version)
-                        }
-                        .buttonStyle(.plain)
-                        .listRowBackground(viewModel.readerCanvasPrimaryColor)
+                    if versions.isEmpty && hasSearchText {
+                        Text(String.localized("versionList.noSearchResults"))
+                            .foregroundStyle(viewModel.readerTextMutedColor)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else {
+                        List(versions, id: \.id) { version in
+                            Button {
+                                viewModel.handleVersionPickerTap(version.id)
+                            } label: {
+                                BibleVersionOverviewListItem(version: version)
+                            }
+                            .buttonStyle(.plain)
+                            .listRowBackground(viewModel.readerCanvasPrimaryColor)
 #if !os(tvOS)
-                        .listRowSeparator(.hidden)
+                            .listRowSeparator(.hidden)
 #endif
-                        .listRowInsets(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16))
+                            .listRowInsets(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16))
+                        }
+                        .listStyle(.plain)
                     }
-                    .listStyle(.plain)
                 } else {
                     VStack {
                         Spacer()
@@ -81,6 +87,16 @@ public struct BibleVersionsListView: View {
             #endif
             .autocorrectionDisabled(true)
             .accessibilityLabel(String.localized("versionList.searchPlaceholder"))
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String.localized("versionList.clearSearch"))
+            }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
@@ -97,6 +113,10 @@ public struct BibleVersionsListView: View {
             return true
         }
         return Set(versions.compactMap { $0.languageTag }).count > 1
+    }
+
+    private var hasSearchText: Bool {
+        !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private var languageDisplay: some View {


### PR DESCRIPTION
## Summary

- add the standard trailing `xmark.circle.fill` control while the version search has input
- clear the query and restore the complete version list when the control is tapped
- show a centered, localized “No versions found” message for non-empty searches with no matches
- provide a localized accessibility label for the clear control

## Why

The Bible version picker previously left users without a quick way to clear a query and displayed a blank list when filtering produced no matches.

## User impact

Version search now behaves like a standard iOS search field and clearly explains an empty result set.

## Dependency

- [youversion/platform-localization#52](https://github.com/youversion/platform-localization/pull/52) adds the source strings.
- After that PR merges, its generated Swift localization sync PR must land before this implementation merges.

## Validation

- `swift test` — 540 tests passed
- strict SwiftLint — 0 violations
- `scripts/check-api-stability.sh check` — no breaking changes
- iPhone 17 Pro simulator on iOS 26.3 — verified no-results state, accessible clear button, and full-list restoration
